### PR TITLE
[codex] add repository summary docs

### DIFF
--- a/docs/summary/architecture.md
+++ b/docs/summary/architecture.md
@@ -1,0 +1,81 @@
+# Architecture
+
+## System View
+
+```mermaid
+flowchart TD
+    User[利用者 / Browser] --> SPA[Vite + React SPA]
+    SPA --> Router[React Router / src/App.tsx]
+    Router --> Pages[src/page]
+    Pages --> Hooks[src/page/hooks.ts]
+    Pages --> Templates[src/component/Template]
+    Templates --> UI[src/component/Organism / Molecule / Atom]
+
+    Hooks --> Actions[src/action thunk]
+    Actions --> Store[Redux store / src/store]
+    Store --> Selectors[src/selector]
+    Selectors --> Pages
+    Store <--> Persist[redux-persist / LocalStorage]
+
+    Actions --> FirebaseAuth[Firebase Auth]
+    Actions --> FirestoreGateway[src/action/firestore]
+    FirestoreGateway <--> Firestore[(Firestore deck/card)]
+    FirebaseAuth --> FirestoreGateway
+
+    SamplePy[sample/generate.py] --> SampleJson[sample/build/output.json]
+    SampleJson --> Reducer[src/store/reducer.ts initial sample deck]
+
+    FirestoreRules[firestore.rules] --> Firestore
+```
+
+## Runtime Boundaries
+
+- Browser 内で動く React SPA が中心です。server-side application code は見当たりません。
+- Redux state は `deck`、`card`、`config` に分かれ、`redux-persist` で LocalStorage に保存されます。
+- Firebase Auth は匿名ログインと Google ログインを扱います。
+- Firestore には `deck` と `card` の collection があり、`src/action/firestore/event.ts` が `updatedAt` を使って snapshot を購読します。
+- `localMode` が true の deck/card は Firestore に保存せず、Redux state のみで扱います。
+
+## State And Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant App as App/useEffect
+    participant Event as action.event
+    participant Auth as Firebase Auth
+    participant Store as Redux Store
+    participant FS as Firestore
+
+    Browser->>App: load SPA
+    App->>Event: init()
+    Event->>Auth: signInAnonymously when config.isAnonymous
+    Auth-->>Event: onAuthStateChanged(user)
+    Event->>Store: configUpdate(uid, isAnonymous, displayName)
+    Event->>FS: subscribe deck/card where uid and updatedAt
+    FS-->>Event: snapshot changes
+    Event->>Store: deck/card bulk insert/update/delete
+    Store-->>Browser: selectors update page props
+```
+
+## Build And Deployment View
+
+```mermaid
+flowchart LR
+    Source[Repository] --> SampleBuild[make -C sample build]
+    Source --> ViteBuild[vite build]
+    Source --> StorybookBuild[storybook build]
+    SampleBuild --> Build[build artifacts]
+    ViteBuild --> Build
+    Build --> FirebaseHosting[Firebase Hosting public=build]
+    FirestoreRules[firestore.rules] --> FirebaseDeploy[firebase deploy firestore:rules]
+    FirebaseDeploy --> FirebaseHosting
+```
+
+## Notable Design Choices
+
+- `src/page` は route container として薄く、UI は Template/Organism 以下に分かれています。
+- domain 操作は `src/action` の thunk に集約されています。
+- reducer は action type 文字列と `equal()` helper で分岐します。
+- Firestore 書き込みの一部は UI 遷移遅延を避けるため `void firestore.xxx(...)` の fire-and-forget になっています。
+- sample deck は Python サブプロジェクトで生成した JSON を build input として取り込みます。

--- a/docs/summary/assumptions-and-gaps.md
+++ b/docs/summary/assumptions-and-gaps.md
@@ -1,0 +1,33 @@
+# Assumptions And Gaps
+
+## Documentation Gaps
+
+- README は最低限の setup/test/deploy token 手順のみで、画面操作、CSV format の詳細、troubleshooting は薄いです。
+- 既存 docs は `docs/architecture.md`、`docs/feature-list.md`、`docs/test-spec.md` などがありますが、runtime/deployment、configuration、commands、data model はまとまっていませんでした。この `docs/summary/` で補っています。
+- `Docs` という大文字 directory は存在せず、既存 repository は `docs/` を使っています。macOS では case-insensitive filesystem の可能性もあるため、既存構成と skill 指定に合わせて `docs/summary/` に出力しました。
+
+## Product / Behavior Gaps
+
+- Deck を空の状態から新規作成する明確な UI route は見当たりません。deck creation は CSV import、sample load、code 内 action として確認できます。
+- `DeckCard` には reimport icon の表示ロジックがありますが、`DeckListPage` では `onClickReimport` がコメントアウトされています。
+- `isPublic` は type、form、Firestore rules にありますが、Deck form 上では disabled です。public deck の作成・公開フローは見当たりません。
+- `useCardInterval` と `nextSeeingAt` の filter は selector にありますが、`deck.swipe()` 内の interval 更新ロジックはコメントアウトされています。
+
+## Technical Gaps
+
+- HTTP API routes は見当たらないため、`openapi.yaml` は生成していません。
+- Message broker、webhook、明示的な event topic は見当たらないため、`asyncapi.yaml` は生成していません。
+- Firestore 以外の persistent database schema や migration は見当たりません。
+- Firestore の index 定義 file は見当たりません。`subscribeDeck()` は `uid`、`updatedAt`、`orderBy(updatedAt)` を組み合わせるため、production Firestore で composite index が必要になる可能性がありますが、local evidence だけでは確定できません。
+- real Firebase project id、API key、deploy token は secrets/env に依存し、repository には含まれていません。
+
+## Testing Gaps
+
+- E2E test framework は見当たりません。
+- coverage report 設定は見当たりません。
+- 複数の skipped tests が残っています。詳細は `docs/summary/testing.md` と既存 `docs/test/missing-test-spec.md` を参照してください。
+
+## Implementation Notes
+
+- `Deck.currentIndex` は型コメントで Firestore に保存しない意図がありますが、`action.deck.update()` は渡された partial deck を Firestore に送ります。呼び出し payload によっては Firestore に保存され得るため、保存対象 field の方針を明文化するとよいです。
+- 一部 Firestore 書き込みは fire-and-forget です。UI 応答性のための意図はコメントから読めますが、失敗時の扱いは統一されていません。

--- a/docs/summary/cli-and-commands.md
+++ b/docs/summary/cli-and-commands.md
@@ -1,0 +1,49 @@
+# CLI And Commands
+
+## npm Scripts
+
+| Command | Source | Purpose |
+| --- | --- | --- |
+| `npm start` | `package.json` | `vite dev` を起動します。 |
+| `npm run build` | `package.json` | `vite build` を実行します。 |
+| `npm run db` | `package.json` | Firebase emulator を起動します。 |
+| `npm run test` | `package.json` | `vitest run --no-file-parallelism` を実行します。Firestore emulator は別途必要です。 |
+| `npm run storybook` | `package.json` | Storybook dev server を起動します。 |
+| `npm run build-storybook` | `package.json` | Storybook static build を実行します。 |
+
+## Make Targets
+
+| Target | Source | Purpose |
+| --- | --- | --- |
+| `make test` | `Makefile` | 通常 Vitest、Firestore specs、sample pytest を順に実行します。 |
+| `make fmt` | `Makefile` | Prettier、ESLint fix、sample ruff format を実行します。 |
+| `make lint` | `Makefile` | TypeScript compile check と ESLint を実行します。 |
+| `make build` | `Makefile` | sample build、Vite build、Storybook build を実行します。 |
+| `make image` | `Makefile` | `docker compose build base` を実行します。 |
+| `make log` | `Makefile` | `docker compose logs -f db` を実行します。 |
+| `make start` | `Makefile` | Firebase emulator、Storybook、Vite dev server を並行起動します。 |
+
+`common.mk` は `docker compose run --rm --remove-orphans` を共通化し、`make npx ARG="..."` のような実行形式を提供します。
+
+## Docker Compose Commands
+
+| Command | Purpose |
+| --- | --- |
+| `docker compose run test` | Firestore emulator healthcheck 後に Vitest を実行します。README では特定 spec file を渡せる例も示されています。 |
+| `docker compose build base` | Node 実行 image を build します。 |
+| `docker compose logs -f db` | Firestore emulator logs を追跡します。 |
+
+## Firebase Commands
+
+| Command | Source | Purpose |
+| --- | --- | --- |
+| `npx firebase login:ci` | `README.md` | CI deploy 用 token を取得します。 |
+| `npx firebase deploy --token ... --only hosting,firestore:rules` | `.github/workflows/deploy.yml` | Firebase Hosting と Firestore rules を deploy します。 |
+
+## Sample Commands
+
+| Command | Source | Purpose |
+| --- | --- | --- |
+| `make -C sample build` | `sample/Makefile` | `python generate.py ./test -o build/output.json` を Docker 経由で実行します。 |
+| `make -C sample test` | `sample/Makefile` | sample 側 pytest を実行します。 |
+| `make -C sample fmt` | `sample/Makefile` | ruff format を実行します。 |

--- a/docs/summary/configuration.md
+++ b/docs/summary/configuration.md
@@ -1,0 +1,59 @@
+# Configuration
+
+## Environment Variables
+
+`.env.example` と `src/vite-env.d.ts` から確認できる Vite 環境変数です。
+
+| Name | Default in `.env.example` | Used By | Purpose / Requiredness |
+| --- | --- | --- | --- |
+| `VITE_PROJECT_ID` | empty | `src/firebase.ts` | Firebase project id。production Firebase へ接続する場合は必要です。 |
+| `VITE_WEB_API_KEY` | empty | `src/firebase.ts` | Firebase web API key。production Firebase へ接続する場合は必要です。 |
+| `VITE_DB_HOST` | `localhost` | `src/firebase.ts`, `docker-compose.yml`, tests | Firestore emulator host。開発・テストで使います。 |
+| `VITE_DB_PORT` | `8080` | `src/firebase.ts`, `docker-compose.yml`, tests | Firestore emulator port。開発・テストで使います。 |
+
+## Build-Time Constants
+
+| Name | Source | Purpose |
+| --- | --- | --- |
+| `__APP_VERSION__` | `vite.config.ts`, `vitest.config.ts` | `package.json` の version を Config 画面に表示します。 |
+
+## Firebase Config
+
+`src/firebase.ts` は `VITE_PROJECT_ID` と `VITE_WEB_API_KEY` から Firebase app を初期化します。
+
+- `authDomain`: `${projectId}.firebaseapp.com`
+- `databaseURL`: `https://${projectId}.firebaseio.com`
+- `storageBucket`: `${projectId}.appspot.com`
+
+開発時のみ `connectFirestoreEmulator()` を呼びます。
+
+## Redux ConfigState
+
+`src/store/reducer.ts` と `src/vite-env.d.ts` で定義され、`redux-persist` により LocalStorage に保存されます。
+
+| Group | Fields | Notes |
+| --- | --- | --- |
+| Layout | `showHeader`, `showSwipeButtonList`, `showSwipeFeedback`, `fullscreen`, `darkMode` | Config 画面や Header から変更されます。 |
+| Study behavior | `shuffled`, `maxNumberOfCardsToLearn`, `hideBodyWhenCardChanged`, `showBackText`, `keepBackTextViewed`, `autoPlay`, `defaultAutoPlay`, `cardInterval`, `useCardInterval` | 学習開始・カード表示・自動再生・カード interval filter に影響します。 |
+| Swipe mapping | `cardSwipeUp`, `cardSwipeDown`, `cardSwipeLeft`, `cardSwipeRight`, `lastSwipe` | `src/action/deck.ts` の `swipe()` が読みます。 |
+| Auth / sync | `uid`, `isAnonymous`, `displayName`, `lastUpdatedAt`, `localMode` | Firebase Auth と Firestore snapshot 同期に使われます。 |
+| Import / metadata | `githubAccessToken`, `loadSample`, `selectedTags` | GitHub raw fetch の Authorization、初期 sample load などに使われます。 |
+| Display tuning | `showScoreSlider`, `sizeBackText` | 型と reducer default に存在します。UI で使われている範囲は限定的です。 |
+
+## Security Rules
+
+`firestore.rules` は `deck` と `card` collection の read/create/update/delete を制御します。
+
+- deck は owner または public deck を read できます。
+- deck create/update は request auth uid と document uid の一致を要求します。
+- card create/update は card owner の検証に加えて、参照先 deck の owner が request auth uid と一致することを要求します。
+
+## GitHub Actions Secrets
+
+Deploy workflow は以下の secrets を参照します。
+
+- `VITE_PROJECT_ID`
+- `VITE_WEB_API_KEY`
+- `FIREBASE_TOKEN`
+
+値は repository に含まれていないため、この summary では名前のみ扱います。

--- a/docs/summary/er-diagram.md
+++ b/docs/summary/er-diagram.md
@@ -1,0 +1,72 @@
+# ER Diagram
+
+Firestore collection と TypeScript 型から確認できるデータ構造です。RDBMS の migration は見当たらないため、Firestore document model として整理しています。
+
+```mermaid
+erDiagram
+    DECK ||--o{ CARD : contains
+
+    DECK {
+        string id
+        string uid
+        string name
+        string url
+        boolean isPublic
+        number createdAt
+        number updatedAt
+        number deletedAt
+        boolean localMode
+        number currentIndex
+        number scoreMax
+        number scoreMin
+        string_array cardOrderIds
+        string_array selectedTags
+        boolean tagAndFilter
+        string category
+        boolean convertToBr
+    }
+
+    CARD {
+        string id
+        string deckId
+        string uid
+        string frontText
+        string backText
+        string_array tags
+        string uniqueKey
+        number createdAt
+        number updatedAt
+        number deletedAt
+        number score
+        number numberOfSeen
+        number lastSeenAt
+        date nextSeeingAt
+        number interval
+        string url
+        number startLine
+        number endLine
+    }
+```
+
+## Collections
+
+| Collection | Source | Notes |
+| --- | --- | --- |
+| `deck` | `src/action/firestore/deck.ts`, `src/vite-env.d.ts` | deck document を `deck.id` で保存します。`create()` は `createdAt` と `updatedAt` を現在時刻に更新します。 |
+| `card` | `src/action/firestore/card.ts`, `src/vite-env.d.ts` | card document を `card.id` で保存します。`deckId` が deck への参照です。 |
+
+## Relationship
+
+- `Card.deckId` が `Deck.id` を参照します。
+- `Deck.cardOrderIds` は学習順を保持する card id 配列です。
+- Firestore rule では card create/update 時に `request.resource.data.deckId` の deck 所有者が `request.auth.uid` と一致することを確認します。
+
+## Deletion Semantics
+
+- `card.logicalRemove()` は `deletedAt` と `updatedAt` を設定する soft delete です。
+- `deck.remove()` は該当 deck の card を query して削除し、deck document も `deleteDoc` します。
+- snapshot 購読では `deletedAt != null` の document を removed event として扱います。
+
+## Local State Only
+
+`ConfigState` は Firestore collection ではなく Redux state と LocalStorage に保存されます。`Deck.currentIndex` は型コメントで Firestore に保存しない意図が書かれていますが、`deck.update()` は渡された field を Firestore に送るため、実際の保存範囲は呼び出し側の payload に依存します。

--- a/docs/summary/er-diagram.md
+++ b/docs/summary/er-diagram.md
@@ -14,7 +14,7 @@ erDiagram
         boolean isPublic
         number createdAt
         number updatedAt
-        number deletedAt
+        number deletedAt "nullable (number | null)"
         boolean localMode
         number currentIndex
         number scoreMax
@@ -36,7 +36,7 @@ erDiagram
         string uniqueKey
         number createdAt
         number updatedAt
-        number deletedAt
+        number deletedAt "nullable (number | null)"
         number score
         number numberOfSeen
         number lastSeenAt

--- a/docs/summary/features.md
+++ b/docs/summary/features.md
@@ -1,0 +1,80 @@
+# Feature Inventory
+
+## Deck 一覧と学習導線
+
+- Root path `/` の `DeckListPage` で deck 一覧を表示します。
+- 各 deck card から Study、Restart、download、edit、delete を実行できます。
+- Restart は `deck.currentIndex` がある場合だけ有効です。
+- Header から dark mode 切替、CSV import、settings へ移動できます。
+
+Key files: `src/page/DeckList.tsx`, `src/component/Organism/Deck.tsx`, `src/page/hooks.ts`
+
+## CSV Import / Export
+
+- `/import` で CSV file を upload し、`Papa.parse` で card に変換します。
+- CSV row は `frontText`, `backText`, `tags`, `uniqueKey` として扱われます。
+- 同じ deck name がない場合は deck を作成し、`uniqueKey` が既存 card と一致するものは update、新規は create します。
+- deck download は card rows を `Papa.unparse` し、`file-saver` で CSV 保存します。
+- sample CSV download も提供されています。
+
+Key files: `src/page/DeckImportPage.tsx`, `src/action/deck.ts`, `src/action/card.ts`, `src/constant.ts`
+
+## Card 一覧と filter
+
+- `/deck/:id` で deck 内 card を表示します。
+- card list には score、学習回数、tags、front text が表示されます。
+- details 内の filter で tags、AND/OR、score min/max を調整できます。
+- selector は selected tags、score range、`useCardInterval` と `nextSeeingAt` に基づいてカードを絞り込み、`numberOfSeen` 昇順に並べます。
+
+Key files: `src/page/CardList.tsx`, `src/component/Template/CardList.tsx`, `src/component/Organism/DeckStartForm.tsx`, `src/selector/card.ts`
+
+## Card 編集と表示
+
+- `/card/:id/edit` で front text、back text、tags を編集できます。
+- `/card/:id` と card list overlay は back text を表示します。
+- category は deck category を基本に、card tags の language mapping がある場合は tag 側を優先します。
+
+Key files: `src/page/CardFormPage.tsx`, `src/page/CardViewPage.tsx`, `src/component/Organism/CardForm.tsx`, `src/util.ts`
+
+## Deck 編集
+
+- `/deck/:id/edit` で deck name、convertToBr、url、category を編集できます。
+- Public と Local Mode は form 上では disabled です。
+- url がある deck は deck card に reload icon が表示され、reimport action を呼べます。ただし `DeckListPage` では `onClickReimport` がコメントアウトされています。
+
+Key files: `src/page/DeckFormPage.tsx`, `src/component/Organism/DeckForm.tsx`, `src/action/deck.ts`
+
+## 学習セッション
+
+- `/deck/:id/start` で filter 条件を調整し、対象 card 数を確認して学習開始します。
+- `deck.start()` は filter 後の cards から `cardOrderIds` を作り、shuffle と max number を適用します。
+- `/deck/:id/study` では front/back text を切り替え、上下左右 swipe または keyboard arrow で操作します。
+- swipe mapping は config の `cardSwipeUp/Down/Left/Right` に従い、score、学習回数、last seen、current index を更新します。
+- controller は card interval 秒で自動送りできます。
+
+Key files: `src/page/DeckStartPage.tsx`, `src/page/DeckSwiperPage.tsx`, `src/action/deck.ts`, `src/component/Organism/Controller.tsx`
+
+## Auth と Firestore Sync
+
+- 初期化時、匿名状態なら Firebase anonymous sign-in を実行します。
+- Google login は anonymous user を Google credential に link し、失敗時は credential sign-in を試します。
+- auth state change 後、uid と `lastUpdatedAt` を使って deck/card snapshot を購読します。
+- `localMode` false の deck/card は Firestore に create/update/delete されます。
+
+Key files: `src/action/event.ts`, `src/firebase.ts`, `src/action/firestore/*`
+
+## Settings
+
+- `/settings` では login/logout、layout、card behavior、auto play、metadata を編集または表示できます。
+- form は `react-hook-form` の `watch()` で変更ごとに `configUpdate` を dispatch します。
+- version は `__APP_VERSION__` から表示されます。
+
+Key files: `src/page/ConfigPage.tsx`, `src/component/Organism/ConfigForm.tsx`, `src/store/reducer.ts`
+
+## Sample Deck
+
+- `sample/generate.py` が Python test files から card data を生成します。
+- `src/store/reducer.ts` は `sample/build/output.json` を初期 sample deck として読み込みます。
+- `action.deck.loadSample()` は config の `loadSample` が true の場合に sample deck を import します。
+
+Key files: `sample/generate.py`, `src/store/reducer.ts`, `src/action/deck.ts`

--- a/docs/summary/module-map.md
+++ b/docs/summary/module-map.md
@@ -1,0 +1,65 @@
+# Module Map
+
+## Source Modules
+
+| Module | Responsibility | Important Dependencies |
+| --- | --- | --- |
+| `src/main.tsx` | React root、Redux Provider、PersistGate の組み立て | `react-dom`, `react-redux`, `redux-persist`, `src/store` |
+| `src/App.tsx` | dark mode class 管理、event init、route 定義 | `react-router-dom`, `src/page`, `src/action/event` |
+| `src/page` | route container。selector と action hook を接続 | `react-redux`, `react-router-dom`, `src/selector`, `src/action` |
+| `src/component/Template` | page から渡された props を使う画面 layout | Organism/Molecule/Atom |
+| `src/component/Organism` | deck/card/config/study のまとまった UI と form | `react-hook-form`, `react-icons`, `react-swipeable` |
+| `src/component/Molecule` | card/list/form/overlay/fullscreen などの中間 UI | Atom |
+| `src/component/Atom` | button/input/textarea/slider/tag/code/math などの基本 UI | Tailwind CSS, KaTeX, highlight.js, react-markdown |
+| `src/action` | thunk による domain 操作、CSV import/export、学習 swipe | `firebase`, `papaparse`, `file-saver`, selectors |
+| `src/action/firestore` | Firestore CRUD と snapshot subscription | Firebase Firestore SDK |
+| `src/store` | Redux reducer、initial sample deck、persist 設定 | `redux`, `redux-thunk`, `redux-persist`, `lodash` |
+| `src/selector` | deck/card/config の derived state | `lodash`, `src/util` |
+| `src/firebase.ts` | Firebase app 初期化と emulator 接続 | Firebase SDK |
+| `sample` | sample card JSON 生成 | Python, click, pytest, ruff |
+
+## Dependency Diagram
+
+```mermaid
+flowchart TD
+    Main[src/main.tsx] --> App[src/App.tsx]
+    Main --> Store[src/store]
+    App --> Pages[src/page]
+    App --> EventAction[src/action/event]
+
+    Pages --> Templates[src/component/Template]
+    Templates --> Organisms[src/component/Organism]
+    Organisms --> Molecules[src/component/Molecule]
+    Molecules --> Atoms[src/component/Atom]
+    Organisms --> Atoms
+
+    Pages --> Selectors[src/selector]
+    Pages --> Actions[src/action]
+    Actions --> Selectors
+    Actions --> Firestore[src/action/firestore]
+    Actions --> StoreTypes[src/action/type]
+    Store --> StoreTypes
+    Store --> SampleJson[sample/build/output.json]
+    Firestore --> FirebaseSDK[Firebase SDK]
+    FirebaseInit[src/firebase.ts] --> FirebaseSDK
+```
+
+## Routing Map
+
+| Path | Page | Primary Function |
+| --- | --- | --- |
+| `/` | `DeckListPage` | deck 一覧、学習開始、再開、download、edit、delete |
+| `/deck/:id` | `CardListPage` | deck 内 card 一覧、filter、score swipe、card edit/delete、back text overlay |
+| `/deck/:id/edit` | `DeckFormPage` | deck metadata 編集 |
+| `/deck/:id/start` | `DeckStartPage` | 学習前 filter と start |
+| `/deck/:id/study` | `DeckSwiperPage` | front/back text 表示、swipe、controller、自動送り |
+| `/card/:id` | `CardViewPage` | card back text 表示 |
+| `/card/:id/edit` | `CardFormPage` | card front/back/tags 編集 |
+| `/settings` | `ConfigPage` | app 設定、Google login/logout、version 表示 |
+| `/import` | `DeckImportPage` | CSV upload と sample CSV download |
+
+## Package Boundaries
+
+- この repository は `package.json` 上は single npm package です。
+- `sample/` は独立した Python/Docker 構成を持つサブプロジェクトですが、生成物は React app の initial state に取り込まれます。
+- Storybook は同じ React components を `src/**/*.stories.tsx` から読みます。

--- a/docs/summary/repository-overview.md
+++ b/docs/summary/repository-overview.md
@@ -1,0 +1,42 @@
+# Repository Overview
+
+このドキュメントは 2026-06-12 時点のリポジトリ内容から作成した snapshot です。
+
+## 目的
+
+Tango は、デッキとカードを管理し、スワイプ UI で学習する React/Vite 製の Web アプリです。初期状態では `localMode` が有効で、Redux state と `redux-persist` による LocalStorage 保存を中心に動きます。`localMode` を無効にし、Google ログインした場合は Firebase Auth と Firestore を使って `deck` / `card` データを同期します。
+
+## 主要構成
+
+| 領域 | 主なファイル | 役割 |
+| --- | --- | --- |
+| エントリポイント | `src/main.tsx`, `src/App.tsx` | React root、Redux Provider、PersistGate、BrowserRouter、画面ルーティング |
+| 画面 | `src/page/*` | ルートごとの container。selector で状態を読み、hook 経由で action を呼ぶ |
+| UI | `src/component/{Template,Organism,Molecule,Atom}` | 画面テンプレート、フォーム、カード表示、入力部品、Storybook stories |
+| 状態管理 | `src/store/*`, `src/selector/*` | Redux reducer、永続化設定、deck/card/config の参照ロジック |
+| 操作ロジック | `src/action/*` | deck/card/config/event の thunk、CSV import/export、学習スワイプ処理 |
+| Firestore 境界 | `src/action/firestore/*`, `firestore.rules` | Firestore CRUD、snapshot 購読、セキュリティルール、テスト用初期化 |
+| Firebase 初期化 | `src/firebase.ts`, `.env.example` | Firebase app 初期化、開発時 Firestore emulator 接続 |
+| sample 生成 | `sample/*` | Python テストファイルから初期カード JSON を生成し、`sample/build/output.json` をアプリ初期データに使う |
+| 実行・CI | `package.json`, `Makefile`, `docker-compose.yml`, `.github/workflows/*` | dev server、build、lint、test、Firebase Hosting deploy、Docker image 更新 |
+
+## 実行形態
+
+- ローカル開発は `npm run db` で Firestore emulator、`npm start` で Vite dev server を起動する形です。
+- Docker Compose では `db` service が Firestore emulator、`base` / `test` service が Node/Vitest 実行環境を提供します。
+- 本番配信は `vite build` の出力先 `build` を Firebase Hosting に deploy する構成です。
+- `firebase.json` は SPA fallback として全パスを `/index.html` に rewrite します。
+
+## 開発ワークフロー
+
+- `npm install` 後、`.env.example` を `.env` にコピーして環境変数を用意します。
+- `npm start` は Vite dev server、`npm run db` は Firebase emulator、`npm run storybook` は Storybook を起動します。
+- `make build` は sample 生成、Vite build、Storybook build を実行します。
+- `make test` は通常の Vitest、Firestore integration test、sample 側 pytest を順に実行します。
+- GitHub Actions の `Test` workflow は `make build`、`make fmt`、`make lint`、`make test` を実行します。
+
+## 意図的に省略したもの
+
+- HTTP API server は見当たらないため、OpenAPI 仕様は生成していません。
+- 明示的な event topic、message broker、webhook contract は見当たらないため、AsyncAPI は生成していません。
+- schema migration や RDBMS schema は見当たらないため、ER は Firestore collection と TypeScript 型に限定しています。

--- a/docs/summary/runtime-and-deployment.md
+++ b/docs/summary/runtime-and-deployment.md
@@ -1,0 +1,53 @@
+# Runtime And Deployment
+
+## Local Development
+
+| Command | Source | Purpose |
+| --- | --- | --- |
+| `cp .env.example .env` | `README.md`, `.env.example` | Vite/Firebase 用の環境変数を用意します。 |
+| `npm install` | `README.md`, `package.json` | Node dependencies を install します。 |
+| `npm run db` | `package.json` | `firebase emulators:start` を起動します。 |
+| `npm start` | `package.json` | `vite dev` を起動します。 |
+| `npm run storybook` | `package.json`, `.storybook/main.ts` | Storybook dev server を起動します。 |
+
+開発時は `src/firebase.ts` が `import.meta.env.DEV` を見て Firestore emulator に接続します。接続先は `VITE_DB_HOST` と `VITE_DB_PORT` です。
+
+## Docker Compose
+
+`docker-compose.yml` は 3 つの service を定義しています。
+
+| Service | Image / Build | Purpose |
+| --- | --- | --- |
+| `db` | `google/cloud-sdk` | `gcloud emulators firestore start` で Firestore emulator を起動します。 |
+| `base` | `ghcr.io/her0e1c1/tango`, build `Dockerfile` | Node/Vitest/開発コマンドの実行環境です。 |
+| `test` | `base` 継承 | `db` healthcheck 後に `vitest` を entrypoint として実行します。 |
+
+`Dockerfile` は `node:23` を使い、`npm ci` で dependencies を `/node_modules` に移動します。`docker-compose.yml` では workspace の `node_modules` を空 volume にして、ホスト側の `node_modules` mount を避けています。
+
+## Build
+
+`make build` は次を実行します。
+
+1. `make -C sample build`: Python script で `sample/build/output.json` を生成します。
+2. `vite build`: `build` directory に SPA を出力します。
+3. `storybook build`: Storybook static build を実行します。
+
+`vite.config.ts` は `build.outDir` を `build` に設定し、`__APP_VERSION__` に `npm_package_version` を埋め込みます。
+
+## Firebase Hosting
+
+`firebase.json` は Hosting の public directory を `build` に設定し、すべての path を `/index.html` に rewrite します。これにより React Router の SPA route が Hosting 上でも解決されます。
+
+## GitHub Actions
+
+| Workflow | Trigger | Actions |
+| --- | --- | --- |
+| `Test` | pull request, workflow dispatch, workflow call | checkout、GHCR login、必要に応じて Docker build、`make build`、`make fmt`、`make lint`、`make test` |
+| `Deploy` | `main` push | `Test` workflow、Docker image 更新、Firebase Hosting と Firestore rules deploy |
+| `Update Docker Image` | workflow dispatch, workflow call | `docker/build-push-action` で `ghcr.io/${{ github.actor }}/tango:latest` を push |
+
+Deploy workflow は secrets から `VITE_PROJECT_ID`、`VITE_WEB_API_KEY`、`FIREBASE_TOKEN` を使います。secret values はこの summary には含めません。
+
+## Sample Subproject
+
+`sample/` は Python 3.13 のサブプロジェクトです。`sample/generate.py` は `test_*.py` を読み、区切り文字 `### __FRONT_TEXT_END__` で front/back text を分割して card JSON を作ります。生成物は React reducer の初期 sample deck に取り込まれます。

--- a/docs/summary/testing.md
+++ b/docs/summary/testing.md
@@ -1,0 +1,46 @@
+# Testing
+
+## Test Commands
+
+| Command | Source | What It Runs |
+| --- | --- | --- |
+| `npm run test` | `package.json` | `vitest run --no-file-parallelism` |
+| `make test` | `Makefile` | 通常 Vitest、Firestore specs、sample pytest |
+| `docker compose run test` | `README.md`, `docker-compose.yml` | Firestore emulator 付きの Vitest |
+| `make lint` | `Makefile` | `tsc` と ESLint |
+| `make build` | `Makefile` | sample build、Vite build、Storybook build |
+
+## Vitest Configuration
+
+`vitest.config.ts` は `globals: true`、`environment: "jsdom"`、`vite-tsconfig-paths` plugin を設定しています。Firestore integration tests は `src/action/firestore/init.ts` で emulator に接続し、mock user token を使います。
+
+## Test Suites
+
+| Area | Files | Notes |
+| --- | --- | --- |
+| Action unit tests | `src/action/*.spec.ts` | deck/card/event/config actions。Firestore や file-saver などは mock される箇所があります。 |
+| Firestore integration | `src/action/firestore/*.spec.ts` | Firestore emulator を使う deck/card tests と rule tests。 |
+| Selectors | `src/selector/*.spec.ts` | deck/card selector の derived state を確認します。 |
+| Component tests | `src/component/Organism/*.spec.tsx` | react-testing-library で form/controller/front text などを検証します。 |
+| Storybook | `src/**/*.stories.tsx`, `.storybook/*` | component catalog と static build の対象です。 |
+| Sample tests | `sample/test/**/*.py` | Python sample source の pytest。sample build 入力にもなります。 |
+
+## Skipped Or Missing Tests Visible In Code
+
+`rg` で確認できる skip は以下です。
+
+- `src/action/firestore/event.spec.ts`: `describe.skip("firestore/event", ...)`
+- `src/action/deck.spec.ts`: `it.skip("should parse file", ...)`
+- `src/component/Organism/Controller.spec.tsx`: `describe.skip("Controller", ...)`
+- `src/component/Organism/DeckStartForm.spec.tsx`: `describe.skip("DeckStartForm", ...)`
+- `src/component/Organism/ConfigForm.spec.tsx`: `it.skip("should update cardInterval", ...)`
+- `src/component/Organism/DeckForm.spec.tsx`: `it.skip("should update isPublic", ...)`
+
+既存の `docs/test/missing-test-spec.md` は、`parseFile`、`spliteCreate` の deck 新規作成分岐、event subscribe/unsubscribe、config update の追加テストを優先候補として整理しています。
+
+## Coverage Boundaries From Local Evidence
+
+- Unit/integration/component/Firestore rules/sample tests は存在します。
+- Browser E2E test framework は見当たりません。
+- Coverage collection や threshold 設定は見当たりません。
+- GitHub Actions は test だけでなく build、format、lint も PR で実行します。

--- a/docs/summary/use-cases.md
+++ b/docs/summary/use-cases.md
@@ -1,0 +1,130 @@
+# Use Cases
+
+## 1. アプリ起動と同期初期化
+
+Actor: 利用者
+
+1. 利用者が SPA を開きます。
+2. `App` が `action.event.init()` を dispatch します。
+3. config が anonymous の場合、Firebase anonymous sign-in を実行します。
+4. auth state change で uid/displayName を config に保存します。
+5. Firestore deck/card snapshot を購読し、差分を Redux state に反映します。
+
+```mermaid
+sequenceDiagram
+    actor User as 利用者
+    participant App as App
+    participant Event as action.event
+    participant Auth as Firebase Auth
+    participant FS as Firestore
+    participant Store as Redux
+
+    User->>App: open SPA
+    App->>Event: init()
+    Event->>Auth: signInAnonymously()
+    Auth-->>Event: onAuthStateChanged(user)
+    Event->>Store: configUpdate(uid, displayName)
+    Event->>FS: subscribeDeck/subscribeCard(uid, lastUpdatedAt)
+    FS-->>Event: snapshot event
+    Event->>Store: deck/card bulk update
+```
+
+## 2. CSV を import して deck/card を作る
+
+Actor: 利用者
+
+1. 利用者が `/import` で CSV file を選択します。
+2. `deck.parseFile()` が `Papa.parse` で rows を読みます。
+3. row は `card.fromRow()` で `frontText/backText/tags/uniqueKey` に変換されます。
+4. `spliteCreate()` が `uniqueKey` で新規 card と更新対象 card を分けます。
+5. 同名 deck がない場合は `deck.create()` で deck を作ります。
+6. 新規 card を bulk create、既存 card を bulk update します。
+
+```mermaid
+sequenceDiagram
+    actor User as 利用者
+    participant Page as DeckImportPage
+    participant Deck as action.deck
+    participant Card as action.card
+    participant Store as Redux
+    participant FS as Firestore
+
+    User->>Page: upload CSV
+    Page->>Deck: parseFile(file)
+    Deck->>Deck: parseCsv(file)
+    Deck->>Card: fromRow(row)
+    Deck->>Store: splitByUniqueKey(cards)
+    Deck->>Deck: create(deckName) if missing
+    Deck->>Card: bulkUpdate(oldCards)
+    Deck->>Card: bulkCreate(newCards, deckId)
+    Card-->>FS: create/update when localMode=false
+    Card-->>Store: card insert/update
+```
+
+## 3. 学習を開始して swipe する
+
+Actor: 利用者
+
+1. 利用者が deck の Study を押して `/deck/:id/start` に移動します。
+2. tag/score filter を調整します。
+3. Start を押すと `deck.start()` が filter 後の cards を取得します。
+4. shuffle と max number を適用して `cardOrderIds` と `currentIndex` を保存します。
+5. `/deck/:id/study` で front text を表示します。
+6. swipe または arrow key で `deck.swipe()` を呼び、score と current index を更新します。
+
+```mermaid
+sequenceDiagram
+    actor User as 利用者
+    participant Start as DeckStartPage
+    participant Selector as selector.card
+    participant Deck as action.deck
+    participant Card as action.card
+    participant Study as DeckSwiperPage
+    participant Store as Redux
+
+    User->>Start: choose filters
+    User->>Start: click Start
+    Start->>Deck: start(deckId)
+    Deck->>Selector: getFilteredByDeckId(deckId)
+    Deck->>Store: deck.update(currentIndex, cardOrderIds)
+    Start->>Study: navigate /study
+    User->>Study: swipe
+    Study->>Deck: swipe(direction, deckId)
+    Deck->>Card: update(score, numberOfSeen, lastSeenAt)
+    Deck->>Store: deck.update(currentIndex)
+```
+
+## 4. Google login して Firestore 同期する
+
+Actor: 利用者
+
+1. 利用者が Settings で Login を押します。
+2. 現在の anonymous user に Google provider を link します。
+3. user 情報を config に保存し、`lastUpdatedAt` を reset します。
+4. uid を使って deck/card snapshot を購読します。
+
+```mermaid
+sequenceDiagram
+    actor User as 利用者
+    participant Settings as ConfigPage
+    participant Event as action.event
+    participant Auth as Firebase Auth
+    participant FS as Firestore
+    participant Store as Redux
+
+    User->>Settings: click Login
+    Settings->>Event: loginGoogle()
+    Event->>Auth: linkWithPopup(currentUser, GoogleAuthProvider)
+    Auth-->>Event: UserCredential
+    Event->>Store: configUpdate(uid, displayName, lastUpdatedAt=0)
+    Event->>FS: subscribeDeck/subscribeCard(uid, 0)
+```
+
+## 5. Deck を CSV として download する
+
+Actor: 利用者
+
+1. 利用者が deck card の download icon を押します。
+2. `deck.download()` が deck 内 card を取得します。
+3. `card.toRow()` で rows に変換します。
+4. `Papa.unparse` で CSV 文字列にし、`file-saver` で保存します。

--- a/docs/summary/use-cases.md
+++ b/docs/summary/use-cases.md
@@ -37,8 +37,8 @@ Actor: 利用者
 2. `deck.parseFile()` が `Papa.parse` で rows を読みます。
 3. row は `card.fromRow()` で `frontText/backText/tags/uniqueKey` に変換されます。
 4. `spliteCreate()` が `uniqueKey` で新規 card と更新対象 card を分けます。
-5. 同名 deck がない場合は `deck.create()` で deck を作ります。
-6. 新規 card を bulk create、既存 card を bulk update します。
+5. 既存 card を先に bulk update します。
+6. 同名 deck がない場合は `deck.create()` で deck を作り、新規 card を bulk create します。
 
 ```mermaid
 sequenceDiagram
@@ -54,8 +54,8 @@ sequenceDiagram
     Deck->>Deck: parseCsv(file)
     Deck->>Card: fromRow(row)
     Deck->>Store: splitByUniqueKey(cards)
-    Deck->>Deck: create(deckName) if missing
     Deck->>Card: bulkUpdate(oldCards)
+    Deck->>Deck: create(deckName) if missing
     Deck->>Card: bulkCreate(newCards, deckId)
     Card-->>FS: create/update when localMode=false
     Card-->>Store: card insert/update


### PR DESCRIPTION
## Summary

- Add a fresh repository summary under `docs/summary/`.
- Cover architecture, data model, runtime/deployment, configuration, commands, module map, features, use cases, testing, and known gaps.
- Document skipped artifacts such as OpenAPI/AsyncAPI where local evidence is not present.

## Impact

This gives future maintainers a current, reviewable documentation snapshot without changing application behavior.

## Validation

- `git diff --cached --check`
- Reviewed staged diff before commit

No app tests were run because this PR only adds Markdown documentation.