### PR TITLE
Fix Firebase hosting deploy config

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
   "projects": {
+    "default": "tango-ts",
     "dev": "tango-ts"
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,7 @@
     "rules": "firestore.rules"
   },
   "hosting": {
+    "site": "tango-ts",
     "public": "build",
     "ignore": [
       "firebase.json",


### PR DESCRIPTION
## Summary
- Set the default Firebase project alias to tango-ts
- Explicitly set the Firebase Hosting site to tango-ts so deploy can resolve the hosting target

## Testing
- node -e "JSON.parse(require('fs').readFileSync('firebase.json','utf8')); JSON.parse(require('fs').readFileSync('.firebaserc','utf8')); console.log('firebase config json ok')"
- git diff --check
- npx firebase deploy --only hosting,firestore:rules --project tango-ts --dry-run --token dummy-token (reached Deploying to 'tango-ts' and then failed on expected dummy-token authentication, not the previous hosting site/target assertion)