### PR TITLE
Refactor Makefile npm commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,46 +2,41 @@ COMPOSE = docker compose
 RUN = $(COMPOSE) run --rm --remove-orphans
 LOG = $(COMPOSE) logs
 SERVICE = base
+NPM = $(RUN) --entrypoint npm $(SERVICE)
+TEST_NPM = $(RUN) --entrypoint npm test
+E2E_NPM = $(RUN) --use-aliases --env-from-file .env.e2e --entrypoint npm base
+SAMPLE_MAKE = $(MAKE) -C sample
 .DEFAULT_GOAL := sh
 
-.PHONY: run
-run:
-	$(RUN) $(OPT) $(SERVICE) $(ARG)
-
 .PHONY: sh
-sh: run
-
-.PHONY: npx
-npx: OPT=--entrypoint npx
-npx: run
+sh:
+	$(RUN) $(SERVICE)
 
 .PHONY: test
 test:
-	@$(MAKE) npx ARG="vitest run --exclude '**/firestore/**/*.spec.ts'"
-	@$(MAKE) npx ARG="vitest run src/action/firestore" SERVICE=test
-	@$(MAKE) -C sample test
+	$(NPM) run test:unit
+	$(TEST_NPM) run test:firestore
+	@$(SAMPLE_MAKE) test
 
 .PHONY: e2e
 e2e:
 	$(COMPOSE) up --wait --wait-timeout 120 --remove-orphans browser app
-	$(COMPOSE) run --rm --remove-orphans --use-aliases --env-from-file .env.e2e base -lc "npm run e2e"
+	$(E2E_NPM) run e2e
 
 .PHONY: fmt
 fmt:
-	@$(MAKE) npx ARG="prettier './src/**/*.{ts,tsx,js,jsx}' --write"
-	@$(MAKE) npx ARG="eslint . --ext ts,tsx --report-unused-disable-directives --fix"
-	@$(MAKE) -C sample fmt
+	$(NPM) run fmt
+	@$(SAMPLE_MAKE) fmt
 
 .PHONY: lint
 lint:
-	@$(MAKE) npx ARG="tsc"
-	@$(MAKE) npx ARG="eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+	$(NPM) run lint
 
 .PHONY: build
 build:
-	@$(MAKE) -C sample build
-	@$(MAKE) npx ARG="vite build"
-	@$(MAKE) npx ARG="storybook build"
+	@$(SAMPLE_MAKE) build
+	$(NPM) run build
+	$(NPM) run build:storybook
 
 .PHONY: image
 image:
@@ -53,7 +48,4 @@ log:
 
 .PHONY: start
 start:
-	npx firebase emulators:start & \
-	npx storybook dev & \
-	npx vite dev --open & \
-	wait
+	$(NPM) run start:all

--- a/package.json
+++ b/package.json
@@ -8,13 +8,23 @@
   },
   "scripts": {
     "start": "vite dev",
+    "start:all": "firebase emulators:start & storybook dev & vite dev --open & wait",
     "build": "vite build",
+    "build:storybook": "storybook build",
     "db": "firebase emulators:start",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "test": "vitest run --no-file-parallelism",
+    "test:unit": "vitest run --exclude '**/firestore/**/*.spec.ts'",
+    "test:firestore": "vitest run src/action/firestore",
+    "fmt": "npm run fmt:prettier && npm run fmt:eslint",
+    "fmt:prettier": "prettier './src/**/*.{ts,tsx,js,jsx}' --write",
+    "fmt:eslint": "eslint . --ext ts,tsx --report-unused-disable-directives --fix",
+    "lint": "npm run lint:tsc && npm run lint:eslint",
+    "lint:tsc": "tsc",
+    "lint:eslint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "storybook": "storybook dev",
-    "build-storybook": "storybook build"
+    "build-storybook": "npm run build:storybook"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.3.2",


### PR DESCRIPTION
## Summary
- move root Node tool commands into package.json scripts
- simplify Makefile targets to call npm through Docker entrypoints
- remove unused generic run/npx Makefile wrappers

## Testing
- make -n sh
- make -n test
- make -n e2e
- make -n build
- make lint