### PR TITLE
Add PR creation rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 
 # misc
 .DS_Store
+.worktrees/
 .env
 .env.*
 !.env.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 # Repository Instructions
 
-- When creating a PR, create a new branch from the latest `main` branch and work in `.worktrees/$BRANCH`.
+- When creating a PR, use `git worktree` to create `.worktrees/$BRANCH` from the latest `main` branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,9 @@
 # Repository Instructions
 
-## Pull Request Creation
+## Pull Requests
 
-- Create new pull request branches from `origin/main` unless the user explicitly asks to use another base.
-- Refresh `origin/main` before creating the branch.
-- Stage only files that clearly belong to the current request. Do not use `git add .`.
-- After committing and before pushing, rebase the branch onto `origin/main`.
-- Before creating a pull request, verify all of the following:
-  - `git status --short --branch` shows a clean working tree.
-  - `git log --oneline origin/main..HEAD` contains only commits for the current request.
-  - `git diff --name-only origin/main...HEAD` contains only files for the current request.
-  - Required verification commands for the change have passed.
-- If unrelated commits or files are present, stop and recreate the branch from `origin/main`.
+- Start PR branches from fresh `origin/main` unless told otherwise.
+- Stage only relevant files; never use `git add .`.
+- Rebase onto `origin/main` before pushing.
+- Before PR creation, check `git status --short --branch`, `git log --oneline origin/main..HEAD`, and `git diff --name-only origin/main...HEAD`.
+- If unrelated commits or files appear, recreate the branch from `origin/main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,3 @@
 # Repository Instructions
 
-## Pull Requests
-
-- Start PR branches from fresh `origin/main` unless told otherwise.
-- Stage only relevant files; never use `git add .`.
-- Rebase onto `origin/main` before pushing.
-- Before PR creation, check `git status --short --branch`, `git log --oneline origin/main..HEAD`, and `git diff --name-only origin/main...HEAD`.
-- If unrelated commits or files appear, recreate the branch from `origin/main`.
+- When creating a PR, create a new branch from the latest `main` branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 # Repository Instructions
 
-- When creating a PR, create a new branch from the latest `main` branch.
+- When creating a PR, create a new branch from the latest `main` branch and work in `.worktrees/$BRANCH`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository Instructions
+
+## Pull Request Creation
+
+- Create new pull request branches from `origin/main` unless the user explicitly asks to use another base.
+- Refresh `origin/main` before creating the branch.
+- Stage only files that clearly belong to the current request. Do not use `git add .`.
+- After committing and before pushing, rebase the branch onto `origin/main`.
+- Before creating a pull request, verify all of the following:
+  - `git status --short --branch` shows a clean working tree.
+  - `git log --oneline origin/main..HEAD` contains only commits for the current request.
+  - `git diff --name-only origin/main...HEAD` contains only files for the current request.
+  - Required verification commands for the change have passed.
+- If unrelated commits or files are present, stop and recreate the branch from `origin/main`.


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository instructions for PR creation
- require fresh origin/main branches, scoped staging, rebase before push, and pre-PR diff checks

## Testing
- Not run; documentation-only change.
- Verified git status, origin/main..HEAD commit list, and origin/main...HEAD changed files before PR creation.