### PR TITLE
Add Copilot PR worktree rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,1 @@
-# Copilot Instructions
-
-- When creating a PR, use `git worktree` to create `.worktrees/$BRANCH` from the latest `main` branch.
+../AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+- When creating a PR, use `git worktree` to create `.worktrees/$BRANCH` from the latest `main` branch.


### PR DESCRIPTION
## Summary
- add Copilot instructions for creating PR work in git worktrees from latest main

## Testing
- Not run; documentation-only change.
- Verified branch is based on origin/main and only changes .github/copilot-instructions.md.