### PR TITLE
Fix Firestore CI test flake

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "e2e:ui": "playwright test --ui",
     "test": "vitest run --no-file-parallelism",
     "test:unit": "vitest run --exclude '**/firestore/**/*.spec.ts'",
-    "test:firestore": "vitest run src/action/firestore",
+    "test:firestore": "vitest run src/action/firestore --no-file-parallelism",
     "fmt": "npm run fmt:prettier && npm run fmt:eslint",
     "fmt:prettier": "prettier './src/**/*.{ts,tsx,js,jsx}' --write",
     "fmt:eslint": "eslint . --ext ts,tsx --report-unused-disable-directives --fix",


### PR DESCRIPTION
## Summary

- Run Firestore Vitest specs with `--no-file-parallelism`.
- Align `test:firestore` with the existing top-level `test` script's file-level serialization.

## Root Cause

The failed Actions job timed out in `src/action/firestore/deck.spec.ts` after the Firestore client hit `RESOURCE_EXHAUSTED: Received message larger than max` while multiple Firestore spec files were running in parallel against the same emulator. The Firestore integration tests share emulator state/transport and are not safe to run as parallel files.

## Validation

- `VITE_DB_PORT=8000 docker compose run --rm --remove-orphans --entrypoint npm test run test:firestore`

The local run completed with 3 Firestore spec files passed, 1 skipped file, 40 passed tests, and 13 skipped tests.