### PR TITLE
Add branch cleanup make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,19 @@ build:
 	$(NPM) run build
 	$(NPM) run build:storybook
 
+.PHONY: clean
+clean: clean-branches
+
+.PHONY: clean-branches
+clean-branches:
+	@git fetch --prune
+	@git branch --format='%(refname:short)|%(worktreepath)|%(upstream:track)' | while IFS='|' read -r branch worktree_path upstream_track; do \
+		[ "$$branch" != "main" ] || continue; \
+		[ "$$upstream_track" = "[gone]" ] || continue; \
+		if [ -n "$$worktree_path" ]; then git worktree remove "$$worktree_path"; fi; \
+		git branch -D "$$branch"; \
+	done
+
 .PHONY: image
 image:
 	$(COMPOSE) build base


### PR DESCRIPTION
## Summary
- add a clean target that depends on clean-branches
- make clean-branches synchronize local PR branches with pruned remote branches
- remove worktrees for local branches whose upstream is gone, then delete those branches
- keep main untouched

## Testing
- one-off temp repo reproduction: a gone upstream branch checked out in a worktree is removed with its worktree
- make -n clean
- git diff --check