### PR TITLE
Refine Makefile targets

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -9,7 +9,7 @@ x-dev: &dev
     VITE_DB_PORT: ${VITE_DB_PORT:-8080}
   working_dir: /workspace
   volumes:
-    - ..:/workspace
+    - ..:/workspace:cached
     - node_modules:/workspace/node_modules
   entrypoint: bash
 
@@ -17,6 +17,7 @@ services:
   db:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
     platform: linux/amd64
+    init: true
     entrypoint: gcloud
     command: emulators firestore start --host-port "0.0.0.0:${VITE_DB_PORT:-8080}" --rules=/firestore.rules
     volumes:
@@ -34,6 +35,7 @@ services:
 
   app:
     <<: *dev
+    init: true
     command: -lc "npx vite dev --host 0.0.0.0 --port 4173"
     networks:
       default:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,16 +42,7 @@ jobs:
       - run: docker compose build dev
         if: ${{ steps.changed.outputs.any_changed == 'true' || inputs.force }}
 
-      - run: make build
-
-      - run: make fmt
-
-      - run: make lint
-
-      - run: make test
-
-      - name: Run Playwright E2E tests
-        run: make e2e
+      - run: make ci
 
       - name: Upload Playwright report
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ test-firestore: ## Run Firestore tests
 test-sample: ## Run sample tests
 	@$(SAMPLE_MAKE) test
 
+.PHONY: ci
+ci: build fmt lint test e2e ## Run the same checks as the pull request CI
+
 .PHONY: e2e
 e2e: ## Run end-to-end tests
 	$(E2E_COMPOSE) up --wait --wait-timeout 120 --remove-orphans browser app

--- a/Makefile
+++ b/Makefile
@@ -1,49 +1,76 @@
 COMPOSE = docker compose -f .devcontainer/compose.yaml
 E2E_COMPOSE = $(COMPOSE) -f .devcontainer/compose.e2e.yaml
 RUN = $(COMPOSE) run --rm --remove-orphans
-LOG = $(COMPOSE) logs
 SERVICE = dev
 NPM = $(RUN) --entrypoint npm $(SERVICE)
 E2E_NPM = $(E2E_COMPOSE) run --rm --remove-orphans --use-aliases --env-from-file .env.e2e --entrypoint npm $(SERVICE)
 SAMPLE_MAKE = $(MAKE) -C sample
-.DEFAULT_GOAL := sh
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-24s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY: sh
-sh:
+sh: ## Open a shell in the dev container
 	$(RUN) --entrypoint bash $(SERVICE)
 
 .PHONY: test
-test:
+test: test-unit test-firestore test-sample ## Run all tests
+
+.PHONY: test-unit
+test-unit: ## Run unit tests
 	$(NPM) run test:unit
+
+.PHONY: test-firestore
+test-firestore: ## Run Firestore tests
 	$(COMPOSE) up --wait --wait-timeout 120 --remove-orphans -d db
 	$(NPM) run test:firestore
+
+.PHONY: test-sample
+test-sample: ## Run sample tests
 	@$(SAMPLE_MAKE) test
 
 .PHONY: e2e
-e2e:
+e2e: ## Run end-to-end tests
 	$(E2E_COMPOSE) up --wait --wait-timeout 120 --remove-orphans browser app
 	$(E2E_NPM) run e2e
 
 .PHONY: fmt
-fmt:
+fmt: ## Format source files
 	$(NPM) run fmt
 	@$(SAMPLE_MAKE) fmt
 
 .PHONY: lint
-lint:
+lint: ## Run lint checks
 	$(NPM) run lint
 
 .PHONY: build
-build:
+build: ## Build app, Storybook, and sample output
 	@$(SAMPLE_MAKE) build
 	$(NPM) run build
 	$(NPM) run build:storybook
 
 .PHONY: clean
-clean: clean-branches
+clean: clean-branches ## Remove local branches whose upstream was deleted
+
+.PHONY: clean-branches-dry-run
+clean-branches-dry-run: ## List local branches whose upstream was deleted
+	@git fetch --prune
+	@git branch --format='%(refname:short)|%(worktreepath)|%(upstream:track)' | while IFS='|' read -r branch worktree_path upstream_track; do \
+		[ "$$branch" != "main" ] || continue; \
+		[ "$$upstream_track" = "[gone]" ] || continue; \
+		if [ -n "$$worktree_path" ]; then echo "$$branch $$worktree_path"; else echo "$$branch"; fi; \
+	done
 
 .PHONY: clean-branches
-clean-branches:
+clean-branches: ## Remove local branches whose upstream was deleted; requires CONFIRM=1
+	@if [ "$(CONFIRM)" != "1" ]; then \
+		echo "Refusing to delete branches without CONFIRM=1."; \
+		echo "Run 'make clean-branches-dry-run' to inspect targets first."; \
+		echo "Run 'make clean-branches CONFIRM=1' to delete them."; \
+		exit 1; \
+	fi
 	@git fetch --prune
 	@git branch --format='%(refname:short)|%(worktreepath)|%(upstream:track)' | while IFS='|' read -r branch worktree_path upstream_track; do \
 		[ "$$branch" != "main" ] || continue; \
@@ -53,13 +80,9 @@ clean-branches:
 	done
 
 .PHONY: image
-image:
+image: ## Build the dev container image
 	$(COMPOSE) build $(SERVICE)
 
-.PHONY: log
-log:
-	$(LOG) -f db
-
 .PHONY: start
-start:
+start: ## Start local development services
 	$(NPM) run start:all

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,20 @@ SAMPLE_MAKE = $(MAKE) -C sample
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-24s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
+.PHONY: init
+init: .env image npm-install ## Initialize local development environment
+
+.env: .env.example
+	cp -n .env.example .env
+
+.PHONY: npm-install
+npm-install: ## Install npm packages in the dev container
+	$(NPM) ci
+
+.PHONY: up
+up: init ## Start development containers
+	$(COMPOSE) up --wait --wait-timeout 120 --remove-orphans -d
+
 .PHONY: sh
 sh: ## Open a shell in the dev container
 	$(RUN) --entrypoint bash $(SERVICE)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,24 @@ Please keep using `localMode`. (note that any data uploaded to database are to b
 ### Setup for development
 
 ```bash
-mise install
-cp .env.example .env
+make init
 ```
 
-### Install Packages
+This runs the `.env`, `image`, and `npm-install` Makefile targets. It creates `.env` from `.env.example` if it does
+not already exist, builds the development container image, and installs npm packages into the container volume used by
+the Makefile targets.
+
+To start the development containers configured by Compose:
 
 ```bash
+make up
+```
+
+If you want to run the app directly on your host machine instead of through Docker, install the local toolchain and
+packages:
+
+```bash
+mise install
 npm ci
 ```
 

--- a/sample/docker-compose.yml
+++ b/sample/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     working_dir: /buildspace
     volumes:
       - ./Pipfile:/buildspace/Pipfile
-      - ./:/workspace
+      - .:/workspace:cached
     command:
       - bash
       - -c

--- a/src/component/Atom/Math.tsx
+++ b/src/component/Atom/Math.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { Style } from ".";
-import Markdown from 'react-markdown'
-import rehypeKatex from 'rehype-katex'
-import remarkMath from 'remark-math'
-import remarkGfm from 'remark-gfm'
-import 'katex/dist/katex.min.css'
+import Markdown from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import remarkMath from "remark-math";
+import remarkGfm from "remark-gfm";
+import "katex/dist/katex.min.css";
 import "github-markdown-css";
 
 export const Math: React.FC<{ text: string }> = (props) => (

--- a/src/component/Template/DeckList.tsx
+++ b/src/component/Template/DeckList.tsx
@@ -9,7 +9,11 @@ export const DeckList: React.FC<{
 }> = (props) => {
   return (
     <Organism.Layout showHeader {...props.layout}>
-      <List>{props.decks?.map((deck, i) => <Organism.DeckCard key={i} deck={deck} {...props.deckCard} />)}</List>
+      <List>
+        {props.decks?.map((deck, i) => (
+          <Organism.DeckCard key={i} deck={deck} {...props.deckCard} />
+        ))}
+      </List>
     </Organism.Layout>
   );
 };


### PR DESCRIPTION
## Summary
- make the default target show help instead of opening a shell
- split test targets into unit, Firestore, and sample targets
- add a dry-run path and confirmation guard for branch cleanup
- remove the log target

## Testing
- make help
- make -n test
- make clean-branches
- make -n log