### PR TITLE
Add mise tasks for local development

### DIFF
--- a/.devcontainer/compose.local.yaml
+++ b/.devcontainer/compose.local.yaml
@@ -1,0 +1,4 @@
+services:
+  db:
+    ports:
+      - "${VITE_DB_PORT:-8080}:${VITE_DB_PORT:-8080}"

--- a/.devcontainer/compose.local.yaml
+++ b/.devcontainer/compose.local.yaml
@@ -1,4 +1,4 @@
 services:
   db:
     ports:
-      - "${VITE_DB_PORT:-8080}:${VITE_DB_PORT:-8080}"
+      - "${VITE_DB_PORT}:${VITE_DB_PORT}"

--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,4 @@ VITE_WEB_API_KEY=
 
 VITE_DB_HOST=localhost
 VITE_DB_PORT=8080
-COMPOSE_FILE=.devcontainer/compose.yaml
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,7 +5,6 @@ const config: StorybookConfig = {
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-docs",
-    "@chromatic-com/storybook",
     "@storybook/addon-themes",
   ],
   framework: {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,6 @@ import type { StorybookConfig } from "@storybook/react-vite";
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.tsx"],
   addons: [
-    "storybook-dark-mode",
     "@storybook/addon-links",
     "@storybook/addon-docs",
     "@chromatic-com/storybook",

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,11 +3,6 @@ import "../src/index.css";
 
 const preview: Preview = {
   parameters: {
-    darkMode: {
-      darkClass: 'dark',
-      stylePreview: true,
-      classTarget: 'html'
-    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,76 @@
 [tools]
 node = "24"
 npm = "11.6.0"
+
+[env]
+COMPOSE_FILE = ".devcontainer/compose.yaml:.devcontainer/compose.local.yaml"
+
+[hooks]
+enter = "echo 'Run `mise run dev` to start local dependencies and the app.'"
+
+[tasks.init]
+alias = "i"
+run = [
+  "test -f .env || cp .env.example .env",
+  "npm ci",
+]
+
+[tasks.up]
+alias = "u"
+run = "docker compose up --wait --wait-timeout 120 --remove-orphans -d db"
+
+[tasks.dev]
+alias = "d"
+depends = ["up"]
+run = "npm start -- --open"
+
+[tasks.test]
+alias = "t"
+depends = ["build-sample", "up"]
+run = "npm test"
+
+[tasks.fmt]
+alias = "f"
+run = "npm run fmt"
+
+[tasks.fmt-check]
+run = "npm run fmt:check"
+
+[tasks.lint]
+alias = "l"
+depends = ["build-sample"]
+run = "npm run lint:check"
+
+[tasks.build-sample]
+run = "docker compose -f sample/docker-compose.yml run --rm --remove-orphans --entrypoint 'python generate.py ./test -o build/output.json' base"
+
+[tasks.build]
+alias = "b"
+depends = ["build-sample"]
+run = [
+  "npm run build",
+  "npm run build:storybook",
+]
+
+[tasks.ci]
+alias = "c"
+depends = ["fmt-check", "lint", "test", "build"]
+
+[tasks.down]
+run = "docker compose down --remove-orphans"
+
+[tasks.ps]
+run = "docker compose ps"
+
+[tasks.clean]
+run = '''
+printf 'Clean all local generated files, node_modules, and Docker volumes? [y/N] '
+read -r answer
+if [ "$answer" != "y" ]; then
+  echo 'Aborted.'
+  exit 0
+fi
+
+docker compose down --volumes --remove-orphans
+rm -rf node_modules build storybook-static test-results playwright-report coverage .firebase sample/build
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,9 @@ COMPOSE_FILE = ".devcontainer/compose.yaml:.devcontainer/compose.local.yaml"
 [hooks]
 enter = "echo 'Run `mise run dev` to start local dependencies and the app.'"
 
+[tasks.default]
+depends = ["dev"]
+
 [tasks.init]
 alias = "i"
 run = [

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 node = "24"
 npm = "11.6.0"
+watchexec = "2.5.1"
 
 [env]
 _.file = ".env"
@@ -14,10 +15,21 @@ depends = ["dev"]
 
 [tasks.init]
 alias = "i"
-run = [
-  "test -f .env || cp .env.example .env",
-  "npm ci",
+depends = ["init-env", "init-deps"]
+
+[tasks.init-env]
+# .env may contain local secrets such as API keys, so never overwrite it if it already exists.
+sources = [".env.example"]
+outputs = [".env"]
+run = "test -f .env || cp .env.example .env"
+
+[tasks.init-deps]
+sources = [
+  "package.json",
+  "package-lock.json",
 ]
+outputs = ["node_modules/.package-lock.json"]
+run = "npm ci"
 
 [tasks.up]
 alias = "u"
@@ -36,6 +48,14 @@ run = "npm run storybook -- --no-open"
 [tasks.test]
 alias = "t"
 depends = ["build-sample", "up"]
+sources = [
+  "src/**/*.{ts,tsx,js,jsx}",
+  "sample/generate.py",
+  "sample/test/**/*",
+  "package.json",
+  "package-lock.json",
+  "vitest.config.ts",
+]
 run = "npm test"
 
 [tasks.fmt]
@@ -51,6 +71,11 @@ depends = ["build-sample"]
 run = "npm run lint:check"
 
 [tasks.build-sample]
+sources = [
+  "sample/generate.py",
+  "sample/test/**/*",
+]
+outputs = ["sample/build/output.json"]
 run = "docker compose -f sample/docker-compose.yml run --rm --remove-orphans --entrypoint 'python generate.py ./test -o build/output.json' base"
 
 [tasks.build]
@@ -72,14 +97,8 @@ run = "docker compose down --remove-orphans"
 run = "docker compose ps"
 
 [tasks.clean]
-run = '''
-printf 'Clean all local generated files, node_modules, and Docker volumes? [y/N] '
-read -r answer
-if [ "$answer" != "y" ]; then
-  echo 'Aborted.'
-  exit 0
-fi
-
-docker compose down --volumes --remove-orphans
-rm -rf node_modules build storybook-static test-results playwright-report coverage .firebase sample/build
-'''
+confirm = "削除してよいですか？"
+run = [
+  "docker compose down --volumes --remove-orphans",
+  "rm -rf node_modules build storybook-static test-results playwright-report coverage .firebase sample/build",
+]

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,7 @@ run = "npm start -- --open"
 [tasks.storybook]
 alias = "s"
 depends = ["build-sample"]
-run = "npm run storybook"
+run = "npm run storybook -- --no-open"
 
 [tasks.test]
 alias = "t"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ node = "24"
 npm = "11.6.0"
 
 [env]
+_.file = ".env"
 COMPOSE_FILE = ".devcontainer/compose.yaml:.devcontainer/compose.local.yaml"
 
 [hooks]

--- a/mise.toml
+++ b/mise.toml
@@ -21,8 +21,13 @@ run = "docker compose up --wait --wait-timeout 120 --remove-orphans -d db"
 
 [tasks.dev]
 alias = "d"
-depends = ["up"]
+depends = ["build-sample", "up"]
 run = "npm start -- --open"
+
+[tasks.storybook]
+alias = "s"
+depends = ["build-sample"]
+run = "npm run storybook"
 
 [tasks.test]
 alias = "t"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "postcss": "^8.5.16",
         "prettier": "^3.9.4",
         "storybook": "^10.4.6",
-        "storybook-dark-mode": "^4.0.1",
         "tailwindcss": "^4.3.2",
         "typescript": "^5.9.3",
         "vite": "^8.1.3",
@@ -658,6 +657,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -669,6 +669,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -676,6 +677,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -686,6 +688,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -693,6 +696,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -703,17 +707,9 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true,
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3122,6 +3118,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4316,43 +4313,6 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
-      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
-      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
@@ -4748,83 +4708,6 @@
         "storybook": "^10.4.6"
       }
     },
-    "node_modules/@storybook/channels": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.0.8.tgz",
-      "integrity": "sha512-L3EGVkabv3fweXnykD/GlNUDO5HtwlIfSovC7BF4MmP7662j2/eqlZrJxDojGtbv11XHjWp/UJHUIfKpcHXYjQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "8.0.8",
-        "@storybook/core-events": "8.0.8",
-        "@storybook/global": "^5.0.0",
-        "telejson": "^7.2.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/client-logger": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.0.8.tgz",
-      "integrity": "sha512-a4BKwl9NLFcuRgMyI7S4SsJeLFK0LCQxIy76V6YyrE1DigoXz4nA4eQxdjLf7JVvU0EZFmNSfbVL/bXzzWKNXA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/components": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.0.8.tgz",
-      "integrity": "sha512-EpBExH4kHWQJSfA8QXJJ5AsLRUGi5X/zWY7ffiYW8rtnBmEnk3T9FpmnyJlY1A8sdd3b1wQ07JGBDHfL1mdELw==",
-      "dev": true,
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@storybook/client-logger": "8.0.8",
-        "@storybook/csf": "^0.1.2",
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^1.2.5",
-        "@storybook/theming": "8.0.8",
-        "@storybook/types": "8.0.8",
-        "memoizerific": "^1.11.3",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@storybook/core-events": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.8.tgz",
-      "integrity": "sha512-PtuvR7vS4glDEdCfKB4f1k3Vs1C3rTWP2DNbF+IjjPhNLMBznCdzTAPcz+NUIBvpjjGnhKwWikJ0yj931YjSVg==",
-      "dev": true,
-      "dependencies": {
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/csf": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.4.tgz",
-      "integrity": "sha512-B9UI/lsQMjF+oEfZCI6YXNoeuBcGZoOP5x8yKbe2tIEmsMjSztFKkpPzi5nLCnBk/MBtl6QJeI3ksJnbsWPkOw==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@storybook/csf-plugin": {
       "version": "10.4.6",
       "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.6.tgz",
@@ -4865,46 +4748,6 @@
       "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
       "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
       "dev": true
-    },
-    "node_modules/@storybook/icons": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.9.tgz",
-      "integrity": "sha512-cOmylsz25SYXaJL/gvTk/dl3pyk7yBFRfeXTsHvTA3dfhoU/LWSq0NKL9nM7WBasJyn6XPSGnLS4RtKXLw5EUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@storybook/manager-api": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.0.8.tgz",
-      "integrity": "sha512-1HU4nfLRi0sD2uw229gb8EQyufNWrLvMNpg013kBsBXRd+Dj4dqF3v+KrYFNtteY7riC4mAJ6YcQ4tBUNYZDug==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "8.0.8",
-        "@storybook/client-logger": "8.0.8",
-        "@storybook/core-events": "8.0.8",
-        "@storybook/csf": "^0.1.2",
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^1.2.5",
-        "@storybook/router": "8.0.8",
-        "@storybook/theming": "8.0.8",
-        "@storybook/types": "8.0.8",
-        "dequal": "^2.0.2",
-        "lodash": "^4.17.21",
-        "memoizerific": "^1.11.3",
-        "store2": "^2.14.2",
-        "telejson": "^7.2.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
     },
     "node_modules/@storybook/react": {
       "version": "10.4.6",
@@ -5013,64 +4856,6 @@
       "peerDependencies": {
         "storybook": "^10.4.6",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@storybook/router": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.0.8.tgz",
-      "integrity": "sha512-wdFdNsEKweigU9VkGZtpb7GhBJLWzbABcwOuEy2h0d5m7egB97hy9BxhANdqkC+PbAHrabxC99Ca3wTj50MoDg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "8.0.8",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/theming": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.0.8.tgz",
-      "integrity": "sha512-43hkNz7yo8Bl97AO2WbxIGprUqMhUZyK9g8383bd30gSxy9nfND/bdSdcgmA8IokDn8qp37Q4QmxtUZdhjMzZQ==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-        "@storybook/client-logger": "8.0.8",
-        "@storybook/global": "^5.0.0",
-        "memoizerific": "^1.11.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/types": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.0.8.tgz",
-      "integrity": "sha512-NGsgCsXnWlaZmHenHDgHGs21zhweZACkqTNsEQ7hvsiF08QeiKAdgJLQg3YeGK73h9mFDRP9djprUtJYab6vnQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "8.0.8",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -5504,6 +5289,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5514,6 +5300,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -5569,16 +5356,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5598,15 +5375,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -5639,30 +5407,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz",
-      "integrity": "sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/@types/file-saver": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
@@ -5684,12 +5428,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
     },
     "node_modules/@types/js-cookie": {
       "version": "3.0.6",
@@ -5730,12 +5468,6 @@
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "dev": true
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -5774,18 +5506,6 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "dev": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
@@ -5830,27 +5550,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -10197,30 +9896,6 @@
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
-    "node_modules/file-system-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
-      "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "11.1.1",
-        "ramda": "0.29.0"
-      }
-    },
-    "node_modules/file-system-cache/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/filesize": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.1.tgz",
@@ -13916,12 +13591,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/map-or-similar": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
-      "dev": true
-    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -14304,15 +13973,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/memoizerific": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
-      "dev": true,
-      "dependencies": {
-        "map-or-similar": "^1.5.0"
       }
     },
     "node_modules/merge-descriptors": {
@@ -16648,16 +16308,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/ramda": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
@@ -18268,13 +17918,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/store2": {
-      "version": "2.14.4",
-      "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.4.tgz",
-      "integrity": "sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/storybook": {
       "version": "10.4.6",
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.6.tgz",
@@ -18320,22 +17963,6 @@
         "vite-plus": {
           "optional": true
         }
-      }
-    },
-    "node_modules/storybook-dark-mode": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-4.0.2.tgz",
-      "integrity": "sha512-zjcwwQ01R5t1VsakA6alc2JDIRVtavryW8J3E3eKLDIlAMcvsgtpxlelWkZs2cuNspk6Z10XzhQVrUWtYc3F0w==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/components": "^8.0.0",
-        "@storybook/core-events": "^8.0.0",
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^1.2.5",
-        "@storybook/manager-api": "^8.0.0",
-        "@storybook/theming": "^8.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "memoizerific": "^1.11.3"
       }
     },
     "node_modules/storybook/node_modules/@storybook/icons": {
@@ -19165,15 +18792,6 @@
         "streamx": "^2.12.5"
       }
     },
-    "node_modules/telejson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
-      "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
-      "dev": true,
-      "dependencies": {
-        "memoizerific": "^1.11.3"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -19550,18 +19168,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "uuid": "^14.0.1"
       },
       "devDependencies": {
-        "@chromatic-com/storybook": "^1.9.0",
         "@firebase/rules-unit-testing": "^3.0.4",
         "@playwright/test": "^1.61.1",
         "@storybook/addon-docs": "^10.4.6",
@@ -480,24 +479,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/@chromatic-com/storybook": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-1.9.0.tgz",
-      "integrity": "sha512-vYQ+TcfktEE3GHnLZXHCzXF/sN9dw+KivH8a5cmPyd9YtQs7fZtHrEgsIjWpYycXiweKMo1Lm1RZsjxk8DH3rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chromatic": "^11.4.0",
-        "filesize": "^10.0.12",
-        "jsonfile": "^6.1.0",
-        "react-confetti": "^6.1.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "yarn": ">=1.22.18"
-      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -7236,30 +7217,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chromatic": {
-      "version": "11.29.0",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.29.0.tgz",
-      "integrity": "sha512-yisBlntp9hHVj19lIQdpTlcYIXuU9H/DbFuu6tyWHmj6hWT2EtukCCcxYXL78XdQt1vm2GfIrtgtKpj/Rzmo4A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
-      },
-      "peerDependencies": {
-        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@chromatic-com/cypress": {
-          "optional": true
-        },
-        "@chromatic-com/playwright": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -9895,15 +9852,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
-    },
-    "node_modules/filesize": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.1.tgz",
-      "integrity": "sha512-L0cdwZrKlwZQkMSFnCflJ6J2Y+5egO/p3vgRSDQGxQt++QbUZe5gMbRO6kg6gzwQDPvq2Fk9AmoxUNfZ5gdqaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.4.0"
-      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -16411,21 +16359,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-confetti": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
-      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
-      "dev": true,
-      "dependencies": {
-        "tween-functions": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.18"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
-      }
-    },
     "node_modules/react-docgen": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
@@ -19151,12 +19084,6 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
-    },
-    "node_modules/tween-functions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
-      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
-      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "@chromatic-com/storybook": "^1.9.0",
     "@firebase/rules-unit-testing": "^3.0.4",
     "@playwright/test": "^1.61.1",
     "@storybook/addon-docs": "^10.4.6",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "postcss": "^8.5.16",
     "prettier": "^3.9.4",
     "storybook": "^10.4.6",
-    "storybook-dark-mode": "^4.0.1",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.9.3",
     "vite": "^8.1.3",


### PR DESCRIPTION
## Summary
- add a local Compose override that publishes the Firestore emulator port
- configure mise tasks for local npm development, DB startup, checks, build, and cleanup
- add short aliases and an enter hint for common mise workflows

## Testing
- mise ci