### PR TITLE
docs: update agent workflow instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Repository Instructions
 
-- Before editing files, run `git fetch origin main`, then create a `git worktree` at `.worktrees/$BRANCH` from `origin/main`.
+- Before editing files, fetch `origin/main`, then create a `git worktree` at `.worktrees/$BRANCH` from it.
 - Do not work directly on `main`.
 - Before finishing changes, run `make ci`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # Repository Instructions
 
-- Before editing files, use `git worktree` to create `.worktrees/$BRANCH` from the latest `main` branch, and do not work directly on the `main` branch.
+- Before editing files, run `git fetch origin main`, then create a `git worktree` at `.worktrees/$BRANCH` from `origin/main`.
+- Do not work directly on `main`.
+- Before finishing changes, run `make ci`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,4 @@
 
 - Before editing files, fetch `origin/main`, then create a `git worktree` at `.worktrees/$BRANCH` from it.
 - Do not work directly on `main`.
-- Before finishing changes, run `make ci`.
+- Before finishing non-documentation changes, run `make ci`.


### PR DESCRIPTION
## Summary
- Clarify that agents should fetch origin/main before creating worktrees
- Keep the main branch work restriction as its own instruction
- Add make ci as the required final verification command

## Testing
- make ci