### PR TITLE
docs: add deck e2e test specs

### DIFF
--- a/docs/e2e/AGENTS.md
+++ b/docs/e2e/AGENTS.md
@@ -1,0 +1,5 @@
+# E2E Documentation Instructions
+
+- テスト仕様書には、具体的なテストデータの値を記述しない。
+- 具体的な seed 値は `docs/e2e/seed.md` に集約する。
+- 各テストケースには、`read`、`write`、`batch` のいずれかのカテゴリを明示する。

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -1,0 +1,8 @@
+# E2E テスト仕様書
+
+## 前提
+
+- Playwright で実行する。
+- 実行コマンドは `make e2e`。
+- テストデータは localStorage に seed し、Firebase 実環境には依存しない。
+- 並列実行時のデータ競合を避けるため、read のテストと write のテストは分ける。

--- a/docs/e2e/deck.md
+++ b/docs/e2e/deck.md
@@ -1,0 +1,47 @@
+# Deck E2E テスト仕様書
+
+## 目的
+
+Deck 管理の主要導線が、ブラウザ上で画面遷移・状態更新まで破綻しないことを確認する。
+
+## テストケース
+
+### 1. Deck 一覧から詳細へ遷移できる
+
+| 項目 | 内容 |
+|---|---|
+| カテゴリ | read |
+| 目的 | Deck 一覧に deck が表示され、deck 名クリックで詳細へ遷移できることを確認する。 |
+| Given | `docs/e2e/seed.md` の Deck/Card が localStorage に保存されている。 |
+| When | `/` を開く。 |
+| Then | 一覧に deck 名が表示される。 |
+| When | deck 名をクリックする。 |
+| Then | deck 詳細画面に遷移する。 |
+| Then | card 一覧に card が表示される。 |
+| Then | browser error が発生しない。 |
+
+### 2. Deck 編集内容を保存して一覧に戻れる
+
+| 項目 | 内容 |
+|---|---|
+| カテゴリ | write |
+| 目的 | Deck の基本情報を編集し、一覧に反映されることを確認する。 |
+| Given | `docs/e2e/seed.md` の Deck が localStorage に保存されている。 |
+| When | deck 編集画面を開く。 |
+| When | deck name を別の値に変更して submit する。 |
+| Then | URL が `/` になる。 |
+| Then | 一覧に変更後の deck 名が表示される。 |
+| Then | browser error が発生しない。 |
+
+### 3. Deck を削除できる
+
+| 項目 | 内容 |
+|---|---|
+| カテゴリ | write |
+| 目的 | 一覧から Deck を削除でき、削除後に一覧から消えることを確認する。 |
+| Given | `docs/e2e/seed.md` の Deck が localStorage に保存されている。 |
+| When | `/` を開く。 |
+| When | deck の delete icon をクリックする。 |
+| When | confirm dialog で OK を選択する。 |
+| Then | 一覧に deck が表示されない。 |
+| Then | browser error が発生しない。 |

--- a/docs/e2e/seed.md
+++ b/docs/e2e/seed.md
@@ -1,0 +1,32 @@
+# E2E Seed データ
+
+## Config
+
+既存 smoke test の `persistedConfig` を基本にする。
+
+| 項目 | 値 |
+|---|---|
+| `uid` | `e2e-user` |
+| `displayName` | `E2E User` |
+| `localMode` | `true` |
+| `loadSample` | `false` |
+
+## Deck
+
+| 項目 | 値 |
+|---|---|
+| `id` | `e2e-deck-1` |
+| `name` | `E2E Deck` |
+| `category` | `English` |
+| `uid` | `e2e-user` |
+| `localMode` | `true` |
+| `currentIndex` | `null` |
+| `cardOrderIds` | `[]` |
+
+## Card
+
+詳細画面の表示確認用に、対象 deck に紐づく card を1枚だけ seed する。
+
+| id | deckId | frontText | backText |
+|---|---|---|---|
+| `e2e-card-1` | `e2e-deck-1` | `apple` | `りんご` |


### PR DESCRIPTION
## Summary
- Add shared E2E documentation rules and assumptions under `docs/e2e`
- Add centralized E2E seed data documentation
- Add Deck management E2E test specification with read/write categories

## Tests
- Not run: documentation-only change