### PR TITLE
test: add deck swipe e2e coverage

### DIFF
--- a/docs/e2e/swipe.md
+++ b/docs/e2e/swipe.md
@@ -1,0 +1,34 @@
+# Swipe E2E テスト仕様書
+
+## 目的
+
+Deck の学習画面で swipe 操作が、表面・裏面表示、学習結果の保存、次 card への遷移まで破綻しないことを確認する。
+
+## テストケース
+
+### 1. Deck 学習画面で card の表面と裏面を表示できる
+
+| 項目     | 内容                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------- |
+| カテゴリ | read                                                                                        |
+| 目的     | Deck 学習画面で現在の card の表面を表示し、裏面表示を切り替えられることを確認する。         |
+| Given    | `docs/e2e/seed.md` の Deck/Card が localStorage に保存され、Deck に学習順が設定されている。 |
+| When     | 対象 deck の学習画面を開く。                                                                |
+| Then     | 現在の card の front text が表示される。                                                    |
+| When     | 裏面表示を切り替える。                                                                      |
+| Then     | 現在の card の back text が表示される。                                                     |
+| Then     | browser error が発生しない。                                                                |
+
+### 2. Deck 学習画面で mastered swipe を実行できる
+
+| 項目     | 内容                                                                                                          |
+| -------- | ------------------------------------------------------------------------------------------------------------- |
+| カテゴリ | write                                                                                                         |
+| 目的     | mastered に対応する swipe 操作で、現在の card の score と学習回数が更新され、次の card に進むことを確認する。 |
+| Given    | `docs/e2e/seed.md` の Deck/Card が localStorage に保存され、Deck に複数 card の学習順が設定されている。       |
+| When     | 対象 deck の学習画面を開く。                                                                                  |
+| When     | mastered に対応する swipe 操作を実行する。                                                                    |
+| Then     | swipe した card の score が増える。                                                                           |
+| Then     | swipe した card の学習回数が増える。                                                                          |
+| Then     | 次の card の front text が表示される。                                                                        |
+| Then     | browser error が発生しない。                                                                                  |

--- a/e2e/swipe.e2e.ts
+++ b/e2e/swipe.e2e.ts
@@ -1,0 +1,164 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const e2eDeck = {
+  id: "e2e-deck-1",
+  name: "E2E Deck",
+  category: "English",
+  uid: "e2e-user",
+  localMode: true,
+  currentIndex: 0,
+  cardOrderIds: ["e2e-card-1", "e2e-card-2"],
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  scoreMax: null,
+  scoreMin: null,
+  isPublic: false,
+  selectedTags: [],
+  tagAndFilter: false,
+  convertToBr: false,
+};
+
+const e2eCards = [
+  {
+    id: "e2e-card-1",
+    deckId: "e2e-deck-1",
+    uid: "e2e-user",
+    frontText: "apple",
+    backText: "りんご",
+    tags: [],
+    uniqueKey: "e2e-card-1",
+    score: 0,
+    numberOfSeen: 0,
+    interval: 0,
+    nextSeeingAt: new Date(0).toISOString(),
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+  },
+  {
+    id: "e2e-card-2",
+    deckId: "e2e-deck-1",
+    uid: "e2e-user",
+    frontText: "banana",
+    backText: "バナナ",
+    tags: [],
+    uniqueKey: "e2e-card-2",
+    score: 0,
+    numberOfSeen: 0,
+    interval: 0,
+    nextSeeingAt: new Date(0).toISOString(),
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+  },
+];
+
+const persistedConfig = {
+  useCardInterval: false,
+  showSwipeButtonList: true,
+  showScoreSlider: false,
+  showHeader: true,
+  showBackText: false,
+  fullscreen: false,
+  maxNumberOfCardsToLearn: 10,
+  hideBodyWhenCardChanged: true,
+  sizeBackText: 0,
+  shuffled: false,
+  autoPlay: false,
+  defaultAutoPlay: false,
+  cardInterval: 60,
+  keepBackTextViewed: false,
+  showSwipeFeedback: false,
+  cardSwipeUp: "GoToNextCardMastered",
+  cardSwipeDown: "GoToNextCardNotMastered",
+  cardSwipeLeft: "GoToPrevCard",
+  cardSwipeRight: "GoToNextCard",
+  darkMode: false,
+  uid: "e2e-user",
+  isAnonymous: false,
+  displayName: "E2E User",
+  selectedTags: [],
+  lastUpdatedAt: 0,
+  githubAccessToken: "",
+  loadSample: false,
+  localMode: true,
+};
+
+const seedSwipeSession = async (page: Page) => {
+  await page.route("https://identitytoolkit.googleapis.com/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        kind: "identitytoolkit#SignupNewUserResponse",
+        idToken: "e2e-id-token",
+        refreshToken: "e2e-refresh-token",
+        expiresIn: "3600",
+        localId: "e2e-user",
+      }),
+    });
+  });
+
+  await page.addInitScript(
+    ({ config, deck, cards }) => {
+      window.localStorage.setItem(
+        "persist:root",
+        JSON.stringify({
+          config: JSON.stringify(config),
+          deck: JSON.stringify({ byId: { [deck.id]: deck }, categories: [deck.category] }),
+          card: JSON.stringify({
+            byId: Object.fromEntries(cards.map((card) => [card.id, card])),
+            tags: [],
+          }),
+          _persist: JSON.stringify({ version: -1, rehydrated: true }),
+        })
+      );
+    },
+    { config: persistedConfig, deck: e2eDeck, cards: e2eCards }
+  );
+};
+
+const persistedCard = async (page: Page, cardId: string) => {
+  return page.evaluate((id) => {
+    const root = JSON.parse(window.localStorage.getItem("persist:root") ?? "{}");
+    return JSON.parse(root.card).byId[id];
+  }, cardId);
+};
+
+test.beforeEach(async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      errors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await seedSwipeSession(page);
+
+  await page.exposeFunction("assertNoBrowserErrors", () => {
+    expect(errors).toEqual([]);
+  });
+});
+
+test("shows the front and back text in the deck study screen", async ({ page }) => {
+  await page.goto("/deck/e2e-deck-1/study");
+
+  await expect(page.getByText("apple")).toBeVisible();
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByText("りんご")).toBeVisible();
+  await page.evaluate(() => (window as any).assertNoBrowserErrors());
+});
+
+test("updates study progress with a mastered deck swipe", async ({ page }) => {
+  await page.goto("/deck/e2e-deck-1/study");
+
+  await expect(page.getByText("apple")).toBeVisible();
+  await page.keyboard.press("ArrowUp");
+
+  await expect(page.getByText("banana")).toBeVisible();
+  await expect.poll(async () => persistedCard(page, "e2e-card-1")).toMatchObject({ score: 1, numberOfSeen: 1 });
+  await page.evaluate(() => (window as any).assertNoBrowserErrors());
+});


### PR DESCRIPTION
## Summary
- add Swipe E2E specification for the deck study screen
- add Playwright coverage for front/back display and mastered swipe progress updates

## Testing
- make ci