### PR TITLE
ci: build Docker image only when dependencies change

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,29 @@ on:
   workflow_call:
 
 jobs:
+  changes:
+    name: Check Docker Image Changes
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files
+        id: changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            Dockerfile
+            package.json
+            package-lock.json
+
   push:
     name: Update Docker Image
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.image == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,10 @@ on:
 jobs:
   changes:
     name: Check Docker Image Changes
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
-      image: ${{ steps.changed.outputs.any_changed }}
+      image: ${{ steps.changed.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -27,7 +28,7 @@ jobs:
   push:
     name: Update Docker Image
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.image == 'true' }}
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.image == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Detect changes to Dockerfile, package.json, and package-lock.json inside the reusable Docker workflow.
- Skip GHCR image build/push when none changed; include deletions via any_modified.
- Preserve direct workflow_dispatch as a force build while respecting cancellation.

## Why
The deploy workflow calls the reusable Docker workflow after every successful main test run, so it previously rebuilt and pushed the same development image for unrelated changes.

## Validation
- Structural assertions verified RED before implementation and GREEN after each behavior change.
- `npx prettier --check .github/workflows/docker.yml`
- Ruby YAML parse
- `git diff --check`
- `make check` (28 test files, 146 passed, 1 skipped)