### PR TITLE
Migrate remote Firestore reads to TanStack Query

### DIFF
--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -3,6 +3,19 @@ import { expect, test, type Page } from "@playwright/test";
 const projectId = "tango-e2e";
 const firestoreBase = `http://db:8080/v1/projects/${projectId}/databases/(default)/documents`;
 
+const fetchFirestore = async (url: string, init: RequestInit) => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  throw lastError;
+};
+
 const encodeTokenPart = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
 
 const emulatorToken = (uid: string) => {
@@ -30,7 +43,7 @@ const field = {
 };
 
 const setDocument = async (collection: "deck" | "card", id: string, fields: object) => {
-  const response = await fetch(`${firestoreBase}/${collection}/${id}`, {
+  const response = await fetchFirestore(`${firestoreBase}/${collection}/${id}`, {
     method: "PATCH",
     headers: { Authorization: "Bearer owner", "Content-Type": "application/json" },
     body: JSON.stringify({ fields }),

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -1,0 +1,188 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const projectId = "tango-e2e";
+const firestoreBase = `http://db:8080/v1/projects/${projectId}/databases/(default)/documents`;
+
+const encodeTokenPart = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
+
+const emulatorToken = (uid: string) => {
+  const now = Math.floor(Date.now() / 1000);
+  const header = encodeTokenPart({ alg: "none", typ: "JWT" });
+  const payload = encodeTokenPart({
+    aud: projectId,
+    auth_time: now,
+    exp: now + 3600,
+    firebase: { identities: {}, sign_in_provider: "anonymous" },
+    iat: now,
+    iss: `https://securetoken.google.com/${projectId}`,
+    sub: uid,
+    user_id: uid,
+  });
+  return `${header}.${payload}.`;
+};
+
+const field = {
+  string: (value: string) => ({ stringValue: value }),
+  boolean: (value: boolean) => ({ booleanValue: value }),
+  integer: (value: number) => ({ integerValue: String(value) }),
+  null: () => ({ nullValue: null }),
+  strings: (values: string[]) => ({ arrayValue: { values: values.map((value) => ({ stringValue: value })) } }),
+};
+
+const setDocument = async (collection: "deck" | "card", id: string, fields: object) => {
+  const response = await fetch(`${firestoreBase}/${collection}/${id}`, {
+    method: "PATCH",
+    headers: { Authorization: "Bearer owner", "Content-Type": "application/json" },
+    body: JSON.stringify({ fields }),
+  });
+  if (!response.ok) throw new Error(`Firestore seed failed: ${response.status} ${await response.text()}`);
+};
+
+const deckFields = (uid: string, name: string) => ({
+  uid: field.string(uid),
+  name: field.string(name),
+  isPublic: field.boolean(false),
+  createdAt: field.integer(1),
+  updatedAt: field.integer(2),
+  deletedAt: field.null(),
+  scoreMax: field.null(),
+  scoreMin: field.null(),
+  selectedTags: field.strings([]),
+  tagAndFilter: field.boolean(false),
+  category: field.string("English"),
+  convertToBr: field.boolean(false),
+});
+
+const cardFields = (uid: string, deckId: string, frontText: string) => ({
+  uid: field.string(uid),
+  deckId: field.string(deckId),
+  frontText: field.string(frontText),
+  backText: field.string("Remote back"),
+  tags: field.strings([]),
+  uniqueKey: field.string("remote-key"),
+  createdAt: field.integer(1),
+  updatedAt: field.integer(2),
+  deletedAt: field.null(),
+  score: field.integer(0),
+  numberOfSeen: field.integer(0),
+});
+
+const persistedConfig = (uid: string) => ({
+  useCardInterval: false,
+  showSwipeButtonList: true,
+  showScoreSlider: false,
+  showHeader: true,
+  fullscreen: false,
+  maxNumberOfCardsToLearn: 10,
+  hideBodyWhenCardChanged: true,
+  sizeBackText: 0,
+  shuffled: false,
+  defaultAutoPlay: false,
+  cardInterval: 60,
+  keepBackTextViewed: false,
+  showSwipeFeedback: false,
+  cardSwipeUp: "GoToNextCardMastered",
+  cardSwipeDown: "GoToNextCardNotMastered",
+  cardSwipeLeft: "GoToPrevCard",
+  cardSwipeRight: "GoToNextCard",
+  darkMode: false,
+  uid,
+  isAnonymous: true,
+  displayName: null,
+  selectedTags: [],
+  lastUpdatedAt: 0,
+  githubAccessToken: "",
+  loadSample: false,
+  localMode: false,
+});
+
+const seedAuth = async (page: Page, uid: string, staleDeck?: object) => {
+  await page.route("https://identitytoolkit.googleapis.com/**", async (route) => {
+    if (route.request().url().includes("accounts:lookup")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          kind: "identitytoolkit#GetAccountInfoResponse",
+          users: [
+            {
+              localId: uid,
+              lastLoginAt: "1",
+              createdAt: "1",
+              lastRefreshAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        kind: "identitytoolkit#SignupNewUserResponse",
+        idToken: emulatorToken(uid),
+        refreshToken: "e2e-refresh-token",
+        expiresIn: "3600",
+        localId: uid,
+      }),
+    });
+  });
+  await page.addInitScript(
+    ({ config, deck }) => {
+      window.localStorage.setItem(
+        "persist:root",
+        JSON.stringify({
+          config: JSON.stringify(config),
+          ...(deck == null ? {} : { deck: JSON.stringify({ byId: { stale: deck }, categories: [] }) }),
+          _persist: JSON.stringify({ version: 2, rehydrated: true }),
+        })
+      );
+    },
+    { config: persistedConfig(uid), deck: staleDeck }
+  );
+};
+
+test("loads UID-scoped remote Decks and Cards again after reload", async ({ page }) => {
+  const uid = "remote-read-user";
+  await setDocument("deck", "remote-read-deck", deckFields(uid, "Remote Query Deck"));
+  await setDocument("card", "remote-read-card", cardFields(uid, "remote-read-deck", "Remote Query Card"));
+  await setDocument("deck", "foreign-deck", deckFields("foreign-user", "Foreign Deck"));
+  await seedAuth(page, uid);
+
+  await page.goto("/");
+  await expect(page.getByText("Remote Query Deck")).toBeVisible();
+  await expect(page.getByText("Foreign Deck")).not.toBeVisible();
+  await page.getByText("Remote Query Deck").click();
+  await expect(page.getByText("Remote Query Card")).toBeVisible();
+
+  await page.reload();
+
+  await expect(page.getByText("Remote Query Card")).toBeVisible();
+});
+
+test("an empty initial snapshot removes a stale Redux remote mirror", async ({ page }) => {
+  const uid = "empty-remote-read-user";
+  const staleDeck = {
+    id: "stale",
+    uid,
+    name: "Stale Remote Deck",
+    isPublic: false,
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+    localMode: false,
+    scoreMax: null,
+    scoreMin: null,
+    selectedTags: [],
+    tagAndFilter: false,
+    category: "",
+    convertToBr: false,
+  };
+  await seedAuth(page, uid, staleDeck);
+
+  await page.goto("/");
+
+  await expect(page.getByText("Stale Remote Deck")).not.toBeVisible();
+  await expect(page.getByRole("status")).toHaveText("No decks yet.");
+});

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -1,20 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
 
 const projectId = "tango-e2e";
-const firestoreBase = `http://db:8080/v1/projects/${projectId}/databases/(default)/documents`;
-
-const fetchFirestore = async (url: string, init: RequestInit) => {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    try {
-      return await fetch(url, init);
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-  }
-  throw lastError;
-};
+const firestorePort = process.env.VITE_DB_PORT ?? "8080";
+const firestoreBase = `http://db:${firestorePort}/v1/projects/${projectId}/databases/(default)/documents`;
 
 const encodeTokenPart = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
 
@@ -43,7 +31,7 @@ const field = {
 };
 
 const setDocument = async (collection: "deck" | "card", id: string, fields: object) => {
-  const response = await fetchFirestore(`${firestoreBase}/${collection}/${id}`, {
+  const response = await fetch(`${firestoreBase}/${collection}/${id}`, {
     method: "PATCH",
     headers: { Authorization: "Bearer owner", "Content-Type": "application/json" },
     body: JSON.stringify({ fields }),

--- a/src/action/deck.spec.ts
+++ b/src/action/deck.spec.ts
@@ -177,6 +177,21 @@ describe("deck action", () => {
       expect(m).toBeCalledWith([""], { type: "text/plain;charset=utf-8" });
       expect(fileSaver.saveAs).toBeCalledWith(expect.anything(), "name.csv");
     });
+
+    it("downloads the supplied composed Query data without reading Redux", () => {
+      const blob = new Blob();
+      const blobConstructor = vi.spyOn(global, "Blob");
+      blobConstructor.mockImplementation(createBlobConstructor(blob));
+      const deck = action.deck.prepare({ name: "Remote deck" }, { uid: "uid", localMode: false });
+      const card = createCard({ frontText: "remote front", backText: "remote back", uniqueKey: "remote-key" });
+
+      action.deck.downloadData(deck, [card]);
+
+      expect(blobConstructor).toHaveBeenCalledWith(["remote front,remote back,,remote-key"], {
+        type: "text/plain;charset=utf-8",
+      });
+      expect(fileSaver.saveAs).toHaveBeenCalledWith(blob, "Remote deck.csv");
+    });
   });
 
   describe("downloadCsvSampleText", () => {

--- a/src/action/deck.ts
+++ b/src/action/deck.ts
@@ -82,6 +82,11 @@ export const download =
     _saveAs(csv, deck.name);
   };
 
+export const downloadData = (deck: Deck, cards: Card[]) => {
+  const csv = Papa.unparse(cards.map(action.card.toRow));
+  _saveAs(csv, deck.name);
+};
+
 export const _saveAs = (content: string, name: string) => {
   if (!name.endsWith(".csv")) {
     name += ".csv";

--- a/src/action/firestore/card.ts
+++ b/src/action/firestore/card.ts
@@ -1,8 +1,27 @@
-import { getFirestore, doc, updateDoc, setDoc, getDoc, deleteDoc } from "firebase/firestore";
+import {
+  getFirestore,
+  doc,
+  updateDoc,
+  setDoc,
+  getDoc,
+  deleteDoc,
+  getDocs,
+  query,
+  collection,
+  where,
+  type Firestore,
+} from "firebase/firestore";
 import { getTimestamp } from "@/action/firestore/mocked";
-import { buildCardCreateDto, buildCardUpdateDto } from "@/action/firestore/dto";
+import { buildCardCreateDto, buildCardUpdateDto, mapCardDocument, type CardDocument } from "@/action/firestore/dto";
 
 const db = getFirestore();
+
+export const readAll = async (uid: string, firestore: Firestore = db): Promise<Card[]> => {
+  const snapshot = await getDocs(query(collection(firestore, "card"), where("uid", "==", uid)));
+  return snapshot.docs
+    .map((document) => mapCardDocument(document.id, document.data() as CardDocument))
+    .filter((card) => card.deletedAt === null);
+};
 
 export const create = async (card: Card, createdAt?: number): Promise<string> => {
   if (createdAt == null) {

--- a/src/action/firestore/deck.ts
+++ b/src/action/firestore/deck.ts
@@ -9,11 +9,19 @@ import {
   deleteDoc,
   getDoc,
   setDoc,
+  type Firestore,
 } from "firebase/firestore";
 import { getTimestamp } from "@/action/firestore/mocked";
-import { buildDeckCreateDto, buildDeckUpdateDto } from "@/action/firestore/dto";
+import { buildDeckCreateDto, buildDeckUpdateDto, mapDeckDocument, type DeckDocument } from "@/action/firestore/dto";
 
 const db = getFirestore();
+
+export const readAll = async (uid: string, firestore: Firestore = db): Promise<Deck[]> => {
+  const snapshot = await getDocs(query(collection(firestore, "deck"), where("uid", "==", uid)));
+  return snapshot.docs
+    .map((document) => mapDeckDocument(document.id, document.data() as DeckDocument))
+    .filter((deck) => deck.deletedAt === null);
+};
 
 export const create = async (deck: Deck): Promise<string> => {
   const createdAt = getTimestamp();

--- a/src/action/firestore/dto.spec.ts
+++ b/src/action/firestore/dto.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { Timestamp } from "firebase/firestore";
 
 import {
   buildCardCreateDto,
   buildCardUpdateDto,
   buildDeckCreateDto,
   buildDeckUpdateDto,
+  mapCardDocument,
   mapDeckDocument,
 } from "@/action/firestore/dto";
 import { createCard, createDeck } from "@/test/factories";
@@ -100,6 +102,79 @@ describe("Firestore DTO builders", () => {
     };
 
     expect(mapDeckDocument("snapshot-id", document)).not.toHaveProperty("url");
+  });
+
+  it("maps only remote card fields using the snapshot id", () => {
+    const document = {
+      id: "payload-id",
+      frontText: "Remote front",
+      backText: "Remote back",
+      tags: ["science"],
+      uniqueKey: "remote-key",
+      deckId: "deck-2",
+      uid: "user-2",
+      createdAt: 10,
+      updatedAt: 20,
+      deletedAt: null,
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 50,
+      nextSeeingAt: Timestamp.fromMillis(60),
+      interval: 7,
+      url: "https://example.com/card",
+      startLine: 8,
+      endLine: 9,
+      localMode: true,
+      currentIndex: 2,
+      cardOrderIds: ["card-2"],
+    };
+
+    expect(mapCardDocument("snapshot-id", document)).toEqual({
+      id: "snapshot-id",
+      frontText: "Remote front",
+      backText: "Remote back",
+      tags: ["science"],
+      uniqueKey: "remote-key",
+      deckId: "deck-2",
+      uid: "user-2",
+      createdAt: 10,
+      updatedAt: 20,
+      deletedAt: null,
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 50,
+      nextSeeingAt: new Date(60),
+      interval: 7,
+      url: "https://example.com/card",
+      startLine: 8,
+      endLine: 9,
+    });
+  });
+
+  it("omits absent optional fields when mapping a remote card", () => {
+    const document = {
+      id: "payload-id",
+      frontText: "Remote front",
+      backText: "Remote back",
+      tags: [],
+      uniqueKey: "remote-key",
+      deckId: "deck-2",
+      uid: "user-2",
+      createdAt: 10,
+      updatedAt: 20,
+      deletedAt: null,
+      score: 0,
+      numberOfSeen: 0,
+    };
+
+    const mapped = mapCardDocument("snapshot-id", document);
+
+    expect(mapped).not.toHaveProperty("lastSeenAt");
+    expect(mapped).not.toHaveProperty("nextSeeingAt");
+    expect(mapped).not.toHaveProperty("interval");
+    expect(mapped).not.toHaveProperty("url");
+    expect(mapped).not.toHaveProperty("startLine");
+    expect(mapped).not.toHaveProperty("endLine");
   });
 
   it("allows only server deck fields when creating", () => {

--- a/src/action/firestore/dto.ts
+++ b/src/action/firestore/dto.ts
@@ -52,7 +52,7 @@ export interface CardDocument {
   score: number;
   numberOfSeen: number;
   lastSeenAt?: number;
-  nextSeeingAt?: Date;
+  nextSeeingAt?: Date | { toDate: () => Date };
   interval?: number;
   url?: string;
   startLine?: number;
@@ -60,6 +60,32 @@ export interface CardDocument {
 }
 
 export type CardUpdateDto = Partial<Omit<CardDocument, "id" | "updatedAt">> & Pick<CardDocument, "updatedAt">;
+
+export const mapCardDocument = (id: CardId, document: CardDocument): Card => {
+  const card: Card = {
+    id,
+    frontText: document.frontText,
+    backText: document.backText,
+    tags: document.tags,
+    uniqueKey: document.uniqueKey,
+    deckId: document.deckId,
+    uid: document.uid,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+    deletedAt: document.deletedAt,
+    score: document.score,
+    numberOfSeen: document.numberOfSeen,
+  };
+  if (document.lastSeenAt !== undefined) card.lastSeenAt = document.lastSeenAt;
+  if (document.nextSeeingAt !== undefined) {
+    card.nextSeeingAt = document.nextSeeingAt instanceof Date ? document.nextSeeingAt : document.nextSeeingAt.toDate();
+  }
+  if (document.interval !== undefined) card.interval = document.interval;
+  if (document.url !== undefined) card.url = document.url;
+  if (document.startLine !== undefined) card.startLine = document.startLine;
+  if (document.endLine !== undefined) card.endLine = document.endLine;
+  return card;
+};
 
 type OmitUndefined<T extends Record<string, unknown>> = {
   [K in keyof T as undefined extends T[K] ? never : K]: T[K];

--- a/src/action/firestore/event.ts
+++ b/src/action/firestore/event.ts
@@ -1,6 +1,81 @@
 import { getFirestore, onSnapshot, where, collection, query, orderBy } from "firebase/firestore";
 
-import { mapDeckDocument, type DeckDocument } from "@/action/firestore/dto";
+import { mapCardDocument, mapDeckDocument, type CardDocument, type DeckDocument } from "@/action/firestore/dto";
+
+export interface RemoteSnapshotMetadata {
+  size: number;
+  fromLocal: boolean;
+}
+
+export interface RemoteChange<T> {
+  added: T[];
+  modified: T[];
+  removed: string[];
+  lastUpdatedAt?: number;
+}
+
+export type RemoteSnapshot<T> =
+  | { type: "replace"; items: T[]; metadata: RemoteSnapshotMetadata }
+  | { type: "change"; event: RemoteChange<T>; metadata: RemoteSnapshotMetadata };
+
+interface RemoteReadProps<T> {
+  uid: string;
+  onSnapshot: (snapshot: RemoteSnapshot<T>) => void;
+  onError: (error: Error) => void;
+}
+
+type RemoteEntity = { id: string; updatedAt: number; deletedAt: number | null };
+
+const subscribeReads = <T extends RemoteEntity>(
+  collectionName: "deck" | "card",
+  props: RemoteReadProps<T>,
+  mapDocument: (id: string, data: Record<string, unknown>) => T
+): Callback => {
+  const q = query(collection(getFirestore(), collectionName), where("uid", "==", props.uid));
+  let initial = true;
+  return onSnapshot(
+    q,
+    { includeMetadataChanges: true },
+    (snapshot) => {
+      const changes = snapshot.docChanges();
+      const metadata = {
+        size: initial ? snapshot.docs.length : changes.length,
+        fromLocal: snapshot.metadata.hasPendingWrites,
+      };
+      if (initial) {
+        initial = false;
+        const items = snapshot.docs
+          .map((document) => mapDocument(document.id, document.data()))
+          .filter((item) => item.deletedAt === null);
+        props.onSnapshot({ type: "replace", items, metadata });
+        return;
+      }
+
+      const event: RemoteChange<T> = { added: [], modified: [], removed: [] };
+      for (const change of changes) {
+        const item = mapDocument(change.doc.id, change.doc.data());
+        if (item.deletedAt !== null || change.type === "removed") {
+          event.removed.push(item.id);
+        } else if (change.type === "added") {
+          event.added.push(item);
+        } else {
+          event.modified.push(item);
+        }
+        event.lastUpdatedAt = Math.max(event.lastUpdatedAt ?? item.updatedAt, item.updatedAt);
+      }
+      if (event.added.length > 0 || event.modified.length > 0 || event.removed.length > 0) {
+        props.onSnapshot({ type: "change", event, metadata });
+      }
+    },
+    props.onError
+  );
+};
+
+export const subscribeDeckReads = (props: RemoteReadProps<Deck>): Callback =>
+  subscribeReads("deck", props, (id, data) => mapDeckDocument(id, data as unknown as DeckDocument));
+
+export const subscribeCardReads = (props: RemoteReadProps<Card>): Callback =>
+  subscribeReads("card", props, (id, data) => mapCardDocument(id, data as unknown as CardDocument));
 
 interface DeckProps {
   uid: string;

--- a/src/action/firestore/eventAdapter.spec.ts
+++ b/src/action/firestore/eventAdapter.spec.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestDocument = { id: string; data: () => Record<string, unknown> };
+type TestChange = { type: "added" | "modified" | "removed"; doc: TestDocument };
+type TestSnapshot = {
+  docs: TestDocument[];
+  docChanges: () => TestChange[];
+  metadata: { hasPendingWrites: boolean };
+};
+
+const mocks = vi.hoisted(() => ({
+  next: undefined as ((snapshot: TestSnapshot) => void) | undefined,
+  error: undefined as ((error: Error) => void) | undefined,
+  unsubscribe: vi.fn(),
+  where: vi.fn((...parts: unknown[]) => parts),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  getFirestore: vi.fn(() => "db"),
+  collection: vi.fn((...parts: unknown[]) => parts),
+  where: mocks.where,
+  orderBy: vi.fn((...parts: unknown[]) => parts),
+  query: vi.fn((...parts: unknown[]) => parts),
+  onSnapshot: vi.fn(
+    (_query: unknown, _options: unknown, next: (snapshot: TestSnapshot) => void, error: (received: Error) => void) => {
+      mocks.next = next;
+      mocks.error = error;
+      return mocks.unsubscribe;
+    }
+  ),
+}));
+
+import { subscribeCardReads, subscribeDeckReads } from "@/action/firestore/event";
+
+const document = (id: string, data: Record<string, unknown>): TestDocument => ({ id, data: () => data });
+const snapshot = (docs: TestDocument[], changes: TestChange[] = [], hasPendingWrites = false): TestSnapshot => ({
+  docs,
+  docChanges: () => changes,
+  metadata: { hasPendingWrites },
+});
+
+const deckDocument = (overrides: Record<string, unknown> = {}) => ({
+  id: "payload-deck",
+  name: "Remote Deck",
+  isPublic: false,
+  uid: "uid-a",
+  createdAt: 1,
+  updatedAt: 2,
+  deletedAt: null,
+  scoreMax: null,
+  scoreMin: null,
+  selectedTags: [],
+  tagAndFilter: false,
+  category: "",
+  convertToBr: false,
+  ...overrides,
+});
+
+const cardDocument = (overrides: Record<string, unknown> = {}) => ({
+  id: "payload-card",
+  frontText: "Remote front",
+  backText: "Remote back",
+  tags: [],
+  uniqueKey: "remote-key",
+  deckId: "deck-a",
+  uid: "uid-a",
+  createdAt: 1,
+  updatedAt: 2,
+  deletedAt: null,
+  score: 0,
+  numberOfSeen: 0,
+  ...overrides,
+});
+
+describe("Firestore remote-read subscriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.next = undefined;
+    mocks.error = undefined;
+  });
+
+  it("emits an empty Deck replacement for the initial snapshot", () => {
+    const onSnapshot = vi.fn();
+
+    const unsubscribe = subscribeDeckReads({ uid: "uid-a", onSnapshot, onError: vi.fn() });
+    mocks.next?.(snapshot([]));
+
+    expect(unsubscribe).toBe(mocks.unsubscribe);
+    expect(mocks.where).toHaveBeenCalledWith("uid", "==", "uid-a");
+    expect(onSnapshot).toHaveBeenCalledWith({
+      type: "replace",
+      items: [],
+      metadata: { size: 0, fromLocal: false },
+    });
+  });
+
+  it("maps active Decks and omits logical deletions from the initial replacement", () => {
+    const onSnapshot = vi.fn();
+    subscribeDeckReads({ uid: "uid-a", onSnapshot, onError: vi.fn() });
+
+    mocks.next?.(
+      snapshot([document("deck-a", deckDocument()), document("deck-deleted", deckDocument({ deletedAt: 3 }))])
+    );
+
+    expect(onSnapshot).toHaveBeenCalledWith({
+      type: "replace",
+      items: [expect.objectContaining({ id: "deck-a", name: "Remote Deck", localMode: false })],
+      metadata: { size: 2, fromLocal: false },
+    });
+  });
+
+  it("emits Deck deltas after the initial replacement", () => {
+    const onSnapshot = vi.fn();
+    subscribeDeckReads({ uid: "uid-a", onSnapshot, onError: vi.fn() });
+    mocks.next?.(snapshot([]));
+    onSnapshot.mockClear();
+
+    mocks.next?.(
+      snapshot(
+        [],
+        [
+          { type: "added", doc: document("deck-added", deckDocument({ updatedAt: 3 })) },
+          { type: "modified", doc: document("deck-modified", deckDocument({ updatedAt: 4 })) },
+          { type: "modified", doc: document("deck-deleted", deckDocument({ updatedAt: 5, deletedAt: 5 })) },
+          { type: "removed", doc: document("deck-removed", deckDocument({ updatedAt: 6 })) },
+        ],
+        true
+      )
+    );
+
+    expect(onSnapshot).toHaveBeenCalledWith({
+      type: "change",
+      event: {
+        added: [expect.objectContaining({ id: "deck-added" })],
+        modified: [expect.objectContaining({ id: "deck-modified" })],
+        removed: ["deck-deleted", "deck-removed"],
+        lastUpdatedAt: 6,
+      },
+      metadata: { size: 4, fromLocal: true },
+    });
+  });
+
+  it("maps Card replacements and deltas through the Card mapper", () => {
+    const onSnapshot = vi.fn();
+    subscribeCardReads({ uid: "uid-a", onSnapshot, onError: vi.fn() });
+
+    mocks.next?.(snapshot([document("card-a", cardDocument({ nextSeeingAt: { toDate: () => new Date(50) } }))]));
+    expect(onSnapshot).toHaveBeenLastCalledWith({
+      type: "replace",
+      items: [expect.objectContaining({ id: "card-a", nextSeeingAt: new Date(50) })],
+      metadata: { size: 1, fromLocal: false },
+    });
+
+    mocks.next?.(snapshot([], [{ type: "modified", doc: document("card-a", cardDocument({ frontText: "Updated" })) }]));
+    expect(onSnapshot).toHaveBeenLastCalledWith({
+      type: "change",
+      event: {
+        added: [],
+        modified: [expect.objectContaining({ id: "card-a", frontText: "Updated" })],
+        removed: [],
+        lastUpdatedAt: 2,
+      },
+      metadata: { size: 1, fromLocal: false },
+    });
+  });
+
+  it("forwards listener errors", () => {
+    const error = new Error("listener failed");
+    const onError = vi.fn();
+    subscribeCardReads({ uid: "uid-a", onSnapshot: vi.fn(), onError });
+
+    mocks.error?.(error);
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/action/firestore/read.spec.ts
+++ b/src/action/firestore/read.spec.ts
@@ -1,0 +1,74 @@
+import "./init";
+import { readFileSync } from "node:fs";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { initializeTestEnvironment, type RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, setDoc, type Firestore } from "firebase/firestore";
+import { v4 as uuid } from "uuid";
+
+import * as firestore from "@/action/firestore";
+import { buildCardCreateDto, buildDeckCreateDto } from "@/action/firestore/dto";
+import { createCard, createDeck } from "@/test/factories";
+
+describe("Firestore full reads", () => {
+  let testEnv: RulesTestEnvironment;
+  let db: Firestore;
+
+  const seed = async (collectionName: "deck" | "card", id: string, data: object) => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await setDoc(doc(context.firestore(), collectionName, id), data);
+    });
+  };
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: "test-read",
+      firestore: {
+        rules: readFileSync("./firestore.rules", "utf8"),
+        host: import.meta.env.VITE_DB_HOST,
+        port: parseInt(import.meta.env.VITE_DB_PORT, 10),
+      },
+    });
+    db = testEnv.authenticatedContext("uid").firestore() as unknown as Firestore;
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  it("reads only active Deck documents for the UID", async () => {
+    const active = createDeck({ id: uuid(), uid: "uid", name: "Active remote", localMode: true });
+    const deleted = createDeck({ id: uuid(), uid: "uid", name: "Deleted remote", deletedAt: 100 });
+    const foreign = createDeck({ id: uuid(), uid: "other", name: "Foreign remote" });
+    await seed("deck", active.id, buildDeckCreateDto(active, active.createdAt));
+    await seed("deck", deleted.id, buildDeckCreateDto(deleted, deleted.createdAt));
+    await seed("deck", foreign.id, buildDeckCreateDto(foreign, foreign.createdAt));
+
+    await expect(firestore.deck.readAll("uid", db)).resolves.toEqual([
+      expect.objectContaining({ id: active.id, name: "Active remote", localMode: false }),
+    ]);
+  });
+
+  it("reads only active Card documents for the UID", async () => {
+    const deck = createDeck({ id: uuid(), uid: "uid" });
+    const active = createCard({ id: uuid(), deckId: deck.id, uid: "uid", frontText: "Active remote" });
+    const deleted = createCard({ id: uuid(), deckId: deck.id, uid: "uid", frontText: "Deleted remote" });
+    const foreign = createCard({ id: uuid(), deckId: "foreign-deck", uid: "other", frontText: "Foreign remote" });
+    await seed("deck", deck.id, buildDeckCreateDto(deck, deck.createdAt));
+    await seed("card", active.id, buildCardCreateDto(active, active.createdAt));
+    await seed("card", deleted.id, { ...buildCardCreateDto(deleted, deleted.createdAt), deletedAt: 100 });
+    await seed("card", foreign.id, buildCardCreateDto(foreign, foreign.createdAt));
+
+    await expect(firestore.card.readAll("uid", db)).resolves.toEqual([
+      expect.objectContaining({ id: active.id, frontText: "Active remote" }),
+    ]);
+  });
+
+  it("returns empty collections when the UID has no documents", async () => {
+    await expect(firestore.deck.readAll("uid", db)).resolves.toEqual([]);
+    await expect(firestore.card.readAll("uid", db)).resolves.toEqual([]);
+  });
+});

--- a/src/action/type.ts
+++ b/src/action/type.ts
@@ -19,6 +19,11 @@ export const deckBulkDelete = (ids: string[]) => ({
 
 export const deckDelete = (deckId: string) => deckBulkDelete([deckId]);
 
+export const remoteDeckReplace = (decks: Deck[]) => ({
+  type: "REMOTE_DECK_REPLACE",
+  payload: { decks },
+});
+
 export const cardBulkInsert = (cards: Card[]) => ({
   type: "CARD_BULK_INSERT",
   payload: { cards },
@@ -39,6 +44,11 @@ export const cardBulkDelete = (ids: string[]) => ({
 });
 
 export const cardDelete = (id: string) => cardBulkDelete([id]);
+
+export const remoteCardReplace = (cards: Card[], localDeckIds: string[]) => ({
+  type: "REMOTE_CARD_REPLACE",
+  payload: { cards, localDeckIds },
+});
 
 export const deckPublicBulkInsert = (decks: Deck[]) => ({
   type: "PUBLIC_DECK_BULK_INSERT",

--- a/src/auth/AuthBootstrap.integration.spec.tsx
+++ b/src/auth/AuthBootstrap.integration.spec.tsx
@@ -8,8 +8,7 @@ const mocks = vi.hoisted(() => ({
   onAuthStateChanged: vi.fn(() => vi.fn()),
   signInAnonymously: vi.fn(),
   dispatch: vi.fn((value: unknown) => value),
-  subscribe: vi.fn(),
-  removeFromLocal: vi.fn(),
+  startRemoteReads: vi.fn(),
   cleanupUid: vi.fn(),
 }));
 
@@ -18,14 +17,12 @@ vi.mock("firebase/auth", () => ({
   onAuthStateChanged: mocks.onAuthStateChanged,
   signInAnonymously: mocks.signInAnonymously,
 }));
-vi.mock("react-redux", () => ({ useDispatch: () => mocks.dispatch }));
-vi.mock("@/action", () => ({
-  event: {
-    subscribe: mocks.subscribe,
-    removeFromLocal: mocks.removeFromLocal,
-  },
+vi.mock("react-redux", () => ({
+  useDispatch: () => mocks.dispatch,
+  useStore: () => ({ getState: () => ({ deck: { byId: {} } }) }),
 }));
 vi.mock("@/query/cleanup", () => ({ cleanupFirestoreUid: mocks.cleanupUid }));
+vi.mock("@/query/remoteReadSession", () => ({ startRemoteReads: mocks.startRemoteReads }));
 
 import { AuthBootstrap } from "@/auth/AuthBootstrap";
 import { AuthProvider, createAuthStore } from "@/auth/AuthContext";
@@ -54,8 +51,7 @@ describe("AuthBootstrap integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.dispatch.mockImplementation((value: unknown) => value);
-    mocks.subscribe.mockResolvedValue(undefined);
-    mocks.removeFromLocal.mockResolvedValue(undefined);
+    mocks.startRemoteReads.mockResolvedValue(undefined);
     mocks.cleanupUid.mockResolvedValue(undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
@@ -65,26 +61,29 @@ describe("AuthBootstrap integration", () => {
     vi.restoreAllMocks();
   });
 
-  it("subscribes once for one confirmed state under StrictMode and AuthProvider", async () => {
+  it("starts remote reads once for one confirmed state under StrictMode and AuthProvider", async () => {
     const { publishUser, store } = createHarness();
 
     act(() => publishUser({ uid: "uid-a", isAnonymous: true, providerData: [] } as unknown as User));
 
-    await waitFor(() => expect(mocks.subscribe).toHaveBeenCalledTimes(1));
-    expect(mocks.subscribe).toHaveBeenCalledWith("uid-a");
+    await waitFor(() => expect(mocks.startRemoteReads).toHaveBeenCalledTimes(1));
+    expect(mocks.startRemoteReads).toHaveBeenCalledWith(
+      "uid-a",
+      expect.objectContaining({ mirrorDecks: expect.any(Function), mirrorCards: expect.any(Function) })
+    );
     store.dispose();
   });
 
   it("automatically retries a failed unchanged auth request only once", async () => {
     const subscribeError = new Error("subscribe failed");
-    mocks.subscribe.mockRejectedValue(subscribeError);
+    mocks.startRemoteReads.mockRejectedValue(subscribeError);
     const { publishUser, store } = createHarness();
 
     act(() => publishUser({ uid: "uid-a", isAnonymous: true, providerData: [] } as unknown as User));
 
-    await waitFor(() => expect(mocks.subscribe).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.startRemoteReads).toHaveBeenCalledTimes(2));
     await Promise.resolve();
-    expect(mocks.subscribe).toHaveBeenCalledTimes(2);
+    expect(mocks.startRemoteReads).toHaveBeenCalledTimes(2);
     expect(console.error).toHaveBeenCalledWith("Auth transition failed", subscribeError);
     store.dispose();
   });

--- a/src/auth/AuthBootstrap.spec.ts
+++ b/src/auth/AuthBootstrap.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { AuthState } from "@/auth/AuthContext";
 
-vi.mock("@/action", () => ({ event: { subscribe: vi.fn(), removeFromLocal: vi.fn() } }));
 vi.mock("@/query/cleanup", () => ({ cleanupFirestoreUid: vi.fn() }));
+vi.mock("@/query/remoteReadSession", () => ({ startRemoteReads: vi.fn() }));
 vi.mock("@/auth/AuthContext", () => ({ useAuth: vi.fn() }));
 
 import { createAuthTransitionController } from "@/auth/AuthBootstrap";
@@ -25,7 +25,6 @@ const createDependencies = () => ({
   syncAuthenticatedUser: vi.fn(),
   cleanupUid: vi.fn(),
   subscribeUid: vi.fn(),
-  removeFromLocal: vi.fn(),
   reportError: vi.fn(),
 });
 
@@ -42,18 +41,17 @@ describe("Auth transition controller", () => {
     expect(dependencies.subscribeUid).not.toHaveBeenCalled();
   });
 
-  it("syncs confirmed metadata, subscribes, then removes stale local records", async () => {
+  it("syncs confirmed metadata, then starts remote reads", async () => {
     const operations: string[] = [];
     const dependencies = createDependencies();
     const user = createUser("uid-a");
     dependencies.syncAuthenticatedUser.mockImplementation(() => operations.push("sync"));
     dependencies.subscribeUid.mockImplementation(() => operations.push("subscribe"));
-    dependencies.removeFromLocal.mockImplementation(() => operations.push("remove-local"));
     const controller = createAuthTransitionController(dependencies);
 
     await controller.transition(authenticated(user));
 
-    expect(operations).toEqual(["sync", "subscribe", "remove-local"]);
+    expect(operations).toEqual(["sync", "subscribe"]);
     expect(dependencies.syncAuthenticatedUser).toHaveBeenCalledWith(user, true);
     expect(dependencies.subscribeUid).toHaveBeenCalledWith("uid-a");
   });
@@ -69,7 +67,6 @@ describe("Auth transition controller", () => {
 
     expect(dependencies.syncAuthenticatedUser).toHaveBeenCalledTimes(1);
     expect(dependencies.subscribeUid).toHaveBeenCalledTimes(1);
-    expect(dependencies.removeFromLocal).toHaveBeenCalledTimes(1);
   });
 
   it("cleans the previous UID before syncing and subscribing the replacement", async () => {
@@ -78,7 +75,6 @@ describe("Auth transition controller", () => {
     dependencies.cleanupUid.mockImplementation((uid) => operations.push(`cleanup:${uid}`));
     dependencies.syncAuthenticatedUser.mockImplementation((user) => operations.push(`sync:${user.uid}`));
     dependencies.subscribeUid.mockImplementation((uid) => operations.push(`subscribe:${uid}`));
-    dependencies.removeFromLocal.mockImplementation(() => undefined);
     const controller = createAuthTransitionController(dependencies);
     await controller.transition(authenticated(createUser("uid-a")));
     operations.length = 0;
@@ -141,7 +137,6 @@ describe("Auth transition controller", () => {
     dependencies.syncAuthenticatedUser.mockClear();
     dependencies.cleanupUid.mockClear();
     dependencies.subscribeUid.mockClear();
-    dependencies.removeFromLocal.mockClear();
     const linkedUser = createUser("uid-a", { isAnonymous: false, displayName: "Ada" });
 
     await controller.transition(authenticated(linkedUser));
@@ -149,7 +144,6 @@ describe("Auth transition controller", () => {
     expect(dependencies.syncAuthenticatedUser).toHaveBeenCalledWith(linkedUser, false);
     expect(dependencies.cleanupUid).not.toHaveBeenCalled();
     expect(dependencies.subscribeUid).not.toHaveBeenCalled();
-    expect(dependencies.removeFromLocal).not.toHaveBeenCalled();
   });
 
   it("detects metadata changed in place on the Firebase User object", async () => {
@@ -225,7 +219,6 @@ describe("Auth transition controller", () => {
     expect(retry).toBe(true);
     expect(replay).toBe(true);
     expect(dependencies.subscribeUid).toHaveBeenCalledTimes(2);
-    expect(dependencies.removeFromLocal).toHaveBeenCalledTimes(1);
   });
 
   it("reports cleanup failures and still prevents a stale generation from subscribing", async () => {

--- a/src/auth/AuthBootstrap.tsx
+++ b/src/auth/AuthBootstrap.tsx
@@ -1,11 +1,11 @@
 import type { User } from "firebase/auth";
 import { useEffect, useRef } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useStore } from "react-redux";
 
-import * as action from "@/action";
 import * as type from "@/action/type";
 import { useAuth, type AuthState } from "@/auth/AuthContext";
 import { cleanupFirestoreUid } from "@/query/cleanup";
+import { startRemoteReads } from "@/query/remoteReadSession";
 
 type AuthenticatedIdentity = {
   uid: string;
@@ -21,7 +21,6 @@ export type AuthTransitionDependencies = {
   syncAuthenticatedUser: (user: User, resetLastUpdatedAt: boolean) => unknown | Promise<unknown>;
   cleanupUid: (uid: string) => unknown | Promise<unknown>;
   subscribeUid: (uid: string) => unknown | Promise<unknown>;
-  removeFromLocal: () => unknown | Promise<unknown>;
   reportError: (error: unknown) => void;
 };
 
@@ -97,13 +96,6 @@ export const createAuthTransitionController = (dependencies: AuthTransitionDepen
 
           await dependencies.subscribeUid(nextIdentity.uid);
           activeIdentity = nextIdentity;
-          if (currentGeneration !== generation) return true;
-
-          try {
-            await dependencies.removeFromLocal();
-          } catch (error) {
-            reportError(error);
-          }
           return true;
         })
         .catch((error) => {
@@ -122,6 +114,7 @@ export const createAuthTransitionController = (dependencies: AuthTransitionDepen
 export const AuthBootstrap = () => {
   const authState = useAuth();
   const dispatch = useDispatch();
+  const store = useStore<RootState>();
   const controllerRef = useRef<ReturnType<typeof createAuthTransitionController>>();
   const retryRef = useRef<{ request: AuthRequest; attempted: boolean }>();
   const nextRequest = getRequest(authState);
@@ -143,8 +136,18 @@ export const AuthBootstrap = () => {
         );
       },
       cleanupUid: cleanupFirestoreUid,
-      subscribeUid: (uid) => dispatch(action.event.subscribe(uid)),
-      removeFromLocal: () => dispatch(action.event.removeFromLocal()),
+      subscribeUid: (uid) =>
+        startRemoteReads(uid, {
+          mirrorDecks: (decks) => {
+            dispatch(type.remoteDeckReplace(decks));
+          },
+          mirrorCards: (cards) => {
+            const localDeckIds = Object.values(store.getState().deck.byId)
+              .filter((deck): deck is Deck => Boolean(deck?.localMode))
+              .map((deck) => deck.id);
+            dispatch(type.remoteCardReplace(cards, localDeckIds));
+          },
+        }),
       reportError: (error) => console.error("Auth transition failed", error),
     });
   }

--- a/src/auth/AuthLogout.integration.spec.tsx
+++ b/src/auth/AuthLogout.integration.spec.tsx
@@ -10,8 +10,7 @@ const mocks = vi.hoisted(() => ({
   signOut: vi.fn(),
   publishUser: undefined as ((user: User | null) => void) | undefined,
   dispatch: vi.fn(),
-  subscribe: vi.fn(),
-  removeFromLocal: vi.fn(),
+  startRemoteReads: vi.fn(),
   cleanupUid: vi.fn(),
   clearStudyStore: vi.fn(),
   operations: [] as string[],
@@ -29,15 +28,13 @@ vi.mock("firebase/auth", () => ({
 vi.mock("firebase/app", () => ({
   FirebaseError: class FirebaseError extends Error {},
 }));
-vi.mock("react-redux", () => ({ useDispatch: () => mocks.dispatch }));
-vi.mock("@/action", () => ({
-  event: {
-    subscribe: mocks.subscribe,
-    removeFromLocal: mocks.removeFromLocal,
-  },
+vi.mock("react-redux", () => ({
+  useDispatch: () => mocks.dispatch,
+  useStore: () => ({ getState: () => ({ deck: { byId: {} } }) }),
 }));
 vi.mock("@/action/firestore", () => ({}));
 vi.mock("@/query/cleanup", () => ({ cleanupFirestoreUid: mocks.cleanupUid }));
+vi.mock("@/query/remoteReadSession", () => ({ startRemoteReads: mocks.startRemoteReads }));
 vi.mock("@/features/study/state/studyStore", () => ({ clearStudyStore: mocks.clearStudyStore }));
 vi.mock("@/lib/realtimeSubscriptions", () => ({
   registerSubscription: vi.fn(),
@@ -67,10 +64,9 @@ it("waits for logout cleanup and local clear before bootstrapping the next anony
     mocks.operations.push(`cleanup:${uid}`);
     await delayedCleanup;
   });
-  mocks.subscribe.mockImplementation(async (uid: string) => {
+  mocks.startRemoteReads.mockImplementation(async (uid: string) => {
     mocks.operations.push(`subscribe:${uid}`);
   });
-  mocks.removeFromLocal.mockResolvedValue(undefined);
   mocks.clearStudyStore.mockImplementation(async () => {
     mocks.operations.push("clear-study");
   });
@@ -105,8 +101,7 @@ it("waits for logout cleanup and local clear before bootstrapping the next anony
     </StrictMode>
   );
   act(() => mocks.publishUser?.(userA));
-  await waitFor(() => expect(mocks.subscribe).toHaveBeenCalledWith("uid-a"));
-  await waitFor(() => expect(mocks.removeFromLocal).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(mocks.startRemoteReads).toHaveBeenCalledWith("uid-a", expect.any(Object)));
   mocks.operations.length = 0;
 
   let pendingLogout!: Promise<void>;
@@ -117,7 +112,7 @@ it("waits for logout cleanup and local clear before bootstrapping the next anony
 
   expect(mocks.operations).toContain("sign-out");
   expect(mocks.signInAnonymously).not.toHaveBeenCalled();
-  expect(mocks.subscribe).not.toHaveBeenCalledWith("uid-b");
+  expect(mocks.startRemoteReads).not.toHaveBeenCalledWith("uid-b", expect.any(Object));
   expect(mocks.operations).not.toContain("sync:uid-b");
   expect(mocks.clearStudyStore).not.toHaveBeenCalled();
   expect(mocks.operations).not.toContain("clear-redux");
@@ -126,7 +121,7 @@ it("waits for logout cleanup and local clear before bootstrapping the next anony
     resolveCleanup();
     await pendingLogout;
   });
-  await waitFor(() => expect(mocks.subscribe).toHaveBeenCalledWith("uid-b"));
+  await waitFor(() => expect(mocks.startRemoteReads).toHaveBeenCalledWith("uid-b", expect.any(Object)));
 
   const clearStudyIndex = mocks.operations.indexOf("clear-study");
   const clearReduxIndex = mocks.operations.indexOf("clear-redux");

--- a/src/features/card/containers/CardFormContainer.spec.tsx
+++ b/src/features/card/containers/CardFormContainer.spec.tsx
@@ -16,6 +16,14 @@ vi.mock("react-redux", () => ({
   },
 }));
 
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => ({
+    status: "ready" as const,
+    retry: vi.fn(),
+    cardById: (id: string) => mocks.state?.card.byId[id],
+  }),
+}));
+
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
 }));

--- a/src/features/card/containers/CardFormContainer.tsx
+++ b/src/features/card/containers/CardFormContainer.tsx
@@ -4,16 +4,13 @@ import { useParams } from "react-router-dom";
 
 import * as C from "@/constant";
 import * as selector from "@/selector";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { CardFormTemplate } from "@/features/card/components/templates/CardFormTemplate";
 import { useCardFormState } from "@/features/card/hooks/useCardFormState";
 
-export const CardFormContainer: React.FC = () => {
-  const params = useParams();
-  const cardId = params.id;
-  if (cardId == null) throw Error("invalid card id");
-
-  const card = useSelector(selector.card.getById(cardId));
+const CardFormContent = ({ card }: { card: Card }) => {
   const config = useSelector(selector.config.get());
   const actions = useActions();
   const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
@@ -31,5 +28,24 @@ export const CardFormContainer: React.FC = () => {
       }}
       cardForm={cardForm}
     />
+  );
+};
+
+export const CardFormContainer: React.FC = () => {
+  const params = useParams();
+  const cardId = params.id;
+  if (cardId == null) throw Error("invalid card id");
+  const remote = useRemoteCollections();
+  const card = remote.cardById(cardId);
+
+  return (
+    <RemoteReadBoundary
+      status={remote.status}
+      hasData={card != null}
+      emptyLabel="Card not found."
+      onRetry={remote.retry}
+    >
+      {card != null ? <CardFormContent card={card} /> : null}
+    </RemoteReadBoundary>
   );
 };

--- a/src/features/card/containers/CardListContainer.spec.tsx
+++ b/src/features/card/containers/CardListContainer.spec.tsx
@@ -15,6 +15,22 @@ vi.mock("react-redux", () => ({
   },
 }));
 
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => {
+    const decks = mocks.state?.deck.byId ?? {};
+    const cards = Object.values(mocks.state?.card.byId ?? {}).filter((card): card is Card => card != null);
+    return {
+      status: "ready" as const,
+      retry: vi.fn(),
+      deckById: (id: string) => decks[id],
+      filteredCardsByDeckId: (id: string) => cards.filter((card) => card.deckId === id),
+      tagsByDeckId: (id: string) => [
+        ...new Set(cards.filter((card) => card.deckId === id).flatMap((card) => card.tags)),
+      ],
+    };
+  },
+}));
+
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
 }));

--- a/src/features/card/containers/CardListContainer.tsx
+++ b/src/features/card/containers/CardListContainer.tsx
@@ -6,24 +6,20 @@ import { useKey } from "react-use";
 import * as C from "@/constant";
 import * as selector from "@/selector";
 import * as util from "@/util";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { CardListTemplate } from "@/features/card/components/templates/CardListTemplate";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
 
-export const CardListContainer: React.FC = () => {
-  const params = useParams();
-  const deckId = params.id;
-  if (deckId == null) throw Error("invalid deck id");
-
+const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; config: ConfigState }) => {
+  const { deck, cards, tags, config } = props;
+  const deckId = deck.id;
   const [showCard, setShowCard] = React.useState<Card>();
   const actions = useActions();
   const deckActions = useDeckActions(deckId);
-  const deck = useSelector(selector.deck.getById(deckId));
-  const cards = useSelector(selector.card.getFilteredByDeckId(deckId));
-  const tags = useSelector(selector.card.getAllTags(deckId));
-  const config = useSelector(selector.config.get());
   const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
   const closeCard = React.useCallback(() => setShowCard(undefined), []);
   const category = showCard == null ? undefined : util.getCategory(deck.category, showCard.tags);
@@ -63,5 +59,27 @@ export const CardListContainer: React.FC = () => {
         : {})}
       onShowCard={setShowCard}
     />
+  );
+};
+
+export const CardListContainer: React.FC = () => {
+  const params = useParams();
+  const deckId = params.id;
+  if (deckId == null) throw Error("invalid deck id");
+  const config = useSelector(selector.config.get());
+  const remote = useRemoteCollections();
+  const deck = remote.deckById(deckId);
+  const cards = remote.filteredCardsByDeckId(deckId, config);
+  const tags = remote.tagsByDeckId(deckId);
+
+  return (
+    <RemoteReadBoundary
+      status={remote.status}
+      hasData={deck != null}
+      emptyLabel="Deck not found."
+      onRetry={remote.retry}
+    >
+      {deck != null ? <CardListContent deck={deck} cards={cards} tags={tags} config={config} /> : null}
+    </RemoteReadBoundary>
   );
 };

--- a/src/features/card/containers/CardViewContainer.tsx
+++ b/src/features/card/containers/CardViewContainer.tsx
@@ -5,17 +5,13 @@ import { useParams } from "react-router-dom";
 import * as C from "@/constant";
 import * as selector from "@/selector";
 import * as util from "@/util";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { CardViewTemplate } from "@/features/card/components/templates/CardViewTemplate";
 
-export const CardViewContainer: React.FC = () => {
-  const params = useParams();
-  const cardId = params.id;
-  if (cardId == null) throw Error("invalid card id");
-
-  const card = useSelector(selector.card.getById(cardId));
+const CardViewContent = ({ card, deck }: { card: Card; deck: Deck }) => {
   const actions = useActions();
-  const deck = useSelector(selector.deck.getById(card.deckId));
   const config = useSelector(selector.config.get());
   const category = util.getCategory(deck.category, card.tags);
 
@@ -35,5 +31,21 @@ export const CardViewContainer: React.FC = () => {
         },
       }}
     />
+  );
+};
+
+export const CardViewContainer: React.FC = () => {
+  const params = useParams();
+  const cardId = params.id;
+  if (cardId == null) throw Error("invalid card id");
+  const remote = useRemoteCollections();
+  const card = remote.cardById(cardId);
+  const deck = card == null ? undefined : remote.deckById(card.deckId);
+  const available = card != null && deck != null;
+
+  return (
+    <RemoteReadBoundary status={remote.status} hasData={available} emptyLabel="Card not found." onRetry={remote.retry}>
+      {available ? <CardViewContent card={card} deck={deck} /> : null}
+    </RemoteReadBoundary>
   );
 };

--- a/src/features/deck/containers/DeckFormContainer.spec.tsx
+++ b/src/features/deck/containers/DeckFormContainer.spec.tsx
@@ -16,6 +16,14 @@ vi.mock("react-redux", () => ({
   },
 }));
 
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => ({
+    status: "ready" as const,
+    retry: vi.fn(),
+    deckById: (id: string) => mocks.state?.deck.byId[id],
+  }),
+}));
+
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
 }));

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -5,20 +5,17 @@ import { useForm } from "react-hook-form";
 
 import * as C from "@/constant";
 import * as selector from "@/selector";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { renameKey } from "@/shared/forms/renameKey";
 import { useActions } from "@/shared/hooks/useActions";
 import { DeckFormTemplate } from "@/features/deck/components/templates/DeckFormTemplate";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 
-export const DeckFormContainer: React.FC = () => {
-  const params = useParams();
-  const deckId = params.id;
-  if (deckId == null) throw Error("invalid deck id");
-
-  const deck = useSelector(selector.deck.getById(deckId));
+const DeckFormContent = ({ deck }: { deck: Deck }) => {
   const config = useSelector(selector.config.get());
   const actions = useActions();
-  const deckActions = useDeckActions(deckId);
+  const deckActions = useDeckActions(deck.id);
   const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
   const { formState, handleSubmit, register } = useForm<Deck>({ defaultValues: deck });
 
@@ -49,5 +46,24 @@ export const DeckFormContainer: React.FC = () => {
         onSubmit: handleSubmit((data) => deckActions.updateAndBack(data)),
       }}
     />
+  );
+};
+
+export const DeckFormContainer: React.FC = () => {
+  const params = useParams();
+  const deckId = params.id;
+  if (deckId == null) throw Error("invalid deck id");
+  const remote = useRemoteCollections();
+  const deck = remote.deckById(deckId);
+
+  return (
+    <RemoteReadBoundary
+      status={remote.status}
+      hasData={deck != null}
+      emptyLabel="Deck not found."
+      onRetry={remote.retry}
+    >
+      {deck != null ? <DeckFormContent deck={deck} /> : null}
+    </RemoteReadBoundary>
   );
 };

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -29,6 +29,21 @@ vi.mock("react-redux", () => ({
   },
 }));
 
+vi.mock("@/action", () => ({ deck: { downloadData: vi.fn() } }));
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => {
+    const decksById = mocks.state?.deck.byId ?? {};
+    return {
+      status: "ready" as const,
+      retry: vi.fn(),
+      decks: Object.values(decksById).filter((deck): deck is Deck => deck != null),
+      deckById: (id: string) => decksById[id],
+      cardsByDeckId: (id: string) =>
+        Object.values(mocks.state?.card.byId ?? {}).filter((card): card is Card => card?.deckId === id),
+    };
+  },
+}));
+
 vi.mock("react-use", () => ({
   useKey: vi.fn(),
 }));

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -2,7 +2,10 @@ import type * as React from "react";
 import { useSelector } from "react-redux";
 import { useKey } from "react-use";
 
+import * as action from "@/action";
 import * as selector from "@/selector";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
 import { useStudyStore } from "@/features/study/hooks/useStudyStore";
@@ -10,40 +13,51 @@ import { useStudyStore } from "@/features/study/hooks/useStudyStore";
 export const DeckListContainer: React.FC = () => {
   const actions = useActions();
   const config = useSelector(selector.config.get());
-  const decks = useSelector(selector.deck.getAll());
+  const remote = useRemoteCollections();
+  const decks = remote.decks;
   const studySession = useStudyStore((state) => state.session);
   useKey("s", actions.goToSettings);
   useKey("i", actions.goToImport);
 
   return (
-    <DeckListTemplate
-      decks={decks}
-      {...(studySession != null
-        ? {
-            studyProgress: {
-              deckId: studySession.deckId,
-              currentIndex: studySession.currentIndex,
-              cardCount: studySession.cardOrderIds.length,
-            },
-          }
-        : {})}
-      layout={{
-        headerProps: {
-          dark: config.darkMode,
-          onClickDarkMode: actions.setDarkMode,
-          onClickLogo: actions.goToTop,
-          onClickMenuItem: actions.goByMenu,
-        },
-      }}
-      deckCard={{
-        onClickEdit: actions.goToEdit,
-        onClickName: actions.goToView,
-        onClickRestart: actions.goToStudy,
-        onClickStudy: actions.goToStart,
-        onClickDownload: actions.deckDownload,
-        onClickDelete: actions.deckRemove,
-        // onClickReimport: actions.deckReimport,
-      }}
-    />
+    <RemoteReadBoundary
+      status={remote.status}
+      hasData={decks.length > 0}
+      emptyLabel="No decks yet."
+      onRetry={remote.retry}
+    >
+      <DeckListTemplate
+        decks={decks}
+        {...(studySession != null
+          ? {
+              studyProgress: {
+                deckId: studySession.deckId,
+                currentIndex: studySession.currentIndex,
+                cardCount: studySession.cardOrderIds.length,
+              },
+            }
+          : {})}
+        layout={{
+          headerProps: {
+            dark: config.darkMode,
+            onClickDarkMode: actions.setDarkMode,
+            onClickLogo: actions.goToTop,
+            onClickMenuItem: actions.goByMenu,
+          },
+        }}
+        deckCard={{
+          onClickEdit: actions.goToEdit,
+          onClickName: actions.goToView,
+          onClickRestart: actions.goToStudy,
+          onClickStudy: actions.goToStart,
+          onClickDownload: (id) => {
+            const deck = remote.deckById(id);
+            if (deck != null) action.deck.downloadData(deck, remote.cardsByDeckId(id));
+          },
+          onClickDelete: actions.deckRemove,
+          // onClickReimport: actions.deckReimport,
+        }}
+      />
+    </RemoteReadBoundary>
   );
 };

--- a/src/features/study/containers/DeckStartContainer.tsx
+++ b/src/features/study/containers/DeckStartContainer.tsx
@@ -4,6 +4,8 @@ import { useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
 import * as selector from "@/selector";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
@@ -11,15 +13,9 @@ import { DeckStartTemplate } from "@/features/study/components/templates/DeckSta
 import { useStudyActions } from "@/features/study/hooks/useStudyActions";
 import { useActions } from "@/shared/hooks/useActions";
 
-export const DeckStartContainer: React.FC = () => {
-  const params = useParams();
-  const deckId = params.id;
-  if (deckId == null) throw Error("invalid deckId");
-
-  const deck = useSelector(selector.deck.getById(deckId));
-  const cards = useSelector(selector.card.getFilteredByDeckId(deckId));
-  const config = useSelector(selector.config.get());
-  const tags = useSelector(selector.card.getAllTags(deckId));
+const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: ConfigState; tags: string[] }) => {
+  const { deck, cards, config, tags } = props;
+  const deckId = deck.id;
   const deckActions = useDeckActions(deckId);
   const studyActions = useStudyActions(deckId);
   const actions = useActions();
@@ -41,5 +37,27 @@ export const DeckStartContainer: React.FC = () => {
       onClickStart={studyActions.start}
       filterSlot={<DeckStartForm {...deckStartForm} />}
     />
+  );
+};
+
+export const DeckStartContainer: React.FC = () => {
+  const params = useParams();
+  const deckId = params.id;
+  if (deckId == null) throw Error("invalid deckId");
+  const config = useSelector(selector.config.get());
+  const remote = useRemoteCollections();
+  const deck = remote.deckById(deckId);
+  const cards = remote.filteredCardsByDeckId(deckId, config);
+  const tags = remote.tagsByDeckId(deckId);
+
+  return (
+    <RemoteReadBoundary
+      status={remote.status}
+      hasData={deck != null}
+      emptyLabel="Deck not found."
+      onRetry={remote.retry}
+    >
+      {deck != null ? <DeckStartContent deck={deck} cards={cards} config={config} tags={tags} /> : null}
+    </RemoteReadBoundary>
   );
 };

--- a/src/features/study/containers/DeckSwiperContainer.spec.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.spec.tsx
@@ -32,6 +32,15 @@ vi.mock("react-redux", () => ({
   },
 }));
 
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => ({
+    status: "ready" as const,
+    retry: vi.fn(),
+    deckById: (id: string) => mocks.state?.deck.byId[id],
+    cardById: (id: string) => mocks.state?.card.byId[id],
+  }),
+}));
+
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
   useParams: () => mocks.params,
@@ -190,7 +199,7 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
 
     const view = render(<DeckSwiperContainer />);
 
-    expect(view.container).toBeEmptyDOMElement();
+    expect(view.getByRole("status")).toHaveTextContent("Study session unavailable.");
     expect(mocks.resetStudy).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
     expect(studyStore.getState().session).toBeNull();

--- a/src/features/study/containers/DeckSwiperContainer.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.tsx
@@ -6,6 +6,8 @@ import { useKey } from "react-use";
 import * as C from "@/constant";
 import * as selector from "@/selector";
 import * as util from "@/util";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { RemoteReadBoundary } from "@/shared/components";
 import { BackText } from "@/features/card/components/BackText";
 import { CardOverlay } from "@/features/card/components/CardOverlay";
 import { FrontText } from "@/features/card/components/FrontText";
@@ -22,8 +24,9 @@ export const DeckSwiperContainer: React.FC = () => {
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
 
-  const deck = useSelector(selector.deck.getById(deckId));
   const config = useSelector(selector.config.get());
+  const remote = useRemoteCollections();
+  const deck = remote.deckById(deckId);
   const activeSession = useStudyStore((state) => state.session);
   const showBackText = useStudyStore((state) => state.showBackText);
   const autoPlay = useStudyStore((state) => state.autoPlay);
@@ -32,7 +35,7 @@ export const DeckSwiperContainer: React.FC = () => {
   const session = activeSession?.deckId === deckId ? activeSession : null;
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
-  const card = useSelector((state: RootState) => (cardId == null ? undefined : state.card.byId[cardId]));
+  const card = cardId == null ? undefined : remote.cardById(cardId);
   const studyActions = useStudyActions(deckId);
   const actions = useActions();
 
@@ -63,12 +66,12 @@ export const DeckSwiperContainer: React.FC = () => {
       exitingDeck.current = undefined;
       return;
     }
-    if (!hydrated || exitingDeck.current === deckId) return;
+    if (!hydrated || remote.status !== "ready" || exitingDeck.current === deckId) return;
 
     exitingDeck.current = deckId;
     studyActions.resetStudy();
     void navigate("/", { replace: true });
-  }, [deckId, hydrated, navigate, studyActions, valid]);
+  }, [deckId, hydrated, navigate, remote.status, studyActions, valid]);
 
   // disable browser back
   React.useEffect(() => {
@@ -82,8 +85,17 @@ export const DeckSwiperContainer: React.FC = () => {
     };
   }, [navigate]);
 
-  if (card == null) {
-    return null;
+  if (card == null || deck == null) {
+    return (
+      <RemoteReadBoundary
+        status={remote.status}
+        hasData={false}
+        emptyLabel="Study session unavailable."
+        onRetry={remote.retry}
+      >
+        {null}
+      </RemoteReadBoundary>
+    );
   }
 
   const category = util.getCategory(deck.category, card.tags);

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -21,6 +21,17 @@ vi.mock("react-redux", () => ({
   },
 }));
 
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => {
+    const cardsById = mocks.state?.card.byId ?? {};
+    return {
+      cardsById,
+      filteredCardsByDeckId: (deckId: string) =>
+        Object.values(cardsById).filter((card): card is Card => card?.deckId === deckId),
+    };
+  },
+}));
+
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
 }));

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 
 import * as action from "@/action";
 import * as selector from "@/selector";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
 import { studyStore } from "@/features/study/state/studyStore";
 import { buildStudyPatch, buildStudySession, calculateNextIndex, resolveSwipeAction } from "@/lib/study";
 
@@ -23,9 +24,10 @@ export interface StudyActions {
 export const useStudyActions = (deckId: DeckId): StudyActions => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const cards = useSelector(selector.card.getFilteredByDeckId(deckId));
-  const cardsById = useSelector((state: RootState) => state.card.byId);
   const config = useSelector(selector.config.get());
+  const remote = useRemoteCollections();
+  const cards = remote.filteredCardsByDeckId(deckId, config);
+  const cardsById = remote.cardsById;
 
   const start = React.useCallback(() => {
     const cardOrderIds = buildStudySession(cards, config);

--- a/src/query/cleanup.spec.ts
+++ b/src/query/cleanup.spec.ts
@@ -1,11 +1,13 @@
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { stopSubscriptions } = vi.hoisted(() => ({
+const { stopSubscriptions, stopRemoteReads } = vi.hoisted(() => ({
   stopSubscriptions: vi.fn(),
+  stopRemoteReads: vi.fn(),
 }));
 
 vi.mock("@/lib/realtimeSubscriptions", () => ({ stopSubscriptions }));
+vi.mock("@/query/remoteReadSession", () => ({ stopRemoteReads }));
 
 import { cleanupFirestoreUid } from "@/query/cleanup";
 import { queryClient } from "@/query/client";
@@ -21,6 +23,7 @@ describe("cleanupFirestoreUid", () => {
 
   beforeEach(() => {
     stopSubscriptions.mockReset();
+    stopRemoteReads.mockReset();
     temporaryClients.length = 0;
   });
 
@@ -35,7 +38,8 @@ describe("cleanupFirestoreUid", () => {
   it("stops subscriptions, awaits cancellation, then removes the UID cache", async () => {
     const operations: string[] = [];
     let finishCancellation: () => void = () => undefined;
-    stopSubscriptions.mockImplementation(() => operations.push("stop"));
+    stopRemoteReads.mockImplementation(() => operations.push("stop-remote"));
+    stopSubscriptions.mockImplementation(() => operations.push("stop-legacy"));
     const cancelQueries = vi.spyOn(queryClient, "cancelQueries").mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -49,14 +53,15 @@ describe("cleanupFirestoreUid", () => {
 
     const cleanup = cleanupFirestoreUid("uid-a");
 
-    expect(operations).toEqual(["stop", "cancel"]);
+    expect(operations).toEqual(["stop-remote", "stop-legacy", "cancel"]);
     expect(removeQueries).not.toHaveBeenCalled();
 
     finishCancellation();
     await cleanup;
 
     const filter = { queryKey: firestoreKeys.uid("uid-a") };
-    expect(operations).toEqual(["stop", "cancel", "remove"]);
+    expect(operations).toEqual(["stop-remote", "stop-legacy", "cancel", "remove"]);
+    expect(stopRemoteReads).toHaveBeenCalledWith("uid-a");
     expect(cancelQueries).toHaveBeenCalledWith(filter);
     expect(removeQueries).toHaveBeenCalledWith(filter);
   });
@@ -75,6 +80,7 @@ describe("cleanupFirestoreUid", () => {
     expect(client.getQueryData(firestoreKeys.decks("uid-b"))).toEqual(["deck-b"]);
     expect(client.getQueryData(firestoreKeys.cards("uid-b"))).toEqual(["card-b"]);
     expect(stopSubscriptions).toHaveBeenCalledTimes(1);
+    expect(stopRemoteReads).toHaveBeenCalledWith("uid-a");
   });
 
   it("finishes cache cleanup before surfacing a subscription stop error", async () => {

--- a/src/query/cleanup.ts
+++ b/src/query/cleanup.ts
@@ -3,10 +3,16 @@ import type { QueryClient } from "@tanstack/react-query";
 import { stopSubscriptions } from "@/lib/realtimeSubscriptions";
 import { queryClient } from "@/query/client";
 import { firestoreKeys } from "@/query/firestoreKeys";
+import { stopRemoteReads } from "@/query/remoteReadSession";
 
 export const cleanupFirestoreUid = async (uid: string, client: QueryClient = queryClient) => {
   const filter = { queryKey: firestoreKeys.uid(uid) };
   const errors: unknown[] = [];
+  try {
+    stopRemoteReads(uid);
+  } catch (error) {
+    errors.push(error);
+  }
   try {
     stopSubscriptions();
   } catch (error) {

--- a/src/query/remoteReadController.spec.ts
+++ b/src/query/remoteReadController.spec.ts
@@ -1,0 +1,180 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { applyRealtimeChange } from "@/lib/realtimeChange";
+import { firestoreKeys } from "@/query/firestoreKeys";
+import {
+  createRemoteReadController,
+  type RemoteReadDependencies,
+  type RemoteSubscriptionProps,
+} from "@/query/remoteReadController";
+import { createCard, createDeck } from "@/test/factories";
+
+const deferred = <T>() => {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+};
+
+const byId = <T extends { id: string }>(items: T[]) => Object.fromEntries(items.map((item) => [item.id, item]));
+
+const createHarness = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const deckSubscriptions: Array<RemoteSubscriptionProps<Deck>> = [];
+  const cardSubscriptions: Array<RemoteSubscriptionProps<Card>> = [];
+  const deckUnsubscribes: ReturnType<typeof vi.fn>[] = [];
+  const cardUnsubscribes: ReturnType<typeof vi.fn>[] = [];
+  const dependencies: RemoteReadDependencies = {
+    client,
+    readDecks: vi.fn(async () => []),
+    readCards: vi.fn(async () => []),
+    subscribeDecks: vi.fn((props) => {
+      deckSubscriptions.push(props);
+      const unsubscribe = vi.fn();
+      deckUnsubscribes.push(unsubscribe);
+      return unsubscribe;
+    }),
+    subscribeCards: vi.fn((props) => {
+      cardSubscriptions.push(props);
+      const unsubscribe = vi.fn();
+      cardUnsubscribes.push(unsubscribe);
+      return unsubscribe;
+    }),
+    mirrorDecks: vi.fn(),
+    mirrorCards: vi.fn(),
+    applyChange: applyRealtimeChange,
+  };
+  return {
+    client,
+    dependencies,
+    controller: createRemoteReadController(dependencies),
+    deckSubscriptions,
+    cardSubscriptions,
+    deckUnsubscribes,
+    cardUnsubscribes,
+  };
+};
+
+describe("remote read controller", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("loads both collections before attaching exactly one listener for each", async () => {
+    const harness = createHarness();
+    const deck = createDeck({ id: "deck-a", localMode: false });
+    const card = createCard({ id: "card-a", deckId: deck.id });
+    vi.mocked(harness.dependencies.readDecks).mockResolvedValue([deck]);
+    vi.mocked(harness.dependencies.readCards).mockResolvedValue([card]);
+
+    const first = harness.controller.start("uid-a");
+    const strictModeReplay = harness.controller.start("uid-a");
+    await Promise.all([first, strictModeReplay]);
+
+    expect(harness.dependencies.readDecks).toHaveBeenCalledTimes(1);
+    expect(harness.dependencies.readCards).toHaveBeenCalledTimes(1);
+    expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(1);
+    expect(harness.dependencies.subscribeCards).toHaveBeenCalledTimes(1);
+    expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual(byId([deck]));
+    expect(harness.client.getQueryData(firestoreKeys.cards("uid-a"))).toEqual(byId([card]));
+    expect(harness.dependencies.mirrorDecks).toHaveBeenLastCalledWith([deck]);
+    expect(harness.dependencies.mirrorCards).toHaveBeenLastCalledWith([card]);
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready" });
+  });
+
+  it("applies replacement and delta snapshots to Query and the Redux mirror together", async () => {
+    const harness = createHarness();
+    const deck = createDeck({ id: "deck-a", localMode: false });
+    vi.mocked(harness.dependencies.readDecks).mockResolvedValue([deck]);
+    await harness.controller.start("uid-a");
+    vi.mocked(harness.dependencies.mirrorDecks).mockClear();
+
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [],
+      metadata: { size: 0, fromLocal: false },
+    });
+
+    expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual({});
+    expect(harness.dependencies.mirrorDecks).toHaveBeenLastCalledWith([]);
+
+    const added = createDeck({ id: "deck-added", localMode: false });
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "change",
+      event: { added: [added], modified: [], removed: [] },
+      metadata: { size: 1, fromLocal: false },
+    });
+
+    expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual(byId([added]));
+    expect(harness.dependencies.mirrorDecks).toHaveBeenLastCalledWith([added]);
+  });
+
+  it("forces one refetch and reconnect, then retains data on a terminal listener error", async () => {
+    const harness = createHarness();
+    const deck = createDeck({ id: "deck-a", localMode: false });
+    vi.mocked(harness.dependencies.readDecks).mockResolvedValue([deck]);
+    await harness.controller.start("uid-a");
+
+    harness.deckSubscriptions[0]?.onError(new Error("first listener failure"));
+    await vi.waitFor(() => expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(2));
+    expect(harness.dependencies.readDecks).toHaveBeenCalledTimes(2);
+    expect(harness.deckUnsubscribes[0]).toHaveBeenCalledTimes(1);
+    expect(harness.cardUnsubscribes[0]).toHaveBeenCalledTimes(1);
+
+    const terminalError = new Error("terminal listener failure");
+    harness.deckSubscriptions[1]?.onError(terminalError);
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "error", error: terminalError })
+    );
+
+    expect(harness.dependencies.readDecks).toHaveBeenCalledTimes(2);
+    expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual(byId([deck]));
+  });
+
+  it("manually retries a terminal error and grants the new connection one automatic recovery", async () => {
+    const harness = createHarness();
+    await harness.controller.start("uid-a");
+    harness.deckSubscriptions[0]?.onError(new Error("automatic recovery"));
+    await vi.waitFor(() => expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(2));
+    harness.deckSubscriptions[1]?.onError(new Error("terminal"));
+    await vi.waitFor(() => expect(harness.controller.getSnapshot().status).toBe("error"));
+
+    await harness.controller.retry();
+
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready" });
+    expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(3);
+    harness.deckSubscriptions[2]?.onError(new Error("new automatic recovery"));
+    await vi.waitFor(() => expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(4));
+  });
+
+  it("prevents delayed work for an old UID from mutating Query, mirrors, or listeners", async () => {
+    const harness = createHarness();
+    const decksA = deferred<Deck[]>();
+    const cardsA = deferred<Card[]>();
+    const deckB = createDeck({ id: "deck-b", uid: "uid-b", localMode: false });
+    const cardB = createCard({ id: "card-b", uid: "uid-b", deckId: deckB.id });
+    vi.mocked(harness.dependencies.readDecks).mockImplementation((uid) =>
+      uid === "uid-a" ? decksA.promise : Promise.resolve([deckB])
+    );
+    vi.mocked(harness.dependencies.readCards).mockImplementation((uid) =>
+      uid === "uid-a" ? cardsA.promise : Promise.resolve([cardB])
+    );
+
+    const startA = harness.controller.start("uid-a");
+    await harness.controller.start("uid-b");
+    decksA.resolve([createDeck({ id: "deck-a", uid: "uid-a", localMode: false })]);
+    cardsA.resolve([createCard({ id: "card-a", uid: "uid-a" })]);
+    await startA;
+
+    expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toBeUndefined();
+    expect(harness.client.getQueryData(firestoreKeys.cards("uid-a"))).toBeUndefined();
+    expect(harness.dependencies.subscribeDecks).not.toHaveBeenCalledWith(expect.objectContaining({ uid: "uid-a" }));
+    expect(harness.dependencies.subscribeCards).not.toHaveBeenCalledWith(expect.objectContaining({ uid: "uid-a" }));
+    expect(harness.dependencies.mirrorDecks).toHaveBeenCalledTimes(1);
+    expect(harness.dependencies.mirrorDecks).toHaveBeenLastCalledWith([deckB]);
+    expect(harness.dependencies.mirrorCards).toHaveBeenCalledTimes(1);
+    expect(harness.dependencies.mirrorCards).toHaveBeenLastCalledWith([cardB]);
+  });
+});

--- a/src/query/remoteReadController.ts
+++ b/src/query/remoteReadController.ts
@@ -1,0 +1,200 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+
+import type { RemoteSnapshot } from "@/action/firestore/event";
+import { firestoreKeys } from "@/query/firestoreKeys";
+
+export type RemoteById<T> = Record<string, T | undefined>;
+
+export interface RemoteSubscriptionProps<T> {
+  uid: string;
+  onSnapshot: (snapshot: RemoteSnapshot<T>) => void;
+  onError: (error: Error) => void;
+}
+
+export type RemoteReadState =
+  | { uid: null; status: "idle" }
+  | { uid: string; status: "loading" | "ready" }
+  | { uid: string; status: "error"; error: Error };
+
+export interface RemoteReadDependencies {
+  client: QueryClient;
+  readDecks: (uid: string) => Promise<Deck[]>;
+  readCards: (uid: string) => Promise<Card[]>;
+  subscribeDecks: (props: RemoteSubscriptionProps<Deck>) => Callback;
+  subscribeCards: (props: RemoteSubscriptionProps<Card>) => Callback;
+  mirrorDecks: (decks: Deck[]) => void;
+  mirrorCards: (cards: Card[]) => void;
+  applyChange: <T extends { id: string }>(
+    previous: RemoteById<T>,
+    event: { added?: T[]; modified?: T[]; removed?: string[] }
+  ) => RemoteById<T>;
+}
+
+const toById = <T extends { id: string }>(items: T[]): RemoteById<T> =>
+  Object.fromEntries(items.map((item) => [item.id, item]));
+
+const toItems = <T>(items: RemoteById<T>): T[] => Object.values(items).filter((item): item is T => item != null);
+
+export const createRemoteReadController = (dependencies: RemoteReadDependencies) => {
+  let activeUid: string | undefined;
+  let generation = 0;
+  let automaticRecoveries = 0;
+  let recovering = false;
+  let unsubscribeDeck: Callback | undefined;
+  let unsubscribeCard: Callback | undefined;
+  let currentStart: Promise<void> | undefined;
+  let state: RemoteReadState = { uid: null, status: "idle" };
+  const listeners = new Set<Callback>();
+
+  const setState = (next: RemoteReadState) => {
+    state = next;
+    listeners.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const isCurrent = (uid: string, currentGeneration: number) => activeUid === uid && generation === currentGeneration;
+
+  const stopListeners = () => {
+    const subscriptions = [unsubscribeDeck, unsubscribeCard];
+    unsubscribeDeck = undefined;
+    unsubscribeCard = undefined;
+    subscriptions.forEach((unsubscribe) => {
+      try {
+        unsubscribe?.();
+      } catch {
+        // A failing unsubscribe must not leave the other listener active.
+      }
+    });
+  };
+
+  const setCollection = <T extends { id: string }>(queryKey: QueryKey, items: T[], mirror: (items: T[]) => void) => {
+    dependencies.client.setQueryData<RemoteById<T>>(queryKey, toById(items));
+    mirror(items);
+  };
+
+  const applySnapshot = <T extends { id: string }>(
+    uid: string,
+    currentGeneration: number,
+    queryKey: QueryKey,
+    snapshot: RemoteSnapshot<T>,
+    mirror: (items: T[]) => void
+  ) => {
+    if (!isCurrent(uid, currentGeneration)) return;
+    const previous = dependencies.client.getQueryData<RemoteById<T>>(queryKey) ?? {};
+    const next =
+      snapshot.type === "replace" ? toById(snapshot.items) : dependencies.applyChange(previous, snapshot.event);
+    dependencies.client.setQueryData(queryKey, next);
+    mirror(toItems(next));
+  };
+
+  const handleListenerError = async (uid: string, currentGeneration: number, error: Error) => {
+    if (!isCurrent(uid, currentGeneration) || recovering) return;
+    stopListeners();
+    if (automaticRecoveries >= 1) {
+      setState({ uid, status: "error", error });
+      return;
+    }
+
+    automaticRecoveries += 1;
+    recovering = true;
+    setState({ uid, status: "loading" });
+    try {
+      await loadAndSubscribe(uid, currentGeneration);
+    } catch (recoveryError) {
+      if (isCurrent(uid, currentGeneration)) {
+        setState({
+          uid,
+          status: "error",
+          error: recoveryError instanceof Error ? recoveryError : new Error(String(recoveryError)),
+        });
+      }
+    } finally {
+      recovering = false;
+    }
+  };
+
+  const attachListeners = (uid: string, currentGeneration: number) => {
+    const onError = (error: Error) => {
+      void handleListenerError(uid, currentGeneration, error);
+    };
+    const nextDeckSubscription = dependencies.subscribeDecks({
+      uid,
+      onSnapshot: (snapshot) =>
+        applySnapshot(uid, currentGeneration, firestoreKeys.decks(uid), snapshot, dependencies.mirrorDecks),
+      onError,
+    });
+    if (!isCurrent(uid, currentGeneration)) {
+      nextDeckSubscription();
+      return;
+    }
+    unsubscribeDeck = nextDeckSubscription;
+
+    const nextCardSubscription = dependencies.subscribeCards({
+      uid,
+      onSnapshot: (snapshot) =>
+        applySnapshot(uid, currentGeneration, firestoreKeys.cards(uid), snapshot, dependencies.mirrorCards),
+      onError,
+    });
+    if (!isCurrent(uid, currentGeneration)) {
+      nextCardSubscription();
+      stopListeners();
+      return;
+    }
+    unsubscribeCard = nextCardSubscription;
+  };
+
+  async function loadAndSubscribe(uid: string, currentGeneration: number) {
+    const [decks, cards] = await Promise.all([dependencies.readDecks(uid), dependencies.readCards(uid)]);
+    if (!isCurrent(uid, currentGeneration)) return;
+
+    setCollection(firestoreKeys.decks(uid), decks, dependencies.mirrorDecks);
+    setCollection(firestoreKeys.cards(uid), cards, dependencies.mirrorCards);
+    attachListeners(uid, currentGeneration);
+    if (isCurrent(uid, currentGeneration)) setState({ uid, status: "ready" });
+  }
+
+  const begin = (uid: string, resetAutomaticRecoveries: boolean) => {
+    stopListeners();
+    activeUid = uid;
+    const currentGeneration = ++generation;
+    recovering = false;
+    if (resetAutomaticRecoveries) automaticRecoveries = 0;
+    setState({ uid, status: "loading" });
+
+    const operation = loadAndSubscribe(uid, currentGeneration).catch((error) => {
+      if (isCurrent(uid, currentGeneration)) {
+        setState({ uid, status: "error", error: error instanceof Error ? error : new Error(String(error)) });
+      }
+      throw error;
+    });
+    currentStart = operation;
+    return operation;
+  };
+
+  return {
+    start: (uid: string) => {
+      if (activeUid === uid && (state.status === "loading" || state.status === "ready")) {
+        return currentStart ?? Promise.resolve();
+      }
+      return begin(uid, true);
+    },
+    retry: () => (activeUid ? begin(activeUid, true) : Promise.resolve()),
+    stop: (uid?: string) => {
+      if (uid && uid !== activeUid) return;
+      stopListeners();
+      activeUid = undefined;
+      generation += 1;
+      recovering = false;
+      currentStart = undefined;
+      setState({ uid: null, status: "idle" });
+    },
+    subscribe: (listener: Callback) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => state,
+  };
+};

--- a/src/query/remoteReadSession.spec.ts
+++ b/src/query/remoteReadSession.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  dependencies: undefined as
+    | {
+        mirrorDecks: (decks: Deck[]) => void;
+        mirrorCards: (cards: Card[]) => void;
+      }
+    | undefined,
+  start: vi.fn(async () => undefined),
+  stop: vi.fn(),
+  retry: vi.fn(async () => undefined),
+  subscribe: vi.fn(),
+  getSnapshot: vi.fn(() => ({ uid: null, status: "idle" as const })),
+  readDecks: vi.fn(),
+  readCards: vi.fn(),
+  subscribeDecks: vi.fn(),
+  subscribeCards: vi.fn(),
+}));
+
+vi.mock("@/action/firestore", () => ({
+  deck: { readAll: mocks.readDecks },
+  card: { readAll: mocks.readCards },
+  event: { subscribeDeckReads: mocks.subscribeDecks, subscribeCardReads: mocks.subscribeCards },
+}));
+vi.mock("@/query/client", () => ({ queryClient: {} }));
+vi.mock("@/lib/realtimeChange", () => ({ applyRealtimeChange: vi.fn() }));
+vi.mock("@/query/remoteReadController", () => ({
+  createRemoteReadController: vi.fn((dependencies) => {
+    mocks.dependencies = dependencies;
+    return {
+      start: mocks.start,
+      stop: mocks.stop,
+      retry: mocks.retry,
+      subscribe: mocks.subscribe,
+      getSnapshot: mocks.getSnapshot,
+    };
+  }),
+}));
+
+import { startRemoteReads, stopRemoteReads } from "@/query/remoteReadSession";
+import { createCard, createDeck } from "@/test/factories";
+
+describe("remote read session", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("connects production gateways and forwards controller snapshots to the active mirrors", async () => {
+    const mirrorDecks = vi.fn();
+    const mirrorCards = vi.fn();
+    const deck = createDeck();
+    const card = createCard();
+
+    await startRemoteReads("uid-a", { mirrorDecks, mirrorCards });
+    mocks.dependencies?.mirrorDecks([deck]);
+    mocks.dependencies?.mirrorCards([card]);
+
+    expect(mocks.start).toHaveBeenCalledWith("uid-a");
+    expect(mirrorDecks).toHaveBeenCalledWith([deck]);
+    expect(mirrorCards).toHaveBeenCalledWith([card]);
+    stopRemoteReads("uid-a");
+    expect(mocks.stop).toHaveBeenCalledWith("uid-a");
+  });
+});

--- a/src/query/remoteReadSession.ts
+++ b/src/query/remoteReadSession.ts
@@ -1,0 +1,41 @@
+import * as firestore from "@/action/firestore";
+import { applyRealtimeChange } from "@/lib/realtimeChange";
+import { queryClient } from "@/query/client";
+import { createRemoteReadController } from "@/query/remoteReadController";
+
+export interface RemoteReadMirrors {
+  mirrorDecks: (decks: Deck[]) => void;
+  mirrorCards: (cards: Card[]) => void;
+}
+
+const emptyMirrors: RemoteReadMirrors = {
+  mirrorDecks: () => undefined,
+  mirrorCards: () => undefined,
+};
+
+let mirrors = emptyMirrors;
+
+export const remoteReadController = createRemoteReadController({
+  client: queryClient,
+  readDecks: firestore.deck.readAll,
+  readCards: firestore.card.readAll,
+  subscribeDecks: firestore.event.subscribeDeckReads,
+  subscribeCards: firestore.event.subscribeCardReads,
+  mirrorDecks: (decks) => mirrors.mirrorDecks(decks),
+  mirrorCards: (cards) => mirrors.mirrorCards(cards),
+  applyChange: applyRealtimeChange,
+});
+
+export const startRemoteReads = (uid: string, nextMirrors: RemoteReadMirrors) => {
+  mirrors = nextMirrors;
+  return remoteReadController.start(uid);
+};
+
+export const stopRemoteReads = (uid?: string) => {
+  remoteReadController.stop(uid);
+  if (remoteReadController.getSnapshot().status === "idle") mirrors = emptyMirrors;
+};
+
+export const retryRemoteReads = () => remoteReadController.retry();
+export const subscribeRemoteReadState = remoteReadController.subscribe;
+export const getRemoteReadState = remoteReadController.getSnapshot;

--- a/src/query/useRemoteCollections.spec.tsx
+++ b/src/query/useRemoteCollections.spec.tsx
@@ -1,0 +1,90 @@
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { firestoreKeys } from "@/query/firestoreKeys";
+import { createTestQueryClient, createQueryWrapper } from "@/query/testUtils";
+import { createCard, createDeck } from "@/test/factories";
+
+const mocks = vi.hoisted(() => ({
+  uid: "uid-a",
+  state: { uid: "uid-a", status: "ready" } as
+    | { uid: string; status: "ready" | "loading" }
+    | { uid: string; status: "error"; error: Error },
+  rootState: undefined as unknown as RootState,
+  retry: vi.fn(),
+}));
+
+vi.mock("@/auth/AuthContext", () => ({
+  useAuth: () => ({ status: "authenticated", uid: mocks.uid, user: { uid: mocks.uid } }),
+}));
+vi.mock("react-redux", () => ({
+  useSelector: (select: (state: RootState) => unknown) => select(mocks.rootState),
+}));
+vi.mock("@/query/remoteReadSession", () => ({
+  subscribeRemoteReadState: () => () => undefined,
+  getRemoteReadState: () => mocks.state,
+  retryRemoteReads: mocks.retry,
+}));
+
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+
+describe("useRemoteCollections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.state = { uid: "uid-a", status: "ready" };
+  });
+
+  it("merges Query remote data with Redux local-only data and lets local IDs win", () => {
+    const localDeck = createDeck({ id: "local", name: "Local", localMode: true });
+    const staleReduxRemote = createDeck({ id: "stale", localMode: false });
+    const remoteCollision = createDeck({ id: "local", name: "Remote collision", localMode: false });
+    const freshRemote = createDeck({ id: "fresh", localMode: false });
+    const localCard = createCard({ id: "local-card", deckId: localDeck.id, frontText: "Local" });
+    const staleReduxCard = createCard({ id: "stale-card", deckId: staleReduxRemote.id });
+    const remoteCardCollision = createCard({ id: "local-card", deckId: freshRemote.id, frontText: "Remote" });
+    const freshRemoteCard = createCard({ id: "fresh-card", deckId: freshRemote.id });
+    mocks.rootState = {
+      deck: { byId: { local: localDeck, stale: staleReduxRemote }, categories: [] },
+      card: { byId: { "local-card": localCard, "stale-card": staleReduxCard }, tags: [] },
+      config: {} as ConfigState,
+    };
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { local: remoteCollision, fresh: freshRemote });
+    client.setQueryData(firestoreKeys.cards("uid-a"), {
+      "local-card": remoteCardCollision,
+      "fresh-card": freshRemoteCard,
+    });
+    const QueryWrapper = createQueryWrapper(client);
+    const wrapper = ({ children }: PropsWithChildren) => <QueryWrapper>{children}</QueryWrapper>;
+
+    const { result } = renderHook(useRemoteCollections, { wrapper });
+
+    expect(result.current.decksById).toEqual({ local: localDeck, fresh: freshRemote });
+    expect(result.current.cardsById).toEqual({ "local-card": localCard, "fresh-card": freshRemoteCard });
+    expect(result.current.cardsByDeckId(freshRemote.id)).toEqual([freshRemoteCard]);
+    expect(result.current.status).toBe("ready");
+  });
+
+  it("exposes terminal state and Retry without dropping cached data", () => {
+    const error = new Error("terminal");
+    const remoteDeck = createDeck({ id: "remote", localMode: false });
+    mocks.state = { uid: "uid-a", status: "error", error };
+    mocks.rootState = {
+      deck: { byId: {}, categories: [] },
+      card: { byId: {}, tags: [] },
+      config: {} as ConfigState,
+    };
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { remote: remoteDeck });
+    const QueryWrapper = createQueryWrapper(client);
+
+    const { result } = renderHook(useRemoteCollections, { wrapper: QueryWrapper });
+    result.current.retry();
+
+    expect(result.current.decks).toEqual([remoteDeck]);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe(error);
+    expect(mocks.retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/query/useRemoteCollections.ts
+++ b/src/query/useRemoteCollections.ts
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useSyncExternalStore } from "react";
 import { useSelector } from "react-redux";
+import { uniq } from "lodash";
 
 import { useAuth } from "@/auth/AuthContext";
+import { filterCardsForDeck } from "@/lib/study";
 import { firestoreKeys } from "@/query/firestoreKeys";
-import type { RemoteById } from "@/query/remoteReadController";
+import type { RemoteById, RemoteReadState } from "@/query/remoteReadController";
 import { getRemoteReadState, retryRemoteReads, subscribeRemoteReadState } from "@/query/remoteReadSession";
 
 const definedEntries = <T>(items: Record<string, T | undefined>) =>
@@ -44,7 +46,8 @@ export const useRemoteCollections = () => {
     return { decksById, cardsById, decks, cards };
   }, [reduxDecks, reduxCards, remoteDeckQuery.data, remoteCardQuery.data]);
 
-  const status = uid === "" ? "idle" : remoteState.uid === uid ? remoteState.status : ("loading" as const);
+  const status: RemoteReadState["status"] =
+    uid === "" ? "idle" : remoteState.uid === uid ? remoteState.status : "loading";
   const error = remoteState.uid === uid && remoteState.status === "error" ? remoteState.error : undefined;
 
   return {
@@ -55,5 +58,12 @@ export const useRemoteCollections = () => {
     deckById: (id: string) => collections.decksById[id],
     cardById: (id: string) => collections.cardsById[id],
     cardsByDeckId: (deckId: string) => collections.cards.filter((card) => card.deckId === deckId),
+    filteredCardsByDeckId: (deckId: string, config: ConfigState) => {
+      const deck = collections.decksById[deckId];
+      const cards = collections.cards.filter((card) => card.deckId === deckId);
+      return deck == null ? [] : filterCardsForDeck(cards, deck, config);
+    },
+    tagsByDeckId: (deckId: string) =>
+      uniq(collections.cards.filter((card) => card.deckId === deckId).flatMap((card) => card.tags)).sort(),
   };
 };

--- a/src/query/useRemoteCollections.ts
+++ b/src/query/useRemoteCollections.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useSyncExternalStore } from "react";
+import { useSelector } from "react-redux";
+
+import { useAuth } from "@/auth/AuthContext";
+import { firestoreKeys } from "@/query/firestoreKeys";
+import type { RemoteById } from "@/query/remoteReadController";
+import { getRemoteReadState, retryRemoteReads, subscribeRemoteReadState } from "@/query/remoteReadSession";
+
+const definedEntries = <T>(items: Record<string, T | undefined>) =>
+  Object.entries(items).filter((entry): entry is [string, T] => entry[1] != null);
+
+export const useRemoteCollections = () => {
+  const authState = useAuth();
+  const uid = authState.status === "authenticated" ? authState.uid : "";
+  const reduxDecks = useSelector((state: RootState) => state.deck.byId);
+  const reduxCards = useSelector((state: RootState) => state.card.byId);
+  const remoteState = useSyncExternalStore(subscribeRemoteReadState, getRemoteReadState, getRemoteReadState);
+  const remoteDeckQuery = useQuery<RemoteById<Deck>>({
+    queryKey: firestoreKeys.decks(uid),
+    queryFn: async () => ({}),
+    enabled: false,
+  });
+  const remoteCardQuery = useQuery<RemoteById<Card>>({
+    queryKey: firestoreKeys.cards(uid),
+    queryFn: async () => ({}),
+    enabled: false,
+  });
+
+  const collections = useMemo(() => {
+    const localDeckEntries = definedEntries(reduxDecks).filter(([, deck]) => deck.localMode);
+    const localDeckIds = new Set(localDeckEntries.map(([id]) => id));
+    const localCardEntries = definedEntries(reduxCards).filter(([, card]) => localDeckIds.has(card.deckId));
+    const decksById = {
+      ...(remoteDeckQuery.data ?? {}),
+      ...Object.fromEntries(localDeckEntries),
+    };
+    const cardsById = {
+      ...(remoteCardQuery.data ?? {}),
+      ...Object.fromEntries(localCardEntries),
+    };
+    const decks = definedEntries(decksById).map(([, deck]) => deck);
+    const cards = definedEntries(cardsById).map(([, card]) => card);
+    return { decksById, cardsById, decks, cards };
+  }, [reduxDecks, reduxCards, remoteDeckQuery.data, remoteCardQuery.data]);
+
+  const status = uid === "" ? "idle" : remoteState.uid === uid ? remoteState.status : ("loading" as const);
+  const error = remoteState.uid === uid && remoteState.status === "error" ? remoteState.error : undefined;
+
+  return {
+    ...collections,
+    status,
+    error,
+    retry: retryRemoteReads,
+    deckById: (id: string) => collections.decksById[id],
+    cardById: (id: string) => collections.cardsById[id],
+    cardsByDeckId: (deckId: string) => collections.cards.filter((card) => card.deckId === deckId),
+  };
+};

--- a/src/query/useRemoteCollections.ts
+++ b/src/query/useRemoteCollections.ts
@@ -15,8 +15,8 @@ const definedEntries = <T>(items: Record<string, T | undefined>) =>
 export const useRemoteCollections = () => {
   const authState = useAuth();
   const uid = authState.status === "authenticated" ? authState.uid : "";
-  const reduxDecks = useSelector((state: RootState) => state.deck.byId);
-  const reduxCards = useSelector((state: RootState) => state.card.byId);
+  const reduxDeckState = useSelector((state: RootState) => state.deck);
+  const reduxCardState = useSelector((state: RootState) => state.card);
   const remoteState = useSyncExternalStore(subscribeRemoteReadState, getRemoteReadState, getRemoteReadState);
   const remoteDeckQuery = useQuery<RemoteById<Deck>>({
     queryKey: firestoreKeys.decks(uid),
@@ -30,6 +30,8 @@ export const useRemoteCollections = () => {
   });
 
   const collections = useMemo(() => {
+    const reduxDecks = reduxDeckState.byId;
+    const reduxCards = reduxCardState.byId;
     const localDeckEntries = definedEntries(reduxDecks).filter(([, deck]) => deck.localMode);
     const localDeckIds = new Set(localDeckEntries.map(([id]) => id));
     const localCardEntries = definedEntries(reduxCards).filter(([, card]) => localDeckIds.has(card.deckId));
@@ -44,7 +46,7 @@ export const useRemoteCollections = () => {
     const decks = definedEntries(decksById).map(([, deck]) => deck);
     const cards = definedEntries(cardsById).map(([, card]) => card);
     return { decksById, cardsById, decks, cards };
-  }, [reduxDecks, reduxCards, remoteDeckQuery.data, remoteCardQuery.data]);
+  }, [reduxDeckState, reduxCardState, remoteDeckQuery.data, remoteCardQuery.data]);
 
   const status: RemoteReadState["status"] =
     uid === "" ? "idle" : remoteState.uid === uid ? remoteState.status : "loading";

--- a/src/shared/components/feedback/RemoteReadBoundary.spec.tsx
+++ b/src/shared/components/feedback/RemoteReadBoundary.spec.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RemoteReadBoundary } from "@/shared/components/feedback/RemoteReadBoundary";
+
+describe("RemoteReadBoundary", () => {
+  it("shows loading instead of children before initial data", () => {
+    render(
+      <RemoteReadBoundary status="loading" hasData={false} onRetry={vi.fn()}>
+        content
+      </RemoteReadBoundary>
+    );
+
+    expect(screen.getByRole("status").textContent).toContain("Loading…");
+    expect(screen.queryByText("content")).toBeNull();
+  });
+
+  it("shows a terminal error and Retry before initial data", () => {
+    const onRetry = vi.fn();
+    render(
+      <RemoteReadBoundary status="error" hasData={false} onRetry={onRetry}>
+        content
+      </RemoteReadBoundary>
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain("Unable to load data.");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps cached content visible beside a terminal sync error", () => {
+    render(
+      <RemoteReadBoundary status="error" hasData onRetry={vi.fn()}>
+        cached content
+      </RemoteReadBoundary>
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain("Sync interrupted. Showing current data.");
+    expect(screen.getByText("cached content")).toBeTruthy();
+  });
+
+  it("shows the caller's empty message after a successful empty read", () => {
+    render(
+      <RemoteReadBoundary status="ready" hasData={false} emptyLabel="No decks yet." onRetry={vi.fn()}>
+        content
+      </RemoteReadBoundary>
+    );
+
+    expect(screen.getByRole("status").textContent).toContain("No decks yet.");
+  });
+});

--- a/src/shared/components/feedback/RemoteReadBoundary.tsx
+++ b/src/shared/components/feedback/RemoteReadBoundary.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/shared/components/forms/Button";
+
+type RemoteReadBoundaryProps = {
+  status: "idle" | "loading" | "ready" | "error";
+  hasData: boolean;
+  emptyLabel?: string;
+  onRetry: () => void;
+  children: ReactNode;
+};
+
+const Status = ({ children }: { children: ReactNode }) => (
+  <div role="status" className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
+    {children}
+  </div>
+);
+
+const ErrorNotice = ({ hasData, onRetry }: Pick<RemoteReadBoundaryProps, "hasData" | "onRetry">) => (
+  <div
+    role="alert"
+    className="mb-4 flex items-center justify-between gap-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+  >
+    <span>{hasData ? "Sync interrupted. Showing current data." : "Unable to load data."}</span>
+    <Button small onClick={onRetry}>
+      Retry
+    </Button>
+  </div>
+);
+
+export const RemoteReadBoundary = (props: RemoteReadBoundaryProps) => {
+  if (props.status === "loading" && !props.hasData) return <Status>Loading…</Status>;
+  if (props.status === "error" && !props.hasData) {
+    return <ErrorNotice hasData={false} onRetry={props.onRetry} />;
+  }
+  if (props.status === "ready" && !props.hasData) return <Status>{props.emptyLabel ?? "No data yet."}</Status>;
+
+  return (
+    <>
+      {props.status === "error" && <ErrorNotice hasData onRetry={props.onRetry} />}
+      {props.children}
+    </>
+  );
+};

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -3,6 +3,7 @@ export * from "@/shared/components/content/Card";
 export * from "@/shared/components/content/Code";
 export * from "@/shared/components/content/Description";
 export * from "@/shared/components/feedback/Feedback";
+export * from "@/shared/components/feedback/RemoteReadBoundary";
 export * from "@/shared/components/feedback/buttonInteraction";
 export * from "@/shared/components/forms/Form";
 export * from "@/shared/components/forms/FormItem";

--- a/src/store/reducer.spec.ts
+++ b/src/store/reducer.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/action", () => ({
+  deck: {
+    prepare: vi.fn((value: Partial<Deck>, config: DeckConfig) => ({ ...value, ...config, id: "sample-deck" })),
+  },
+  card: {
+    prepare: vi.fn((value: Partial<Card>, valueDeck: Deck) => ({
+      ...value,
+      id: value.uniqueKey ?? "sample-card",
+      deckId: valueDeck.id,
+      uid: valueDeck.uid,
+    })),
+  },
+}));
+
+import * as type from "@/action/type";
+import { card, deck } from "@/store/reducer";
+import { createCard, createDeck } from "@/test/factories";
+
+describe("remote Redux mirrors", () => {
+  it("replaces remote Decks while preserving local Decks and local ID collisions", () => {
+    const local = createDeck({ id: "local", name: "Local", category: "local-category", localMode: true });
+    const staleRemote = createDeck({ id: "stale", name: "Stale", localMode: false });
+    const remoteCollision = createDeck({ id: "local", name: "Remote collision", localMode: false });
+    const freshRemote = createDeck({ id: "fresh", name: "Fresh", category: "remote-category", localMode: false });
+    const state: DeckState = {
+      byId: { [local.id]: local, [staleRemote.id]: staleRemote },
+      categories: ["stale-category"],
+    };
+
+    const result = deck(state, type.remoteDeckReplace([remoteCollision, freshRemote]));
+
+    expect(result.byId).toEqual({ local, fresh: freshRemote });
+    expect(result.categories).toEqual(["local-category", "remote-category"]);
+  });
+
+  it("removes every stale remote Deck when the replacement is empty", () => {
+    const local = createDeck({ id: "local", localMode: true });
+    const remote = createDeck({ id: "remote", localMode: false });
+
+    const result = deck({ byId: { local, remote }, categories: ["stale"] }, type.remoteDeckReplace([]));
+
+    expect(result).toEqual({ byId: { local }, categories: [] });
+  });
+
+  it("replaces remote Cards while preserving Cards in local Decks and local ID collisions", () => {
+    const local = createCard({ id: "local", deckId: "local-deck", frontText: "Local", tags: ["local-tag"] });
+    const staleRemote = createCard({ id: "stale", deckId: "remote-deck" });
+    const remoteCollision = createCard({ id: "local", deckId: "remote-deck", frontText: "Remote collision" });
+    const freshRemote = createCard({ id: "fresh", deckId: "remote-deck", tags: ["remote-tag"] });
+    const state: CardState = {
+      byId: { [local.id]: local, [staleRemote.id]: staleRemote },
+      tags: ["stale-tag"],
+    };
+
+    const result = card(state, type.remoteCardReplace([remoteCollision, freshRemote], ["local-deck"]));
+
+    expect(result.byId).toEqual({ local, fresh: freshRemote });
+    expect(result.tags).toEqual(["local-tag", "remote-tag"]);
+  });
+
+  it("removes every stale remote Card when the replacement is empty", () => {
+    const local = createCard({ id: "local", deckId: "local-deck" });
+    const remote = createCard({ id: "remote", deckId: "remote-deck" });
+
+    const result = card({ byId: { local, remote }, tags: ["stale"] }, type.remoteCardReplace([], ["local-deck"]));
+
+    expect(result).toEqual({ byId: { local }, tags: [] });
+  });
+});

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -60,6 +60,24 @@ export const deck = (state = deckInitialState, action: Action) => {
       delete state.byId[id];
     });
     return { ...state };
+  } else if (equal(action, type.remoteDeckReplace)) {
+    const byId = {} as DeckState["byId"];
+    Object.values(state.byId)
+      .filter(util.isDefined)
+      .filter((item) => item.localMode)
+      .forEach((item) => {
+        byId[item.id] = item;
+      });
+    action.payload.decks.forEach((item) => {
+      if (byId[item.id] == null) byId[item.id] = item;
+    });
+    const categories = uniq(
+      Object.values(byId)
+        .filter(util.isDefined)
+        .map((item) => item.category)
+        .filter((category) => !!category)
+    );
+    return { byId, categories };
   } else {
     return state;
   }
@@ -105,6 +123,24 @@ export const card = (state = cardInitialState, action: Action) => {
         if (ids.includes(c.deckId)) delete state.byId[c.id];
       });
     return { ...state };
+  } else if (equal(action, type.remoteCardReplace)) {
+    const localDeckIds = new Set(action.payload.localDeckIds);
+    const byId = {} as CardState["byId"];
+    Object.values(state.byId)
+      .filter(util.isDefined)
+      .filter((item) => localDeckIds.has(item.deckId))
+      .forEach((item) => {
+        byId[item.id] = item;
+      });
+    action.payload.cards.forEach((item) => {
+      if (byId[item.id] == null) byId[item.id] = item;
+    });
+    const tags = uniq(
+      Object.values(byId)
+        .filter(util.isDefined)
+        .flatMap((item) => item.tags)
+    );
+    return { byId, tags };
   } else {
     return state;
   }


### PR DESCRIPTION
## Summary
- add UID-scoped Firestore reads and full-replacement realtime adapters
- orchestrate Query cache updates, Redux mirrors, reconnect recovery, and auth lifecycle cleanup
- compose local and remote Deck/Card data for feature consumers with loading, empty, error, and retry feedback
- cover scoped reads, stale mirror replacement, reloads, and consumer behavior with unit, integration, and browser tests

## Testing
- `make check`
- `make test-firestore`
- `make e2e`

Parent: #257
Closes #259