### PR TITLE
Migrate Card writes and study swipes to Query mutations

### DIFF
--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -39,6 +39,14 @@ const setDocument = async (collection: "deck" | "card", id: string, fields: obje
   if (!response.ok) throw new Error(`Firestore seed failed: ${response.status} ${await response.text()}`);
 };
 
+const getDocument = async (collection: "deck" | "card", id: string) => {
+  const response = await fetch(`${firestoreBase}/${collection}/${id}`, {
+    headers: { Authorization: "Bearer owner" },
+  });
+  if (!response.ok) throw new Error(`Firestore read failed: ${response.status} ${await response.text()}`);
+  return (await response.json()) as { fields: Record<string, { stringValue?: string }> };
+};
+
 const deckFields = (uid: string, name: string) => ({
   uid: field.string(uid),
   name: field.string(name),
@@ -157,9 +165,18 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
   await page.getByText("Remote Query Deck").click();
   await expect(page.getByText("Remote Query Card")).toBeVisible();
 
+  await page.goto("/card/remote-read-card/edit");
+  const frontText = page.locator("textarea[name='frontText']");
+  await frontText.fill("Updated Remote Query Card");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("Updated Remote Query Card")).toBeVisible();
+  await expect
+    .poll(async () => (await getDocument("card", "remote-read-card")).fields.frontText?.stringValue)
+    .toBe("Updated Remote Query Card");
+
   await page.reload();
 
-  await expect(page.getByText("Remote Query Card")).toBeVisible();
+  await expect(page.getByText("Updated Remote Query Card")).toBeVisible();
 });
 
 test("an empty initial snapshot removes a stale Redux remote mirror", async ({ page }) => {

--- a/src/action/card.spec.ts
+++ b/src/action/card.spec.ts
@@ -2,7 +2,6 @@ import { expect, it, describe, vi, beforeEach } from "vitest";
 
 import * as card from "@/action/card";
 import * as action from "@/action";
-import * as firestore from "@/action/firestore";
 import { createCard } from "@/test/factories";
 
 vi.mock("./firestore");
@@ -38,31 +37,6 @@ describe("card action", () => {
     it("should be empty", async () => {
       const c = createCard({ frontText: "", backText: "", tags: [], uniqueKey: "" });
       expect(card.toRow(c)).toEqual(["", "", "", ""]);
-    });
-  });
-
-  describe("update", () => {
-    it("should update", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      getState.mockReturnValue({ deck: { byId: { deckId: {} } } });
-
-      const c = { id: "id", deckId: "deckId" } as Card;
-      const f = card.update(c);
-      await f(dispatch, getState, undefined);
-      expect(firestore.card.update).lastCalledWith(c);
-    });
-  });
-
-  describe("remove", () => {
-    it("should remove", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      const [id, deckId] = ["id", "deckId"];
-      const c = { id, deckId } as Card;
-      getState.mockReturnValue({ card: { byId: { id: c } }, deck: { byId: { deckId: {} } } });
-
-      const f = card.remove(id);
-      await f(dispatch, getState, undefined);
-      expect(firestore.card.logicalRemove).lastCalledWith(id);
     });
   });
 

--- a/src/action/card.ts
+++ b/src/action/card.ts
@@ -42,29 +42,11 @@ export const bulkCreate =
       cards.map(async (card) => {
         const c = prepare(card, deck);
         if (!deck.localMode) {
-          void firestore.card.create(c);
+          await firestore.card.create(c);
         }
         await dispatch(action.type.cardInsert(c));
       })
     );
-  };
-
-export const update =
-  (card: CardEdit): ThunkResult =>
-  async (dispatch, getState) => {
-    const deck = selector.deck.getById(card.deckId)(getState());
-    if (!deck.localMode) {
-      void firestore.card.update(card);
-    }
-    await dispatch(action.type.cardUpdate(card));
-  };
-
-export const updateBy =
-  (cardId: CardId, callback: (c: Card) => Partial<Card>): ThunkResult =>
-  async (dispatch, getState) => {
-    const prev = selector.card.getById(cardId)(getState());
-    const card = { ...prev, ...callback(prev) };
-    await dispatch(update(card));
   };
 
 export const bulkUpdate =
@@ -75,20 +57,10 @@ export const bulkUpdate =
         await dispatch(action.type.cardUpdate(c));
         const deck = selector.deck.getById(c.deckId)(getState());
         if (!deck.localMode) {
-          void firestore.card.update(c);
+          await firestore.card.update(c);
         }
       })
     );
-  };
-
-export const remove =
-  (id: string): ThunkResult =>
-  async (dispatch, getState) => {
-    const deck = selector.deck.getByCardId(id)(getState());
-    if (!deck.localMode) {
-      void firestore.card.logicalRemove(id);
-    }
-    await dispatch(action.type.cardDelete(id));
   };
 
 export const filterCardsForUpdate = (cards: CardEdit[], state: CardState): Card[] => {

--- a/src/action/firestore/card.spec.ts
+++ b/src/action/firestore/card.spec.ts
@@ -80,6 +80,15 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
     expect((await getDoc(doc(db, "card", c.id))).data()).toEqual(n);
   });
 
+  it("should upsert a complete card", async () => {
+    const deckId = await initDeck();
+    const c = { ...newCard, deckId, id: uuid(), frontText: "upserted" };
+
+    await firestore.card.upsert(c);
+
+    expect((await getDoc(doc(db, "card", c.id))).data()).toEqual(c);
+  });
+
   it("should logical-remove a card", async () => {
     const deckId = await initDeck();
     const c = { ...newCard, deckId, id: uuid() };

--- a/src/action/firestore/card.ts
+++ b/src/action/firestore/card.ts
@@ -32,6 +32,14 @@ export const create = async (card: Card, createdAt?: number): Promise<string> =>
   return card.id;
 };
 
+export const upsert = async (card: Card): Promise<string> => {
+  const timestamp = getTimestamp();
+  const createdAt = card.createdAt > 0 ? card.createdAt : timestamp;
+  const ref = doc(db, "card", card.id);
+  await setDoc(ref, { ...buildCardCreateDto(card, createdAt), updatedAt: timestamp });
+  return card.id;
+};
+
 export const update = async (card: CardEdit) => {
   const ref = doc(db, "card", card.id);
   await updateDoc(ref, buildCardUpdateDto(card, getTimestamp()));

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -5,6 +5,7 @@ import { Card as Outline, Description, Score, Tag, Title } from "@/shared/compon
 import { useSwipeable } from "react-swipeable";
 
 export interface CardActionsProps {
+  disabled?: boolean;
   onSwipedLeft?: (id: string) => void;
   onSwipedRight?: (id: string) => void;
   onDelete?: (id: string) => void;
@@ -24,19 +25,19 @@ export const Card: React.FC<
 > = (props) => {
   const id = props.card.id;
   const goToView = React.useCallback(() => {
-    props.goToView?.(id);
+    if (!props.disabled) props.goToView?.(id);
   }, [id, props]);
   const goToEdit = React.useCallback(() => {
-    props.goToEdit?.(id);
+    if (!props.disabled) props.goToEdit?.(id);
   }, [id, props]);
   const onDelete = React.useCallback(() => {
-    props.onDelete?.(id);
+    if (!props.disabled) props.onDelete?.(id);
   }, [id, props]);
   const onSwipedLeft = React.useCallback(() => {
-    props.onSwipedLeft?.(id);
+    if (!props.disabled) props.onSwipedLeft?.(id);
   }, [id, props]);
   const onSwipedRight = React.useCallback(() => {
-    props.onSwipedRight?.(id);
+    if (!props.disabled) props.onSwipedRight?.(id);
   }, [id, props]);
   const handlers = useSwipeable({
     onSwipedLeft,
@@ -46,12 +47,7 @@ export const Card: React.FC<
   return (
     <div {...handlers}>
       <IconContext.Provider value={{ className: "dark:text-gray-200 text-2xl" }}>
-        <Outline
-          full
-          border
-          className="px-4 py-2"
-          {...(props.filtered !== undefined ? { disabled: props.filtered } : {})}
-        >
+        <Outline full border className="px-4 py-2" disabled={Boolean(props.filtered || props.disabled)}>
           <div className="flex items-center whitespace-nowrap gap-1">
             <Score className="mr-1 shrink-0" score={props.card.score} />
             <Description>studied {props.card.numberOfSeen ?? 0} time(s)</Description>

--- a/src/features/card/components/templates/CardFormTemplate.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.tsx
@@ -5,11 +5,13 @@ import { CardForm, type CardFormProps } from "@/features/card/components/CardFor
 export interface CardFormTemplateProps {
   layout?: LayoutProps;
   cardForm?: CardFormProps;
+  feedbackSlot?: React.ReactNode;
 }
 
 export const CardFormTemplate: React.FC<CardFormTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
+      {props.feedbackSlot}
       {props.cardForm != null && <CardForm {...props.cardForm} />}
     </Layout>
   );

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -16,11 +16,14 @@ export interface CardListTemplateProps {
   card?: CardProps;
   overlay?: CardListOverlayProps;
   onShowCard?: (card: Card) => void;
+  feedbackSlot?: React.ReactNode;
+  isCardPending?: (id: CardId) => boolean;
 }
 
 export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
+      {props.feedbackSlot}
       {props.overlay != null && (
         <Overlay
           position="center"
@@ -40,6 +43,7 @@ export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
           <Card
             key={c.id}
             card={c}
+            disabled={props.isCardPending?.(c.id) ?? false}
             {...(props.card?.onSwipedLeft !== undefined ? { onSwipedLeft: props.card.onSwipedLeft } : {})}
             {...(props.card?.onSwipedRight !== undefined ? { onSwipedRight: props.card.onSwipedRight } : {})}
             {...(props.card?.onDelete !== undefined ? { onDelete: props.card.onDelete } : {})}

--- a/src/features/card/containers/CardFormContainer.spec.tsx
+++ b/src/features/card/containers/CardFormContainer.spec.tsx
@@ -6,7 +6,8 @@ import "@testing-library/jest-dom/vitest";
 const mocks = vi.hoisted(() => ({
   params: { id: "card-id" as string | undefined },
   state: null as RootState | null,
-  cardUpdateAndBack: vi.fn(),
+  cardUpdate: vi.fn(),
+  navigate: vi.fn(),
 }));
 
 vi.mock("react-redux", () => ({
@@ -26,11 +27,20 @@ vi.mock("@/query/useRemoteCollections", () => ({
 
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/features/card/hooks/useCardMutations", () => ({
+  useCardMutations: () => ({
+    update: mocks.cardUpdate,
+    pending: false,
+    error: null,
+    retry: vi.fn(),
+  }),
 }));
 
 vi.mock("@/shared/hooks/useActions", () => ({
   useActions: () => ({
-    cardUpdateAndBack: mocks.cardUpdateAndBack,
     goToTop: vi.fn(),
     goByMenu: vi.fn(),
     setDarkMode: vi.fn(),
@@ -63,7 +73,9 @@ describe("CardFormContainer", () => {
       config: { darkMode: false } as ConfigState,
       card: { byId: { [card.id]: card }, tags: [] },
     };
-    mocks.cardUpdateAndBack.mockReset();
+    mocks.cardUpdate.mockReset();
+    mocks.cardUpdate.mockResolvedValue(undefined);
+    mocks.navigate.mockReset();
   });
 
   afterEach(() => {
@@ -75,7 +87,8 @@ describe("CardFormContainer", () => {
 
     await userEvent.click(view.getByRole("button", { name: /save/i }));
 
-    expect(mocks.cardUpdateAndBack).toHaveBeenCalledWith(card);
+    expect(mocks.cardUpdate).toHaveBeenCalledWith(card);
+    expect(mocks.navigate).toHaveBeenCalledWith(-1);
   });
 
   it("submits edited front and back text", async () => {
@@ -89,7 +102,7 @@ describe("CardFormContainer", () => {
     await userEvent.type(backText, "UPDATED BACK");
     await userEvent.click(view.getByRole("button", { name: /save/i }));
 
-    expect(mocks.cardUpdateAndBack).toHaveBeenCalledWith({
+    expect(mocks.cardUpdate).toHaveBeenCalledWith({
       ...card,
       frontText: "UPDATED FRONT",
       backText: "UPDATED BACK",
@@ -102,7 +115,17 @@ describe("CardFormContainer", () => {
     await userEvent.click(view.container.querySelector("input[name='tags'][value='math']") as Element);
     await userEvent.click(view.getByRole("button", { name: /save/i }));
 
-    expect(mocks.cardUpdateAndBack).toHaveBeenCalledWith({ ...card, tags: ["math"] });
+    expect(mocks.cardUpdate).toHaveBeenCalledWith({ ...card, tags: ["math"] });
+  });
+
+  it("does not navigate when the Card write fails", async () => {
+    mocks.cardUpdate.mockRejectedValueOnce(new Error("write failed"));
+    const view = render(<CardFormContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: /save/i }));
+
+    expect(mocks.cardUpdate).toHaveBeenCalledWith(card);
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it("preserves the invalid route error", () => {

--- a/src/features/card/containers/CardFormContainer.tsx
+++ b/src/features/card/containers/CardFormContainer.tsx
@@ -1,20 +1,34 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import * as C from "@/constant";
 import * as selector from "@/selector";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/shared/components";
+import { RemoteMutationNotice, RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { CardFormTemplate } from "@/features/card/components/templates/CardFormTemplate";
 import { useCardFormState } from "@/features/card/hooks/useCardFormState";
+import { useCardMutations } from "@/features/card/hooks/useCardMutations";
 
 const CardFormContent = ({ card }: { card: Card }) => {
   const config = useSelector(selector.config.get());
   const actions = useActions();
+  const navigate = useNavigate();
+  const mutations = useCardMutations();
   const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
-  const cardForm = useCardFormState({ card, categoryOptions, onSubmit: actions.cardUpdateAndBack });
+  const cardForm = useCardFormState({
+    card,
+    categoryOptions,
+    onSubmit: async (nextCard) => {
+      try {
+        await mutations.update(nextCard);
+        void navigate(-1);
+      } catch {
+        // The mutation notice owns error feedback and retry.
+      }
+    },
+  });
 
   return (
     <CardFormTemplate
@@ -26,6 +40,9 @@ const CardFormContent = ({ card }: { card: Card }) => {
           onClickMenuItem: actions.goByMenu,
         },
       }}
+      feedbackSlot={
+        <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+      }
       cardForm={cardForm}
     />
   );

--- a/src/features/card/containers/CardListContainer.spec.tsx
+++ b/src/features/card/containers/CardListContainer.spec.tsx
@@ -6,6 +6,19 @@ import "@testing-library/jest-dom/vitest";
 const mocks = vi.hoisted(() => ({
   params: { id: "deck-id" as string | undefined },
   state: null as RootState | null,
+  cardUpdateBy: vi.fn(),
+  cardRemove: vi.fn(),
+}));
+
+vi.mock("@/features/card/hooks/useCardMutations", () => ({
+  useCardMutations: () => ({
+    updateBy: mocks.cardUpdateBy,
+    remove: mocks.cardRemove,
+    isPending: () => false,
+    pending: false,
+    error: null,
+    retry: vi.fn(),
+  }),
 }));
 
 vi.mock("react-redux", () => ({

--- a/src/features/card/containers/CardListContainer.tsx
+++ b/src/features/card/containers/CardListContainer.tsx
@@ -7,18 +7,20 @@ import * as C from "@/constant";
 import * as selector from "@/selector";
 import * as util from "@/util";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/shared/components";
+import { RemoteMutationNotice, RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { CardListTemplate } from "@/features/card/components/templates/CardListTemplate";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
+import { useCardMutations } from "@/features/card/hooks/useCardMutations";
 
 const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; config: ConfigState }) => {
   const { deck, cards, tags, config } = props;
   const deckId = deck.id;
   const [showCard, setShowCard] = React.useState<Card>();
   const actions = useActions();
+  const mutations = useCardMutations();
   const deckActions = useDeckActions(deckId);
   const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
   const closeCard = React.useCallback(() => setShowCard(undefined), []);
@@ -40,11 +42,18 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
         },
       }}
       card={{
-        onSwipedLeft: actions.cardUpdateBy((card) => ({ score: card.score - 1 })),
-        onSwipedRight: actions.cardUpdateBy((card) => ({ score: card.score + 1 })),
+        onSwipedLeft: (id) => void mutations.updateBy(id, (card) => ({ score: card.score - 1 })).catch(() => undefined),
+        onSwipedRight: (id) =>
+          void mutations.updateBy(id, (card) => ({ score: card.score + 1 })).catch(() => undefined),
         goToEdit: actions.goToCardEdit,
-        onDelete: actions.cardRemove,
+        onDelete: (id) => {
+          if (window.confirm("Are you sure?")) void mutations.remove(id).catch(() => undefined);
+        },
       }}
+      feedbackSlot={
+        <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+      }
+      isCardPending={mutations.isPending}
       {...(showCard != null && category != null
         ? {
             overlay: {

--- a/src/features/card/hooks/useCardFormState.ts
+++ b/src/features/card/hooks/useCardFormState.ts
@@ -7,7 +7,7 @@ import type { CardFormProps } from "@/features/card/components/CardForm";
 export interface UseCardFormStateOptions {
   card: Card;
   categoryOptions: Option[];
-  onSubmit?: (card: Card) => void;
+  onSubmit?: (card: Card) => void | Promise<void>;
 }
 
 export const useCardFormState = ({ card, categoryOptions, onSubmit }: UseCardFormStateOptions): CardFormProps => {

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as type from "@/action/type";
+import { firestoreKeys } from "@/query/firestoreKeys";
+import { createTestQueryClient, createQueryWrapper } from "@/query/testUtils";
+import { createCard, createDeck } from "@/test/factories";
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  deck: null as Deck | null,
+  card: null as Card | null,
+  create: vi.fn(),
+  update: vi.fn(),
+  logicalRemove: vi.fn(),
+  upsert: vi.fn(),
+  readAll: vi.fn(),
+}));
+
+vi.mock("react-redux", () => ({ useDispatch: () => mocks.dispatch }));
+vi.mock("@/auth/AuthContext", () => ({
+  useAuth: () => ({ status: "authenticated", uid: "uid-a", user: { uid: "uid-a" } }),
+}));
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => ({
+    deckById: () => mocks.deck,
+    cardById: () => mocks.card,
+  }),
+}));
+vi.mock("@/action/firestore", () => ({
+  card: {
+    create: mocks.create,
+    update: mocks.update,
+    logicalRemove: mocks.logicalRemove,
+    upsert: mocks.upsert,
+    readAll: mocks.readAll,
+  },
+}));
+
+import { useCardMutations } from "@/features/card/hooks/useCardMutations";
+
+describe("useCardMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.update.mockResolvedValue(undefined);
+    mocks.readAll.mockResolvedValue([]);
+  });
+
+  it("updates localMode Cards only through Redux", async () => {
+    mocks.deck = createDeck({ localMode: true });
+    mocks.card = createCard({ deckId: mocks.deck.id });
+    const client = createTestQueryClient();
+    const { result } = renderHook(useCardMutations, { wrapper: createQueryWrapper(client) });
+
+    await act(async () => result.current.update(mocks.card as Card));
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(type.cardUpdate(mocks.card));
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("awaits remote writes and keeps them out of Redux", async () => {
+    mocks.deck = createDeck({ localMode: false });
+    mocks.card = createCard({ deckId: mocks.deck.id, score: 0 });
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.cards("uid-a"), { [mocks.card.id]: mocks.card });
+    const { result } = renderHook(useCardMutations, { wrapper: createQueryWrapper(client) });
+
+    await act(async () => result.current.update({ ...mocks.card, score: 1 } as Card));
+
+    expect(mocks.update).toHaveBeenCalledWith({ ...mocks.card, score: 1 });
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(client.getQueryData(firestoreKeys.cards("uid-a"))).toEqual({
+      [mocks.card.id]: { ...mocks.card, score: 1 },
+    });
+  });
+});

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -1,0 +1,133 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+
+import * as type from "@/action/type";
+import * as firestore from "@/action/firestore";
+import { useAuth } from "@/auth/AuthContext";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { createCardMutationService } from "@/query/cardMutationService";
+
+type CardMutationVariables =
+  | { kind: "create"; card: Card; local: boolean }
+  | { kind: "update"; card: CardEdit; local: boolean }
+  | { kind: "remove"; id: CardId; local: boolean }
+  | { kind: "bulkUpsert"; cards: Card[]; localIds: CardId[] };
+
+const variableIds = (variables: CardMutationVariables): CardId[] => {
+  if (variables.kind === "remove") return [variables.id];
+  if (variables.kind === "bulkUpsert") return variables.cards.map((card) => card.id);
+  return [variables.card.id];
+};
+
+export const useCardMutations = () => {
+  const auth = useAuth();
+  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const dispatch = useDispatch();
+  const client = useQueryClient();
+  const remote = useRemoteCollections();
+  const [, renderPending] = useState(0);
+  const pendingCounts = useRef(new Map<CardId, number>());
+  const lastFailed = useRef<CardMutationVariables>();
+  const service = useMemo(
+    () =>
+      createCardMutationService({
+        client,
+        createCard: firestore.card.create,
+        updateCard: firestore.card.update,
+        removeCard: firestore.card.logicalRemove,
+        upsertCard: firestore.card.upsert,
+        readCards: firestore.card.readAll,
+      }),
+    [client]
+  );
+
+  const mutation = useMutation({
+    retry: false,
+    mutationFn: async (variables: CardMutationVariables) => {
+      if (variables.kind === "create") {
+        if (variables.local) dispatch(type.cardInsert(variables.card));
+        else await service.create(uid, variables.card);
+      } else if (variables.kind === "update") {
+        if (variables.local) dispatch(type.cardUpdate(variables.card));
+        else await service.update(uid, variables.card);
+      } else if (variables.kind === "remove") {
+        if (variables.local) dispatch(type.cardDelete(variables.id));
+        else await service.remove(uid, variables.id);
+      } else {
+        const localIds = new Set(variables.localIds);
+        const localCards = variables.cards.filter((card) => localIds.has(card.id));
+        const remoteCards = variables.cards.filter((card) => !localIds.has(card.id));
+        if (localCards.length > 0) dispatch(type.cardBulkInsert(localCards));
+        if (remoteCards.length > 0) await service.bulkUpsert(uid, remoteCards);
+      }
+    },
+  });
+
+  const run = useCallback(
+    async (variables: CardMutationVariables) => {
+      const ids = variableIds(variables);
+      ids.forEach((id) => {
+        pendingCounts.current.set(id, (pendingCounts.current.get(id) ?? 0) + 1);
+      });
+      renderPending((value) => value + 1);
+      try {
+        await mutation.mutateAsync(variables);
+        lastFailed.current = undefined;
+      } catch (error) {
+        lastFailed.current = variables;
+        throw error;
+      } finally {
+        ids.forEach((id) => {
+          const count = (pendingCounts.current.get(id) ?? 1) - 1;
+          if (count === 0) pendingCounts.current.delete(id);
+          else pendingCounts.current.set(id, count);
+        });
+        renderPending((value) => value + 1);
+      }
+    },
+    [mutation]
+  );
+
+  const isLocal = useCallback(
+    (deckId: DeckId) => {
+      const deck = remote.deckById(deckId);
+      if (deck == null) throw new Error(`Deck ${deckId} is not available`);
+      return deck.localMode;
+    },
+    [remote]
+  );
+
+  const update = useCallback(
+    (card: CardEdit) => run({ kind: "update", card, local: isLocal(card.deckId) }),
+    [isLocal, run]
+  );
+
+  return {
+    create: (card: Card) => run({ kind: "create", card, local: isLocal(card.deckId) }),
+    update,
+    updateBy: (id: CardId, callback: (card: Card) => Partial<Card>) => {
+      const card = remote.cardById(id);
+      if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
+      return update({ ...card, ...callback(card) });
+    },
+    remove: (id: CardId) => {
+      const card = remote.cardById(id);
+      if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
+      return run({ kind: "remove", id, local: isLocal(card.deckId) });
+    },
+    bulkUpsert: (cards: Card[]) =>
+      run({
+        kind: "bulkUpsert",
+        cards,
+        localIds: cards.filter((card) => isLocal(card.deckId)).map((card) => card.id),
+      }),
+    isPending: (id: CardId) => pendingCounts.current.has(id),
+    pending: pendingCounts.current.size > 0,
+    error: mutation.error,
+    retry: () => {
+      const variables = lastFailed.current;
+      if (variables != null) void run(variables).catch(() => undefined);
+    },
+  };
+};

--- a/src/features/study/components/SwipeButtonList.tsx
+++ b/src/features/study/components/SwipeButtonList.tsx
@@ -16,6 +16,7 @@ const labels = {
 };
 
 export interface SwipeButtonListProps {
+  disabled?: boolean;
   onClickUp?: () => void;
   onClickDown?: () => void;
   onClickLeft?: () => void;
@@ -31,6 +32,7 @@ export const SwipeButtonList: React.FC<SwipeButtonListProps> = (props) => {
           aria-label={labels[d]}
           key={d}
           className="flex-1 items-center content-center hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
+          disabled={props.disabled}
           onClick={() => {
             if (d === "cardSwipeUp") {
               props.onClickUp?.();

--- a/src/features/study/components/templates/DeckSwiperTemplate.tsx
+++ b/src/features/study/components/templates/DeckSwiperTemplate.tsx
@@ -17,6 +17,7 @@ export interface DeckSwiperTemplateProps {
   swipeOverlay?: SwipeButtonListProps;
   controller?: ControllerProps;
   swipeButtonList?: SwipeButtonListProps;
+  feedbackSlot?: React.ReactNode;
 }
 
 export const DeckSwiperTemplate: React.FC<DeckSwiperTemplateProps> = (props) => {
@@ -27,6 +28,7 @@ export const DeckSwiperTemplate: React.FC<DeckSwiperTemplateProps> = (props) => 
       {...(props.showBackText !== undefined ? { scroll: props.showBackText } : {})}
       {...props.layout}
     >
+      {props.feedbackSlot}
       {props.showBackText && props.backTextSlot != null ? (
         <>
           <Shared.Overlay

--- a/src/features/study/containers/DeckSwiperContainer.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.tsx
@@ -7,7 +7,7 @@ import * as C from "@/constant";
 import * as selector from "@/selector";
 import * as util from "@/util";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/shared/components";
+import { RemoteMutationNotice, RemoteReadBoundary } from "@/shared/components";
 import { BackText } from "@/features/card/components/BackText";
 import { CardOverlay } from "@/features/card/components/CardOverlay";
 import { FrontText } from "@/features/card/components/FrontText";
@@ -100,10 +100,15 @@ export const DeckSwiperContainer: React.FC = () => {
 
   const category = util.getCategory(deck.category, card.tags);
   const swipeActions: SwipeButtonListProps = {
-    onClickUp: studyActions.swipeUp,
-    onClickDown: studyActions.swipeDown,
-    onClickLeft: studyActions.swipeLeft,
-    onClickRight: studyActions.swipeRight,
+    disabled: studyActions.pending,
+    ...(studyActions.pending
+      ? {}
+      : {
+          onClickUp: studyActions.swipeUp,
+          onClickDown: studyActions.swipeDown,
+          onClickLeft: studyActions.swipeLeft,
+          onClickRight: studyActions.swipeRight,
+        }),
   };
 
   return (
@@ -120,14 +125,21 @@ export const DeckSwiperContainer: React.FC = () => {
           onClickMenuItem: actions.goByMenu,
         },
       }}
+      feedbackSlot={
+        <RemoteMutationNotice pending={studyActions.pending} error={studyActions.error} onRetry={studyActions.retry} />
+      }
       frontTextSlot={
         <FrontText
           {...(category !== undefined ? { category } : {})}
           text={card.frontText}
-          onSwipeUp={studyActions.swipeUp}
-          onSwipeDown={studyActions.swipeDown}
-          onSwipeLeft={studyActions.swipeLeft}
-          onSwipeRight={studyActions.swipeRight}
+          {...(!studyActions.pending
+            ? {
+                onSwipeUp: studyActions.swipeUp,
+                onSwipeDown: studyActions.swipeDown,
+                onSwipeLeft: studyActions.swipeLeft,
+                onSwipeRight: studyActions.swipeRight,
+              }
+            : {})}
           onClick={studyActions.toggleShowBackText}
         />
       }

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   cardUpdate: vi.fn(),
   deckUpdate: vi.fn(),
   configUpdate: vi.fn(),
+  pendingIds: new Set<CardId>(),
 }));
 
 vi.mock("react-redux", () => ({
@@ -34,6 +35,16 @@ vi.mock("@/query/useRemoteCollections", () => ({
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/features/card/hooks/useCardMutations", () => ({
+  useCardMutations: () => ({
+    update: mocks.cardUpdate,
+    isPending: (id: CardId) => mocks.pendingIds.has(id),
+    pending: false,
+    error: null,
+    retry: vi.fn(),
+  }),
 }));
 
 vi.mock("@/action", () => ({
@@ -103,7 +114,8 @@ describe("useStudyActions", () => {
     vi.clearAllMocks();
     vi.spyOn(Date, "now").mockReturnValue(946684800000);
     mocks.dispatch.mockResolvedValue(undefined);
-    mocks.cardUpdate.mockImplementation((patch) => ({ type: "CARD_UPDATE", payload: patch }));
+    mocks.cardUpdate.mockResolvedValue(undefined);
+    mocks.pendingIds.clear();
     mocks.state = createRootState();
     studyStore.setState({
       session: null,
@@ -218,7 +230,7 @@ describe("useStudyActions", () => {
       lastSeenAt: 946684800000,
     };
     expect(mocks.cardUpdate).toHaveBeenCalledWith(patch);
-    expect(mocks.dispatch).toHaveBeenCalledWith({ type: "CARD_UPDATE", payload: patch });
+    expect(mocks.dispatch).not.toHaveBeenCalled();
     expect(studyStore.getState()).toMatchObject({
       session: {
         deckId: deck.id,
@@ -230,6 +242,36 @@ describe("useStudyActions", () => {
     });
     expect(mocks.deckUpdate).not.toHaveBeenCalled();
     expect(mocks.configUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rolls the optimistic study index back when the Card write fails", async () => {
+    studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
+    studyStore.setState({ showBackText: true });
+    mocks.cardUpdate.mockRejectedValueOnce(new Error("write failed"));
+    const { result } = renderHook(() => useStudyActions(deck.id));
+
+    await act(async () => {
+      await result.current.swipeRight();
+    });
+
+    expect(studyStore.getState()).toMatchObject({
+      session: { currentIndex: 0 },
+      showBackText: true,
+      lastSwipe: undefined,
+    });
+  });
+
+  it("blocks another swipe while the target Card is pending", async () => {
+    studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
+    mocks.pendingIds.add(card1.id);
+    const { result } = renderHook(() => useStudyActions(deck.id));
+
+    await act(async () => {
+      await result.current.swipeRight();
+    });
+
+    expect(mocks.cardUpdate).not.toHaveBeenCalled();
+    expect(studyStore.getState().session?.currentIndex).toBe(0);
   });
 
   it("keeps back text visible when the long-lived config allows it", async () => {

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -1,13 +1,13 @@
 import React from "react";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import * as action from "@/action";
 import * as selector from "@/selector";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
 import { studyStore } from "@/features/study/state/studyStore";
 import { buildStudyPatch, buildStudySession, calculateNextIndex, resolveSwipeAction } from "@/lib/study";
+import { useCardMutations } from "@/features/card/hooks/useCardMutations";
 
 export interface StudyActions {
   start: () => void;
@@ -19,15 +19,18 @@ export interface StudyActions {
   toggleShowBackText: () => void;
   toggleAutoPlay: () => void;
   resetStudy: () => void;
+  pending: boolean;
+  error: unknown;
+  retry: () => void;
 }
 
 export const useStudyActions = (deckId: DeckId): StudyActions => {
-  const dispatch = useDispatch();
   const navigate = useNavigate();
   const config = useSelector(selector.config.get());
   const remote = useRemoteCollections();
   const cards = remote.filteredCardsByDeckId(deckId, config);
   const cardsById = remote.cardsById;
+  const cardMutations = useCardMutations();
 
   const start = React.useCallback(() => {
     const cardOrderIds = buildStudySession(cards, config);
@@ -54,7 +57,13 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
 
       const cardId = session.cardOrderIds[session.currentIndex];
       const card = cardId == null ? undefined : cardsById[cardId];
-      if (card == null) return;
+      if (card == null || cardMutations.isPending(card.id)) return;
+
+      const previous = {
+        session: { ...session },
+        showBackText: state.showBackText,
+        lastSwipe: state.lastSwipe,
+      };
 
       state.setLastSwipe(direction);
       if (config.hideBodyWhenCardChanged) {
@@ -62,14 +71,18 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
       }
 
       const patch = buildStudyPatch(card, swipeAction, Date.now());
-      await dispatch(action.card.update(patch));
-
-      const current = studyStore.getState();
-      if (current.session?.deckId === deckId) {
-        current.setCurrentIndex(calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction));
+      const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
+      state.setCurrentIndex(nextIndex);
+      try {
+        await cardMutations.update(patch);
+      } catch {
+        const current = studyStore.getState();
+        if (current.session?.deckId === deckId && current.session.currentIndex === nextIndex) {
+          studyStore.setState(previous);
+        }
       }
     },
-    [cardsById, config, deckId, dispatch]
+    [cardMutations, cardsById, config, deckId]
   );
 
   return React.useMemo(
@@ -88,7 +101,10 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
       toggleShowBackText: () => studyStore.getState().toggleShowBackText(),
       toggleAutoPlay: () => studyStore.getState().toggleAutoPlay(),
       resetStudy: () => studyStore.getState().resetStudy(),
+      pending: cardMutations.pending,
+      error: cardMutations.error,
+      retry: cardMutations.retry,
     }),
-    [deckId, start, swipe]
+    [cardMutations.error, cardMutations.pending, cardMutations.retry, deckId, start, swipe]
   );
 };

--- a/src/query/cardMutationService.spec.ts
+++ b/src/query/cardMutationService.spec.ts
@@ -58,11 +58,26 @@ describe("createCardMutationService", () => {
     dependencies.updateCard.mockRejectedValueOnce(new Error("write failed"));
     const service = createCardMutationService({ client, ...dependencies });
 
-    await expect(service.update(uid, { id: card.id, deckId: card.deckId, score: 2 })).rejects.toThrow(
-      "write failed"
-    );
+    await expect(service.update(uid, { id: card.id, deckId: card.deckId, score: 2 })).rejects.toThrow("write failed");
 
     expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ card, other });
+  });
+
+  it("does not let an old rollback overwrite a newer listener snapshot", async () => {
+    const card = createCard({ id: "card", score: 1 });
+    const write = deferred<void>();
+    dependencies.updateCard.mockReturnValueOnce(write.promise);
+    client.setQueryData(firestoreKeys.cards(uid), { card });
+    const service = createCardMutationService({ client, ...dependencies });
+
+    const update = service.update(uid, { id: card.id, deckId: card.deckId, score: 2 });
+    await vi.waitFor(() => expect(dependencies.updateCard).toHaveBeenCalled());
+    const listenerCard = { ...card, score: 3 };
+    client.setQueryData(firestoreKeys.cards(uid), { card: listenerCard });
+    write.reject(new Error("old write failed"));
+
+    await expect(update).rejects.toThrow("old write failed");
+    expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ card: listenerCard });
   });
 
   it("serializes the same Card while allowing different Cards to update concurrently", async () => {

--- a/src/query/cardMutationService.spec.ts
+++ b/src/query/cardMutationService.spec.ts
@@ -1,0 +1,113 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCardMutationService } from "@/query/cardMutationService";
+import { firestoreKeys } from "@/query/firestoreKeys";
+import { createCard } from "@/test/factories";
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("createCardMutationService", () => {
+  const uid = "uid-a";
+  let client: QueryClient;
+  const dependencies = {
+    createCard: vi.fn<(card: Card) => Promise<string>>(),
+    updateCard: vi.fn<(card: CardEdit) => Promise<void>>(),
+    removeCard: vi.fn<(id: CardId) => Promise<void>>(),
+    upsertCard: vi.fn<(card: Card) => Promise<string>>(),
+    readCards: vi.fn<(uid: string) => Promise<Card[]>>(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    dependencies.createCard.mockResolvedValue("created");
+    dependencies.updateCard.mockResolvedValue(undefined);
+    dependencies.removeCard.mockResolvedValue(undefined);
+    dependencies.upsertCard.mockResolvedValue("upserted");
+    dependencies.readCards.mockResolvedValue([]);
+  });
+
+  it("optimistically creates and removes only the target Card", async () => {
+    const existing = createCard({ id: "existing" });
+    const created = createCard({ id: "created" });
+    client.setQueryData(firestoreKeys.cards(uid), { existing });
+    const service = createCardMutationService({ client, ...dependencies });
+
+    await service.create(uid, created);
+    expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ existing, created });
+    expect(dependencies.createCard).toHaveBeenCalledWith(created);
+
+    await service.remove(uid, created.id);
+    expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ existing });
+    expect(dependencies.removeCard).toHaveBeenCalledWith(created.id);
+  });
+
+  it("rolls back only the failed target Card", async () => {
+    const card = createCard({ id: "card", score: 1 });
+    const other = createCard({ id: "other", score: 5 });
+    client.setQueryData(firestoreKeys.cards(uid), { card, other });
+    dependencies.updateCard.mockRejectedValueOnce(new Error("write failed"));
+    const service = createCardMutationService({ client, ...dependencies });
+
+    await expect(service.update(uid, { id: card.id, deckId: card.deckId, score: 2 })).rejects.toThrow(
+      "write failed"
+    );
+
+    expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ card, other });
+  });
+
+  it("serializes the same Card while allowing different Cards to update concurrently", async () => {
+    const cardA = createCard({ id: "a", score: 0 });
+    const cardB = createCard({ id: "b", score: 0 });
+    client.setQueryData(firestoreKeys.cards(uid), { a: cardA, b: cardB });
+    const first = deferred<void>();
+    dependencies.updateCard.mockImplementationOnce(() => first.promise).mockResolvedValue(undefined);
+    const service = createCardMutationService({ client, ...dependencies });
+
+    const updateA1 = service.update(uid, { id: "a", deckId: cardA.deckId, score: 1 });
+    const updateA2 = service.update(uid, { id: "a", deckId: cardA.deckId, score: 2 });
+    const updateB = service.update(uid, { id: "b", deckId: cardB.deckId, score: 3 });
+    await vi.waitFor(() => expect(dependencies.updateCard).toHaveBeenCalledTimes(2));
+    expect(dependencies.updateCard).toHaveBeenNthCalledWith(1, {
+      id: "a",
+      deckId: cardA.deckId,
+      score: 1,
+    });
+    expect(dependencies.updateCard).toHaveBeenNthCalledWith(2, {
+      id: "b",
+      deckId: cardB.deckId,
+      score: 3,
+    });
+
+    first.resolve();
+    await Promise.all([updateA1, updateA2, updateB]);
+    expect(dependencies.updateCard).toHaveBeenNthCalledWith(3, {
+      id: "a",
+      deckId: cardA.deckId,
+      score: 2,
+    });
+  });
+
+  it("authoritatively refetches after a partial bulk upsert failure", async () => {
+    const first = createCard({ id: "first" });
+    const second = createCard({ id: "second" });
+    dependencies.upsertCard.mockResolvedValueOnce(first.id).mockRejectedValueOnce(new Error("partial"));
+    const authoritative = createCard({ id: "authoritative" });
+    dependencies.readCards.mockResolvedValue([authoritative]);
+    const service = createCardMutationService({ client, ...dependencies });
+
+    await expect(service.bulkUpsert(uid, [first, second])).rejects.toThrow("1 of 2 Card writes failed");
+
+    expect(dependencies.readCards).toHaveBeenCalledWith(uid);
+    expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ authoritative });
+  });
+});

--- a/src/query/cardMutationService.ts
+++ b/src/query/cardMutationService.ts
@@ -1,0 +1,107 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { firestoreKeys } from "@/query/firestoreKeys";
+import type { RemoteById } from "@/query/remoteReadController";
+
+export interface CardMutationServiceDependencies {
+  client: QueryClient;
+  createCard: (card: Card) => Promise<string>;
+  updateCard: (card: CardEdit) => Promise<void>;
+  removeCard: (id: CardId) => Promise<void>;
+  upsertCard: (card: Card) => Promise<string>;
+  readCards: (uid: string) => Promise<Card[]>;
+}
+
+const toById = (cards: Card[]): RemoteById<Card> => Object.fromEntries(cards.map((card) => [card.id, card]));
+
+export const createCardMutationService = (dependencies: CardMutationServiceDependencies) => {
+  const tails = new Map<CardId, Promise<void>>();
+
+  const cards = (uid: string) =>
+    dependencies.client.getQueryData<RemoteById<Card>>(firestoreKeys.cards(uid)) ?? {};
+
+  const replaceCards = (uid: string, next: RemoteById<Card>) => {
+    dependencies.client.setQueryData(firestoreKeys.cards(uid), next);
+  };
+
+  const enqueue = async <T>(ids: CardId[], task: () => Promise<T>): Promise<T> => {
+    const uniqueIds = [...new Set(ids)];
+    const previous = uniqueIds.map((id) => tails.get(id)).filter((tail): tail is Promise<void> => tail != null);
+    const operation = Promise.all(previous).then(task);
+    const settled = operation.then(
+      () => undefined,
+      () => undefined
+    );
+    uniqueIds.forEach((id) => tails.set(id, settled));
+    try {
+      return await operation;
+    } finally {
+      uniqueIds.forEach((id) => {
+        if (tails.get(id) === settled) tails.delete(id);
+      });
+    }
+  };
+
+  const optimistic = async <T>(
+    uid: string,
+    ids: CardId[],
+    next: (previous: RemoteById<Card>) => RemoteById<Card>,
+    write: () => Promise<T>
+  ): Promise<T> =>
+    enqueue(ids, async () => {
+      const previous = cards(uid);
+      replaceCards(uid, next(previous));
+      try {
+        return await write();
+      } catch (error) {
+        replaceCards(uid, previous);
+        throw error;
+      }
+    });
+
+  return {
+    create: (uid: string, card: Card) =>
+      optimistic(uid, [card.id], (previous) => ({ ...previous, [card.id]: card }), () =>
+        dependencies.createCard(card)
+      ),
+    update: (uid: string, patch: CardEdit) =>
+      optimistic(
+        uid,
+        [patch.id],
+        (previous) => {
+          const current = previous[patch.id];
+          if (current == null) throw new Error(`Card ${patch.id} is not available`);
+          return { ...previous, [patch.id]: { ...current, ...patch } };
+        },
+        () => dependencies.updateCard(patch)
+      ),
+    remove: (uid: string, id: CardId) =>
+      optimistic(
+        uid,
+        [id],
+        (previous) => {
+          const next = { ...previous };
+          delete next[id];
+          return next;
+        },
+        () => dependencies.removeCard(id)
+      ),
+    bulkUpsert: (uid: string, upserts: Card[]) =>
+      enqueue(
+        upserts.map((card) => card.id),
+        async () => {
+          const previous = cards(uid);
+          replaceCards(uid, { ...previous, ...toById(upserts) });
+          const results = await Promise.allSettled(upserts.map(dependencies.upsertCard));
+          const failures = results.filter((result) => result.status === "rejected");
+          if (failures.length === 0) return;
+
+          const authoritative = await dependencies.readCards(uid);
+          replaceCards(uid, toById(authoritative));
+          throw new Error(`${failures.length} of ${upserts.length} Card writes failed`, {
+            cause: failures.map((failure) => failure.reason),
+          });
+        }
+      ),
+  };
+};

--- a/src/query/cardMutationService.ts
+++ b/src/query/cardMutationService.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { isEqual } from "lodash";
 
 import { firestoreKeys } from "@/query/firestoreKeys";
 import type { RemoteById } from "@/query/remoteReadController";
@@ -17,8 +18,7 @@ const toById = (cards: Card[]): RemoteById<Card> => Object.fromEntries(cards.map
 export const createCardMutationService = (dependencies: CardMutationServiceDependencies) => {
   const tails = new Map<CardId, Promise<void>>();
 
-  const cards = (uid: string) =>
-    dependencies.client.getQueryData<RemoteById<Card>>(firestoreKeys.cards(uid)) ?? {};
+  const cards = (uid: string) => dependencies.client.getQueryData<RemoteById<Card>>(firestoreKeys.cards(uid)) ?? {};
 
   const replaceCards = (uid: string, next: RemoteById<Card>) => {
     dependencies.client.setQueryData(firestoreKeys.cards(uid), next);
@@ -32,7 +32,9 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
       () => undefined,
       () => undefined
     );
-    uniqueIds.forEach((id) => tails.set(id, settled));
+    uniqueIds.forEach((id) => {
+      tails.set(id, settled);
+    });
     try {
       return await operation;
     } finally {
@@ -50,19 +52,32 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
   ): Promise<T> =>
     enqueue(ids, async () => {
       const previous = cards(uid);
-      replaceCards(uid, next(previous));
+      const optimisticCards = next(previous);
+      replaceCards(uid, optimisticCards);
       try {
         return await write();
       } catch (error) {
-        replaceCards(uid, previous);
+        const current = cards(uid);
+        const rollback = { ...current };
+        ids.forEach((id) => {
+          const optimisticCard = optimisticCards[id];
+          if (!isEqual(current[id], optimisticCard)) return;
+          const previousCard = previous[id];
+          if (previousCard == null) delete rollback[id];
+          else rollback[id] = previousCard;
+        });
+        replaceCards(uid, rollback);
         throw error;
       }
     });
 
   return {
     create: (uid: string, card: Card) =>
-      optimistic(uid, [card.id], (previous) => ({ ...previous, [card.id]: card }), () =>
-        dependencies.createCard(card)
+      optimistic(
+        uid,
+        [card.id],
+        (previous) => ({ ...previous, [card.id]: card }),
+        () => dependencies.createCard(card)
       ),
     update: (uid: string, patch: CardEdit) =>
       optimistic(
@@ -98,9 +113,7 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
 
           const authoritative = await dependencies.readCards(uid);
           replaceCards(uid, toById(authoritative));
-          throw new Error(`${failures.length} of ${upserts.length} Card writes failed`, {
-            cause: failures.map((failure) => failure.reason),
-          });
+          throw new Error(`${failures.length} of ${upserts.length} Card writes failed`);
         }
       ),
   };

--- a/src/shared/components/feedback/RemoteMutationNotice.tsx
+++ b/src/shared/components/feedback/RemoteMutationNotice.tsx
@@ -1,0 +1,19 @@
+import { Button } from "@/shared/components/forms/Button";
+
+export const RemoteMutationNotice = (props: { pending: boolean; error: unknown; onRetry: () => void }) => {
+  if (props.error != null) {
+    return (
+      <div role="alert" className="my-2 flex items-center justify-between rounded border border-red-300 p-2 text-sm">
+        <span>Unable to save changes.</span>
+        <Button small onClick={props.onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+  return props.pending ? (
+    <div role="status" className="my-2 text-sm text-gray-500">
+      Saving…
+    </div>
+  ) : null;
+};

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -4,6 +4,7 @@ export * from "@/shared/components/content/Code";
 export * from "@/shared/components/content/Description";
 export * from "@/shared/components/feedback/Feedback";
 export * from "@/shared/components/feedback/RemoteReadBoundary";
+export * from "@/shared/components/feedback/RemoteMutationNotice";
 export * from "@/shared/components/feedback/buttonInteraction";
 export * from "@/shared/components/forms/Form";
 export * from "@/shared/components/forms/FormItem";

--- a/src/shared/hooks/useActions.ts
+++ b/src/shared/hooks/useActions.ts
@@ -56,13 +56,6 @@ export const useActions = () => {
       deckDownloadCsvSampleText: () => {
         dispatch(action.deck.downloadCsvSampleText());
       },
-      cardUpdate: (card: Card) => dispatch(action.card.update(card)),
-      cardUpdateBy: (f: (c: Card) => Partial<Card>) => (id: CardId) => dispatch(action.card.updateBy(id, f)),
-      cardUpdateAndBack: (card: Card) => {
-        dispatch(action.card.update(card));
-        void navigate(-1);
-      },
-      cardRemove: (id: CardId) => window.confirm("Are you sure?") && dispatch(action.card.remove(id)),
       login: () => dispatch(action.config.loginGoogle()),
       logout: (confirmedUid: string) => dispatch(action.config.logout(confirmedUid)),
       configUpdate: (config: ConfigState) => dispatch(action.config.updateAll(config)),


### PR DESCRIPTION
## Summary
- add Card-scoped optimistic mutation coordination with per-Card serialization and targeted rollback
- route local Card writes to Redux and await remote create, update, logical delete, and bulk upsert operations
- block duplicate study swipes and restore the Zustand study index when a write fails
- expose pending, error, and Retry feedback from Card containers
- verify remote Card editing against the Firestore Emulator and across reloads

## Testing
- `make check`
- `make test-firestore`
- `make e2e`

Depends on #270
Parent: #257
Closes #260