### PR TITLE
Migrate Deck writes and imports to Query mutations

### DIFF
--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -162,7 +162,15 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
   await page.goto("/");
   await expect(page.getByText("Remote Query Deck")).toBeVisible();
   await expect(page.getByText("Foreign Deck")).not.toBeVisible();
-  await page.getByText("Remote Query Deck").click();
+  await page.goto("/deck/remote-read-deck/edit");
+  await page.locator("input[name='name']").fill("Updated Remote Query Deck");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("Updated Remote Query Deck")).toBeVisible();
+  await expect
+    .poll(async () => (await getDocument("deck", "remote-read-deck")).fields.name?.stringValue)
+    .toBe("Updated Remote Query Deck");
+
+  await page.getByText("Updated Remote Query Deck").click();
   await expect(page.getByText("Remote Query Card")).toBeVisible();
 
   await page.goto("/card/remote-read-card/edit");

--- a/src/action/deck.spec.ts
+++ b/src/action/deck.spec.ts
@@ -3,7 +3,6 @@ import { expect, expectTypeOf, it, describe, vi, beforeEach, afterEach } from "v
 // import moment from "moment";
 import * as fileSaver from "file-saver";
 
-import * as firestore from "@/action/firestore";
 import * as action from "@/action";
 import * as C from "@/constant";
 import { createBlobConstructor, createCard } from "@/test/factories";
@@ -58,97 +57,6 @@ describe("deck action", () => {
     });
   });
 
-  describe("create", () => {
-    it("should create", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      const config = { uid: "uid", localMode: false };
-      getState.mockReturnValue({ config, deck: { byId: {} } });
-
-      const f = action.deck.create("name");
-      await f(dispatch, getState, undefined);
-      const deck = action.deck.prepare({ name: "name" }, config);
-      expect(firestore.deck.create).lastCalledWith(deck);
-    });
-  });
-
-  describe("update", () => {
-    it("should update", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      getState.mockReturnValue({ config: { uid: "uid" } });
-
-      const d = { name: "deck" } as Deck;
-      const f = action.deck.update(d);
-      await f(dispatch, getState, undefined);
-      expect(firestore.deck.update).lastCalledWith(d);
-    });
-  });
-
-  describe("remove", () => {
-    it("should remove", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      getState.mockReturnValue({ deck: { byId: { deckId: { uid: "uid" } } } });
-
-      const f = action.deck.remove("deckId");
-      await f(dispatch, getState, undefined);
-      expect(firestore.deck.remove).toHaveBeenCalledWith("deckId", "uid");
-    });
-  });
-
-  describe("spliteCreate", () => {
-    const deck = { name: "name", id: "1" } as Deck;
-    const deckState = { byId: { "1": deck }, categories: [] } as DeckState;
-    const cardState = { byId: { 1: createCard({ id: "1", deckId: "1", uniqueKey: "a" }) }, tags: [] };
-    // TODO: add test case for not existing name
-    it("should splite & create", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      getState.mockReturnValue({ deck: deckState, card: cardState });
-
-      const bulkUpdate = vi.spyOn(action.card, "bulkUpdate");
-      const bulkCreate = vi.spyOn(action.card, "bulkCreate");
-      const create = vi.spyOn(action.deck, "create");
-
-      const cards = [{ frontText: "front", backText: "back", tags: [], uniqueKey: "a" }] satisfies CardRaw[];
-      const f = action.deck.spliteCreate("name", cards);
-      await f(dispatch, getState, undefined);
-      expect(bulkUpdate).lastCalledWith([{ ...cards[0], id: "1", deckId: "1" }]);
-      expect(bulkCreate).toBeCalledTimes(1);
-      expect(create).toBeCalledTimes(0);
-      expect(dispatch).toBeCalledTimes(2);
-    });
-  });
-
-  describe("parseUrl", () => {
-    it("should parse url", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      getState.mockReturnValue({ config: {} });
-      const spliteCreate = vi.spyOn(action.deck, "spliteCreate");
-      global.fetch = vi.fn().mockReturnValue(Promise.resolve(new Response("front,back")));
-
-      const url = "http://example.com/deck-name.csv";
-      const f = action.deck.parseUrl(url);
-      await f(dispatch, getState, undefined);
-      expect(spliteCreate).toHaveBeenCalledWith("deck-name.csv", [
-        { frontText: "front", backText: "back", uniqueKey: "", tags: [] as string[] },
-      ] satisfies CardRaw[]);
-      expect(dispatch).toBeCalledTimes(1);
-    });
-  });
-
-  describe("parseFile", () => {
-    it("should parse file", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      const spliteCreate = vi.spyOn(action.deck, "spliteCreate");
-
-      const file = new File([new Blob(["front,back"])], "deck-name.csv");
-      const f = action.deck.parseFile(file);
-      await f(dispatch, getState, undefined);
-      expect(spliteCreate).toHaveBeenCalledWith("deck-name.csv", [
-        { frontText: "front", backText: "back", uniqueKey: "", tags: [] as string[] },
-      ] satisfies CardRaw[]);
-      expect(dispatch).toBeCalledTimes(1);
-    });
-  });
-
   describe("parseCsv", () => {
     it("parses string content as raw cards", async () => {
       const cards = await action.deck.parseCsv("front,back");
@@ -165,19 +73,6 @@ describe("deck action", () => {
   });
 
   describe("download", () => {
-    it("should download", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
-      const blob = new Blob();
-      const m = vi.spyOn(global, "Blob"); // FIXME: affect Blob after this test
-      m.mockImplementation(createBlobConstructor(blob));
-      getState.mockReturnValue({ deck: { byId: { id: { name: "name", cardIds: [] } } }, card: { byId: {} } });
-
-      const f = action.deck.download("id");
-      await f(dispatch, getState, undefined);
-      expect(m).toBeCalledWith([""], { type: "text/plain;charset=utf-8" });
-      expect(fileSaver.saveAs).toBeCalledWith(expect.anything(), "name.csv");
-    });
-
     it("downloads the supplied composed Query data without reading Redux", () => {
       const blob = new Blob();
       const blobConstructor = vi.spyOn(global, "Blob");
@@ -195,14 +90,12 @@ describe("deck action", () => {
   });
 
   describe("downloadCsvSampleText", () => {
-    it("should download", async () => {
-      const [dispatch, getState] = [vi.fn(), vi.fn()];
+    it("should download", () => {
       const blob = new Blob();
       const m = vi.spyOn(global, "Blob");
       m.mockImplementation(createBlobConstructor(blob));
 
-      const f = action.deck.downloadCsvSampleText();
-      await f(dispatch, getState, undefined);
+      action.deck.downloadCsvSampleText();
       expect(m).toBeCalledWith([C.CSV_SAMPLE_TEXT], { type: "text/plain;charset=utf-8" });
       expect(fileSaver.saveAs).toBeCalledWith(expect.anything(), "sample.csv");
     });

--- a/src/action/deck.ts
+++ b/src/action/deck.ts
@@ -2,13 +2,9 @@
 import { saveAs } from "file-saver";
 import * as Papa from "papaparse";
 
-import * as type from "@/action/type";
 import * as C from "@/constant";
-import type { ThunkResult } from "@/action/index";
 import * as action from "@/action";
-import * as selector from "@/selector";
 import * as firestore from "@/action/firestore";
-import sampleCards from "../../sample/build/output.json";
 
 export const prepare = (deck: DeckRaw, config: DeckConfig): Deck => {
   const { uid, localMode } = config;
@@ -41,47 +37,6 @@ export const generateName = (deckName: string, state: DeckState): string => {
   }
 };
 
-export const create =
-  (deckName: string): ThunkResult<Promise<string>> =>
-  async (dispatch, getState) => {
-    const name = generateName(deckName, getState().deck);
-    const deck = prepare({ name } as Deck, getState().config);
-    if (!deck.localMode) {
-      await firestore.deck.create(deck);
-    }
-    await dispatch(type.deckInsert(deck));
-    return deck.id;
-  };
-
-export const update =
-  (deck: DeckEdit): ThunkResult =>
-  async (dispatch) => {
-    // must be no deplay when going to deck swiper page
-    if (!deck.localMode) {
-      void firestore.deck.update(deck); // fire&forget
-    }
-    await dispatch(type.deckUpdate(deck));
-  };
-
-export const remove =
-  (deckId: string): ThunkResult =>
-  async (dispatch, getState) => {
-    const deck = selector.deck.getById(deckId)(getState());
-    if (!deck.localMode) {
-      void firestore.deck.remove(deckId, deck.uid); // fire&forget
-    }
-    await dispatch(type.deckDelete(deckId));
-  };
-
-export const download =
-  (id: string): ThunkResult =>
-  async (_dispatch, getState) => {
-    const cards = selector.card.getAllByDeckId(id)(getState());
-    const csv = Papa.unparse(cards.map(action.card.toRow));
-    const deck = selector.deck.getById(id)(getState());
-    _saveAs(csv, deck.name);
-  };
-
 export const downloadData = (deck: Deck, cards: Card[]) => {
   const csv = Papa.unparse(cards.map(action.card.toRow));
   _saveAs(csv, deck.name);
@@ -95,68 +50,9 @@ export const _saveAs = (content: string, name: string) => {
   saveAs(blob, name);
 };
 
-export const downloadCsvSampleText = (): ThunkResult => async () => {
+export const downloadCsvSampleText = () => {
   _saveAs(C.CSV_SAMPLE_TEXT, "sample.csv");
 };
-
-export const spliteCreate =
-  (deckName: string, cards: CardRaw[]): ThunkResult =>
-  async (dispatch, getState) => {
-    const [newCards, oldCards] = selector.card.splitByUniqueKey(cards)(getState());
-    await dispatch(action.card.bulkUpdate(oldCards));
-    let deckId = selector.deck.findByName(deckName)(getState());
-    if (deckId == null) {
-      deckId = await dispatch(action.deck.create(deckName));
-    }
-    await dispatch(action.card.bulkCreate(newCards, deckId));
-    process.env.NODE_ENV !== "production" &&
-      console.log(
-        (deckId == null ? "CREATE" : "UPATE") +
-          ` ${deckName} DECK WITH NEW ${newCards.length} AND OLD ${oldCards.length} CARDS`
-      );
-  };
-
-export const reimport =
-  (id: string): ThunkResult =>
-  async (dispatch, getState) => {
-    const deck = getState().deck.byId[id];
-    if (deck == null) throw Error("invalid deck id");
-    if (deck.url == null || deck.url === "") throw Error("no deck url");
-    await dispatch(parseUrl(deck.url, deck.name));
-  };
-
-export const parseUrl =
-  (url: string, deckName?: string): ThunkResult =>
-  async (dispatch, getState) => {
-    if (deckName == null) deckName = url.split("/").pop() ?? "no name";
-    const token = getState().config.githubAccessToken;
-    let headers = {} as Record<string, string>;
-    if (token !== "") {
-      headers = {
-        Accept: "application/vnd.github.raw",
-        Authorization: `Bearer ${token}`,
-      };
-    }
-    const res = await fetch(url, { headers });
-    const text = await res.text();
-    const cards = await parseCsv(text);
-    await dispatch(action.deck.spliteCreate(deckName, cards));
-  };
-
-export const loadSample = (): ThunkResult => async (dispatch, getState) => {
-  if (getState().config.loadSample) {
-    const deckName = "Sample Deck";
-    await dispatch(action.deck.spliteCreate(deckName, sampleCards));
-    await dispatch(type.configUpdate({ loadSample: false }));
-  }
-};
-
-export const parseFile =
-  (file: File): ThunkResult =>
-  async (dispatch) => {
-    const cards = await parseCsv(file);
-    await dispatch(action.deck.spliteCreate(file.name, cards));
-  };
 
 export const parseCsv = async (content: unknown): Promise<CardRaw[]> => {
   if (typeof content !== "string" && !(typeof File !== "undefined" && content instanceof File)) {

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -116,11 +116,11 @@ export const useCardMutations = () => {
       if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
       return run({ kind: "remove", id, local: isLocal(card.deckId) });
     },
-    bulkUpsert: (cards: Card[]) =>
+    bulkUpsert: (cards: Card[], localMode?: boolean) =>
       run({
         kind: "bulkUpsert",
         cards,
-        localIds: cards.filter((card) => isLocal(card.deckId)).map((card) => card.id),
+        localIds: cards.filter((card) => localMode ?? isLocal(card.deckId)).map((card) => card.id),
       }),
     isPending: (id: CardId) => pendingCounts.current.has(id),
     pending: pendingCounts.current.size > 0,

--- a/src/features/deck/components/templates/DeckFormTemplate.tsx
+++ b/src/features/deck/components/templates/DeckFormTemplate.tsx
@@ -5,11 +5,13 @@ import { DeckForm, type DeckFormProps } from "@/features/deck/components/DeckFor
 export interface DeckFormTemplateProps {
   layout?: React.ComponentProps<typeof Layout>;
   deckForm?: DeckFormProps;
+  feedbackSlot?: React.ReactNode;
 }
 
 export const DeckFormTemplate: React.FC<DeckFormTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
+      {props.feedbackSlot}
       {props.deckForm != null && <DeckForm {...props.deckForm} />}
     </Layout>
   );

--- a/src/features/deck/components/templates/DeckListTemplate.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.tsx
@@ -12,11 +12,13 @@ export interface DeckListTemplateProps {
   layout?: React.ComponentProps<typeof Layout>;
   deckCard?: DeckCardActions;
   studyProgress?: ActiveStudyProgress;
+  feedbackSlot?: React.ReactNode;
 }
 
 export const DeckListTemplate: React.FC<DeckListTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
+      {props.feedbackSlot}
       <List>
         {props.decks?.map((deck) => {
           const studyProgress = props.studyProgress?.deckId === deck.id ? props.studyProgress : undefined;

--- a/src/features/deck/containers/DeckFormContainer.spec.tsx
+++ b/src/features/deck/containers/DeckFormContainer.spec.tsx
@@ -37,7 +37,12 @@ vi.mock("@/shared/hooks/useActions", () => ({
 }));
 
 vi.mock("@/features/deck/hooks/useDeckActions", () => ({
-  useDeckActions: () => ({ updateAndBack: mocks.updateAndBack }),
+  useDeckActions: () => ({
+    updateAndBack: mocks.updateAndBack,
+    pending: false,
+    error: null,
+    retry: vi.fn(),
+  }),
 }));
 
 import { DeckFormContainer } from "@/features/deck/containers/DeckFormContainer";

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -6,7 +6,7 @@ import { useForm } from "react-hook-form";
 import * as C from "@/constant";
 import * as selector from "@/selector";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/shared/components";
+import { RemoteMutationNotice, RemoteReadBoundary } from "@/shared/components";
 import { renameKey } from "@/shared/forms/renameKey";
 import { useActions } from "@/shared/hooks/useActions";
 import { DeckFormTemplate } from "@/features/deck/components/templates/DeckFormTemplate";
@@ -29,6 +29,9 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
           onClickMenuItem: actions.goByMenu,
         },
       }}
+      feedbackSlot={
+        <RemoteMutationNotice pending={deckActions.pending} error={deckActions.error} onRetry={deckActions.retry} />
+      }
       deckForm={{
         deck,
         fields: {

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -52,6 +52,10 @@ vi.mock("@/shared/hooks/useActions", () => ({
   useActions: () => mocks.actions,
 }));
 
+vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
+  useDeckMutations: () => ({ remove: vi.fn(), pending: false, error: null, retry: vi.fn() }),
+}));
+
 import { DeckListContainer } from "@/features/deck/containers/DeckListContainer";
 
 describe("DeckListContainer", () => {

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -5,15 +5,17 @@ import { useKey } from "react-use";
 import * as action from "@/action";
 import * as selector from "@/selector";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/shared/components";
+import { RemoteMutationNotice, RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
 import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
 import { useStudyStore } from "@/features/study/hooks/useStudyStore";
+import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
 
 export const DeckListContainer: React.FC = () => {
   const actions = useActions();
   const config = useSelector(selector.config.get());
   const remote = useRemoteCollections();
+  const mutations = useDeckMutations();
   const decks = remote.decks;
   const studySession = useStudyStore((state) => state.session);
   useKey("s", actions.goToSettings);
@@ -28,6 +30,9 @@ export const DeckListContainer: React.FC = () => {
     >
       <DeckListTemplate
         decks={decks}
+        feedbackSlot={
+          <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+        }
         {...(studySession != null
           ? {
               studyProgress: {
@@ -54,7 +59,12 @@ export const DeckListContainer: React.FC = () => {
             const deck = remote.deckById(id);
             if (deck != null) action.deck.downloadData(deck, remote.cardsByDeckId(id));
           },
-          onClickDelete: actions.deckRemove,
+          onClickDelete: (id) => {
+            const deck = remote.deckById(id);
+            if (deck != null && window.confirm("Are you sure of removing this deck?")) {
+              void mutations.remove(deck).catch(() => undefined);
+            }
+          },
           // onClickReimport: actions.deckReimport,
         }}
       />

--- a/src/features/deck/hooks/useDeckActions.ts
+++ b/src/features/deck/hooks/useDeckActions.ts
@@ -1,23 +1,32 @@
 import * as React from "react";
-import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import * as action from "@/action";
+import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
 
 export const useDeckActions = (id: DeckId) => {
-  const dispatch = useDispatch();
   const navigate = useNavigate();
+  const remote = useRemoteCollections();
+  const mutations = useDeckMutations();
   return React.useMemo(
     () => ({
-      update: (deck: Deck) => {
-        dispatch(action.deck.update(deck));
+      update: mutations.update,
+      updateAndBack: async (deck: Deck) => {
+        try {
+          await mutations.update(deck);
+          void navigate(-1);
+        } catch {
+          // The mutation notice owns error feedback and retry.
+        }
       },
-      updateAndBack: (deck: Deck) => {
-        dispatch(action.deck.update(deck));
-        void navigate(-1);
+      remove: () => {
+        const deck = remote.deckById(id);
+        return deck == null ? Promise.reject(new Error(`Deck ${id} is not available`)) : mutations.remove(deck);
       },
-      remove: () => dispatch(action.deck.remove(id)),
+      pending: mutations.pending,
+      error: mutations.error,
+      retry: mutations.retry,
     }),
-    [dispatch, navigate, id]
+    [id, mutations, navigate, remote]
   );
 };

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useRef } from "react";
+import { useDispatch } from "react-redux";
+
+import * as firestore from "@/action/firestore";
+import * as type from "@/action/type";
+import { useAuth } from "@/auth/AuthContext";
+import { createDeckMutationService } from "@/query/deckMutationService";
+
+type Variables = { kind: "create"; deck: Deck } | { kind: "update"; deck: DeckEdit } | { kind: "remove"; deck: Deck };
+
+export const useDeckMutations = () => {
+  const auth = useAuth();
+  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const client = useQueryClient();
+  const dispatch = useDispatch();
+  const lastFailed = useRef<Variables>();
+  const service = useMemo(
+    () =>
+      createDeckMutationService({
+        client,
+        createDeck: firestore.deck.create,
+        updateDeck: firestore.deck.update,
+        removeDeck: firestore.deck.remove,
+      }),
+    [client]
+  );
+  const mutation = useMutation({
+    retry: false,
+    mutationFn: async (variables: Variables) => {
+      const deck = variables.deck;
+      if (deck.localMode) {
+        if (variables.kind === "create") dispatch(type.deckInsert(deck as Deck));
+        else if (variables.kind === "update") dispatch(type.deckUpdate(deck));
+        else dispatch(type.deckDelete(deck.id));
+        return;
+      }
+      if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
+      if (variables.kind === "create") await service.create(uid, deck as Deck);
+      else if (variables.kind === "update") await service.update(uid, deck);
+      else await service.remove(uid, deck.id);
+    },
+  });
+  const run = useCallback(
+    async (variables: Variables) => {
+      try {
+        await mutation.mutateAsync(variables);
+        lastFailed.current = undefined;
+      } catch (error) {
+        lastFailed.current = variables;
+        throw error;
+      }
+    },
+    [mutation]
+  );
+
+  return {
+    create: (deck: Deck) => run({ kind: "create", deck }),
+    update: (deck: DeckEdit) => run({ kind: "update", deck }),
+    remove: (deck: Deck) => run({ kind: "remove", deck }),
+    pending: mutation.isPending,
+    error: mutation.error,
+    retry: () => {
+      const variables = lastFailed.current;
+      if (variables != null) void run(variables).catch(() => undefined);
+    },
+  };
+};

--- a/src/features/import/components/templates/DeckImportTemplate.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.tsx
@@ -8,11 +8,18 @@ export const DeckImportTemplate: React.FC<{
   onDownloadSample?: () => void;
   sampleText: string;
   layout?: LayoutProps;
+  pending?: boolean;
+  feedbackSlot?: React.ReactNode;
 }> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
+      {props.feedbackSlot}
       <Title>Deck Upload</Title>
-      <Upload className="my-2" {...(props.onChange !== undefined ? { onChange: props.onChange } : {})} />
+      <Upload
+        className="my-2"
+        {...(props.pending !== undefined ? { disabled: props.pending } : {})}
+        {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
+      />
       <Title>CSV File Format</Title>
       <Description className="my-2">{`There are 3 columns without header: front text, back text, and tags (optional).`}</Description>
       <div className="flex justify-start items-center">

--- a/src/features/import/containers/DeckImportContainer.spec.tsx
+++ b/src/features/import/containers/DeckImportContainer.spec.tsx
@@ -1,14 +1,25 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  deckUploadAndBack: vi.fn(),
+  importFile: vi.fn(),
+  navigate: vi.fn(),
   deckDownloadCsvSampleText: vi.fn(),
   goToTop: vi.fn(),
   goToSettings: vi.fn(),
   useKey: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
+vi.mock("@/features/import/hooks/useDeckImport", () => ({
+  useDeckImport: () => ({
+    importFile: mocks.importFile,
+    pending: false,
+    error: null,
+    retry: vi.fn(),
+  }),
 }));
 
 vi.mock("react-redux", () => ({
@@ -26,7 +37,6 @@ vi.mock("react-use", () => ({
 
 vi.mock("@/shared/hooks/useActions", () => ({
   useActions: () => ({
-    deckUploadAndBack: mocks.deckUploadAndBack,
     deckDownloadCsvSampleText: mocks.deckDownloadCsvSampleText,
     goToTop: mocks.goToTop,
     goToSettings: mocks.goToSettings,
@@ -40,6 +50,7 @@ import { DeckImportContainer } from "@/features/import/containers/DeckImportCont
 describe("DeckImportContainer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.importFile.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -55,7 +66,8 @@ describe("DeckImportContainer", () => {
     });
     await userEvent.click(view.getByText("download"));
 
-    expect(mocks.deckUploadAndBack).toHaveBeenCalledWith(file);
+    expect(mocks.importFile).toHaveBeenCalledWith(file);
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith(-1));
     expect(mocks.deckDownloadCsvSampleText).toHaveBeenCalledOnce();
     expect(mocks.useKey).toHaveBeenCalledWith("t", mocks.goToTop);
     expect(mocks.useKey).toHaveBeenCalledWith("s", mocks.goToSettings);

--- a/src/features/import/containers/DeckImportContainer.tsx
+++ b/src/features/import/containers/DeckImportContainer.tsx
@@ -1,21 +1,35 @@
 import type React from "react";
 import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 import * as C from "@/constant";
 import { DeckImportTemplate } from "@/features/import/components/templates/DeckImportTemplate";
 import * as selector from "@/selector";
 import { useActions } from "@/shared/hooks/useActions";
+import { useDeckImport } from "@/features/import/hooks/useDeckImport";
+import { RemoteMutationNotice } from "@/shared/components";
 
 export const DeckImportContainer: React.FC = () => {
   const actions = useActions();
   const config = useSelector(selector.config.get());
+  const navigate = useNavigate();
+  const deckImport = useDeckImport();
   useKey("t", actions.goToTop);
   useKey("s", actions.goToSettings);
 
   return (
     <DeckImportTemplate
-      onChange={actions.deckUploadAndBack}
+      onChange={(file) => {
+        void deckImport
+          .importFile(file)
+          .then(() => navigate(-1))
+          .catch(() => undefined);
+      }}
       onDownloadSample={actions.deckDownloadCsvSampleText}
+      pending={deckImport.pending}
+      feedbackSlot={
+        <RemoteMutationNotice pending={deckImport.pending} error={deckImport.error} onRetry={deckImport.retry} />
+      }
       sampleText={C.CSV_SAMPLE_TEXT}
       layout={{
         headerProps: {

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createQueryWrapper, createTestQueryClient } from "@/query/testUtils";
+import { createCard, createConfig, createDeck } from "@/test/factories";
+import type { DeckImportResult } from "@/features/import/hooks/useDeckImport";
+
+const mocks = vi.hoisted(() => ({
+  config: {} as ConfigState,
+  decks: [] as Deck[],
+  cards: [] as Card[],
+  parseCsv: vi.fn(),
+  prepareDeck: vi.fn(),
+  prepareCard: vi.fn(),
+  createDeck: vi.fn(),
+  bulkUpsert: vi.fn(),
+}));
+
+vi.mock("react-redux", () => ({ useSelector: () => mocks.config }));
+vi.mock("@/auth/AuthContext", () => ({
+  useAuth: () => ({ status: "authenticated", uid: "uid-a", user: { uid: "uid-a" } }),
+}));
+vi.mock("@/query/useRemoteCollections", () => ({
+  useRemoteCollections: () => ({
+    decks: mocks.decks,
+    cardsByDeckId: (id: DeckId) => mocks.cards.filter((card) => card.deckId === id),
+  }),
+}));
+vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
+  useDeckMutations: () => ({ create: mocks.createDeck }),
+}));
+vi.mock("@/features/card/hooks/useCardMutations", () => ({
+  useCardMutations: () => ({ bulkUpsert: mocks.bulkUpsert }),
+}));
+vi.mock("@/action", () => ({
+  deck: { parseCsv: mocks.parseCsv, prepare: mocks.prepareDeck },
+  card: { prepare: mocks.prepareCard },
+}));
+
+import { useDeckImport } from "@/features/import/hooks/useDeckImport";
+
+describe("useDeckImport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.config = createConfig({ localMode: false, githubAccessToken: "" });
+    mocks.decks = [];
+    mocks.cards = [];
+    mocks.parseCsv.mockResolvedValue([{ frontText: "front", backText: "back", tags: [], uniqueKey: "key" }]);
+    mocks.prepareDeck.mockReturnValue(createDeck({ id: "deck", uid: "uid-a", localMode: false }));
+    mocks.prepareCard.mockReturnValue(createCard({ id: "card", deckId: "deck" }));
+    mocks.createDeck.mockResolvedValue(undefined);
+    mocks.bulkUpsert.mockResolvedValue(undefined);
+  });
+
+  it("awaits Deck creation and Card upsert as one import operation", async () => {
+    const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
+    let imported: DeckImportResult | undefined;
+
+    await act(async () => {
+      imported = await result.current.importFile(file);
+    });
+
+    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).toHaveBeenCalledWith([expect.objectContaining({ id: "card" })], false);
+    expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" });
+  });
+
+  it("treats a non-2xx URL response as an error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("missing", { status: 404 }));
+    const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+
+    await expect(result.current.importUrl("https://example.test/deck.csv")).rejects.toThrow(
+      "Unable to fetch Deck CSV (404)"
+    );
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+  });
+
+  it("rejects a second import while the first is pending", async () => {
+    let finish!: (cards: CardRaw[]) => void;
+    mocks.parseCsv.mockReturnValueOnce(new Promise((resolve) => (finish = resolve)));
+    const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
+
+    const first = result.current.importFile(file);
+    await expect(result.current.importFile(file)).rejects.toThrow("already running");
+    finish([]);
+    await first;
+  });
+});

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -1,0 +1,127 @@
+import { useMutation } from "@tanstack/react-query";
+import { useRef } from "react";
+import { useSelector } from "react-redux";
+
+import * as action from "@/action";
+import { useAuth } from "@/auth/AuthContext";
+import { useCardMutations } from "@/features/card/hooks/useCardMutations";
+import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+import { CardBulkMutationError } from "@/query/cardMutationService";
+import * as selector from "@/selector";
+
+export interface DeckImportResult {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  deckId: DeckId;
+}
+
+type ImportRequest = { name: string; content: string | File };
+
+export const useDeckImport = () => {
+  const auth = useAuth();
+  const config = useSelector(selector.config.get());
+  const remote = useRemoteCollections();
+  const deckMutations = useDeckMutations();
+  const cardMutations = useCardMutations();
+  const running = useRef(false);
+  const lastRequest = useRef<ImportRequest>();
+
+  const operation = useMutation({
+    retry: false,
+    mutationFn: async ({ name, content }: ImportRequest): Promise<DeckImportResult> => {
+      const rawCards = await action.deck.parseCsv(content);
+      let deck = remote.decks.find((candidate) => candidate.name === name);
+      if (deck == null) {
+        const uid = auth.status === "authenticated" ? auth.uid : "";
+        if (!config.localMode && uid === "") throw new Error("A confirmed user is required for remote imports");
+        deck = action.deck.prepare({ name }, { uid, localMode: config.localMode });
+        await deckMutations.create(deck);
+      }
+
+      const existing = remote.cardsByDeckId(deck.id);
+      const byUniqueKey = new Map(existing.map((card) => [card.uniqueKey, card]));
+      const upserts: Card[] = [];
+      const createdIds = new Set<CardId>();
+      const updatedIds = new Set<CardId>();
+      let created = 0;
+      let updated = 0;
+      let skipped = 0;
+      rawCards.forEach((raw) => {
+        const current = byUniqueKey.get(raw.uniqueKey);
+        if (current == null) {
+          const card = action.card.prepare(raw, deck);
+          upserts.push(card);
+          createdIds.add(card.id);
+          created += 1;
+        } else if (
+          current.frontText === raw.frontText &&
+          current.backText === raw.backText &&
+          current.tags.join("\0") === raw.tags.join("\0")
+        ) {
+          skipped += 1;
+        } else {
+          upserts.push({ ...current, ...raw });
+          updatedIds.add(current.id);
+          updated += 1;
+        }
+      });
+      try {
+        if (upserts.length > 0) await cardMutations.bulkUpsert(upserts, deck.localMode);
+      } catch (error) {
+        const failedIds = error instanceof CardBulkMutationError ? error.failedIds : upserts.map((card) => card.id);
+        const failed = new Set(failedIds);
+        throw Object.assign(new Error(`Deck import did not complete: ${String(error)}`), {
+          result: {
+            created: [...createdIds].filter((id) => !failed.has(id)).length,
+            updated: [...updatedIds].filter((id) => !failed.has(id)).length,
+            skipped,
+            failed: failed.size,
+            deckId: deck.id,
+          },
+        });
+      }
+      return { created, updated, skipped, failed: 0, deckId: deck.id };
+    },
+  });
+
+  const run = async (request: ImportRequest) => {
+    if (running.current) throw new Error("A Deck import is already running");
+    running.current = true;
+    lastRequest.current = request;
+    try {
+      return await operation.mutateAsync(request);
+    } finally {
+      running.current = false;
+    }
+  };
+
+  const importUrl = async (url: string, name?: string) => {
+    const headers: Record<string, string> = {};
+    if (config.githubAccessToken !== "") {
+      headers.Accept = "application/vnd.github.raw";
+      headers.Authorization = `Bearer ${config.githubAccessToken}`;
+    }
+    const response = await fetch(url, { headers });
+    if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
+    return await run({ name: name ?? url.split("/").pop() ?? "no name", content: await response.text() });
+  };
+
+  return {
+    importFile: (file: File) => run({ name: file.name, content: file }),
+    importUrl,
+    reimport: (deck: Deck) => {
+      if (deck.url == null || deck.url === "") return Promise.reject(new Error("Deck has no import URL"));
+      return importUrl(deck.url, deck.name);
+    },
+    pending: operation.isPending || running.current,
+    error: operation.error,
+    data: operation.data,
+    retry: () => {
+      const request = lastRequest.current;
+      if (request != null && !running.current) void run(request).catch(() => undefined);
+    },
+  };
+};

--- a/src/query/cardMutationService.spec.ts
+++ b/src/query/cardMutationService.spec.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createCardMutationService } from "@/query/cardMutationService";
+import { type CardBulkMutationError, createCardMutationService } from "@/query/cardMutationService";
 import { firestoreKeys } from "@/query/firestoreKeys";
 import { createCard } from "@/test/factories";
 
@@ -120,7 +120,9 @@ describe("createCardMutationService", () => {
     dependencies.readCards.mockResolvedValue([authoritative]);
     const service = createCardMutationService({ client, ...dependencies });
 
-    await expect(service.bulkUpsert(uid, [first, second])).rejects.toThrow("1 of 2 Card writes failed");
+    const error = await service.bulkUpsert(uid, [first, second]).catch((cause: unknown) => cause);
+    expect(error).toEqual(expect.objectContaining({ message: "1 of 2 Card writes failed" }));
+    expect((error as CardBulkMutationError).failedIds).toEqual([second.id]);
 
     expect(dependencies.readCards).toHaveBeenCalledWith(uid);
     expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ authoritative });

--- a/src/query/cardMutationService.ts
+++ b/src/query/cardMutationService.ts
@@ -3,6 +3,7 @@ import { isEqual } from "lodash";
 
 import { firestoreKeys } from "@/query/firestoreKeys";
 import type { RemoteById } from "@/query/remoteReadController";
+import { cardMutationLock, withMutationLocks } from "@/query/mutationLocks";
 
 export interface CardMutationServiceDependencies {
   client: QueryClient;
@@ -13,35 +14,22 @@ export interface CardMutationServiceDependencies {
   readCards: (uid: string) => Promise<Card[]>;
 }
 
+export class CardBulkMutationError extends Error {
+  constructor(
+    public readonly failedIds: CardId[],
+    total: number
+  ) {
+    super(`${failedIds.length} of ${total} Card writes failed`);
+  }
+}
+
 const toById = (cards: Card[]): RemoteById<Card> => Object.fromEntries(cards.map((card) => [card.id, card]));
 
 export const createCardMutationService = (dependencies: CardMutationServiceDependencies) => {
-  const tails = new Map<CardId, Promise<void>>();
-
   const cards = (uid: string) => dependencies.client.getQueryData<RemoteById<Card>>(firestoreKeys.cards(uid)) ?? {};
 
   const replaceCards = (uid: string, next: RemoteById<Card>) => {
     dependencies.client.setQueryData(firestoreKeys.cards(uid), next);
-  };
-
-  const enqueue = async <T>(ids: CardId[], task: () => Promise<T>): Promise<T> => {
-    const uniqueIds = [...new Set(ids)];
-    const previous = uniqueIds.map((id) => tails.get(id)).filter((tail): tail is Promise<void> => tail != null);
-    const operation = Promise.all(previous).then(task);
-    const settled = operation.then(
-      () => undefined,
-      () => undefined
-    );
-    uniqueIds.forEach((id) => {
-      tails.set(id, settled);
-    });
-    try {
-      return await operation;
-    } finally {
-      uniqueIds.forEach((id) => {
-        if (tails.get(id) === settled) tails.delete(id);
-      });
-    }
   };
 
   const optimistic = async <T>(
@@ -50,7 +38,7 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
     next: (previous: RemoteById<Card>) => RemoteById<Card>,
     write: () => Promise<T>
   ): Promise<T> =>
-    enqueue(ids, async () => {
+    withMutationLocks(ids.map(cardMutationLock), async () => {
       const previous = cards(uid);
       const optimisticCards = next(previous);
       replaceCards(uid, optimisticCards);
@@ -102,18 +90,21 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
         () => dependencies.removeCard(id)
       ),
     bulkUpsert: (uid: string, upserts: Card[]) =>
-      enqueue(
-        upserts.map((card) => card.id),
+      withMutationLocks(
+        upserts.map((card) => cardMutationLock(card.id)),
         async () => {
           const previous = cards(uid);
           replaceCards(uid, { ...previous, ...toById(upserts) });
           const results = await Promise.allSettled(upserts.map(dependencies.upsertCard));
-          const failures = results.filter((result) => result.status === "rejected");
-          if (failures.length === 0) return;
+          const failedIds = results.flatMap((result, index) => {
+            const card = upserts[index];
+            return result.status === "rejected" && card != null ? [card.id] : [];
+          });
+          if (failedIds.length === 0) return;
 
           const authoritative = await dependencies.readCards(uid);
           replaceCards(uid, toById(authoritative));
-          throw new Error(`${failures.length} of ${upserts.length} Card writes failed`);
+          throw new CardBulkMutationError(failedIds, upserts.length);
         }
       ),
   };

--- a/src/query/deckMutationService.spec.ts
+++ b/src/query/deckMutationService.spec.ts
@@ -1,0 +1,83 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCardMutationService } from "@/query/cardMutationService";
+import { createDeckMutationService } from "@/query/deckMutationService";
+import { firestoreKeys } from "@/query/firestoreKeys";
+import { createCard, createDeck } from "@/test/factories";
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
+describe("createDeckMutationService", () => {
+  const uid = "uid-a";
+  let client: QueryClient;
+  const dependencies = {
+    createDeck: vi.fn(),
+    updateDeck: vi.fn(),
+    removeDeck: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new QueryClient();
+    dependencies.createDeck.mockResolvedValue("deck");
+    dependencies.updateDeck.mockResolvedValue(undefined);
+    dependencies.removeDeck.mockResolvedValue(undefined);
+  });
+
+  it("rolls back a failed Deck update", async () => {
+    const deck = createDeck({ id: "deck", name: "Before", localMode: false });
+    client.setQueryData(firestoreKeys.decks(uid), { deck });
+    dependencies.updateDeck.mockRejectedValueOnce(new Error("failed"));
+    const service = createDeckMutationService({ client, ...dependencies });
+
+    await expect(service.update(uid, { ...deck, name: "After" })).rejects.toThrow("failed");
+    expect(client.getQueryData(firestoreKeys.decks(uid))).toEqual({ deck });
+  });
+
+  it("rolls back a failed Deck delete together with its child Cards", async () => {
+    const deck = createDeck({ id: "deck", localMode: false });
+    const card = createCard({ id: "card", deckId: deck.id });
+    client.setQueryData(firestoreKeys.decks(uid), { deck });
+    client.setQueryData(firestoreKeys.cards(uid), { card });
+    dependencies.removeDeck.mockRejectedValueOnce(new Error("failed"));
+    const service = createDeckMutationService({ client, ...dependencies });
+
+    await expect(service.remove(uid, deck.id)).rejects.toThrow("failed");
+    expect(client.getQueryData(firestoreKeys.decks(uid))).toEqual({ deck });
+    expect(client.getQueryData(firestoreKeys.cards(uid))).toEqual({ card });
+  });
+
+  it("waits for a child Card mutation before deleting its Deck", async () => {
+    const deck = createDeck({ id: "deck", localMode: false });
+    const card = createCard({ id: "card", deckId: deck.id });
+    client.setQueryData(firestoreKeys.decks(uid), { deck });
+    client.setQueryData(firestoreKeys.cards(uid), { card });
+    const write = deferred();
+    const updateCard = vi.fn(() => write.promise);
+    const cardService = createCardMutationService({
+      client,
+      createCard: vi.fn(),
+      updateCard,
+      removeCard: vi.fn(),
+      upsertCard: vi.fn(),
+      readCards: vi.fn(),
+    });
+    const deckService = createDeckMutationService({ client, ...dependencies });
+
+    const update = cardService.update(uid, { ...card, score: 1 });
+    await vi.waitFor(() => expect(updateCard).toHaveBeenCalled());
+    const remove = deckService.remove(uid, deck.id);
+    expect(dependencies.removeDeck).not.toHaveBeenCalled();
+    write.resolve();
+    await update;
+    await remove;
+    expect(dependencies.removeDeck).toHaveBeenCalledWith(deck.id, uid);
+  });
+});

--- a/src/query/deckMutationService.ts
+++ b/src/query/deckMutationService.ts
@@ -1,0 +1,91 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { isEqual } from "lodash";
+
+import { firestoreKeys } from "@/query/firestoreKeys";
+import { cardMutationLock, deckMutationLock, withMutationLocks } from "@/query/mutationLocks";
+import type { RemoteById } from "@/query/remoteReadController";
+
+export interface DeckMutationServiceDependencies {
+  client: QueryClient;
+  createDeck: (deck: Deck) => Promise<string>;
+  updateDeck: (deck: DeckEdit) => Promise<void>;
+  removeDeck: (deckId: DeckId, uid: string) => Promise<void>;
+}
+
+export const createDeckMutationService = (dependencies: DeckMutationServiceDependencies) => {
+  const decks = (uid: string) => dependencies.client.getQueryData<RemoteById<Deck>>(firestoreKeys.decks(uid)) ?? {};
+  const cards = (uid: string) => dependencies.client.getQueryData<RemoteById<Card>>(firestoreKeys.cards(uid)) ?? {};
+  const setDecks = (uid: string, next: RemoteById<Deck>) =>
+    dependencies.client.setQueryData(firestoreKeys.decks(uid), next);
+  const setCards = (uid: string, next: RemoteById<Card>) =>
+    dependencies.client.setQueryData(firestoreKeys.cards(uid), next);
+
+  return {
+    create: (uid: string, deck: Deck) =>
+      withMutationLocks([deckMutationLock(deck.id)], async () => {
+        const previous = decks(uid);
+        setDecks(uid, { ...previous, [deck.id]: deck });
+        try {
+          return await dependencies.createDeck(deck);
+        } catch (error) {
+          const current = decks(uid);
+          if (isEqual(current[deck.id], deck)) {
+            const rollback = { ...current };
+            if (previous[deck.id] == null) delete rollback[deck.id];
+            else rollback[deck.id] = previous[deck.id];
+            setDecks(uid, rollback);
+          }
+          throw error;
+        }
+      }),
+    update: (uid: string, patch: DeckEdit) =>
+      withMutationLocks([deckMutationLock(patch.id)], async () => {
+        const previous = decks(uid);
+        const currentDeck = previous[patch.id];
+        if (currentDeck == null) throw new Error(`Deck ${patch.id} is not available`);
+        const optimistic = { ...currentDeck, ...patch };
+        setDecks(uid, { ...previous, [patch.id]: optimistic });
+        try {
+          await dependencies.updateDeck(patch);
+        } catch (error) {
+          const current = decks(uid);
+          if (isEqual(current[patch.id], optimistic)) setDecks(uid, { ...current, [patch.id]: currentDeck });
+          throw error;
+        }
+      }),
+    remove: (uid: string, id: DeckId) => {
+      const childIds = Object.values(cards(uid))
+        .filter((card): card is Card => card?.deckId === id)
+        .map((card) => card.id);
+      return withMutationLocks([deckMutationLock(id), ...childIds.map(cardMutationLock)], async () => {
+        const previousDecks = decks(uid);
+        const previousCards = cards(uid);
+        const nextDecks = { ...previousDecks };
+        const nextCards = { ...previousCards };
+        delete nextDecks[id];
+        childIds.forEach((cardId) => {
+          delete nextCards[cardId];
+        });
+        setDecks(uid, nextDecks);
+        setCards(uid, nextCards);
+        try {
+          await dependencies.removeDeck(id, uid);
+        } catch (error) {
+          const currentDecks = decks(uid);
+          const currentCards = cards(uid);
+          const rollbackDecks = { ...currentDecks };
+          const rollbackCards = { ...currentCards };
+          if (currentDecks[id] == null && previousDecks[id] != null) rollbackDecks[id] = previousDecks[id];
+          childIds.forEach((cardId) => {
+            if (currentCards[cardId] == null && previousCards[cardId] != null) {
+              rollbackCards[cardId] = previousCards[cardId];
+            }
+          });
+          setDecks(uid, rollbackDecks);
+          setCards(uid, rollbackCards);
+          throw error;
+        }
+      });
+    },
+  };
+};

--- a/src/query/mutationLocks.ts
+++ b/src/query/mutationLocks.ts
@@ -1,0 +1,24 @@
+const tails = new Map<string, Promise<void>>();
+
+export const withMutationLocks = async <T>(keys: string[], task: () => Promise<T>): Promise<T> => {
+  const uniqueKeys = [...new Set(keys)];
+  const previous = uniqueKeys.map((key) => tails.get(key)).filter((tail): tail is Promise<void> => tail != null);
+  const operation = Promise.all(previous).then(task);
+  const settled = operation.then(
+    () => undefined,
+    () => undefined
+  );
+  uniqueKeys.forEach((key) => {
+    tails.set(key, settled);
+  });
+  try {
+    return await operation;
+  } finally {
+    uniqueKeys.forEach((key) => {
+      if (tails.get(key) === settled) tails.delete(key);
+    });
+  }
+};
+
+export const cardMutationLock = (id: CardId) => `card:${id}`;
+export const deckMutationLock = (id: DeckId) => `deck:${id}`;

--- a/src/shared/components/forms/Upload.tsx
+++ b/src/shared/components/forms/Upload.tsx
@@ -2,7 +2,9 @@ import cx from "classnames";
 import type * as React from "react";
 import { AiOutlineCloudUpload } from "react-icons/ai";
 
-export const Upload: React.FC<{ className?: string; onChange?: (file: File) => void }> = (props) => (
+export const Upload: React.FC<{ className?: string; disabled?: boolean; onChange?: (file: File) => void }> = (
+  props
+) => (
   <label
     className={cx(props.className, "flex", "max-w-sm", "h-48", "rounded-lg", "border", "cursor-pointer", "shadow-lg")}
   >
@@ -15,6 +17,7 @@ export const Upload: React.FC<{ className?: string; onChange?: (file: File) => v
         type="file"
         className="h-full w-full opacity-0 bg-pink-800"
         accept=".csv"
+        disabled={props.disabled}
         onChange={(e) => {
           if (e.target.files != null) {
             const file = e.target.files[0];

--- a/src/shared/hooks/useActions.ts
+++ b/src/shared/hooks/useActions.ts
@@ -44,17 +44,8 @@ export const useActions = () => {
           void navigate("/");
         }
       },
-      deckDownload: (id: DeckId) => dispatch(action.deck.download(id)),
-      deckRemove: (id: DeckId) =>
-        window.confirm("Are you sure of removing this deck?") && dispatch(action.deck.remove(id)),
-      deckReimport: (id: DeckId) =>
-        window.confirm("Are you sure of reloading this deck?") && dispatch(action.deck.reimport(id)),
-      deckUploadAndBack: (file: File) => {
-        dispatch(action.deck.parseFile(file));
-        void navigate(-1);
-      },
       deckDownloadCsvSampleText: () => {
-        dispatch(action.deck.downloadCsvSampleText());
+        action.deck.downloadCsvSampleText();
       },
       login: () => dispatch(action.config.loginGoogle()),
       logout: (confirmedUid: string) => dispatch(action.config.logout(confirmedUid)),


### PR DESCRIPTION
## Summary
- route local and remote Deck create, update, and delete through composed mutation hooks
- coordinate Deck deletion with child Card mutations and targeted optimistic rollback
- migrate file, URL, and reimport flows to one awaited operation with result counts and retry feedback
- remove obsolete Deck write/import thunks and cover remote Deck editing end to end

## Validation
- make check (54 files, 315 tests)
- make test-firestore (59 passed, 13 existing skipped)
- make e2e (15 passed)

Depends on #271
Parent: #257
Closes #261