### PR TITLE
Document Biome adoption

### DIFF
--- a/docs/adr/20260715-adopt-biome.md
+++ b/docs/adr/20260715-adopt-biome.md
@@ -1,0 +1,15 @@
+# Adopt Biome
+
+Status: Accepted
+
+## Context
+
+Using ESLint and Prettier required separate formatter and linter dependencies, plugins, and configuration. Consolidating them reduces dependencies and maintenance. Biome is implemented in Rust, provides fast checks, and has strong community adoption.
+
+## Decision
+
+Replace ESLint and Prettier with Biome 2.5.3, pinned exactly, while preserving `tsc`, existing npm script names, formatting and linting scopes, and key lint policies. The migration was implemented in [PR #223](https://github.com/her0e1c1/tango/pull/223).
+
+## Consequences
+
+Formatting and linting use one tool and configuration with fewer dependencies and faster checks. Application runtime behavior is unchanged. Biome upgrades require reviewing rule and formatting changes because its behavior and rule set do not exactly match ESLint and Prettier.

--- a/docs/adr/20260715-adopt-biome.md
+++ b/docs/adr/20260715-adopt-biome.md
@@ -4,12 +4,8 @@ Status: Accepted
 
 ## Context
 
-Using ESLint and Prettier required separate formatter and linter dependencies, plugins, and configuration. Consolidating them reduces dependencies and maintenance. Biome is implemented in Rust, provides fast checks, and has strong community adoption.
+ESLint and Prettier require separate dependencies and configuration. Biome combines formatting and linting, reduces dependencies, is written in Rust, and is fast and widely adopted.
 
 ## Decision
 
-Replace ESLint and Prettier with Biome 2.5.3, pinned exactly, while preserving `tsc`, existing npm script names, formatting and linting scopes, and key lint policies. The migration was implemented in [PR #223](https://github.com/her0e1c1/tango/pull/223).
-
-## Consequences
-
-Formatting and linting use one tool and configuration with fewer dependencies and faster checks. Application runtime behavior is unchanged. Biome upgrades require reviewing rule and formatting changes because its behavior and rule set do not exactly match ESLint and Prettier.
+Replace ESLint and Prettier with Biome. See [PR #223](https://github.com/her0e1c1/tango/pull/223).

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -2,4 +2,5 @@
 
 - Name ADR files using the `YYYYMMDD-$TITLE.md` format.
 - Set `Status` to `Proposed`, `Accepted`, `Deprecated`, or `Superseded`.
-- Keep ADRs concise. Include only the context, decision, and consequences needed to understand the decision.
+- Follow `Be simple.` Prefer only `Context` and `Decision`.
+- Add `Consequences` only when essential. Link implementation PRs instead of repeating their details.


### PR DESCRIPTION
## Summary

- add a concise ADR for adopting Biome
- clarify ADR guidance to prefer `Context` and `Decision`

## Why

Biome combines formatting and linting, reduces dependencies, is fast, and is widely adopted.

## Validation

- `git diff --check origin/main...HEAD`
- independent simplicity review: approved

Documentation only; `make check` is not required.