### PR TITLE
Unify shared content and feedback with Calm Focus

### DIFF
--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -14,6 +14,17 @@ const ownedPresentationFiles = [
   "shared/components/layout/List.tsx",
   "shared/components/layout/FullScreen.tsx",
   "shared/components/content/Logo.tsx",
+  "shared/components/content/Card.tsx",
+  "shared/components/content/Title.tsx",
+  "shared/components/content/Section.tsx",
+  "shared/components/content/Description.tsx",
+  "shared/components/content/Style.tsx",
+  "shared/components/content/TagList.tsx",
+  "shared/components/content/Score.tsx",
+  "shared/components/content/Code.tsx",
+  "shared/components/content/Math.tsx",
+  "shared/components/feedback/Feedback.tsx",
+  "shared/components/feedback/Overlay.tsx",
   "shared/components/forms/Button.tsx",
 ];
 const semanticColorRoles = [

--- a/src/shared/components/content/Card.stories.tsx
+++ b/src/shared/components/content/Card.stories.tsx
@@ -35,5 +35,11 @@ export const Border: Story = {
 };
 
 export const TooLong: Story = {
-  args: { children: "this is a too long text".repeat(30) },
+  args: { children: "this is a too long text ".repeat(30) },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};
+
+export const Dark: Story = {
+  args: { border: true, children: "Calm Focus surface in dark mode" },
+  globals: { theme: "dark" },
 };

--- a/src/shared/components/content/Card.tsx
+++ b/src/shared/components/content/Card.tsx
@@ -12,12 +12,9 @@ export const Card: React.FC<{
     <div className={cx("flex", props.full ? "w-full" : ["w-full", "md:w-1/2", "lg:w-1/3"])}>
       <div
         className={cx(
-          "flex-1 flex flex-col justify-between",
-          "overflow-hidden",
-          "rounded shadow",
-          "dark:text-gray-300",
-          !props.disabled ? ["bg-gray-100", "dark:bg-gray-700"] : ["bg-gray-50", "dark:bg-gray-500"],
-          props.border && ["border", "dark:border-black"],
+          "flex min-w-0 flex-1 flex-col justify-between overflow-hidden rounded-surface text-ink shadow-surface",
+          props.disabled ? "bg-surface-muted" : "bg-surface",
+          props.border && "border border-border",
           props.className
         )}
       >

--- a/src/shared/components/content/Code.scss
+++ b/src/shared/components/content/Code.scss
@@ -6,3 +6,8 @@ code[data-theme="light"] {
 code[data-theme="dark"] {
   @include meta.load-css("highlight.js/styles/atom-one-dark-reasonable");
 }
+
+code[data-theme] {
+  background: transparent;
+  color: inherit;
+}

--- a/src/shared/components/content/Code.stories.tsx
+++ b/src/shared/components/content/Code.stories.tsx
@@ -18,3 +18,16 @@ type Story = StoryObj<typeof meta>;
 export const Python: Story = {
   args: { category: "python" },
 };
+
+export const WideMobile: Story = {
+  args: {
+    category: "typescript",
+    text: "const veryWideValue = createValueWithManyArguments(firstArgument, secondArgument, thirdArgument);",
+  },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};
+
+export const Dark: Story = {
+  args: { category: "python" },
+  globals: { theme: "dark" },
+};

--- a/src/shared/components/content/Code.tsx
+++ b/src/shared/components/content/Code.tsx
@@ -9,15 +9,22 @@ const Highlight: React.FC<{ category: string; dark: boolean; children: React.Rea
     hljs.highlightAll();
   }, []);
   return (
-    <pre className={cx("dark:bg-black", props.category)}>
-      <code data-theme={props.dark ? "dark" : "light"}>{props.children}</code>
+    <pre
+      className={cx(
+        "max-w-full overflow-x-auto rounded-control border border-border bg-surface-muted p-3 text-ink",
+        props.category
+      )}
+    >
+      <code className="block min-w-max" data-theme={props.dark ? "dark" : "light"}>
+        {props.children}
+      </code>
     </pre>
   );
 };
 
 export const Code: React.FC<{ text: string; category: string }> = (props) => {
   return (
-    <Style div>
+    <Style div className="max-w-full overflow-hidden">
       <Highlight category={props.category} dark={document.querySelector("html")?.classList.contains("dark") ?? false}>
         {props.text} {/* Don't pass any <Component /> here but string */}
       </Highlight>

--- a/src/shared/components/content/ContentHierarchy.spec.tsx
+++ b/src/shared/components/content/ContentHierarchy.spec.tsx
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Card } from "@/shared/components/content/Card";
+import { Description } from "@/shared/components/content/Description";
+import { Section } from "@/shared/components/content/Section";
+import { Style } from "@/shared/components/content/Style";
+import { TagList } from "@/shared/components/content/TagList";
+import { Title } from "@/shared/components/content/Title";
+
+afterEach(cleanup);
+
+describe("shared content hierarchy", () => {
+  it("uses the Calm Focus surface hierarchy while retaining Card props", () => {
+    const view = render(<Card className="custom-card">Card content</Card>);
+    const surface = screen.getByText("Card content");
+    expect(view.container.firstElementChild).toHaveClass("w-full", "md:w-1/2", "lg:w-1/3");
+    expect(surface).toHaveClass("rounded-surface", "bg-surface", "text-ink", "shadow-surface", "custom-card");
+
+    view.rerender(
+      <Card full disabled border>
+        Disabled card
+      </Card>
+    );
+    expect(view.container.firstElementChild).toHaveClass("w-full");
+    expect(screen.getByText("Disabled card")).toHaveClass("bg-surface-muted", "border", "border-border");
+  });
+
+  it("wraps long titles and retains keyboard click behavior", () => {
+    const onClick = vi.fn();
+    render(<Title onClick={onClick}>A continuous-title-that-must-wrap-on-narrow-screens</Title>);
+    const title = screen.getByText(/continuous-title/);
+    expect(title).toHaveClass("text-title", "text-ink", "min-w-0", "break-words");
+    fireEvent.keyDown(title, { key: "Enter" });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("gives sections, descriptions, and styled text semantic type roles", () => {
+    const view = render(
+      <>
+        <Section title="Section title" />
+        <Description>Description text</Description>
+        <Style>Styled text</Style>
+      </>
+    );
+    expect(screen.getByText("Section title")).toHaveClass("text-body", "text-ink-muted", "border-border");
+    expect(screen.getByText("Description text")).toHaveClass("text-caption", "text-ink-muted", "break-words");
+    expect(screen.getByText("Styled text")).toHaveClass("text-ink", "break-words");
+    expect(view.container).toHaveTextContent("Section titleDescription textStyled text");
+  });
+
+  it("wraps ordinary tag lists and constrains long lists without horizontal scrolling", () => {
+    const view = render(<TagList>Tags</TagList>);
+    expect(screen.getByText("Tags")).toHaveClass("flex-wrap", "min-w-0", "overflow-x-hidden");
+
+    view.rerender(<TagList hasManyItems>Many tags</TagList>);
+    expect(screen.getByText("Many tags")).toHaveClass("max-h-64", "flex-col", "flex-nowrap", "overflow-y-auto");
+    expect(screen.getByText("Many tags")).not.toHaveClass("flex-wrap");
+  });
+});

--- a/src/shared/components/content/Description.stories.tsx
+++ b/src/shared/components/content/Description.stories.tsx
@@ -20,5 +20,8 @@ export const Short: Story = {
 };
 
 export const Long: Story = {
-  args: { children: "this text is too long".repeat(30) },
+  args: { children: "this text is too long ".repeat(30) },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
 };
+
+export const Dark: Story = { args: { children: "Muted dark-mode description" }, globals: { theme: "dark" } };

--- a/src/shared/components/content/Description.tsx
+++ b/src/shared/components/content/Description.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import type * as React from "react";
 
 export const Description: React.FC<{ label?: string; className?: string; children?: React.ReactNode }> = (props) => (
-  <div className={cx("inline-block text-sm text-gray-500 dark:text-gray-500", props.className)}>
+  <div className={cx("inline-block min-w-0 break-words text-caption text-ink-muted", props.className)}>
     {props.label ?? props.children}
   </div>
 );

--- a/src/shared/components/content/Math.stories.tsx
+++ b/src/shared/components/content/Math.stories.tsx
@@ -30,3 +30,13 @@ export const Markdown: Story = {
     text: fixture.math.markdown,
   },
 };
+
+export const WideMobile: Story = {
+  args: { text: "$$\\sum_{i=1}^{n} \\frac{x_i^2 + y_i^2}{\\sqrt{a_i^2 + b_i^2}} = \\prod_{j=1}^{m}(1 + z_j)$$" },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};
+
+export const Dark: Story = {
+  args: { text: fixture.math.markdown },
+  globals: { theme: "dark" },
+};

--- a/src/shared/components/content/Math.tsx
+++ b/src/shared/components/content/Math.tsx
@@ -8,7 +8,7 @@ import "katex/dist/katex.min.css";
 import "github-markdown-css/github-markdown.css";
 
 export const Math: React.FC<{ text: string }> = (props) => (
-  <Style className="markdown-body">
+  <Style className="markdown-body max-w-full overflow-x-auto rounded-control bg-surface p-1 text-ink">
     <Markdown remarkPlugins={[remarkMath, remarkGfm]} rehypePlugins={[rehypeKatex]}>
       {props.text}
     </Markdown>

--- a/src/shared/components/content/RichContent.spec.tsx
+++ b/src/shared/components/content/RichContent.spec.tsx
@@ -1,0 +1,31 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Code } from "@/shared/components/content/Code";
+import { Math } from "@/shared/components/content/Math";
+
+afterEach(cleanup);
+
+describe("shared rich content", () => {
+  it("keeps code copyable, categorized, and horizontally scrollable", async () => {
+    const text = "const veryWideValue = 'copy me without clipping';";
+    const view = render(<Code text={text} category="typescript" />);
+    const pre = view.container.querySelector("pre");
+    const code = view.container.querySelector("code");
+
+    expect(pre).toHaveClass("typescript", "max-w-full", "overflow-x-auto", "bg-surface-muted");
+    expect(code).toHaveTextContent(text);
+    expect(code).toHaveAttribute("data-theme", "light");
+    await waitFor(() => expect(code).toHaveClass("hljs"));
+  });
+
+  it("keeps GFM and KaTeX rendering readable inside narrow surfaces", () => {
+    const view = render(<Math text={"| A | B |\n| - | - |\n| 1 | 2 |\n\n$$x^2$$"} />);
+    const wrapper = view.container.firstElementChild;
+
+    expect(wrapper).toHaveClass("markdown-body", "max-w-full", "overflow-x-auto", "bg-surface");
+    expect(view.container.querySelector("table")).toBeInTheDocument();
+    expect(view.container.querySelector(".katex")).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/content/Score.stories.tsx
+++ b/src/shared/components/content/Score.stories.tsx
@@ -20,6 +20,10 @@ export const Negative: Story = {
   args: { score: -1 },
 };
 
+export const Neutral: Story = {
+  args: { score: 0 },
+};
+
 export const Positive10: Story = {
   args: { score: 10 },
 };
@@ -30,4 +34,9 @@ export const Negative10: Story = {
 
 export const Large: Story = {
   args: { score: 1, large: true },
+};
+
+export const Dark: Story = {
+  args: { score: 10, large: true },
+  globals: { theme: "dark" },
 };

--- a/src/shared/components/content/Score.tsx
+++ b/src/shared/components/content/Score.tsx
@@ -3,24 +3,24 @@ import type * as React from "react";
 
 export const Score: React.FC<{ score?: number; large?: boolean; className?: string }> = (props) => {
   const score = props.score ?? 0;
+  const cue = score > 0 ? "positive" : score < 0 ? "negative" : "neutral";
   return (
     <div
+      role="status"
+      aria-label={`Score ${score}, ${cue}`}
       className={cx(
-        "rounded-full flex justify-center",
+        "flex justify-center rounded-pill font-semibold text-ink-inverse",
         {
-          "text-sm w-5 h-5 ": !props.large,
-          "text-lg w-10 h-10 ": props.large,
-          "text-blue-700 bg-blue-300": score === 0,
-          "dark:text-blue-300 dark:bg-blue-700": score === 0,
-          "text-green-700 bg-green-300": score > 0,
-          "dark:text-green-300 dark:bg-green-700": score > 0,
-          "text-red-700 bg-red-300": score < 0,
-          "dark:text-red-300 dark:bg-red-700": score < 0,
+          "h-5 min-w-5 px-1 text-caption": !props.large,
+          "h-10 min-w-10 px-2 text-lg": props.large,
+          "bg-info": score === 0,
+          "bg-success": score > 0,
+          "bg-danger": score < 0,
         },
         props.className
       )}
     >
-      <span className="self-center">{score}</span>
+      <span className="self-center">{score > 0 ? `+${score}` : score}</span>
     </div>
   );
 };

--- a/src/shared/components/content/Score.tsx
+++ b/src/shared/components/content/Score.tsx
@@ -20,7 +20,7 @@ export const Score: React.FC<{ score?: number; large?: boolean; className?: stri
         props.className
       )}
     >
-      <span className="self-center">{score > 0 ? `+${score}` : score}</span>
+      <span className="self-center">{score}</span>
     </div>
   );
 };

--- a/src/shared/components/content/Section.stories.tsx
+++ b/src/shared/components/content/Section.stories.tsx
@@ -15,3 +15,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Page: Story = { args: { page: true } };
+
+export const Dark: Story = { globals: { theme: "dark" } };

--- a/src/shared/components/content/Section.tsx
+++ b/src/shared/components/content/Section.tsx
@@ -2,7 +2,9 @@ import type * as React from "react";
 
 export const Section: React.FC<{ title: string; page?: boolean }> = (props) =>
   props.page ? (
-    <div className="mt-4 font-bold text-lg mb-2">{props.title}</div>
+    <div className="mb-2 mt-4 break-words text-title font-bold text-ink">{props.title}</div>
   ) : (
-    <div className="mt-2 font-light text-lg mb-2 border-b border-gray-200 text-gray-300">{props.title}</div>
+    <div className="mb-2 mt-2 break-words border-b border-border pb-1 text-body font-semibold text-ink-muted">
+      {props.title}
+    </div>
   );

--- a/src/shared/components/content/StatusContent.spec.tsx
+++ b/src/shared/components/content/StatusContent.spec.tsx
@@ -16,7 +16,7 @@ describe("shared status content", () => {
     render(<Score score={score} />);
     const status = screen.getByLabelText(`Score ${score}, ${cue}`);
     expect(status).toHaveClass(colorClass, "text-ink-inverse", "rounded-pill");
-    expect(status).toHaveTextContent(score > 0 ? `+${score}` : `${score}`);
+    expect(status.querySelector("span")?.textContent).toBe(`${score}`);
   });
 
   it.each([

--- a/src/shared/components/content/StatusContent.spec.tsx
+++ b/src/shared/components/content/StatusContent.spec.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Score } from "@/shared/components/content/Score";
+import { Feedback, type FeedbackTone } from "@/shared/components/feedback/Feedback";
+
+afterEach(cleanup);
+
+describe("shared status content", () => {
+  it.each([
+    [2, "positive", "bg-success"],
+    [-2, "negative", "bg-danger"],
+    [0, "neutral", "bg-info"],
+  ] as const)("gives score %s a semantic %s cue", (score, cue, colorClass) => {
+    render(<Score score={score} />);
+    const status = screen.getByLabelText(`Score ${score}, ${cue}`);
+    expect(status).toHaveClass(colorClass, "text-ink-inverse", "rounded-pill");
+    expect(status).toHaveTextContent(score > 0 ? `+${score}` : `${score}`);
+  });
+
+  it.each([
+    ["neutral", "Information", "bg-info"],
+    ["success", "Success", "bg-success"],
+    ["warning", "Warning", "bg-warning"],
+    ["error", "Error", "bg-danger"],
+  ] as const)("renders %s feedback with a non-color label", (tone, label, colorClass) => {
+    render(<Feedback tone={tone as FeedbackTone}>Saved</Feedback>);
+    const status = screen.getByRole("status");
+    expect(status).toHaveClass(colorClass);
+    expect(status).toHaveTextContent(`${label}: Saved`);
+    expect(screen.getByText(`${label}:`, { exact: false })).toHaveClass("sr-only");
+  });
+});

--- a/src/shared/components/content/Style.tsx
+++ b/src/shared/components/content/Style.tsx
@@ -9,7 +9,7 @@ export const Style: React.FC<{
 }> = (props) => {
   const Tag = props.div ? "div" : "span";
   return (
-    <Tag onClick={props.onClick} className={cx("text-black", "dark:text-gray-300", "dark:bg-black", props.className)}>
+    <Tag onClick={props.onClick} className={cx("min-w-0 break-words text-ink", props.className)}>
       {props.children}
     </Tag>
   );

--- a/src/shared/components/content/TagList.stories.tsx
+++ b/src/shared/components/content/TagList.stories.tsx
@@ -27,6 +27,8 @@ export const TooLong: Story = {
 
 export const TooLongWithScroll: Story = {
   args: {
+    hasManyItems: true,
     children: fixture.tags.toolong.map((t) => <Tag key={t} label={t} />),
   },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
 };

--- a/src/shared/components/content/TagList.tsx
+++ b/src/shared/components/content/TagList.tsx
@@ -6,7 +6,12 @@ export const TagList: React.FC<{
   children?: React.ReactNode;
 }> = (props) => {
   return (
-    <div className={cx("gap-2", "flex", "flex-wrap", "overflow-scroll", props.hasManyItems && "flex-col max-h-64")}>
+    <div
+      className={cx(
+        "flex min-w-0 gap-2 overflow-x-hidden",
+        props.hasManyItems ? "max-h-64 flex-col flex-nowrap overflow-y-auto" : "flex-wrap"
+      )}
+    >
       {props.children}
     </div>
   );

--- a/src/shared/components/content/Title.stories.tsx
+++ b/src/shared/components/content/Title.stories.tsx
@@ -29,5 +29,10 @@ export const Short: Story = {
 };
 
 export const Long: Story = {
-  args: { children: "this text is too long".repeat(30) },
+  args: { children: "one-continuous-title-that-remains-readable-on-a-narrow-mobile-screen" },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};
+
+export const Dark: Story = {
+  globals: { theme: "dark" },
 };

--- a/src/shared/components/content/Title.tsx
+++ b/src/shared/components/content/Title.tsx
@@ -8,9 +8,8 @@ export const Title: React.FC<{ className?: string; onClick?: () => void; childre
     <div
       {...clickInteraction}
       className={cx(
-        "inline-block font-bold text-xl mr-2",
-        "text-black dark:text-gray-300",
-        { "cursor-pointer hover:opacity-50": props.onClick },
+        "mr-2 inline-block min-w-0 break-words text-title font-bold text-ink",
+        { "cursor-pointer transition-opacity duration-fast ease-calm hover:opacity-70": props.onClick },
         props.className
       )}
     >

--- a/src/shared/components/feedback/Feedback.stories.tsx
+++ b/src/shared/components/feedback/Feedback.stories.tsx
@@ -18,3 +18,11 @@ type Story = StoryObj<typeof meta>;
 export const ArrowUp: Story = {
   args: { children: <AiOutlineArrowUp /> },
 };
+
+export const Success: Story = { args: { children: "Changes saved", tone: "success" } };
+export const Warning: Story = { args: { children: "Connection is unstable", tone: "warning" } };
+export const Error: Story = { args: { children: "Could not save changes", tone: "error" } };
+export const Dark: Story = {
+  args: { children: "Dark-mode feedback", tone: "neutral" },
+  globals: { theme: "dark" },
+};

--- a/src/shared/components/feedback/Feedback.tsx
+++ b/src/shared/components/feedback/Feedback.tsx
@@ -1,10 +1,32 @@
+import cx from "classnames";
 import type * as React from "react";
 
-export const Feedback: React.FC<{ children: React.ReactNode }> = (props) =>
-  props.children == null ? null : (
-    <div className="fixed left-0 right-0 bottom-36 flex justify-center">
-      <div className="w-8 h-8 rounded-full bg-gray-600/50 flex justify-center items-center font-semibold">
+export type FeedbackTone = "neutral" | "success" | "warning" | "error";
+
+const tonePresentation: Record<FeedbackTone, { className: string; label: string }> = {
+  neutral: { className: "bg-info", label: "Information" },
+  success: { className: "bg-success", label: "Success" },
+  warning: { className: "bg-warning", label: "Warning" },
+  error: { className: "bg-danger", label: "Error" },
+};
+
+export const Feedback: React.FC<{ children: React.ReactNode; tone?: FeedbackTone }> = (props) => {
+  if (props.children == null) return null;
+
+  const presentation = tonePresentation[props.tone ?? "neutral"];
+  return (
+    <div className="fixed inset-x-0 bottom-36 z-20 flex justify-center px-shell-gutter">
+      <div
+        role="status"
+        aria-live="polite"
+        className={cx(
+          "flex min-h-touch max-w-reading items-center justify-center gap-1 rounded-pill px-4 py-2 font-semibold text-ink-inverse shadow-elevated",
+          presentation.className
+        )}
+      >
+        <span className="sr-only">{presentation.label}: </span>
         {props.children}
       </div>
     </div>
   );
+};

--- a/src/shared/components/feedback/Overlay.spec.tsx
+++ b/src/shared/components/feedback/Overlay.spec.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Overlay } from "@/shared/components/feedback/Overlay";
+
+afterEach(cleanup);
+
+describe("shared overlay surface", () => {
+  it("uses a shared backdrop and constrained scrolling for center content", () => {
+    render(<Overlay position="center">Long overlay content</Overlay>);
+    const overlay = screen.getByText("Long overlay content");
+    expect(overlay).toHaveClass(
+      "inset-0",
+      "overflow-x-hidden",
+      "overflow-y-auto",
+      "bg-surface-elevated",
+      "text-ink",
+      "shadow-elevated"
+    );
+    expect(overlay).toHaveClass("before:bg-canvas/70");
+  });
+
+  it.each([
+    ["left", "inset-y-0", "left-0"],
+    ["right", "inset-y-0", "right-0"],
+    ["top", "inset-x-0", "top-0"],
+    ["bottom", "inset-x-0", "bottom-0"],
+  ] as const)("retains the %s position contract", (position, insetClass, edgeClass) => {
+    render(<Overlay position={position}>Overlay</Overlay>);
+    expect(screen.getByText("Overlay")).toHaveClass(insetClass, edgeClass);
+  });
+
+  it("retains click, accessible name, custom class, and shared focus appearance", () => {
+    const onClick = vi.fn();
+    render(
+      <Overlay position="center" onClick={onClick} ariaLabel="Close overlay" className="custom-overlay">
+        Content
+      </Overlay>
+    );
+    const overlay = screen.getByRole("button", { name: "Close overlay" });
+    expect(overlay).toHaveClass("custom-overlay", "focus-visible:outline-focus");
+    fireEvent.click(overlay);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/components/feedback/Overlay.stories.tsx
+++ b/src/shared/components/feedback/Overlay.stories.tsx
@@ -9,9 +9,7 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
-  args: {
-    className: "bg-gray-300",
-  },
+  args: { children: "Overlay content" },
 } satisfies Meta<typeof Template>;
 
 export default meta;
@@ -45,4 +43,17 @@ export const Bottom: Story = {
   args: {
     position: "bottom",
   },
+};
+
+export const LongMobile: Story = {
+  args: {
+    position: "center",
+    children: "Long overlay content remains readable and scrollable. ".repeat(80),
+  },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};
+
+export const Dark: Story = {
+  args: { position: "center", children: "Dark-mode overlay surface" },
+  globals: { theme: "dark" },
 };

--- a/src/shared/components/feedback/Overlay.tsx
+++ b/src/shared/components/feedback/Overlay.tsx
@@ -14,18 +14,19 @@ export const Overlay: React.FC<{
     <div
       {...clickInteraction}
       {...(props.onClick !== undefined && props.ariaLabel !== undefined ? { "aria-label": props.ariaLabel } : {})}
-      className={cx([
-        props.className,
-        "absolute",
-        "z-10",
+      className={cx(
+        "absolute z-10 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control bg-surface-elevated text-ink shadow-elevated",
+        "before:pointer-events-none before:fixed before:inset-0 before:-z-10 before:bg-canvas/70",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2",
         ["left", "right"].includes(props.position) && "w-20",
         ["top", "bottom"].includes(props.position) && "h-10",
-        props.position === "center" && ["top-0", "bottom-0", "left-0", "right-0"],
-        props.position === "left" && ["top-0", "bottom-0", "left-0"],
-        props.position === "right" && ["top-0", "bottom-0", "right-0"],
-        props.position === "top" && ["top-0", "left-0", "right-0"],
-        props.position === "bottom" && ["bottom-0", "left-0", "right-0"],
-      ])}
+        props.position === "center" && "inset-0",
+        props.position === "left" && "inset-y-0 left-0",
+        props.position === "right" && "inset-y-0 right-0",
+        props.position === "top" && "inset-x-0 top-0",
+        props.position === "bottom" && "inset-x-0 bottom-0",
+        props.className
+      )}
     >
       {props.children}
     </div>


### PR DESCRIPTION
## Summary

- migrate shared content hierarchy components to Calm Focus typography, spacing, surfaces, elevation, and semantic color tokens
- preserve GFM, Highlight.js, and KaTeX rendering while making long code, Markdown, math, titles, and tags readable on narrow surfaces
- add semantic score and feedback tones with non-color cues, and standardize overlay surface, backdrop, scrolling, and focus presentation
- add representative mobile, long-content, light, and dark Storybook states plus focused component contracts

## Why

The shared content and feedback components still used raw palette utilities and inconsistent overflow behavior, so their hierarchy and contrast diverged between light and dark modes. Long content could also be clipped or made unreachable in narrow and overlay contexts.

## Impact

Existing component props, callbacks, keyboard interaction, category rendering, Markdown plugins, syntax highlighting, and KaTeX behavior are retained. Recovery orchestration, empty states, toast queues, and route-level error handling remain out of scope.

## Validation

- `npm run test:unit -- src/shared/components/content src/shared/components/feedback src/lib/calmFocusVisualContract.spec.ts src/lib/componentArchitecture.spec.ts src/lib/sharedComponentPublicApi.spec.ts src/lib/interactionAccessibility.spec.tsx`
- `npm run build:storybook`
- `make check` (57 test files, 332 tests)
- `make build`
- independent code review completed; long tag-list reachability finding fixed and re-reviewed

Closes #216