### PR TITLE
Document TanStack Query server state decision

### DIFF
--- a/docs/adr/20260716-use-tanstack-query-for-server-state.md
+++ b/docs/adr/20260716-use-tanstack-query-for-server-state.md
@@ -1,0 +1,11 @@
+# Use TanStack Query for Server State
+
+Status: Accepted
+
+## Context
+
+TanStack Query manages server state, so Redux selectors for Deck and Card data duplicate that responsibility.
+
+## Decision
+
+Use TanStack Query for server state, access the remaining local Redux state directly, and remove `src/selector`. See [PR #278](https://github.com/her0e1c1/tango/pull/278).


### PR DESCRIPTION
## Summary

- document TanStack Query as the owner of server state
- record the removal of the legacy selector module in PR #278

## Testing

- `git diff --check origin/main...HEAD`
- not run (`make check` is not required for documentation-only changes)