### PR TITLE
Unify shared form controls with Calm Focus

### DIFF
--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -26,6 +26,8 @@ const ownedPresentationFiles = [
   "shared/components/feedback/Feedback.tsx",
   "shared/components/feedback/Overlay.tsx",
   "shared/components/forms/Button.tsx",
+  "shared/components/forms/Form.tsx",
+  "shared/components/forms/FormItem.tsx",
   "shared/components/forms/Input.tsx",
   "shared/components/forms/Select.tsx",
   "shared/components/forms/Textarea.tsx",

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -26,6 +26,9 @@ const ownedPresentationFiles = [
   "shared/components/feedback/Feedback.tsx",
   "shared/components/feedback/Overlay.tsx",
   "shared/components/forms/Button.tsx",
+  "shared/components/forms/Input.tsx",
+  "shared/components/forms/Select.tsx",
+  "shared/components/forms/Textarea.tsx",
 ];
 const semanticColorRoles = [
   "canvas",

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -29,6 +29,10 @@ const ownedPresentationFiles = [
   "shared/components/forms/Input.tsx",
   "shared/components/forms/Select.tsx",
   "shared/components/forms/Textarea.tsx",
+  "shared/components/forms/Slider.tsx",
+  "shared/components/forms/Switch.tsx",
+  "shared/components/forms/Tag.tsx",
+  "shared/components/forms/Upload.tsx",
 ];
 const semanticColorRoles = [
   "canvas",

--- a/src/shared/components/forms/Form.stories.tsx
+++ b/src/shared/components/forms/Form.stories.tsx
@@ -11,7 +11,7 @@ const reviewForm = () => (
       <Input defaultValue="Japanese verbs" />
     </FormItem>
     <FormItem label="Shuffle cards" extra="The existing extra copy uses the same supporting hierarchy.">
-      <Switch checked />
+      <Switch checked onChange={() => undefined} />
     </FormItem>
     <FormItem col label="Daily review target" help="Choose a value between 1 and 100." error="Enter a whole number.">
       <Input defaultValue="One hundred and twenty" />

--- a/src/shared/components/forms/Form.stories.tsx
+++ b/src/shared/components/forms/Form.stories.tsx
@@ -2,6 +2,22 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Form as Template } from "@/shared/components/forms/Form";
 import { FormItem } from "@/shared/components/forms/FormItem";
+import { Input } from "@/shared/components/forms/Input";
+import { Switch } from "@/shared/components/forms/Switch";
+
+const reviewForm = () => (
+  <Template div>
+    <FormItem col label="Deck name" help="Shown in your library and study history.">
+      <Input defaultValue="Japanese verbs" />
+    </FormItem>
+    <FormItem label="Shuffle cards" extra="The existing extra copy uses the same supporting hierarchy.">
+      <Switch checked />
+    </FormItem>
+    <FormItem col label="Daily review target" help="Choose a value between 1 and 100." error="Enter a whole number.">
+      <Input defaultValue="One hundred and twenty" />
+    </FormItem>
+  </Template>
+);
 
 const meta = {
   title: "Shared/Form",
@@ -13,13 +29,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    children: (
-      <>
-        <FormItem label="label" extra="this is extra" text>
-          text
-        </FormItem>
-      </>
-    ),
-  },
+  render: () => reviewForm(),
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-6">
+      <div className="bg-canvas p-4 text-ink">{reviewForm()}</div>
+      <div className="dark bg-canvas p-4 text-ink">{reviewForm()}</div>
+    </div>
+  ),
+};
+
+export const NarrowMobile: Story = {
+  render: () => reviewForm(),
+  parameters: { viewport: { defaultViewport: "iphone5" } },
 };

--- a/src/shared/components/forms/Form.tsx
+++ b/src/shared/components/forms/Form.tsx
@@ -3,5 +3,5 @@ import type React from "react";
 export const Form: React.FC<{ div?: boolean; onSubmit?: () => void; children?: React.ReactNode }> = (props) => {
   const { div, ...rest } = props;
   const Tag = div ? "div" : "form";
-  return <Tag className="px-3" {...rest} />;
+  return <Tag className="w-full space-y-4 px-3 text-ink" {...rest} />;
 };

--- a/src/shared/components/forms/FormItem.stories.tsx
+++ b/src/shared/components/forms/FormItem.stories.tsx
@@ -12,9 +12,9 @@ const meta = {
   component: Template,
   tags: ["autodocs"],
   args: {
-    label: "label",
-    extra: "this is extra",
-    children: "text",
+    label: "Deck owner",
+    help: "This supporting text explains the displayed value.",
+    children: "Alex Morgan",
   },
 } satisfies Meta<typeof Template>;
 
@@ -23,9 +23,20 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const TooLongText: Story = {
+export const HelpAndError: Story = {
   args: {
-    children: "this is too long text".repeat(30),
+    label: "Deck name",
+    help: "Shown in your library and study history.",
+    error: "A deck name is required.",
+    children: <Input defaultValue="" />,
+    col: true,
+  },
+};
+
+export const LongLabelAndValue: Story = {
+  args: {
+    label: "A deliberately long label that demonstrates wrapping on compact screens",
+    children: "A long read-only value can wrap without pushing the shared form beyond the available content width.",
   },
 };
 
@@ -55,6 +66,33 @@ export const ItemSlider: Story = {
 
 export const ItemInput: Story = {
   args: {
-    children: <Input value="value" />,
+    children: <Input defaultValue="value" />,
   },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="bg-canvas p-4 text-ink">
+        <Template label="Light surface" help="Supporting copy remains quiet.">
+          Value
+        </Template>
+      </div>
+      <div className="dark bg-canvas p-4 text-ink">
+        <Template label="Dark surface" help="Supporting copy remains quiet." error="Error copy stays distinct.">
+          Value
+        </Template>
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowMobile: Story = {
+  args: {
+    col: true,
+    label: "A long mobile label that wraps before the control",
+    help: "The item stacks at narrow widths.",
+    children: <Input defaultValue="Compact value" />,
+  },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
 };

--- a/src/shared/components/forms/FormItem.tsx
+++ b/src/shared/components/forms/FormItem.tsx
@@ -5,15 +5,21 @@ import { Description } from "@/shared/components/content/Description";
 export const FormItem: React.FC<{
   label: string;
   extra?: string;
+  help?: string;
+  error?: string;
   text?: boolean;
   col?: boolean;
   children?: React.ReactNode;
 }> = (props) => (
-  <div className="w-full pb-2 md:pb-4">
-    <div className={cx("flex", props.col && "flex-col md:flex-row")}>
-      <div className="basis-full mr-2 md:basis-48 md:text-base dark:text-gray-400 mb-1 md:mb-0">{props.label}</div>
-      <div className="flex-1 text-gray-500 md:text-right">{props.text ?? props.children}</div>
+  <div className="w-full min-w-0">
+    <div className={cx("flex gap-2", props.col && "flex-col md:flex-row")}>
+      <div className="min-w-0 basis-full break-words text-body font-medium text-ink md:basis-48 md:shrink-0">
+        {props.label}
+      </div>
+      <div className="min-w-0 flex-1 break-words text-ink-muted md:text-right">{props.text ?? props.children}</div>
     </div>
     {props.extra != null && <Description label={props.extra} />}
+    {props.help != null && <Description label={props.help} />}
+    {props.error != null && <div className="text-caption font-medium text-danger">{props.error}</div>}
   </div>
 );

--- a/src/shared/components/forms/FormLayout.spec.tsx
+++ b/src/shared/components/forms/FormLayout.spec.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Form } from "@/shared/components/forms/Form";
+import { FormItem } from "@/shared/components/forms/FormItem";
+
+afterEach(cleanup);
+
+describe("shared form layout", () => {
+  it("presents label, value, help, and error with a clear visual hierarchy", () => {
+    const view = render(
+      <Form>
+        <FormItem label="Deck name" help="Shown in your library" error="A deck name is required">
+          Current deck
+        </FormItem>
+      </Form>
+    );
+
+    expect(view.container.firstElementChild).toHaveClass("w-full", "space-y-4", "px-3", "text-ink");
+
+    const label = screen.getByText("Deck name");
+    const value = screen.getByText("Current deck");
+    const help = screen.getByText("Shown in your library");
+    const error = screen.getByText("A deck name is required");
+
+    expect(label).toHaveClass("font-medium", "text-ink");
+    expect(value).toHaveClass("text-ink-muted");
+    expect(help).toHaveClass("text-caption", "text-ink-muted");
+    expect(error).toHaveClass("text-caption", "font-medium", "text-danger");
+    expect(label.compareDocumentPosition(value) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(value.compareDocumentPosition(help) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(help.compareDocumentPosition(error) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("allows long labels and values to wrap without widening the form", () => {
+    render(
+      <FormItem label="A deliberately long label that needs room to wrap on compact screens">
+        A value that can also wrap safely
+      </FormItem>
+    );
+
+    expect(screen.getByText(/deliberately long label/)).toHaveClass("min-w-0", "break-words", "md:basis-48");
+    expect(screen.getByText(/value that can also wrap/)).toHaveClass("min-w-0", "break-words");
+  });
+
+  it("keeps legacy extra copy and stacks column items on mobile", () => {
+    const view = render(
+      <FormItem col label="Maximum cards" extra="The existing extra prop remains visible">
+        Slider control
+      </FormItem>
+    );
+
+    expect(view.container.firstElementChild?.firstElementChild).toHaveClass("flex", "flex-col", "gap-2", "md:flex-row");
+    expect(screen.getByText("The existing extra prop remains visible")).toHaveClass("text-caption", "text-ink-muted");
+    expect(screen.getByText("Slider control")).toBeVisible();
+  });
+});

--- a/src/shared/components/forms/Input.stories.tsx
+++ b/src/shared/components/forms/Input.stories.tsx
@@ -27,7 +27,7 @@ export const States: Story = {
 };
 
 export const Invalid: Story = {
-  args: { type: "email", defaultValue: "invalid-email" },
+  args: { required: true, defaultValue: "" },
 };
 
 export const LongValue: Story = {

--- a/src/shared/components/forms/Input.stories.tsx
+++ b/src/shared/components/forms/Input.stories.tsx
@@ -22,9 +22,12 @@ export const States: Story = {
       <Template placeholder="Placeholder value" />
       <Template defaultValue="Read-only value" readOnly />
       <Template defaultValue="Disabled value" disabled />
-      <Template type="email" defaultValue="invalid-email" />
     </div>
   ),
+};
+
+export const Invalid: Story = {
+  args: { type: "email", defaultValue: "invalid-email" },
 };
 
 export const LongValue: Story = {

--- a/src/shared/components/forms/Input.stories.tsx
+++ b/src/shared/components/forms/Input.stories.tsx
@@ -15,3 +15,39 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const States: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <Template placeholder="Placeholder value" />
+      <Template defaultValue="Read-only value" readOnly />
+      <Template defaultValue="Disabled value" disabled />
+      <Template type="email" defaultValue="invalid-email" />
+    </div>
+  ),
+};
+
+export const LongValue: Story = {
+  args: {
+    defaultValue:
+      "A deliberately long single-line value demonstrates how the shared input behaves when content exceeds its available width.",
+  },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="bg-canvas p-4 text-ink">
+        <Template defaultValue="Light surface" />
+      </div>
+      <div className="dark bg-canvas p-4 text-ink">
+        <Template defaultValue="Dark surface" />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: { defaultValue: "A long value on a narrow mobile viewport" },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};

--- a/src/shared/components/forms/Input.tsx
+++ b/src/shared/components/forms/Input.tsx
@@ -29,7 +29,7 @@ export const Input: React.FC<{
       onChange={props.onChange}
       onBlur={props.onBlur}
       className={cx(
-        "w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
+        "min-h-touch w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
         props.className
       )}
     />

--- a/src/shared/components/forms/Input.tsx
+++ b/src/shared/components/forms/Input.tsx
@@ -7,6 +7,9 @@ export const Input: React.FC<{
   type?: string;
   value?: string;
   defaultValue?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   inputRef?: React.Ref<HTMLInputElement>;
@@ -18,23 +21,13 @@ export const Input: React.FC<{
       name={props.name}
       defaultValue={props.defaultValue}
       value={props.value}
+      disabled={props.disabled}
+      readOnly={props.readOnly}
+      placeholder={props.placeholder}
       onChange={props.onChange}
       onBlur={props.onBlur}
       className={cx(
-        `shadow
-         appearance-none
-         border
-         rounded
-         w-full
-         py-2
-         px-3
-         text-gray-700
-         dark:bg-black
-         dark:text-gray-100
-         leading-tight
-         focus:outline-hidden
-         focus:ring-2
-         focus:ring-blue-500`,
+        "w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
         props.className
       )}
     />

--- a/src/shared/components/forms/Input.tsx
+++ b/src/shared/components/forms/Input.tsx
@@ -9,6 +9,7 @@ export const Input: React.FC<{
   defaultValue?: string;
   disabled?: boolean;
   readOnly?: boolean;
+  required?: boolean;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -23,6 +24,7 @@ export const Input: React.FC<{
       value={props.value}
       disabled={props.disabled}
       readOnly={props.readOnly}
+      required={props.required}
       placeholder={props.placeholder}
       onChange={props.onChange}
       onBlur={props.onBlur}

--- a/src/shared/components/forms/Select.stories.tsx
+++ b/src/shared/components/forms/Select.stories.tsx
@@ -20,3 +20,46 @@ export const Default: Story = {};
 export const Empty: Story = {
   args: { empty: true },
 };
+
+export const States: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <Template options={fixture.form.options.default} />
+      <Template options={fixture.form.options.default} empty />
+      <Template options={fixture.form.options.default} disabled />
+    </div>
+  ),
+};
+
+export const LongValue: Story = {
+  args: {
+    options: [
+      {
+        label: "A deliberately long selected option demonstrates how the shared select behaves at constrained widths",
+        value: "long",
+      },
+    ],
+    defaultValue: "long",
+  },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="bg-canvas p-4 text-ink">
+        <Template options={fixture.form.options.default} />
+      </div>
+      <div className="dark bg-canvas p-4 text-ink">
+        <Template options={fixture.form.options.default} />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: {
+    options: [{ label: "A long option in a narrow mobile viewport", value: "mobile" }],
+    defaultValue: "mobile",
+  },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};

--- a/src/shared/components/forms/Select.stories.tsx
+++ b/src/shared/components/forms/Select.stories.tsx
@@ -21,6 +21,10 @@ export const Empty: Story = {
   args: { empty: true },
 };
 
+export const Invalid: Story = {
+  args: { empty: true, required: true, defaultValue: "" },
+};
+
 export const States: Story = {
   render: () => (
     <div className="grid gap-4">

--- a/src/shared/components/forms/Select.tsx
+++ b/src/shared/components/forms/Select.tsx
@@ -9,8 +9,11 @@ export interface Option {
 export const Select: React.FC<{
   options?: Option[];
   empty?: boolean;
+  className?: string;
   name?: string;
   value?: string;
+  defaultValue?: string;
+  disabled?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLSelectElement>) => void;
   inputRef?: React.Ref<HTMLSelectElement>;
@@ -24,12 +27,13 @@ export const Select: React.FC<{
       ref={props.inputRef}
       name={props.name}
       value={props.value}
+      defaultValue={props.defaultValue}
+      disabled={props.disabled}
       onChange={props.onChange}
       onBlur={props.onBlur}
       className={cx(
-        `block appearance-none w-full bg-white border border-gray-400
-        hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight
-        focus:outline-hidden focus:ring-2 focus:ring-blue-500`
+        "block w-full appearance-none rounded-control border border-border bg-surface px-4 py-2 pr-8 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted",
+        props.className
       )}
     >
       {options?.map((o) => (

--- a/src/shared/components/forms/Select.tsx
+++ b/src/shared/components/forms/Select.tsx
@@ -14,6 +14,7 @@ export const Select: React.FC<{
   value?: string;
   defaultValue?: string;
   disabled?: boolean;
+  required?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLSelectElement>) => void;
   inputRef?: React.Ref<HTMLSelectElement>;
@@ -29,6 +30,7 @@ export const Select: React.FC<{
       value={props.value}
       defaultValue={props.defaultValue}
       disabled={props.disabled}
+      required={props.required}
       onChange={props.onChange}
       onBlur={props.onBlur}
       className={cx(

--- a/src/shared/components/forms/Select.tsx
+++ b/src/shared/components/forms/Select.tsx
@@ -34,7 +34,7 @@ export const Select: React.FC<{
       onChange={props.onChange}
       onBlur={props.onBlur}
       className={cx(
-        "block w-full appearance-none rounded-control border border-border bg-surface px-4 py-2 pr-8 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted",
+        "block min-h-touch w-full appearance-none rounded-control border border-border bg-surface px-4 py-2 pr-8 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted",
         props.className
       )}
     >

--- a/src/shared/components/forms/SelectionControl.spec.tsx
+++ b/src/shared/components/forms/SelectionControl.spec.tsx
@@ -102,6 +102,25 @@ describe("shared selection controls", () => {
     expect(screen.queryByText("biology.csv")).not.toBeInTheDocument();
   });
 
+  it("gives the slider native input a shared mobile touch target", () => {
+    const view = render(<Slider />);
+
+    expect(view.container.querySelector("input[type=range]")).toHaveClass("min-h-touch");
+  });
+
+  it("gives the switch clickable wrapper a shared mobile touch target", () => {
+    const view = render(<Switch />);
+
+    expect(view.container.firstElementChild).toHaveClass("min-h-touch", "min-w-touch");
+  });
+
+  it("gives the tag clickable presentation a shared mobile touch target", () => {
+    const view = render(<Tag label="Biology" />);
+    const input = view.container.querySelector("input[type=checkbox]");
+
+    expect(input?.nextElementSibling).toHaveClass("min-h-touch", "min-w-touch");
+  });
+
   it("disables every native control with a consistent non-color cue", () => {
     const slider = render(<Slider disabled value="3" />);
     const sliderInput = slider.container.querySelector("input");

--- a/src/shared/components/forms/SelectionControl.spec.tsx
+++ b/src/shared/components/forms/SelectionControl.spec.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Slider } from "@/shared/components/forms/Slider";
+import { Switch } from "@/shared/components/forms/Switch";
+import { Tag } from "@/shared/components/forms/Tag";
+import { Upload } from "@/shared/components/forms/Upload";
+
+afterEach(cleanup);
+
+describe("shared selection controls", () => {
+  it("keeps the slider controlled value, native handlers, and input ref", () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    const view = render(
+      <Slider inputRef={inputRef} min={0} max={10} name="confidence" value="4" onChange={onChange} onBlur={onBlur} />
+    );
+
+    const input = view.container.querySelector<HTMLInputElement>("input[type=range]");
+    if (input == null) throw new Error("Slider input is missing");
+    expect(input).toHaveValue("4");
+    expect(input).toHaveAttribute("name", "confidence");
+    expect(inputRef.current).toBe(input);
+    fireEvent.change(input, { target: { value: "7" } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the switch checked state, native value, handlers, and input ref", () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    const view = render(
+      <Switch checked inputRef={inputRef} name="published" value="yes" onChange={onChange} onBlur={onBlur} />
+    );
+
+    const input = view.container.querySelector<HTMLInputElement>("input[type=checkbox]");
+    if (input == null) throw new Error("Switch input is missing");
+    expect(input).toBeChecked();
+    expect(input).toHaveAttribute("value", "yes");
+    expect(inputRef.current).toBe(input);
+    fireEvent.click(input);
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it("shows tag selection with shape as well as semantic color", () => {
+    const view = render(<Tag checked label="Biology" primary />);
+
+    const input = view.container.querySelector<HTMLInputElement>("input[type=checkbox]");
+    if (input == null) throw new Error("Tag input is missing");
+    const presentation = input?.nextElementSibling;
+    expect(input).toBeChecked();
+    expect(presentation).toHaveClass("bg-accent-primary", "peer-checked:ring-2", "peer-checked:ring-current");
+  });
+
+  it("keeps tag native values, handlers, and input ref", () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    const view = render(
+      <Tag inputRef={inputRef} label="History" name="topic" value="history" onChange={onChange} onBlur={onBlur} />
+    );
+
+    const input = view.container.querySelector<HTMLInputElement>("input[type=checkbox]");
+    if (input == null) throw new Error("Tag input is missing");
+    expect(input).not.toBeChecked();
+    expect(input).toHaveAttribute("value", "history");
+    expect(inputRef.current).toBe(input);
+    fireEvent.click(input);
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it("passes the chosen native file to the unchanged upload callback", () => {
+    const onChange = vi.fn();
+    const file = new File(["front,back"], "biology.csv", { type: "text/csv" });
+    const view = render(<Upload onChange={onChange} />);
+
+    const input = view.container.querySelector<HTMLInputElement>("input[type=file]");
+    if (input == null) throw new Error("Upload input is missing");
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(input?.files?.[0]).toBe(file);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(file);
+  });
+
+  it("presents the chosen file from controlled props without storing native file state", () => {
+    const view = render(<Upload fileName="biology.csv" />);
+
+    expect(screen.getByText("biology.csv")).toHaveClass("font-semibold", "text-ink");
+    expect(view.container.querySelector("input[type=file]")).toHaveValue("");
+
+    view.rerender(<Upload />);
+    expect(screen.queryByText("biology.csv")).not.toBeInTheDocument();
+  });
+
+  it("disables every native control with a consistent non-color cue", () => {
+    const slider = render(<Slider disabled value="3" />);
+    const sliderInput = slider.container.querySelector("input");
+    expect(sliderInput).toBeDisabled();
+    expect(sliderInput).toHaveClass("disabled:cursor-not-allowed", "disabled:opacity-50");
+    slider.unmount();
+
+    const switchView = render(<Switch disabled checked />);
+    const switchInput = switchView.container.querySelector("input");
+    expect(switchInput).toBeDisabled();
+    expect(switchInput?.nextElementSibling).toHaveClass("peer-disabled:cursor-not-allowed", "peer-disabled:opacity-50");
+    switchView.unmount();
+
+    const tag = render(<Tag disabled checked label="Disabled" />);
+    const tagInput = tag.container.querySelector("input");
+    expect(tagInput).toBeDisabled();
+    expect(tagInput?.nextElementSibling).toHaveClass("peer-disabled:cursor-not-allowed", "peer-disabled:opacity-50");
+    tag.unmount();
+
+    const upload = render(<Upload disabled />);
+    const uploadInput = upload.container.querySelector("input");
+    expect(uploadInput).toBeDisabled();
+    expect(upload.container.firstElementChild).toHaveClass("cursor-not-allowed", "opacity-50");
+  });
+});

--- a/src/shared/components/forms/SelectionControl.spec.tsx
+++ b/src/shared/components/forms/SelectionControl.spec.tsx
@@ -102,10 +102,16 @@ describe("shared selection controls", () => {
     expect(screen.queryByText("biology.csv")).not.toBeInTheDocument();
   });
 
-  it("gives the slider native input a shared mobile touch target", () => {
+  it("separates the slider mobile touch target from its visual rail", () => {
     const view = render(<Slider />);
+    const input = view.container.querySelector("input[type=range]");
+    const rail = view.container.querySelector<HTMLElement>('[aria-hidden="true"]');
 
-    expect(view.container.querySelector("input[type=range]")).toHaveClass("min-h-touch");
+    expect(input).toHaveClass("min-h-touch", "bg-transparent");
+    expect(input).not.toHaveClass("h-2", "bg-surface-muted", "rounded-pill");
+    expect(rail).not.toBe(input);
+    expect(input?.parentElement).toContainElement(rail);
+    expect(rail).toHaveClass("pointer-events-none", "h-2", "w-full", "rounded-pill", "bg-surface-muted");
   });
 
   it("gives the switch clickable wrapper a shared mobile touch target", () => {

--- a/src/shared/components/forms/Slider.stories.tsx
+++ b/src/shared/components/forms/Slider.stories.tsx
@@ -12,4 +12,32 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { args: { value: "40" } };
+
+export const Values: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <Template value="20" />
+      <Template value="70" />
+      <Template value="40" disabled />
+    </div>
+  ),
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="bg-canvas p-4">
+        <Template value="35" />
+      </div>
+      <div className="dark bg-canvas p-4">
+        <Template value="65" />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: { value: "55" },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};

--- a/src/shared/components/forms/Slider.tsx
+++ b/src/shared/components/forms/Slider.tsx
@@ -23,11 +23,7 @@ export const Slider: React.FC<{
       value={props.value}
       onChange={props.onChange}
       onBlur={props.onBlur}
-      className={`
-        w-full h-2 bg-blue-100 appearance-none dark:bg-blue-900
-       disabled:bg-gray-100
-       dark:disabled:bg-gray-900
-      `}
+      className="h-2 w-full appearance-none rounded-pill bg-surface-muted accent-accent-primary transition-opacity duration-fast ease-calm disabled:cursor-not-allowed disabled:opacity-50"
     />
   );
 };

--- a/src/shared/components/forms/Slider.tsx
+++ b/src/shared/components/forms/Slider.tsx
@@ -12,18 +12,24 @@ export const Slider: React.FC<{
   inputRef?: React.Ref<HTMLInputElement>;
 }> = (props) => {
   return (
-    <input
-      type="range"
-      min={props.min}
-      max={props.max}
-      step={props.step ?? 1}
-      disabled={props.disabled}
-      ref={props.inputRef}
-      name={props.name}
-      value={props.value}
-      onChange={props.onChange}
-      onBlur={props.onBlur}
-      className="h-2 min-h-touch w-full appearance-none rounded-pill bg-surface-muted accent-accent-primary transition-opacity duration-fast ease-calm disabled:cursor-not-allowed disabled:opacity-50"
-    />
+    <div className="relative min-h-touch w-full">
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-1/2 h-2 w-full -translate-y-1/2 rounded-pill bg-surface-muted"
+      />
+      <input
+        type="range"
+        min={props.min}
+        max={props.max}
+        step={props.step ?? 1}
+        disabled={props.disabled}
+        ref={props.inputRef}
+        name={props.name}
+        value={props.value}
+        onChange={props.onChange}
+        onBlur={props.onBlur}
+        className="absolute inset-0 min-h-touch w-full appearance-none bg-transparent accent-accent-primary transition-opacity duration-fast ease-calm disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </div>
   );
 };

--- a/src/shared/components/forms/Slider.tsx
+++ b/src/shared/components/forms/Slider.tsx
@@ -23,7 +23,7 @@ export const Slider: React.FC<{
       value={props.value}
       onChange={props.onChange}
       onBlur={props.onBlur}
-      className="h-2 w-full appearance-none rounded-pill bg-surface-muted accent-accent-primary transition-opacity duration-fast ease-calm disabled:cursor-not-allowed disabled:opacity-50"
+      className="h-2 min-h-touch w-full appearance-none rounded-pill bg-surface-muted accent-accent-primary transition-opacity duration-fast ease-calm disabled:cursor-not-allowed disabled:opacity-50"
     />
   );
 };

--- a/src/shared/components/forms/Switch.stories.tsx
+++ b/src/shared/components/forms/Switch.stories.tsx
@@ -18,10 +18,34 @@ export const Checked: Story = {
   args: { checked: true },
 };
 
+export const Disabled: Story = {
+  args: { checked: true, disabled: true },
+};
+
 export const Small: Story = {
   args: { small: true },
 };
 
 export const Large: Story = {
   args: { large: true },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="flex gap-3 bg-canvas p-4">
+        <Template />
+        <Template checked />
+      </div>
+      <div className="dark flex gap-3 bg-canvas p-4">
+        <Template />
+        <Template checked />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: { checked: true },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
 };

--- a/src/shared/components/forms/Switch.tsx
+++ b/src/shared/components/forms/Switch.tsx
@@ -14,7 +14,7 @@ export const Switch: React.FC<{
   inputRef?: React.Ref<HTMLInputElement>;
 }> = (props) => {
   return (
-    <label className={cx("inline-block", props.className)}>
+    <label className={cx("inline-flex min-h-touch min-w-touch items-center justify-center", props.className)}>
       <input
         ref={props.inputRef}
         name={props.name}

--- a/src/shared/components/forms/Switch.tsx
+++ b/src/shared/components/forms/Switch.tsx
@@ -14,7 +14,7 @@ export const Switch: React.FC<{
   inputRef?: React.Ref<HTMLInputElement>;
 }> = (props) => {
   return (
-    <label className={cx("inline-block")}>
+    <label className={cx("inline-block", props.className)}>
       <input
         ref={props.inputRef}
         name={props.name}
@@ -28,18 +28,17 @@ export const Switch: React.FC<{
       />
       <span
         className={cx(
-          "flex items-center shrink-0 p-1 rounded-full",
-          "duration-300",
-          "ease-in-out",
-          "bg-gray-300",
-          "peer-checked:bg-green-400",
+          "flex shrink-0 items-center rounded-pill border border-border bg-surface-muted p-1",
+          "transition-colors duration-normal ease-calm",
+          "peer-checked:border-accent-secondary peer-checked:bg-accent-secondary",
+          "peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
           props.small
             ? ["w-8 h-5", "after:w-4 after:h-4", "peer-checked:after:translate-x-2"]
             : props.large
               ? ["w-16 h-10", "after:w-8 after:h-8", "peer-checked:after:translate-x-6"]
               : ["w-10 h-6", "after:w-5 after:h-5", "peer-checked:after:translate-x-3"],
-          "after:bg-white after:rounded-full after:shadow-md",
-          "after:duration-300"
+          "after:rounded-full after:bg-surface-elevated after:shadow-surface",
+          "after:transition-transform after:duration-normal after:ease-calm"
         )}
       ></span>
     </label>

--- a/src/shared/components/forms/Tag.stories.tsx
+++ b/src/shared/components/forms/Tag.stories.tsx
@@ -52,6 +52,10 @@ export const Checked: Story = {
   args: { checked: true },
 };
 
+export const Disabled: Story = {
+  args: { checked: true, disabled: true, label: "disabled tag" },
+};
+
 export const Clickable: Story = {
   args: {
     onChange: () => {
@@ -90,4 +94,24 @@ export const PrimaryClickableChecked: Story = {
     },
     checked: true,
   },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="flex gap-3 bg-canvas p-4 text-ink">
+        <Template label="Light" />
+        <Template checked primary label="Selected" />
+      </div>
+      <div className="dark flex gap-3 bg-canvas p-4 text-ink">
+        <Template label="Dark" />
+        <Template checked primary label="Selected" />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: { checked: true, label: "Selected on mobile", round: true },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
 };

--- a/src/shared/components/forms/Tag.tsx
+++ b/src/shared/components/forms/Tag.tsx
@@ -36,7 +36,7 @@ export const Tag: React.FC<{
       <div
         className={cx(
           props.className,
-          "select-none",
+          "inline-flex min-h-touch min-w-touch select-none items-center justify-center",
           "whitespace-nowrap",
           "font-medium",
           "align-middle",

--- a/src/shared/components/forms/Tag.tsx
+++ b/src/shared/components/forms/Tag.tsx
@@ -8,6 +8,7 @@ export const Tag: React.FC<{
   large?: boolean;
   label?: string;
   checked?: boolean;
+  disabled?: boolean;
   default?: boolean;
   primary?: boolean;
   hidden?: boolean;
@@ -25,6 +26,7 @@ export const Tag: React.FC<{
         type="checkbox"
         className="hidden peer"
         checked={props.checked}
+        disabled={props.disabled}
         ref={props.inputRef}
         name={props.name}
         value={props.value}
@@ -38,26 +40,17 @@ export const Tag: React.FC<{
           "whitespace-nowrap",
           "font-medium",
           "align-middle",
-          props.round ? "rounded-full" : "rounded",
+          "border border-border transition-colors duration-fast ease-calm peer-checked:ring-2 peer-checked:ring-current",
+          "peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+          props.round ? "rounded-pill" : "rounded-control",
           props.large ? ["py-3 px-4 text-lg"] : props.small ? ["py-1 px-1 text-xs"] : ["py-2 px-3 text-sm"],
           props.primary
-            ? [
-                "bg-blue-200",
-                "text-blue-500",
-                "peer-checked:bg-blue-300",
-                "dark:bg-blue-700",
-                "dark:text-blue-400",
-                "dark:peer-checked:bg-blue-900",
-              ]
+            ? ["bg-accent-primary text-ink-inverse", "peer-checked:border-accent-primary"]
             : [
-                "bg-gray-200",
-                "text-gray-500",
-                "peer-checked:bg-gray-300",
-                "dark:bg-gray-700",
-                "dark:text-gray-400",
-                "dark:peer-checked:bg-gray-900",
+                "bg-surface-muted text-ink",
+                "peer-checked:border-accent-secondary peer-checked:bg-accent-secondary peer-checked:text-ink-inverse",
               ],
-          props.onChange != null && "cursor-pointer"
+          props.onChange != null && !props.disabled && "cursor-pointer"
         )}
       >
         {props.label ?? props.children}

--- a/src/shared/components/forms/TextControl.spec.tsx
+++ b/src/shared/components/forms/TextControl.spec.tsx
@@ -166,6 +166,16 @@ describe("shared text controls", () => {
   });
 
   it.each([
+    ["input", () => render(<Input />)],
+    ["select", () => render(<Select options={[{ label: "Primary", value: "primary" }]} />)],
+    ["textarea", () => render(<Textarea />)],
+  ])("gives the native %s a shared mobile touch target", (_name, renderControl) => {
+    const view = renderControl();
+
+    expect(view.container.firstElementChild).toHaveClass("min-h-touch");
+  });
+
+  it.each([
     ["input", () => render(<Input required defaultValue="" />)],
     [
       "select",

--- a/src/shared/components/forms/TextControl.spec.tsx
+++ b/src/shared/components/forms/TextControl.spec.tsx
@@ -166,7 +166,7 @@ describe("shared text controls", () => {
   });
 
   it.each([
-    ["input", () => render(<Input type="email" defaultValue="not-an-email" />)],
+    ["input", () => render(<Input required defaultValue="" />)],
     [
       "select",
       () => render(<Select empty required defaultValue="" options={[{ label: "Primary", value: "primary" }]} />),

--- a/src/shared/components/forms/TextControl.spec.tsx
+++ b/src/shared/components/forms/TextControl.spec.tsx
@@ -164,4 +164,19 @@ describe("shared text controls", () => {
       expect(control).toHaveClass("focus-visible:border-focus");
     }
   });
+
+  it.each([
+    ["input", () => render(<Input type="email" defaultValue="not-an-email" />)],
+    [
+      "select",
+      () => render(<Select empty required defaultValue="" options={[{ label: "Primary", value: "primary" }]} />),
+    ],
+    ["textarea", () => render(<Textarea required />)],
+  ])("makes invalid styling reachable on the native %s", (_name, renderControl) => {
+    const view = renderControl();
+    const element = view.container.firstElementChild;
+
+    expect(element).toBeInvalid();
+    expect(element).toHaveClass("invalid:border-danger");
+  });
 });

--- a/src/shared/components/forms/TextControl.spec.tsx
+++ b/src/shared/components/forms/TextControl.spec.tsx
@@ -1,0 +1,167 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Input } from "@/shared/components/forms/Input";
+import { Select } from "@/shared/components/forms/Select";
+import { Textarea } from "@/shared/components/forms/Textarea";
+
+afterEach(cleanup);
+
+const sharedVisualClasses = [
+  "border-border",
+  "bg-surface",
+  "text-ink",
+  "rounded-control",
+  "shadow-surface",
+  "focus-visible:border-focus",
+  "invalid:border-danger",
+  "disabled:bg-surface-muted",
+  "disabled:text-ink-muted",
+  "disabled:cursor-not-allowed",
+];
+
+describe("shared text controls", () => {
+  it("keeps native input values, refs, and handlers", () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+
+    render(<Input inputRef={inputRef} defaultValue="Original" name="title" onChange={onChange} onBlur={onBlur} />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("Original");
+    expect(inputRef.current).toBe(input);
+    fireEvent.change(input, { target: { value: "Updated" } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it("keeps native select values, refs, and handlers", () => {
+    const inputRef = createRef<HTMLSelectElement>();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+
+    render(
+      <Select
+        inputRef={inputRef}
+        defaultValue="secondary"
+        options={[
+          { label: "Primary", value: "primary" },
+          { label: "Secondary", value: "secondary" },
+        ]}
+        name="category"
+        onChange={onChange}
+        onBlur={onBlur}
+      />
+    );
+
+    const select = screen.getByRole("combobox");
+    expect(select).toHaveValue("secondary");
+    expect(inputRef.current).toBe(select);
+    fireEvent.change(select, { target: { value: "primary" } });
+    fireEvent.blur(select);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it("keeps native textarea values, refs, and handlers", () => {
+    const inputRef = createRef<HTMLTextAreaElement>();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+
+    render(
+      <Textarea inputRef={inputRef} defaultValue="Original notes" name="notes" onChange={onChange} onBlur={onBlur} />
+    );
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue("Original notes");
+    expect(inputRef.current).toBe(textarea);
+    fireEvent.change(textarea, { target: { value: "Updated notes" } });
+    fireEvent.blur(textarea);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it("styles input states with semantic Calm Focus roles", () => {
+    render(
+      <Input
+        className="custom-input"
+        disabled
+        readOnly
+        placeholder="Deck title"
+        type="email"
+        defaultValue="not-an-email"
+      />
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("placeholder", "Deck title");
+    expect(input).toHaveClass(
+      ...sharedVisualClasses,
+      "placeholder:text-ink-muted",
+      "read-only:bg-surface-muted",
+      "custom-input"
+    );
+  });
+
+  it("styles select states with semantic colors in light and dark modes", () => {
+    render(
+      <div className="dark">
+        <Select
+          className="custom-select"
+          disabled
+          defaultValue="primary"
+          options={[{ label: "Primary", value: "primary" }]}
+        />
+      </div>
+    );
+
+    const select = screen.getByRole("combobox");
+    expect(select).toBeDisabled();
+    expect(select).toHaveClass(...sharedVisualClasses, "custom-select");
+  });
+
+  it("styles textarea states with semantic Calm Focus roles", () => {
+    render(
+      <Textarea
+        className="custom-textarea"
+        disabled
+        readOnly
+        placeholder="Card details"
+        defaultValue="Long-form content"
+      />
+    );
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeDisabled();
+    expect(textarea).toHaveAttribute("readonly");
+    expect(textarea).toHaveAttribute("placeholder", "Card details");
+    expect(textarea).toHaveClass(
+      ...sharedVisualClasses,
+      "placeholder:text-ink-muted",
+      "read-only:bg-surface-muted",
+      "custom-textarea"
+    );
+  });
+
+  it("keeps each focusable control on the native focus path", () => {
+    const view = render(
+      <>
+        <Input />
+        <Select options={[{ label: "Primary", value: "primary" }]} />
+        <Textarea />
+      </>
+    );
+
+    for (const control of view.container.querySelectorAll<HTMLElement>("input, select, textarea")) {
+      control.focus();
+      expect(control).toHaveFocus();
+      expect(control).toHaveClass("focus-visible:border-focus");
+    }
+  });
+});

--- a/src/shared/components/forms/Textarea.stories.tsx
+++ b/src/shared/components/forms/Textarea.stories.tsx
@@ -14,6 +14,10 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const Invalid: Story = {
+  args: { required: true, defaultValue: "" },
+};
+
 export const States: Story = {
   render: () => (
     <div className="grid gap-4">

--- a/src/shared/components/forms/Textarea.stories.tsx
+++ b/src/shared/components/forms/Textarea.stories.tsx
@@ -6,10 +6,48 @@ const meta = {
   title: "Shared/Textarea",
   component: Template,
   tags: ["autodocs"],
-  args: {},
+  args: { rows: 4 },
 } satisfies Meta<typeof Template>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const States: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <Template rows={3} placeholder="Placeholder content" />
+      <Template rows={3} defaultValue="Read-only content" readOnly />
+      <Template rows={3} defaultValue="Disabled content" disabled />
+    </div>
+  ),
+};
+
+export const LongValue: Story = {
+  args: {
+    defaultValue:
+      "Long-form text should remain comfortable to read and edit inside the shared textarea. This story provides enough content to demonstrate wrapping, vertical space, and the control surface without changing its native behavior.",
+  },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="bg-canvas p-4 text-ink">
+        <Template rows={3} defaultValue="Light surface" />
+      </div>
+      <div className="dark bg-canvas p-4 text-ink">
+        <Template rows={3} defaultValue="Dark surface" />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: {
+    defaultValue:
+      "A longer textarea value demonstrates readable wrapping and comfortable editing on a narrow mobile viewport.",
+  },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};

--- a/src/shared/components/forms/Textarea.tsx
+++ b/src/shared/components/forms/Textarea.tsx
@@ -29,7 +29,7 @@ export const Textarea: React.FC<{
       onBlur={props.onBlur}
       rows={props.rows}
       className={cx(
-        "w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
+        "min-h-touch w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
         props.className
       )}
     />

--- a/src/shared/components/forms/Textarea.tsx
+++ b/src/shared/components/forms/Textarea.tsx
@@ -9,6 +9,7 @@ export const Textarea: React.FC<{
   defaultValue?: string;
   disabled?: boolean;
   readOnly?: boolean;
+  required?: boolean;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
@@ -22,6 +23,7 @@ export const Textarea: React.FC<{
       defaultValue={props.defaultValue}
       disabled={props.disabled}
       readOnly={props.readOnly}
+      required={props.required}
       placeholder={props.placeholder}
       onChange={props.onChange}
       onBlur={props.onBlur}

--- a/src/shared/components/forms/Textarea.tsx
+++ b/src/shared/components/forms/Textarea.tsx
@@ -6,6 +6,10 @@ export const Textarea: React.FC<{
   rows?: number;
   name?: string;
   value?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
   inputRef?: React.Ref<HTMLTextAreaElement>;
@@ -15,24 +19,15 @@ export const Textarea: React.FC<{
       ref={props.inputRef}
       name={props.name}
       value={props.value}
+      defaultValue={props.defaultValue}
+      disabled={props.disabled}
+      readOnly={props.readOnly}
+      placeholder={props.placeholder}
       onChange={props.onChange}
       onBlur={props.onBlur}
       rows={props.rows}
       className={cx(
-        `shadow
-         appearance-none
-         border
-         rounded
-         w-full
-         py-2
-         px-3
-         text-gray-700
-         dark:bg-black
-         dark:text-gray-100
-         leading-tight
-         focus:outline-hidden
-         focus:ring-2
-         focus:ring-blue-500`,
+        "w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
         props.className
       )}
     />

--- a/src/shared/components/forms/Upload.stories.tsx
+++ b/src/shared/components/forms/Upload.stories.tsx
@@ -16,3 +16,29 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const FileChosen: Story = {
+  args: { fileName: "biology-cards.csv" },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <div className="bg-canvas p-4">
+        <Template fileName="light-cards.csv" />
+      </div>
+      <div className="dark bg-canvas p-4">
+        <Template fileName="dark-cards.csv" />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowViewport: Story = {
+  args: { fileName: "a-long-file-name-on-a-narrow-mobile-viewport.csv" },
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};

--- a/src/shared/components/forms/Upload.tsx
+++ b/src/shared/components/forms/Upload.tsx
@@ -2,20 +2,29 @@ import cx from "classnames";
 import type * as React from "react";
 import { AiOutlineCloudUpload } from "react-icons/ai";
 
-export const Upload: React.FC<{ className?: string; disabled?: boolean; onChange?: (file: File) => void }> = (
-  props
-) => (
+export const Upload: React.FC<{
+  className?: string;
+  disabled?: boolean;
+  fileName?: string;
+  onChange?: (file: File) => void;
+}> = (props) => (
   <label
-    className={cx(props.className, "flex", "max-w-sm", "h-48", "rounded-lg", "border", "cursor-pointer", "shadow-lg")}
+    className={cx(
+      "flex h-48 max-w-sm rounded-surface border-2 border-border bg-surface text-ink shadow-surface transition-shadow duration-normal ease-calm",
+      props.fileName ? "border-solid shadow-elevated" : "border-dashed",
+      props.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+      props.className
+    )}
   >
-    <div className={cx("relative", "flex-1", "cursor-pointer")}>
-      <div className={cx("absolute", "justify-center", "items-center", "w-full", "h-full", "flex", "flex-col")}>
-        <AiOutlineCloudUpload size={24} className="text-xl" />
-        <span className="text-base tracking-wide">Upload a csv file</span>
+    <div className="relative flex-1">
+      <div className="absolute flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center">
+        <AiOutlineCloudUpload size={24} className="text-xl text-accent-primary" />
+        <span className="text-base tracking-wide text-ink-muted">Upload a csv file</span>
+        {props.fileName ? <span className="max-w-full truncate font-semibold text-ink">{props.fileName}</span> : null}
       </div>
       <input
         type="file"
-        className="h-full w-full opacity-0 bg-pink-800"
+        className="h-full w-full cursor-inherit opacity-0"
         accept=".csv"
         disabled={props.disabled}
         onChange={(e) => {


### PR DESCRIPTION
## Summary

- migrate shared text, selection, upload, and form-layout controls to Calm Focus semantic tokens
- add consistent native state presentation, non-color selection cues, controlled file-name display, and shared mobile touch targets
- add representative light, dark, state, and narrow-viewport Storybook stories
- add focused behavior/layout tests and extend the Calm Focus visual contract

## Why

The shared form components still used raw palette utilities and inconsistent interaction-state styling after the Calm Focus foundation and shared button work landed. This change aligns the remaining controls while preserving their controlled/stateless behavior and leaving accessibility semantics owned by #204 unchanged.

## Impact

Form controls now have consistent light/dark surfaces, invalid/disabled/read-only presentation, non-color state cues, and 44px mobile touch targets. Validation rules, autosave behavior, server error recovery, and component-library dependencies are unchanged.

## Testing

- `npm run test:unit -- src/shared/components/forms src/lib/calmFocusVisualContract.spec.ts src/lib/componentArchitecture.spec.ts src/lib/sharedComponentPublicApi.spec.ts` (70 tests passed)
- `npm run build:storybook`
- `make check` (354 tests passed)
- `make build`

Closes #215