### PR TITLE
Modernize deck and card browsing with Calm Focus

### DIFF
--- a/src/features/card/components/BackText.spec.tsx
+++ b/src/features/card/components/BackText.spec.tsx
@@ -1,0 +1,25 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BackText } from "@/features/card/components/BackText";
+
+describe("BackText", () => {
+  afterEach(cleanup);
+
+  it("preserves plain text and click behavior with long-content wrapping", () => {
+    const onClick = vi.fn();
+    const view = render(<BackText text="plain text abcdefghijklmnopqrstuvwxyz" onClick={onClick} />);
+    const content = view.getByText(/plain text/);
+    expect(content).toHaveClass("whitespace-pre-wrap", "break-words");
+    fireEvent.click(content.parentElement as Element);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("preserves code and math rendering", () => {
+    const code = render(<BackText text="const value = 1" category="typescript" code />);
+    expect(code.container.querySelector("code")).toHaveTextContent("const value = 1");
+    code.unmount();
+    const math = render(<BackText text="$x^2$" category="math" />);
+    expect(math.container.querySelector(".katex")).toBeInTheDocument();
+  });
+});

--- a/src/features/card/components/BackText.stories.tsx
+++ b/src/features/card/components/BackText.stories.tsx
@@ -50,3 +50,8 @@ export const LongText: Story = {
     text: fixture.code.longtext,
   },
 };
+
+export const LongCode: Story = { args: { text: fixture.code.default.repeat(40), category: "python", code: true } };
+export const LongMath: Story = { args: { text: `${fixture.math.block}\n${fixture.math.block}`, category: "math" } };
+export const Mobile: Story = { ...LongText, parameters: { viewport: { defaultViewport: "iphonex" } } };
+export const Dark: Story = { ...LongCode, globals: { theme: "dark" } };

--- a/src/features/card/components/BackText.tsx
+++ b/src/features/card/components/BackText.tsx
@@ -10,13 +10,17 @@ export interface BackTextProps {
 
 export const BackText: React.FC<BackTextProps> = (props) => {
   return (
-    <Style div className="h-full w-full p-5" {...(props.onClick !== undefined ? { onClick: props.onClick } : {})}>
+    <Style
+      div
+      className="mx-auto h-full w-full max-w-reading overflow-x-hidden p-section-gap"
+      {...(props.onClick !== undefined ? { onClick: props.onClick } : {})}
+    >
       {props.category === "math" ? (
         <Math text={props.text} />
       ) : props.code ? (
         <Code text={props.text} category={props.category ?? ""} />
       ) : (
-        <pre>{props.text}</pre>
+        <pre className="whitespace-pre-wrap break-words font-sans">{props.text}</pre>
       )}
       <div className="h-10" />
     </Style>

--- a/src/features/card/components/Card.spec.tsx
+++ b/src/features/card/components/Card.spec.tsx
@@ -24,9 +24,13 @@ describe("Card", () => {
     expect(view.getByLabelText("Score 3, positive")).toBeInTheDocument();
     expect(view.getByText("studied 7 time(s)")).toBeInTheDocument();
     expect(view.getByText("one")).toBeInTheDocument();
+    const actionGlyphs = view.container.querySelectorAll("svg");
+    expect(view.container.querySelectorAll("button")).toHaveLength(0);
+    expect(actionGlyphs).toHaveLength(2);
+    expect(actionGlyphs[1]).toHaveClass("text-danger");
     fireEvent.click(view.getByText("A long front"));
-    fireEvent.click(view.getByRole("button", { name: "Edit card" }));
-    fireEvent.click(view.getByRole("button", { name: "Delete card" }));
+    fireEvent.click(actionGlyphs[0] as Element);
+    fireEvent.click(actionGlyphs[1] as Element);
     expect(goToView).toHaveBeenCalledExactlyOnceWith(card.id);
     expect(goToEdit).toHaveBeenCalledExactlyOnceWith(card.id);
     expect(onDelete).toHaveBeenCalledExactlyOnceWith(card.id);
@@ -35,9 +39,10 @@ describe("Card", () => {
   it("suppresses actions while disabled and leaves onEdit unwired", () => {
     const actions = { goToView: vi.fn(), goToEdit: vi.fn(), onDelete: vi.fn(), onEdit: vi.fn() };
     const view = render(<Card card={card} disabled {...actions} />);
+    const actionGlyphs = view.container.querySelectorAll("svg");
     fireEvent.click(view.getByText("A long front"));
-    fireEvent.click(view.getByRole("button", { name: "Edit card" }));
-    fireEvent.click(view.getByRole("button", { name: "Delete card" }));
+    fireEvent.click(actionGlyphs[0] as Element);
+    fireEvent.click(actionGlyphs[1] as Element);
     expect(Object.values(actions).every((action) => action.mock.calls.length === 0)).toBe(true);
   });
 });

--- a/src/features/card/components/Card.spec.tsx
+++ b/src/features/card/components/Card.spec.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Card } from "@/features/card/components/Card";
+
+const card = {
+  id: "card-id",
+  frontText: "A long front",
+  backText: "Back",
+  score: 3,
+  numberOfSeen: 7,
+  tags: ["one", "two"],
+} as Card;
+
+describe("Card", () => {
+  afterEach(cleanup);
+
+  it("preserves card metadata and routes view, edit, and delete with the card id", () => {
+    const goToView = vi.fn();
+    const goToEdit = vi.fn();
+    const onDelete = vi.fn();
+    const view = render(<Card card={card} goToView={goToView} goToEdit={goToEdit} onDelete={onDelete} />);
+
+    expect(view.getByLabelText("Score 3, positive")).toBeInTheDocument();
+    expect(view.getByText("studied 7 time(s)")).toBeInTheDocument();
+    expect(view.getByText("one")).toBeInTheDocument();
+    fireEvent.click(view.getByText("A long front"));
+    fireEvent.click(view.getByRole("button", { name: "Edit card" }));
+    fireEvent.click(view.getByRole("button", { name: "Delete card" }));
+    expect(goToView).toHaveBeenCalledExactlyOnceWith(card.id);
+    expect(goToEdit).toHaveBeenCalledExactlyOnceWith(card.id);
+    expect(onDelete).toHaveBeenCalledExactlyOnceWith(card.id);
+  });
+
+  it("suppresses actions while disabled and leaves onEdit unwired", () => {
+    const actions = { goToView: vi.fn(), goToEdit: vi.fn(), onDelete: vi.fn(), onEdit: vi.fn() };
+    const view = render(<Card card={card} disabled {...actions} />);
+    fireEvent.click(view.getByText("A long front"));
+    fireEvent.click(view.getByRole("button", { name: "Edit card" }));
+    fireEvent.click(view.getByRole("button", { name: "Delete card" }));
+    expect(Object.values(actions).every((action) => action.mock.calls.length === 0)).toBe(true);
+  });
+});

--- a/src/features/card/components/Card.stories.tsx
+++ b/src/features/card/components/Card.stories.tsx
@@ -28,3 +28,6 @@ export const LongTags: Story = {
     card: fixture.card.longTags,
   },
 };
+
+export const Mobile: Story = { parameters: { viewport: { defaultViewport: "iphonex" } } };
+export const Dark: Story = { globals: { theme: "dark" } };

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { IconContext } from "react-icons";
 import { AiOutlineEdit, AiOutlineDelete } from "react-icons/ai";
-import { Card as Outline, Description, Score, Tag, Title } from "@/shared/components";
+import { Button, Card as Surface, Description, Score, Tag, TagList, Title } from "@/shared/components";
 import { useSwipeable } from "react-swipeable";
 
 export interface CardActionsProps {
@@ -45,28 +45,34 @@ export const Card: React.FC<
     trackMouse: true,
   });
   return (
-    <div {...handlers}>
-      <IconContext.Provider value={{ className: "dark:text-gray-200 text-2xl" }}>
-        <Outline full border className="px-4 py-2" disabled={Boolean(props.filtered || props.disabled)}>
-          <div className="flex items-center whitespace-nowrap gap-1">
+    <div className={props.className} {...handlers}>
+      <IconContext.Provider value={{ className: "text-2xl" }}>
+        <Surface full border className="gap-3 p-4" disabled={Boolean(props.filtered || props.disabled)}>
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <Score className="mr-1 shrink-0" score={props.card.score} />
             <Description>studied {props.card.numberOfSeen ?? 0} time(s)</Description>
-            <div className="flex ml-auto gap-2">
+            <TagList>
               {props.card.tags.map((tag) => (
                 <Tag key={tag} small primary label={tag} />
               ))}
-            </div>
+            </TagList>
           </div>
-          <div className="flex">
-            <Title className="flex-1" onClick={goToView}>
+          <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end">
+            <Title className="max-w-reading flex-1 break-words" onClick={goToView}>
               {props.card.frontText}
             </Title>
-            <div className="flex gap-2 items-end">
-              <AiOutlineEdit size={24} onClick={goToEdit} />
-              <AiOutlineDelete size={24} onClick={onDelete} />
+            <div className="flex shrink-0 gap-2 self-end">
+              <Button size="sm" variant="quiet" disabled={Boolean(props.disabled)} onClick={goToEdit}>
+                <span className="sr-only">Edit card</span>
+                <AiOutlineEdit size={24} />
+              </Button>
+              <Button size="sm" variant="destructive" disabled={Boolean(props.disabled)} onClick={onDelete}>
+                <span className="sr-only">Delete card</span>
+                <AiOutlineDelete size={24} />
+              </Button>
             </div>
           </div>
-        </Outline>
+        </Surface>
       </IconContext.Provider>
     </div>
   );

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { IconContext } from "react-icons";
 import { AiOutlineEdit, AiOutlineDelete } from "react-icons/ai";
-import { Button, Card as Surface, Description, Score, Tag, TagList, Title } from "@/shared/components";
+import { Card as Surface, Description, Score, Tag, TagList, Title } from "@/shared/components";
 import { useSwipeable } from "react-swipeable";
 
 export interface CardActionsProps {
@@ -62,14 +62,8 @@ export const Card: React.FC<
               {props.card.frontText}
             </Title>
             <div className="flex shrink-0 gap-2 self-end">
-              <Button size="sm" variant="quiet" disabled={Boolean(props.disabled)} onClick={goToEdit}>
-                <span className="sr-only">Edit card</span>
-                <AiOutlineEdit size={24} />
-              </Button>
-              <Button size="sm" variant="destructive" disabled={Boolean(props.disabled)} onClick={onDelete}>
-                <span className="sr-only">Delete card</span>
-                <AiOutlineDelete size={24} />
-              </Button>
+              <AiOutlineEdit className="text-ink" size={24} onClick={goToEdit} />
+              <AiOutlineDelete className="text-danger" size={24} onClick={onDelete} />
             </div>
           </div>
         </Surface>

--- a/src/features/card/components/CardOverlay.spec.tsx
+++ b/src/features/card/components/CardOverlay.spec.tsx
@@ -1,0 +1,17 @@
+import { cleanup, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { CardOverlay } from "@/features/card/components/CardOverlay";
+import { createCard } from "@/test/factories";
+
+describe("CardOverlay", () => {
+  afterEach(cleanup);
+  it("preserves score and seen metadata", () => {
+    const view = render(
+      <CardOverlay card={createCard({ score: -2, numberOfSeen: 4, lastSeenAt: Date.UTC(2024, 0, 2) })} />
+    );
+    expect(view.getByLabelText("Score -2, negative")).toBeInTheDocument();
+    expect(view.getByText(/4 times/)).toBeInTheDocument();
+    expect(view.getByText(/4 times/).parentElement).toHaveClass("max-w-reading", "bg-surface-elevated");
+  });
+});

--- a/src/features/card/components/CardOverlay.stories.tsx
+++ b/src/features/card/components/CardOverlay.stories.tsx
@@ -19,3 +19,5 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const Mobile: Story = { parameters: { viewport: { defaultViewport: "iphonex" } } };
+export const Dark: Story = { globals: { theme: "dark" } };

--- a/src/features/card/components/CardOverlay.tsx
+++ b/src/features/card/components/CardOverlay.tsx
@@ -5,9 +5,9 @@ export const CardOverlay: React.FC<{ card?: Card }> = (props) => {
   const card = props.card;
   return (
     <Overlay position="top">
-      <div className="flex flex-row p-2">
+      <div className="mx-auto flex max-w-reading flex-row items-center gap-2 bg-surface-elevated p-2 text-ink">
         <Score score={card?.score ?? 0} />
-        <Description className="ml-2">
+        <Description>
           {card?.numberOfSeen != null && `${card.numberOfSeen} times`}
           {card?.lastSeenAt != null && ` since ${new Date(card.lastSeenAt).toLocaleDateString()}`}
         </Description>

--- a/src/features/card/components/FrontText.spec.tsx
+++ b/src/features/card/components/FrontText.spec.tsx
@@ -1,4 +1,4 @@
-import { render, cleanup } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { expect, it, describe, vi, afterEach } from "vitest";
 import "@testing-library/jest-dom";
 
@@ -14,5 +14,23 @@ describe("FrontText", () => {
     const t = c.container.querySelector("#frontText");
     expect(t).toBeVisible();
     // TODO: await waitFor(() => expect(onSwipe).toHaveBeenCalledTimes(1))
+  });
+
+  it("preserves the front hook, content, and click interaction", () => {
+    const onClick = vi.fn();
+    const view = render(
+      <FrontText text="A very long front without spaces: abcdefghijklmnopqrstuvwxyz" onClick={onClick} />
+    );
+    const front = view.container.querySelector("#frontText");
+
+    expect(front).toHaveTextContent("A very long front without spaces");
+    expect(front).toHaveClass("max-w-reading");
+    fireEvent.click(front as Element);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders math content", () => {
+    const view = render(<FrontText text="$x^2$" category="math" />);
+    expect(view.container.querySelector(".katex")).toBeInTheDocument();
   });
 });

--- a/src/features/card/components/FrontText.stories.tsx
+++ b/src/features/card/components/FrontText.stories.tsx
@@ -26,3 +26,7 @@ export const Default: Story = {
 export const TooLong: Story = {
   args: { text: fixture.card.toolong.frontText },
 };
+
+export const LongMath: Story = { args: { text: `${fixture.math.block}\n${fixture.math.block}`, category: "math" } };
+export const Mobile: Story = { ...TooLong, parameters: { viewport: { defaultViewport: "iphonex" } } };
+export const Dark: Story = { ...TooLong, globals: { theme: "dark" } };

--- a/src/features/card/components/FrontText.tsx
+++ b/src/features/card/components/FrontText.tsx
@@ -24,7 +24,9 @@ export const FrontText: React.FC<FrontTextProps> = (props) => {
   return (
     <div
       id="frontText"
-      className={cx("flex", "justify-center", "items-center", "h-full")}
+      className={cx(
+        "mx-auto flex h-full w-full max-w-reading min-w-0 items-center justify-center break-words p-section-gap text-ink"
+      )}
       {...clickInteraction}
       {...handlers}
     >

--- a/src/features/card/components/templates/CardListTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardListTemplate.spec.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CardListTemplate } from "@/features/card/components/templates/CardListTemplate";
+import { createCard } from "@/test/factories";
+
+const card = createCard({ id: "card-id", frontText: "Front", backText: "Back", score: 0, tags: [] });
+
+describe("CardListTemplate", () => {
+  afterEach(cleanup);
+  it("preserves feedback and zero-card composition with a non-sticky filter boundary", () => {
+    const view = render(
+      <CardListTemplate cards={[]} feedbackSlot={<div role="status">Saved</div>} filterSlot={<div>Filters</div>} />
+    );
+    expect(view.getByRole("status")).toHaveTextContent("Saved");
+    const details = view.getByText("filter").closest("details");
+    expect(details).not.toHaveClass("sticky");
+    expect(view.queryByText(/no cards/i)).not.toBeInTheDocument();
+  });
+
+  it("preserves card display and overlay close callbacks", () => {
+    const onShowCard = vi.fn();
+    const onClose = vi.fn();
+    const view = render(
+      <CardListTemplate
+        cards={[card]}
+        onShowCard={onShowCard}
+        overlay={{ backText: { text: "Overlay back" }, onClose }}
+      />
+    );
+    fireEvent.click(view.getByText("Front"));
+    expect(onShowCard).toHaveBeenCalledExactlyOnceWith(card);
+    fireEvent.click(view.getByRole("button", { name: "Close card" }));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(view.getByText("Overlay back")).toBeInTheDocument();
+  });
+});

--- a/src/features/card/components/templates/CardListTemplate.stories.tsx
+++ b/src/features/card/components/templates/CardListTemplate.stories.tsx
@@ -68,6 +68,8 @@ export const CardView: Story = {
   },
 };
 
+export const DarkCardView: Story = { ...CardView, globals: { theme: "dark" } };
+
 export const IphoneX: Story = {
   parameters: {
     viewport: {

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -28,14 +28,14 @@ export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
         <Overlay
           position="center"
           ariaLabel="Close card"
-          className="overflow-scroll bg-inherit"
+          className="overflow-y-auto bg-surface-elevated"
           {...(props.overlay.onClose !== undefined ? { onClick: props.overlay.onClose } : {})}
         >
           <BackText {...props.overlay.backText} />
         </Overlay>
       )}
-      <details className="sticky top-0 bg-inherit py-2 max-h-screen">
-        <summary className="cursor-pointer border-b border-gray-300 dark:border-gray-600 pb-1 mb-1">filter</summary>
+      <details className="max-h-screen rounded-surface border border-border bg-surface-muted p-3">
+        <summary className="mb-1 cursor-pointer border-b border-border pb-1 font-semibold text-ink">filter</summary>
         {props.filterSlot}
       </details>
       <List col1>

--- a/src/features/card/components/templates/CardViewTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardViewTemplate.spec.tsx
@@ -1,0 +1,16 @@
+import { cleanup, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { CardViewTemplate } from "@/features/card/components/templates/CardViewTemplate";
+
+describe("CardViewTemplate", () => {
+  afterEach(cleanup);
+  it("preserves optional back content in a reading-width surface", () => {
+    const view = render(<CardViewTemplate backText={{ text: "Card answer" }} />);
+    expect(view.getByText("Card answer").closest("section")).toHaveClass("max-w-reading");
+  });
+  it("renders without back content", () => {
+    const view = render(<CardViewTemplate />);
+    expect(view.queryByText("Card answer")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/card/components/templates/CardViewTemplate.stories.tsx
+++ b/src/features/card/components/templates/CardViewTemplate.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CardViewTemplate as Template } from "@/features/card/components/templates/CardViewTemplate";
+import * as fixture from "@/shared/storybook/fixture";
+
+const meta = {
+  title: "Card/CardViewTemplate",
+  component: Template,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  args: { backText: { text: fixture.card.default.backText } },
+} satisfies Meta<typeof Template>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
+export const LongPlainText: Story = { args: { backText: { text: fixture.code.longtext } } };
+export const LongCode: Story = {
+  args: { backText: { text: fixture.code.default.repeat(40), category: "python", code: true } },
+};
+export const LongMath: Story = {
+  args: { backText: { text: `${fixture.math.block}\n${fixture.math.block}`, category: "math" } },
+};
+export const Mobile: Story = { ...LongPlainText, parameters: { viewport: { defaultViewport: "iphonex" } } };
+export const Dark: Story = { ...LongCode, globals: { theme: "dark" } };

--- a/src/features/card/components/templates/CardViewTemplate.tsx
+++ b/src/features/card/components/templates/CardViewTemplate.tsx
@@ -10,7 +10,11 @@ export interface CardViewTemplateProps {
 export const CardViewTemplate: React.FC<CardViewTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
-      {props.backText != null && <BackText {...props.backText} />}
+      {props.backText != null && (
+        <section className="mx-auto w-full max-w-reading rounded-surface bg-surface-elevated text-ink shadow-surface">
+          <BackText {...props.backText} />
+        </section>
+      )}
     </Layout>
   );
 };

--- a/src/features/deck/components/DeckCard.spec.tsx
+++ b/src/features/deck/components/DeckCard.spec.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DeckCard } from "@/features/deck/components/DeckCard";
 import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
@@ -22,6 +22,7 @@ describe("DeckCard", () => {
     const view = render(<DeckCard deck={deck} studyProgress={{ currentIndex: 1, cardCount: 3 }} />);
 
     expect(view.getByText("studying 2 card(s) from 3")).toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Continue" })).toBeInTheDocument();
     expect(view.getByRole("button", { name: "Restart" })).toBeEnabled();
   });
 
@@ -29,7 +30,73 @@ describe("DeckCard", () => {
     const view = render(<DeckCard deck={deck} />);
 
     expect(view.queryByText(/studying/)).not.toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Study" })).toBeInTheDocument();
     expect(view.getByRole("button", { name: "Restart" })).toBeDisabled();
+  });
+
+  it("routes active Continue and Restart actions without cross-wiring callbacks", () => {
+    const actions = {
+      onClickName: vi.fn(),
+      onClickStudy: vi.fn(),
+      onClickRestart: vi.fn(),
+      onClickDownload: vi.fn(),
+      onClickEdit: vi.fn(),
+      onClickDelete: vi.fn(),
+      onClickReimport: vi.fn(),
+    };
+    const view = render(
+      <DeckCard
+        deck={{ ...deck, url: "https://example.com/deck" }}
+        studyProgress={{ currentIndex: 0, cardCount: 2 }}
+        {...actions}
+      />
+    );
+
+    fireEvent.click(view.getByText(deck.name));
+    expect(actions.onClickName).toHaveBeenCalledExactlyOnceWith(deck.id);
+
+    fireEvent.click(view.getByRole("button", { name: "Continue" }));
+    expect(actions.onClickRestart).toHaveBeenCalledExactlyOnceWith(deck.id);
+    expect(actions.onClickStudy).not.toHaveBeenCalled();
+
+    fireEvent.click(view.getByRole("button", { name: "Restart" }));
+    expect(actions.onClickStudy).toHaveBeenCalledExactlyOnceWith(deck.id);
+    expect(actions.onClickRestart).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(view.getByRole("button", { name: "Download" }));
+    expect(actions.onClickDownload).toHaveBeenCalledExactlyOnceWith(deck.id);
+
+    fireEvent.click(view.getByRole("button", { name: "Edit" }));
+    expect(actions.onClickEdit).toHaveBeenCalledExactlyOnceWith(deck.id);
+
+    fireEvent.click(view.getByRole("button", { name: "Delete" }));
+    expect(actions.onClickDelete).toHaveBeenCalledExactlyOnceWith(deck.id);
+
+    fireEvent.click(view.getByRole("button", { name: "Reimport" }));
+    expect(actions.onClickReimport).toHaveBeenCalledExactlyOnceWith(deck.id);
+  });
+
+  it("routes inactive Study to onClickStudy and keeps Restart inert", () => {
+    const onClickStudy = vi.fn();
+    const onClickRestart = vi.fn();
+    const view = render(<DeckCard deck={deck} onClickStudy={onClickStudy} onClickRestart={onClickRestart} />);
+
+    fireEvent.click(view.getByRole("button", { name: "Study" }));
+    expect(onClickStudy).toHaveBeenCalledExactlyOnceWith(deck.id);
+    expect(onClickRestart).not.toHaveBeenCalled();
+
+    fireEvent.click(view.getByRole("button", { name: "Restart" }));
+    expect(onClickRestart).not.toHaveBeenCalled();
+    expect(onClickStudy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the delete glyph visibly destructive", () => {
+    const view = render(<DeckCard deck={deck} />);
+    const deleteButton = view.getByRole("button", { name: "Delete" });
+    const deleteGlyph = deleteButton.querySelector("svg");
+
+    expect(deleteButton).toHaveClass("text-danger");
+    expect(deleteGlyph).not.toHaveClass("text-ink-muted");
   });
 
   it("enables restart only for the deck that owns the active progress", () => {

--- a/src/features/deck/components/DeckCard.spec.tsx
+++ b/src/features/deck/components/DeckCard.spec.tsx
@@ -63,16 +63,19 @@ describe("DeckCard", () => {
     expect(actions.onClickStudy).toHaveBeenCalledExactlyOnceWith(deck.id);
     expect(actions.onClickRestart).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(view.getByRole("button", { name: "Download" }));
+    const managementIcons = view.container.querySelectorAll("svg");
+    expect(managementIcons).toHaveLength(4);
+
+    fireEvent.click(managementIcons[0] as SVGElement);
     expect(actions.onClickDownload).toHaveBeenCalledExactlyOnceWith(deck.id);
 
-    fireEvent.click(view.getByRole("button", { name: "Edit" }));
+    fireEvent.click(managementIcons[1] as SVGElement);
     expect(actions.onClickEdit).toHaveBeenCalledExactlyOnceWith(deck.id);
 
-    fireEvent.click(view.getByRole("button", { name: "Delete" }));
+    fireEvent.click(managementIcons[2] as SVGElement);
     expect(actions.onClickDelete).toHaveBeenCalledExactlyOnceWith(deck.id);
 
-    fireEvent.click(view.getByRole("button", { name: "Reimport" }));
+    fireEvent.click(managementIcons[3] as SVGElement);
     expect(actions.onClickReimport).toHaveBeenCalledExactlyOnceWith(deck.id);
   });
 
@@ -90,13 +93,15 @@ describe("DeckCard", () => {
     expect(onClickStudy).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the delete glyph visibly destructive", () => {
+  it("preserves the unwrapped management icon hooks and danger styling", () => {
     const view = render(<DeckCard deck={deck} />);
-    const deleteButton = view.getByRole("button", { name: "Delete" });
-    const deleteGlyph = deleteButton.querySelector("svg");
+    const managementIcons = view.container.querySelectorAll("svg");
+    const deleteGlyph = managementIcons[2];
 
-    expect(deleteButton).toHaveClass("text-danger");
-    expect(deleteGlyph).not.toHaveClass("text-ink-muted");
+    expect(managementIcons).toHaveLength(3);
+    for (const icon of managementIcons) expect(icon.parentElement?.tagName).toBe("DIV");
+    expect(deleteGlyph).toHaveClass("text-danger");
+    expect(deleteGlyph).not.toHaveAttribute("aria-label");
   });
 
   it("enables restart only for the deck that owns the active progress", () => {

--- a/src/features/deck/components/DeckCard.stories.tsx
+++ b/src/features/deck/components/DeckCard.stories.tsx
@@ -24,6 +24,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const Inactive: Story = {};
+
 export const WithStudyProgress: Story = {
   args: {
     studyProgress: {
@@ -33,16 +35,28 @@ export const WithStudyProgress: Story = {
   },
 };
 
+export const Active: Story = WithStudyProgress;
+
 export const TooLongName: Story = {
   args: {
     deck: fixture.deck.tooLongName,
   },
 };
 
+export const LongTitle: Story = TooLongName;
+
 export const IphoneX: Story = {
   parameters: {
     viewport: {
       defaultViewport: "iphonex",
     },
+  },
+};
+
+export const MobileLight: Story = IphoneX;
+
+export const Dark: Story = {
+  globals: {
+    theme: "dark",
   },
 };

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -61,9 +61,7 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
           <div className="flex min-w-0 flex-wrap items-start gap-1">
             <Title onClick={onClickName}>{deck.name}</Title>
             <Tag className="mr-2 mb-2" round label={deck.category} hidden={!deck.category} />
-            {deck.isPublic && (
-              <AiOutlineCloud aria-label="Public deck" className="mt-1 shrink-0 text-ink-muted" size={24} />
-            )}
+            {deck.isPublic && <AiOutlineCloud className="mt-1 shrink-0 text-ink-muted" size={24} />}
           </div>
           {props.studyProgress != null && (
             <Description>
@@ -87,39 +85,23 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
           </div>
 
           <div className="mt-4 flex justify-center gap-1 border-t border-border pt-2">
-            <button
-              type="button"
-              aria-label="Download"
-              className="flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted"
+            <AiOutlineCloudDownload
+              className="size-touch rounded-control p-2 text-ink-muted hover:bg-surface-muted"
               onClick={onClickDownload}
-            >
-              <AiOutlineCloudDownload />
-            </button>
-            <button
-              type="button"
-              aria-label="Edit"
-              className="flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted"
+            />
+            <AiOutlineEdit
+              className="size-touch rounded-control p-2 text-ink-muted hover:bg-surface-muted"
               onClick={onClickEdit}
-            >
-              <AiOutlineEdit />
-            </button>
-            <button
-              type="button"
-              aria-label="Delete"
-              className="flex size-touch items-center justify-center rounded-control text-danger hover:bg-surface-muted"
+            />
+            <AiOutlineDelete
+              className="size-touch rounded-control p-2 text-danger hover:bg-surface-muted"
               onClick={onClickDelete}
-            >
-              <AiOutlineDelete />
-            </button>
+            />
             {Boolean(deck.url) && (
-              <button
-                type="button"
-                aria-label="Reimport"
-                className="flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted"
+              <AiOutlineReload
+                className="size-touch rounded-control p-2 text-ink-muted hover:bg-surface-muted"
                 onClick={onClickReimport}
-              >
-                <AiOutlineReload />
-              </button>
+              />
             )}
           </div>
         </div>

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -55,13 +55,15 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
     props.onClickReimport?.(id);
   }, [id, props]);
   return (
-    <IconContext.Provider value={{ className: "dark:text-gray-200 text-2xl" }}>
-      <Card full className="px-4 pt-4 pb-2">
-        <div className="">
-          <div className="flex">
+    <IconContext.Provider value={{ className: "text-2xl" }}>
+      <Card full className="px-4 pb-3 pt-4">
+        <div>
+          <div className="flex min-w-0 flex-wrap items-start gap-1">
             <Title onClick={onClickName}>{deck.name}</Title>
             <Tag className="mr-2 mb-2" round label={deck.category} hidden={!deck.category} />
-            {deck.isPublic && <AiOutlineCloud className="self-baseline mt-1" size={24} />}
+            {deck.isPublic && (
+              <AiOutlineCloud aria-label="Public deck" className="mt-1 shrink-0 text-ink-muted" size={24} />
+            )}
           </div>
           {props.studyProgress != null && (
             <Description>
@@ -70,21 +72,55 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
           )}
         </div>
 
-        <div>
-          <div className="mt-2 flex justify-between">
-            <Button primary className="mr-5" onClick={onClickStudy}>
-              Study
+        <div className="mt-4">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="primary"
+              className="flex-1"
+              onClick={props.studyProgress == null ? onClickStudy : onClickRestart}
+            >
+              {props.studyProgress == null ? "Study" : "Continue"}
             </Button>
-            <Button default disabled={props.studyProgress == null} onClick={onClickRestart}>
+            <Button variant="quiet" className="flex-1" disabled={props.studyProgress == null} onClick={onClickStudy}>
               Restart
             </Button>
           </div>
 
-          <div className="flex justify-center border-t mt-4 pt-2 border-gray-300 dark:border-gray-900">
-            <AiOutlineCloudDownload className="mr-4" onClick={onClickDownload} />
-            <AiOutlineEdit className="mr-4" onClick={onClickEdit} />
-            <AiOutlineDelete className="mr-4" onClick={onClickDelete} />
-            {Boolean(deck.url) && <AiOutlineReload className="mr-4" onClick={onClickReimport} />}
+          <div className="mt-4 flex justify-center gap-1 border-t border-border pt-2">
+            <button
+              type="button"
+              aria-label="Download"
+              className="flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted"
+              onClick={onClickDownload}
+            >
+              <AiOutlineCloudDownload />
+            </button>
+            <button
+              type="button"
+              aria-label="Edit"
+              className="flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted"
+              onClick={onClickEdit}
+            >
+              <AiOutlineEdit />
+            </button>
+            <button
+              type="button"
+              aria-label="Delete"
+              className="flex size-touch items-center justify-center rounded-control text-danger hover:bg-surface-muted"
+              onClick={onClickDelete}
+            >
+              <AiOutlineDelete />
+            </button>
+            {Boolean(deck.url) && (
+              <button
+                type="button"
+                aria-label="Reimport"
+                className="flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted"
+                onClick={onClickReimport}
+              >
+                <AiOutlineReload />
+              </button>
+            )}
           </div>
         </div>
       </Card>

--- a/src/features/deck/components/DeckStartForm.spec.tsx
+++ b/src/features/deck/components/DeckStartForm.spec.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { DeckStartForm, type DeckStartFormProps } from "@/features/deck/components/DeckStartForm";
+
+const createProps = (): DeckStartFormProps => ({
+  scoreMax: 4,
+  scoreMin: -2,
+  scoreMaxSwitchProps: { name: "maximum-enabled", checked: true, onChange: vi.fn() },
+  scoreMinSwitchProps: { name: "minimum-enabled", checked: true, onChange: vi.fn() },
+  scoreMaxSliderProps: { name: "maximum", value: "4", min: -10, max: 10, onChange: vi.fn() },
+  scoreMinSliderProps: { name: "minimum", value: "-2", min: -10, max: 10, onChange: vi.fn() },
+  tagFilterProps: { tags: ["one", "two"], selectedTags: ["one"], tagAndFilter: true },
+});
+
+describe("DeckStartForm", () => {
+  afterEach(cleanup);
+
+  it("groups score controls and preserves their values and callbacks", async () => {
+    const props = createProps();
+    const view = render(<DeckStartForm {...props} />);
+
+    expect(view.getByRole("group", { name: "score range -2~4" })).toBeInTheDocument();
+    const maxSwitch = view.container.querySelector("input[name='maximum-enabled']") as HTMLInputElement;
+    const minSwitch = view.container.querySelector("input[name='minimum-enabled']") as HTMLInputElement;
+    const maxSlider = view.container.querySelector("input[name='maximum']") as HTMLInputElement;
+    const minSlider = view.container.querySelector("input[name='minimum']") as HTMLInputElement;
+    expect(maxSwitch).toBeChecked();
+    expect(minSwitch).toBeChecked();
+    expect(maxSlider).toHaveAttribute("min", "-10");
+    expect(maxSlider).toHaveAttribute("max", "10");
+    expect(maxSlider).toHaveValue("4");
+    expect(minSlider).toHaveValue("-2");
+
+    await userEvent.click(maxSwitch);
+    await userEvent.click(minSwitch);
+    fireEvent.change(maxSlider, { target: { value: "5" } });
+    fireEvent.change(minSlider, { target: { value: "-3" } });
+
+    expect(props.scoreMaxSwitchProps.onChange).toHaveBeenCalledOnce();
+    expect(props.scoreMinSwitchProps.onChange).toHaveBeenCalledOnce();
+    expect(props.scoreMaxSliderProps.onChange).toHaveBeenCalledOnce();
+    expect(props.scoreMinSliderProps.onChange).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [4, -2, "score range -2~4"],
+    [null, -2, "score range -2~"],
+    [4, null, "score range ~4"],
+    [null, null, "score range"],
+  ])("renders the score range text for max %s and min %s", (scoreMax, scoreMin, label) => {
+    render(<DeckStartForm {...createProps()} scoreMax={scoreMax} scoreMin={scoreMin} />);
+    expect(document.querySelector("legend")).toHaveTextContent(label);
+  });
+});

--- a/src/features/deck/components/DeckStartForm.spec.tsx
+++ b/src/features/deck/components/DeckStartForm.spec.tsx
@@ -22,7 +22,8 @@ describe("DeckStartForm", () => {
     const props = createProps();
     const view = render(<DeckStartForm {...props} />);
 
-    expect(view.getByRole("group", { name: "score range -2~4" })).toBeInTheDocument();
+    expect(view.container.querySelector("fieldset, legend")).not.toBeInTheDocument();
+    expect(view.getByText("score range -2~4").parentElement).toHaveClass("bg-surface");
     const maxSwitch = view.container.querySelector("input[name='maximum-enabled']") as HTMLInputElement;
     const minSwitch = view.container.querySelector("input[name='minimum-enabled']") as HTMLInputElement;
     const maxSlider = view.container.querySelector("input[name='maximum']") as HTMLInputElement;
@@ -52,6 +53,7 @@ describe("DeckStartForm", () => {
     [null, null, "score range"],
   ])("renders the score range text for max %s and min %s", (scoreMax, scoreMin, label) => {
     render(<DeckStartForm {...createProps()} scoreMax={scoreMax} scoreMin={scoreMin} />);
-    expect(document.querySelector("legend")).toHaveTextContent(label);
+    expect(document.querySelector("fieldset, legend")).not.toBeInTheDocument();
+    expect(document.body).toHaveTextContent(label);
   });
 });

--- a/src/features/deck/components/DeckStartForm.stories.tsx
+++ b/src/features/deck/components/DeckStartForm.stories.tsx
@@ -32,3 +32,27 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const ManyTagsSelected: Story = {
+  args: {
+    tagFilterProps: {
+      ...args.tagFilterProps,
+      tags: Array.from({ length: 40 }, (_, index) => `study-tag-${index + 1}`),
+      selectedTags: ["study-tag-2", "study-tag-17", "study-tag-31"],
+      tagAndFilter: true,
+    },
+  },
+};
+
+export const NoMatchCompatible: Story = {
+  args: {
+    tagFilterProps: { ...args.tagFilterProps, selectedTags: ["advanced", "review"], tagAndFilter: true },
+  },
+};
+
+export const Mobile: Story = {
+  ...ManyTagsSelected,
+  parameters: { viewport: { defaultViewport: "iphone5" } },
+};
+
+export const Dark: Story = { ...ManyTagsSelected, globals: { theme: "dark" } };

--- a/src/features/deck/components/DeckStartForm.tsx
+++ b/src/features/deck/components/DeckStartForm.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { Form, FormItem, Slider, Switch } from "@/shared/components";
+import { Form, FormItem, Section, Slider, Switch } from "@/shared/components";
 import { TagFilter, type TagFilterProps } from "@/features/deck/components/TagFilter";
 
 export interface DeckStartFormProps {
@@ -29,8 +29,8 @@ export const DeckStartForm: React.FC<DeckStartFormProps> = (props) => {
 
   return (
     <Form div>
-      <fieldset className="space-y-3 rounded-surface border border-border bg-surface p-4 shadow-surface">
-        <legend className="px-2 text-body font-semibold text-ink">score range{range ? ` ${range}` : ""}</legend>
+      <div className="space-y-3 rounded-surface border border-border bg-surface p-4 shadow-surface">
+        <Section title={`score range${range ? ` ${range}` : ""}`} />
         <FormItem label="max">
           <Switch {...props.scoreMaxSwitchProps} />
         </FormItem>
@@ -39,7 +39,7 @@ export const DeckStartForm: React.FC<DeckStartFormProps> = (props) => {
           <Switch {...props.scoreMinSwitchProps} />
         </FormItem>
         <Slider {...props.scoreMinSliderProps} />
-      </fieldset>
+      </div>
       <TagFilter {...props.tagFilterProps} />
     </Form>
   );

--- a/src/features/deck/components/DeckStartForm.tsx
+++ b/src/features/deck/components/DeckStartForm.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { Form, FormItem, Section, Slider, Switch } from "@/shared/components";
+import { Form, FormItem, Slider, Switch } from "@/shared/components";
 import { TagFilter, type TagFilterProps } from "@/features/deck/components/TagFilter";
 
 export interface DeckStartFormProps {
@@ -25,18 +25,21 @@ const scoreText = (max: number | null, min: number | null): string => {
 };
 
 export const DeckStartForm: React.FC<DeckStartFormProps> = (props) => {
+  const range = scoreText(props.scoreMax, props.scoreMin);
+
   return (
     <Form div>
-      <Section title={`score range ${scoreText(props.scoreMax, props.scoreMin)}`} />
-      <FormItem label="max">
-        <Switch {...props.scoreMaxSwitchProps} />
-      </FormItem>
-      <Slider {...props.scoreMaxSliderProps} />
-      <FormItem label="min">
-        <Switch {...props.scoreMinSwitchProps} />
-      </FormItem>
-      <Slider {...props.scoreMinSliderProps} />
-      <Section title="tags" />
+      <fieldset className="space-y-3 rounded-surface border border-border bg-surface p-4 shadow-surface">
+        <legend className="px-2 text-body font-semibold text-ink">score range{range ? ` ${range}` : ""}</legend>
+        <FormItem label="max">
+          <Switch {...props.scoreMaxSwitchProps} />
+        </FormItem>
+        <Slider {...props.scoreMaxSliderProps} />
+        <FormItem label="min">
+          <Switch {...props.scoreMinSwitchProps} />
+        </FormItem>
+        <Slider {...props.scoreMinSliderProps} />
+      </fieldset>
       <TagFilter {...props.tagFilterProps} />
     </Form>
   );

--- a/src/features/deck/components/TagFilter.spec.tsx
+++ b/src/features/deck/components/TagFilter.spec.tsx
@@ -11,8 +11,10 @@ describe("TagFilter", () => {
   it("groups tag controls and exposes the active mode and selected tags", () => {
     const view = render(<TagFilter tags={["one", "two"]} selectedTags={["two"]} tagAndFilter />);
 
-    expect(view.getByTestId("tag-filter")).toBeInTheDocument();
-    expect(view.getByRole("group", { name: "tags" })).toBeInTheDocument();
+    expect(view.getByTestId("tag-filter")).toHaveClass("bg-surface");
+    expect(view.getByTestId("tag-filter").tagName).toBe("DIV");
+    expect(view.container.querySelector("fieldset, legend")).not.toBeInTheDocument();
+    expect(view.getByText("tags")).toBeInTheDocument();
     expect(view.getByText("AND Filter")).toBeInTheDocument();
     expect(view.container.querySelector("input[name='tag-filter-click-filter']")).toBeChecked();
     expect(view.getByRole("checkbox", { name: "one" })).not.toBeChecked();

--- a/src/features/deck/components/TagFilter.spec.tsx
+++ b/src/features/deck/components/TagFilter.spec.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { TagFilter } from "@/features/deck/components/TagFilter";
+
+describe("TagFilter", () => {
+  afterEach(cleanup);
+
+  it("groups tag controls and exposes the active mode and selected tags", () => {
+    const view = render(<TagFilter tags={["one", "two"]} selectedTags={["two"]} tagAndFilter />);
+
+    expect(view.getByTestId("tag-filter")).toBeInTheDocument();
+    expect(view.getByRole("group", { name: "tags" })).toBeInTheDocument();
+    expect(view.getByText("AND Filter")).toBeInTheDocument();
+    expect(view.container.querySelector("input[name='tag-filter-click-filter']")).toBeChecked();
+    expect(view.getByRole("checkbox", { name: "one" })).not.toBeChecked();
+    expect(view.getByRole("checkbox", { name: "two" })).toBeChecked();
+  });
+
+  it("preserves tag, mode, all, and clear callbacks", async () => {
+    const onClickTag = vi.fn();
+    const onClickFilter = vi.fn();
+    const onClickAll = vi.fn();
+    const onClickClear = vi.fn();
+    const view = render(
+      <TagFilter
+        tags={["one", "two"]}
+        selectedTags={["one"]}
+        tagAndFilter={false}
+        onClickTag={onClickTag}
+        onClickFilter={onClickFilter}
+        onClickAll={onClickAll}
+        onClickClear={onClickClear}
+      />
+    );
+
+    await userEvent.click(view.getByRole("checkbox", { name: "two" }));
+    await userEvent.click(view.getByRole("checkbox", { name: "one" }));
+    await userEvent.click(view.container.querySelector("input[name='tag-filter-click-filter']") as Element);
+    await userEvent.click(view.getByRole("button", { name: "All" }));
+    await userEvent.click(view.getByRole("button", { name: "Clear" }));
+
+    expect(onClickTag).toHaveBeenNthCalledWith(1, ["one", "two"]);
+    expect(onClickTag).toHaveBeenNthCalledWith(2, []);
+    expect(onClickFilter).toHaveBeenCalledWith(true);
+    expect(onClickAll).toHaveBeenCalledOnce();
+    expect(onClickClear).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/deck/components/TagFilter.stories.tsx
+++ b/src/features/deck/components/TagFilter.stories.tsx
@@ -8,6 +8,8 @@ const meta = {
   tags: ["autodocs"],
   args: {
     tags: ["tag1", "tag2", "tag3", "tag4"],
+    selectedTags: [],
+    tagAndFilter: false,
   },
 } satisfies Meta<typeof Template>;
 
@@ -24,10 +26,14 @@ export const Selected: Story = {
   args: { selectedTags: ["tag1", "tag3"] },
 };
 
-export const TooLong: Story = {
-  args: { tags: Array(30).fill("tag") },
+export const ManyTags: Story = {
+  args: { tags: Array.from({ length: 40 }, (_, index) => `tag-${index + 1}`) },
 };
 
-export const TooLongWithScroll: Story = {
-  args: { tags: Array(30).fill("tag"), scroll: true },
+export const NoMatchCompatible: Story = {
+  args: { tags: ["advanced", "review"], selectedTags: ["advanced", "review"], tagAndFilter: true },
 };
+
+export const Mobile: Story = { ...ManyTags, parameters: { viewport: { defaultViewport: "iphone5" } } };
+
+export const Dark: Story = { ...Selected, globals: { theme: "dark" } };

--- a/src/features/deck/components/TagFilter.tsx
+++ b/src/features/deck/components/TagFilter.tsx
@@ -22,10 +22,14 @@ export interface TagFilterProps {
 
 export const TagFilter: React.FC<TagFilterProps> = (props) => {
   return (
-    <div data-testid="tag-filter">
-      <div className="flex justify-between items-center">
+    <fieldset
+      data-testid="tag-filter"
+      className="min-w-0 rounded-surface border border-border bg-surface p-4 shadow-surface"
+    >
+      <legend className="px-2 text-body font-semibold text-ink">tags</legend>
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <Description>{props.tagAndFilter ? "AND" : "OR"} Filter</Description>
-        <div className="flex justify-end mb-3 gap-3 items-center">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <Switch
             name="tag-filter-click-filter"
             {...(props.tagAndFilter !== undefined ? { checked: props.tagAndFilter } : {})}
@@ -49,7 +53,6 @@ export const TagFilter: React.FC<TagFilterProps> = (props) => {
         {props.tags?.map((tag) => (
           <Tag
             className="mr-1 mb-1"
-            primary
             small
             key={tag}
             label={tag}
@@ -60,6 +63,6 @@ export const TagFilter: React.FC<TagFilterProps> = (props) => {
           />
         ))}
       </TagList>
-    </div>
+    </fieldset>
   );
 };

--- a/src/features/deck/components/TagFilter.tsx
+++ b/src/features/deck/components/TagFilter.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { Button, Description, Switch, Tag, TagList } from "@/shared/components";
+import { Button, Description, Section, Switch, Tag, TagList } from "@/shared/components";
 
 const updateTags = (tags: string[], tag: string) => {
   if (tags.includes(tag)) {
@@ -22,11 +22,11 @@ export interface TagFilterProps {
 
 export const TagFilter: React.FC<TagFilterProps> = (props) => {
   return (
-    <fieldset
+    <div
       data-testid="tag-filter"
       className="min-w-0 rounded-surface border border-border bg-surface p-4 shadow-surface"
     >
-      <legend className="px-2 text-body font-semibold text-ink">tags</legend>
+      <Section title="tags" />
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Description>{props.tagAndFilter ? "AND" : "OR"} Filter</Description>
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -63,6 +63,6 @@ export const TagFilter: React.FC<TagFilterProps> = (props) => {
           />
         ))}
       </TagList>
-    </fieldset>
+    </div>
   );
 };

--- a/src/features/deck/components/templates/DeckListTemplate.spec.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.spec.tsx
@@ -1,0 +1,22 @@
+import { cleanup, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
+
+describe("DeckListTemplate", () => {
+  afterEach(cleanup);
+
+  it("provides a clear page heading and preserves feedback content", () => {
+    const view = render(<DeckListTemplate decks={[]} feedbackSlot={<div role="status">Saved</div>} />);
+
+    expect(view.getByRole("heading", { level: 1, name: "Decks" })).toBeInTheDocument();
+    expect(view.getByRole("status")).toHaveTextContent("Saved");
+  });
+
+  it("does not introduce an empty-state message", () => {
+    const view = render(<DeckListTemplate decks={[]} />);
+
+    expect(view.queryByText(/no decks/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/deck/components/templates/DeckListTemplate.stories.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.stories.tsx
@@ -25,6 +25,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const Inactive: Story = {};
+
 export const WithStudyProgress: Story = {
   args: {
     studyProgress: {
@@ -35,11 +37,15 @@ export const WithStudyProgress: Story = {
   },
 };
 
+export const Active: Story = WithStudyProgress;
+
 export const Empty: Story = {
   args: {
     decks: [],
   },
 };
+
+export const EmptyComposition: Story = Empty;
 
 export const Long: Story = {
   args: {
@@ -52,6 +58,14 @@ export const IphoneX: Story = {
     viewport: {
       defaultViewport: "iphonex",
     },
+  },
+};
+
+export const MobileLight: Story = IphoneX;
+
+export const Dark: Story = {
+  globals: {
+    theme: "dark",
   },
 };
 

--- a/src/features/deck/components/templates/DeckListTemplate.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.tsx
@@ -19,6 +19,7 @@ export const DeckListTemplate: React.FC<DeckListTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
       {props.feedbackSlot}
+      <h1 className="break-words text-title font-bold text-ink">Decks</h1>
       <List>
         {props.decks?.map((deck) => {
           const studyProgress = props.studyProgress?.deckId === deck.id ? props.studyProgress : undefined;

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -36,6 +36,8 @@ const ownedPresentationFiles = [
   "shared/components/forms/Tag.tsx",
   "shared/components/forms/Upload.tsx",
   "features/deck/components/DeckCard.tsx",
+  "features/deck/components/DeckStartForm.tsx",
+  "features/deck/components/TagFilter.tsx",
   "features/deck/components/templates/DeckListTemplate.tsx",
   "features/card/components/Card.tsx",
   "features/card/components/FrontText.tsx",
@@ -222,5 +224,10 @@ describe("Calm Focus visual contract", () => {
     );
 
     expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("gives the deck filter surfaces semantic Calm Focus treatment", () => {
+    expect(readOwnedSource("features/deck/components/DeckStartForm.tsx")).toMatch(/bg-surface/);
+    expect(readOwnedSource("features/deck/components/TagFilter.tsx")).toMatch(/bg-surface/);
   });
 });

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -35,6 +35,8 @@ const ownedPresentationFiles = [
   "shared/components/forms/Switch.tsx",
   "shared/components/forms/Tag.tsx",
   "shared/components/forms/Upload.tsx",
+  "features/deck/components/DeckCard.tsx",
+  "features/deck/components/templates/DeckListTemplate.tsx",
 ];
 const semanticColorRoles = [
   "canvas",

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -37,6 +37,12 @@ const ownedPresentationFiles = [
   "shared/components/forms/Upload.tsx",
   "features/deck/components/DeckCard.tsx",
   "features/deck/components/templates/DeckListTemplate.tsx",
+  "features/card/components/Card.tsx",
+  "features/card/components/FrontText.tsx",
+  "features/card/components/BackText.tsx",
+  "features/card/components/CardOverlay.tsx",
+  "features/card/components/templates/CardListTemplate.tsx",
+  "features/card/components/templates/CardViewTemplate.tsx",
 ];
 const semanticColorRoles = [
   "canvas",


### PR DESCRIPTION
## Summary
- refresh deck browsing with responsive hierarchy and distinct Study, Continue, and Restart actions
- unify card list, answer surfaces, overlays, and study filters with Calm Focus semantic styling
- preserve existing routes, callbacks, swipe behavior, empty-state composition, and #204 selector ownership
- add focused unit coverage and light/dark, desktop/mobile, and long-content stories

## Testing
- npm run test:unit -- src/features/deck/components src/features/card/components src/lib/calmFocusVisualContract.spec.ts src/lib/componentArchitecture.spec.ts
- env -u COMPOSE_FILE make check
- env -u COMPOSE_FILE make build
- env -u COMPOSE_FILE make e2e

Closes #219