### PR TITLE
Modernize utility routes with Calm Focus

### DIFF
--- a/docs/superpowers/plans/2026-07-16-calm-focus-utility-routes.md
+++ b/docs/superpowers/plans/2026-07-16-calm-focus-utility-routes.md
@@ -1,0 +1,276 @@
+# Calm Focus Utility Routes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Deck/Card editing, CSV Import, and Settings one Calm Focus form and section hierarchy without changing their existing state or behavior.
+
+**Architecture:** Keep containers and presentation props unchanged. Apply existing shared form/content primitives and semantic utilities inside the four feature components and three route templates, then protect behavior with focused React Testing Library specs and protect presentation ownership with the Calm Focus source contract.
+
+**Tech Stack:** React 18, TypeScript, Tailwind CSS 4 semantic utilities, Vitest, React Testing Library, Storybook 10, Docker Compose via Make.
+
+---
+
+## File Map
+
+- `src/lib/calmFocusVisualContract.spec.ts`: add all seven utility-route presentation files to Calm Focus ownership and assert route-level surface treatment.
+- `src/features/deck/components/DeckForm.tsx`: group editable fields, unavailable controls, metadata, and primary action.
+- `src/features/deck/components/templates/DeckFormTemplate.tsx`: provide the Deck editor page title and bounded route surface.
+- `src/features/card/components/CardForm.tsx`: group editable fields, tags, metadata, and primary action.
+- `src/features/card/components/templates/CardFormTemplate.tsx`: provide the Card editor page title and bounded route surface.
+- `src/features/import/components/templates/DeckImportTemplate.tsx`: unify upload, format guidance, sample action, and code sample.
+- `src/features/settings/components/ConfigForm.tsx`: group account, layout, study, autoplay, and metadata while preserving auto-save controls.
+- `src/features/settings/components/templates/ConfigFormTemplate.tsx`: provide the Settings page title and bounded route surface.
+- Matching `*.stories.tsx` files: add long-content, disabled/pending, light/dark, logged-in/out, and mobile review states.
+- New colocated `*.spec.tsx` files: verify presentation hierarchy and unchanged callbacks/values.
+
+### Task 1: Establish the Utility-Route Visual Contract
+
+**Files:**
+- Modify: `src/lib/calmFocusVisualContract.spec.ts`
+
+- [ ] **Step 1: Write the failing ownership assertion**
+
+Add these paths to `ownedPresentationFiles`:
+
+```ts
+"features/deck/components/DeckForm.tsx",
+"features/deck/components/templates/DeckFormTemplate.tsx",
+"features/card/components/CardForm.tsx",
+"features/card/components/templates/CardFormTemplate.tsx",
+"features/import/components/templates/DeckImportTemplate.tsx",
+"features/settings/components/ConfigForm.tsx",
+"features/settings/components/templates/ConfigFormTemplate.tsx",
+```
+
+Add an assertion that reads each template and expects a semantic surface utility such as `bg-surface` or `bg-surface-elevated`.
+
+- [ ] **Step 2: Run the contract and verify RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev run test:unit -- src/lib/calmFocusVisualContract.spec.ts
+```
+
+Expected: FAIL because the current Import template still contains `dark:shadow-gray-100` and the route templates do not yet provide semantic surfaces.
+
+- [ ] **Step 3: Commit the failing contract with the first feature tests rather than alone**
+
+Do not modify production code in this task.
+
+### Task 2: Modernize Deck Editing
+
+**Files:**
+- Create: `src/features/deck/components/DeckForm.spec.tsx`
+- Create: `src/features/deck/components/templates/DeckFormTemplate.spec.tsx`
+- Modify: `src/features/deck/components/DeckForm.tsx`
+- Modify: `src/features/deck/components/templates/DeckFormTemplate.tsx`
+- Modify: `src/features/deck/components/DeckForm.stories.tsx`
+- Modify: `src/features/deck/components/templates/DeckFormTemplate.stories.tsx`
+- Test: `src/features/deck/containers/DeckFormContainer.spec.tsx`
+
+- [ ] **Step 1: Write the DeckForm failing tests**
+
+Render a complete deck and real shared controls. Assert:
+
+```ts
+expect(screen.getByRole("heading", { name: "Deck details" })).toBeVisible();
+expect(screen.getByRole("heading", { name: "Availability" })).toBeVisible();
+expect(screen.getByRole("heading", { name: "Metadata" })).toBeVisible();
+expect(screen.getByText(/not available yet/i)).toBeVisible();
+expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+```
+
+Also submit once with `isSubmitting={false}` and verify `onSubmit`, and verify name, URL, convert, category, Public, Local Mode, id, created, and updated values remain rendered. Query Public and Local Mode inputs and assert both are disabled.
+
+- [ ] **Step 2: Write the DeckFormTemplate failing test**
+
+Render `feedbackSlot` and `deckForm`. Assert the page heading `Edit deck`, feedback, and form appear in order inside a bounded semantic surface (`max-w-*`, `bg-surface`, `rounded-surface`, `border-border`).
+
+- [ ] **Step 3: Verify both Deck specs are RED separately**
+
+Run each new spec with `npm run test:unit -- <path>` through the dev container. Expected: FAIL on the missing headings and route surface.
+
+- [ ] **Step 4: Implement the minimal Deck presentation**
+
+Use semantic markup similar to:
+
+```tsx
+<Form onSubmit={...}>
+  <section aria-labelledby="deck-details-heading">
+    <h2 id="deck-details-heading" className="... text-ink">Deck details</h2>
+    {/* existing editable FormItems */}
+  </section>
+  <section aria-labelledby="deck-availability-heading" className="... bg-surface-muted ...">
+    <h2 id="deck-availability-heading">Availability</h2>
+    {/* disabled Public and Local Mode controls plus explicit unavailable help */}
+  </section>
+  <section aria-labelledby="deck-metadata-heading">
+    <h2 id="deck-metadata-heading">Metadata</h2>
+    {/* existing id and timestamps */}
+  </section>
+  <Button primary type="submit" disabled={props.isSubmitting}>Save</Button>
+</Form>
+```
+
+In the template, render `Edit deck` as the single page heading and wrap feedback/form in `mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6`.
+
+- [ ] **Step 5: Verify Deck GREEN**
+
+Run both new specs, `src/features/deck/containers/DeckFormContainer.spec.tsx`, and `src/lib/calmFocusVisualContract.spec.ts` together. Expected: PASS.
+
+- [ ] **Step 6: Extend Deck stories**
+
+Add create/edit-like long values, submitting/disabled, dark theme, and iPhone fixtures using existing Storybook viewport and theme parameters.
+
+- [ ] **Step 7: Commit Deck work**
+
+```bash
+git add src/lib/calmFocusVisualContract.spec.ts src/features/deck/components
+git commit -m "feat: modernize deck editing"
+```
+
+### Task 3: Modernize Card Editing
+
+**Files:**
+- Create: `src/features/card/components/CardForm.spec.tsx`
+- Create: `src/features/card/components/templates/CardFormTemplate.spec.tsx`
+- Modify: `src/features/card/components/CardForm.tsx`
+- Modify: `src/features/card/components/templates/CardFormTemplate.tsx`
+- Modify: `src/features/card/components/CardForm.stories.tsx`
+- Modify: `src/features/card/components/templates/CardFormTemplate.stories.tsx`
+- Test: `src/features/card/containers/CardFormContainer.spec.tsx`
+
+- [ ] **Step 1: Write failing Card component/template tests**
+
+Assert `Card content`, `Tags`, and `Metadata` section headings; existing text/tag values; id, unique key, created and last-seen metadata; submit callback; submitting state; feedback composition; `Edit card` page heading; and the same bounded semantic template surface used by Deck.
+
+- [ ] **Step 2: Verify Card RED separately**
+
+Run each new spec individually. Expected: FAIL on missing section/page headings and surface classes.
+
+- [ ] **Step 3: Implement minimal Card presentation**
+
+Keep all current props and inputs. Group front/back text, tags, and metadata in semantic sections; retain the sole Save action; and use the same template measure/surface contract as Deck.
+
+- [ ] **Step 4: Verify Card GREEN**
+
+Run both new specs, `src/features/card/containers/CardFormContainer.spec.tsx`, and `src/lib/calmFocusVisualContract.spec.ts`. Expected: PASS.
+
+- [ ] **Step 5: Extend Card stories and commit**
+
+Add long text/tags, submitting, dark, and mobile states, then commit:
+
+```bash
+git add src/lib/calmFocusVisualContract.spec.ts src/features/card/components
+git commit -m "feat: modernize card editing"
+```
+
+### Task 4: Modernize CSV Import Presentation
+
+**Files:**
+- Create: `src/features/import/components/templates/DeckImportTemplate.spec.tsx`
+- Modify: `src/features/import/components/templates/DeckImportTemplate.tsx`
+- Modify: `src/features/import/components/templates/DeckImportTemplate.stories.tsx`
+- Test: `src/features/import/containers/DeckImportContainer.spec.tsx`
+
+- [ ] **Step 1: Write the failing Import template test**
+
+Render callbacks and sample text. Assert one `Import decks` page heading; `Choose a CSV file`, `CSV format`, and `Sample` section headings; upload callback with a real `File`; accessible sample-download callback; visible explanation and code sample; pending upload disabled state; feedback placement; and semantic overflow surface classes.
+
+- [ ] **Step 2: Verify Import RED**
+
+Run the new spec alone. Expected: FAIL on the new hierarchy and semantic surface assertions.
+
+- [ ] **Step 3: Implement minimal Import presentation**
+
+Replace repeated `Title` blocks and the raw shadow color with one bounded semantic surface containing three sections. Use the shared `Button` for the sample download while preserving its accessible name and callback, shared `Upload`, `Description`, and `Code`; use `overflow-x-auto` for the sample.
+
+- [ ] **Step 4: Verify Import GREEN**
+
+Run the new template spec, container spec, accessibility spec, and visual contract. Expected: PASS.
+
+- [ ] **Step 5: Extend Import stories and commit**
+
+Add default/no-file, pending, long sample, dark, and iPhone states, then commit:
+
+```bash
+git add src/lib/calmFocusVisualContract.spec.ts src/features/import/components
+git commit -m "feat: modernize import presentation"
+```
+
+### Task 5: Modernize Settings Presentation
+
+**Files:**
+- Create: `src/features/settings/components/ConfigForm.spec.tsx`
+- Create: `src/features/settings/components/templates/ConfigFormTemplate.spec.tsx`
+- Modify: `src/features/settings/components/ConfigForm.tsx`
+- Modify: `src/features/settings/components/templates/ConfigFormTemplate.tsx`
+- Modify: `src/features/settings/components/ConfigForm.stories.tsx`
+- Modify: `src/features/settings/components/templates/ConfigFormTemplate.stories.tsx`
+- Test: `src/features/settings/containers/ConfigContainer.spec.tsx`
+- Test: `src/features/settings/hooks/useConfigFormState.spec.tsx`
+
+- [ ] **Step 1: Write failing ConfigForm tests**
+
+Assert `Account`, `Layout`, `Study`, `Autoplay`, and `Metadata` section headings; logged-out Login and logged-in Logout callbacks; all eight switch fields; both slider values; token input; version and user id; and existing labels. Trigger representative switch, slider, and token input callbacks to prove presentation forwarding remains intact.
+
+- [ ] **Step 2: Write the failing ConfigFormTemplate test**
+
+Assert one `Settings` page heading, retained form composition, and the same bounded semantic surface contract as the other utility routes.
+
+- [ ] **Step 3: Verify Settings RED separately**
+
+Run each new spec individually. Expected: FAIL on missing grouping/page heading/surface assertions.
+
+- [ ] **Step 4: Implement minimal Settings presentation**
+
+Keep `<Form div>` and every existing field prop. Rename only the misspelled visible `Show Heaer` label to `Show Header`; visually group the existing controls under Account, Layout, Study, Autoplay, and Metadata. Move the page-level Settings heading to the template so the form uses section-level headings only.
+
+- [ ] **Step 5: Verify Settings GREEN**
+
+Run both new specs, Config container and hook specs, and the visual contract. Expected: PASS and unchanged auto-save tests.
+
+- [ ] **Step 6: Extend Settings stories and commit**
+
+Add logged-in/out, long identity/token/metadata, dark, and iPhone states, then commit:
+
+```bash
+git add src/lib/calmFocusVisualContract.spec.ts src/features/settings/components
+git commit -m "feat: modernize settings presentation"
+```
+
+### Task 6: Regression Verification and Publication Readiness
+
+**Files:**
+- Verify only; modify tests only if a genuine regression is found.
+
+- [ ] **Step 1: Run focused feature and architecture tests**
+
+Run all new specs, four relevant container specs, `src/features/settings/hooks/useConfigFormState.spec.tsx`, `src/lib/calmFocusVisualContract.spec.ts`, `src/lib/componentArchitecture.spec.ts`, and `src/lib/interactionAccessibility.spec.tsx`. Expected: PASS.
+
+- [ ] **Step 2: Run Storybook build**
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev run build:storybook
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run repository checks**
+
+```bash
+direnv exec . make check
+direnv exec . make build
+direnv exec . make e2e
+```
+
+Expected: each command exits 0.
+
+- [ ] **Step 4: Audit the final diff and issue checklist**
+
+Confirm no container state ownership, handler, schema, persistence, auth, sync, Import workflow, or navigation behavior changed. Confirm every owned presentation file uses semantic colors and each story set covers desktop/mobile and light/dark review.
+
+- [ ] **Step 5: Prepare the PR**
+
+Use an English title and body, include `Closes #218`, summarize the three UI groups, and list the exact verification commands and results.

--- a/docs/superpowers/specs/2026-07-16-calm-focus-utility-routes-design.md
+++ b/docs/superpowers/specs/2026-07-16-calm-focus-utility-routes-design.md
@@ -1,0 +1,60 @@
+# Calm Focus Utility Routes Design
+
+## Goal
+
+Unify Deck and Card editing, CSV Import, and Settings under the existing Calm Focus form and content hierarchy without changing validation, persistence, authentication, synchronization, or route behavior.
+
+## Approach
+
+Apply the existing shared `Form`, `FormItem`, `Section`, content, control, and semantic color primitives directly in each utility-route component. Keep the current component boundaries and presentation props so containers continue to own state and handlers. Avoid a utility-route wrapper or additional shared API unless an existing primitive cannot express the approved layout.
+
+## Component Design
+
+### Deck and Card editing
+
+- Give each template a clear page title and a bounded reading-width surface.
+- Group editable fields, disabled availability controls, and metadata into consistent sections.
+- Keep existing values, callbacks, submit behavior, submitting state, and the absence of a cancel action.
+- Make Public and Local Mode controls visibly unavailable through their disabled control shape and explanatory text.
+
+### CSV Import
+
+- Present upload, format guidance, sample download, and code sample as one shared content/form hierarchy.
+- Keep upload and sample-download callbacks unchanged.
+- Keep preview, validation, result, and workflow-step changes out of scope.
+
+### Settings
+
+- Group account, layout, study, autoplay, and metadata controls into distinct semantic sections.
+- Keep login/logout, switches, sliders, token input, persisted values, and auto-save wiring unchanged.
+- Do not add explicit save, synchronization state, or authentication lifecycle behavior.
+
+## Responsive and Visual Behavior
+
+- Use a bounded desktop measure and a single-column mobile flow.
+- Allow labels, help text, metadata, and code samples to wrap or scroll without colliding with fixed or sticky application elements.
+- Use only Calm Focus semantic color utilities and shared surface, spacing, radius, typography, and control contracts.
+- Extend stories with light/dark, desktop/mobile, long-content, disabled, and route-specific state fixtures.
+
+## Data Flow and Error Handling
+
+Containers remain responsible for all state, persistence, authentication, navigation, and error reporting. Presentation components receive the same values and callbacks they do today. Existing feedback slots remain in place, and this change introduces no new error state or side effect.
+
+## Testing
+
+Follow test-driven development for each surface:
+
+1. Extend `calmFocusVisualContract.spec.ts` and add focused component/template assertions.
+2. Run each focused spec and confirm the intended presentation assertion fails.
+3. Apply the smallest presentation change that satisfies the contract.
+4. Rerun focused specs with the visual and component architecture contracts.
+5. Run Storybook build, `make check`, application build, and end-to-end tests before publishing the PR.
+
+Existing container tests protect handlers, values, auto-save, authentication, and navigation behavior. Component tests protect hierarchy, disabled state, callbacks, metadata, and retained template composition.
+
+## Non-goals
+
+- Import preview, validation, results, or multi-step workflow
+- Local/cloud synchronization clarity or lifecycle changes
+- Form schema, persistence model, or state ownership changes
+- New cancel, save, navigation, or authentication actions

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -95,8 +95,9 @@ test("shows settings and allows changing a local setting", async ({ page }) => {
 test("shows the import screen", async ({ page }) => {
   await page.goto("/import");
 
-  await expect(page.getByText("Deck Upload")).toBeVisible();
-  await expect(page.getByText("CSV File Format")).toBeVisible();
-  await expect(page.getByText("CSV Sample")).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "Import decks", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Choose a CSV file", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "CSV format", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Sample", exact: true })).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });

--- a/src/features/card/components/CardForm.spec.tsx
+++ b/src/features/card/components/CardForm.spec.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { CardForm, type CardFormProps } from "@/features/card/components/CardForm";
+import { createCard } from "@/test/factories";
+
+const createdAt = Date.UTC(2026, 0, 2);
+const lastSeenAt = Date.UTC(2026, 1, 3);
+
+const createProps = (overrides: Partial<CardFormProps> = {}): CardFormProps => ({
+  card: createCard({
+    id: "card-123",
+    frontText: "What is the capital of Japan?",
+    backText: "Tokyo",
+    tags: ["geography"],
+    uniqueKey: "japan-capital",
+    createdAt,
+    lastSeenAt,
+  }),
+  fields: {
+    frontText: { name: "frontText", value: "What is the capital of Japan?", onChange: vi.fn() },
+    backText: { name: "backText", value: "Tokyo", onChange: vi.fn() },
+    tags: [
+      {
+        label: "Geography",
+        value: "geography",
+        input: { name: "tags", value: "geography", checked: true, onChange: vi.fn() },
+      },
+      {
+        label: "Travel",
+        value: "travel",
+        input: { name: "tags", value: "travel", checked: false, onChange: vi.fn() },
+      },
+    ],
+  },
+  ...overrides,
+});
+
+describe("CardForm", () => {
+  afterEach(cleanup);
+
+  it("groups card content, tags, and metadata while preserving values and callbacks", async () => {
+    const props = createProps();
+    const view = render(<CardForm {...props} />);
+    const frontText = view.container.querySelector("textarea[name='frontText']") as HTMLTextAreaElement;
+    const backText = view.container.querySelector("textarea[name='backText']") as HTMLTextAreaElement;
+    const geography = view.container.querySelector("input[name='tags'][value='geography']") as HTMLInputElement;
+    const travel = view.container.querySelector("input[name='tags'][value='travel']") as HTMLInputElement;
+
+    expect(view.getByRole("heading", { level: 2, name: "Card content" })).toBeVisible();
+    expect(view.getByRole("heading", { level: 2, name: "Tags" })).toBeVisible();
+    expect(view.getByRole("heading", { level: 2, name: "Metadata" })).toBeVisible();
+    expect(frontText).toHaveValue("What is the capital of Japan?");
+    expect(backText).toHaveValue("Tokyo");
+    expect(geography).toBeChecked();
+    expect(travel).not.toBeChecked();
+    expect(view.getByText("japan-capital")).toBeVisible();
+    expect(view.getByText("card-123")).toBeVisible();
+    expect(view.getByText(String(createdAt))).toBeVisible();
+    expect(view.getByText(new Date(lastSeenAt).toLocaleDateString())).toBeVisible();
+
+    fireEvent.change(frontText, { target: { value: "Updated front" } });
+    fireEvent.change(backText, { target: { value: "Updated back" } });
+    await userEvent.click(travel);
+
+    expect(props.fields.frontText.onChange).toHaveBeenCalledOnce();
+    expect(props.fields.backText.onChange).toHaveBeenCalledOnce();
+    expect(props.fields.tags[1]?.input.onChange).toHaveBeenCalledOnce();
+  });
+
+  it("uses unique section heading relationships for each form instance", () => {
+    const view = render(
+      <>
+        <CardForm {...createProps()} />
+        <CardForm {...createProps()} />
+      </>
+    );
+    const sections = view.container.querySelectorAll("section[aria-labelledby]");
+    const labelledByIds = Array.from(sections, (section) => section.getAttribute("aria-labelledby"));
+
+    expect(sections).toHaveLength(6);
+    expect(new Set(labelledByIds).size).toBe(6);
+    for (const section of sections) {
+      const headingId = section.getAttribute("aria-labelledby");
+      expect(headingId).not.toBeNull();
+      expect(section.querySelector(`h2[id='${headingId}']`)).toBeInTheDocument();
+    }
+  });
+
+  it("submits when idle and has no cancel action", async () => {
+    const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());
+    const view = render(<CardForm {...createProps({ isSubmitting: false, onSubmit })} />);
+    const save = view.getByRole("button", { name: "Save" });
+
+    expect(save).toBeEnabled();
+    expect(view.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+    await userEvent.click(save);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("disables Save only while submitting", () => {
+    const view = render(<CardForm {...createProps({ isSubmitting: true })} />);
+
+    expect(view.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+});

--- a/src/features/card/components/CardForm.stories.tsx
+++ b/src/features/card/components/CardForm.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { CardForm as Template, type CardFormFields } from "@/features/card/components/CardForm";
 import type { Option } from "@/shared/components/forms/Select";
 import * as fixture from "@/shared/storybook/fixture";
+import { INITIAL_VIEWPORTS } from "@/shared/storybook/storybookViewports";
 
 const fieldsFor = (card: Card, options: Option[]): CardFormFields => ({
   frontText: { value: card.frontText, onChange: () => undefined },
@@ -14,10 +15,22 @@ const fieldsFor = (card: Card, options: Option[]): CardFormFields => ({
   })),
 });
 
+const longCard: Card = {
+  ...fixture.card.long,
+  tags: [...fixture.tags.toolong],
+};
+const longTagOptions = fixture.tags.toolong.map((tag) => ({ label: tag, value: tag }));
+
 const meta = {
   title: "Card/CardForm",
   component: Template,
   tags: ["autodocs"],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: "desktop",
+    },
+  },
   argTypes: {
     onSubmit: { action: "onSubmit" },
   },
@@ -37,4 +50,25 @@ export const TooManyOptions: Story = {
     card: fixture.card.default,
     fields: fieldsFor(fixture.card.default, fixture.form.options.toomany),
   },
+};
+
+export const LongValues: Story = {
+  args: {
+    card: longCard,
+    fields: fieldsFor(longCard, longTagOptions),
+  },
+};
+
+export const Submitting: Story = {
+  args: { isSubmitting: true },
+};
+
+export const DarkReview: Story = {
+  ...LongValues,
+  globals: { theme: "dark" },
+};
+
+export const IphoneReview: Story = {
+  ...LongValues,
+  parameters: { viewport: { defaultViewport: "iphonex" } },
 };

--- a/src/features/card/components/CardForm.tsx
+++ b/src/features/card/components/CardForm.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react";
+import { useId } from "react";
 
 import { Button, Form, FormItem, Tag, TagList, Textarea } from "@/shared/components";
 import type { Option } from "@/shared/components/forms/Select";
@@ -21,31 +22,52 @@ export interface CardFormProps {
 }
 
 export const CardForm: React.FC<CardFormProps> = (props) => {
+  const sectionHeadingIdPrefix = useId();
+  const contentHeadingId = `${sectionHeadingIdPrefix}-card-content-heading`;
+  const tagsHeadingId = `${sectionHeadingIdPrefix}-card-tags-heading`;
+  const metadataHeadingId = `${sectionHeadingIdPrefix}-card-metadata-heading`;
+
   return (
     <Form {...(props.onSubmit !== undefined ? { onSubmit: props.onSubmit } : {})}>
-      <FormItem col label="Front Text">
-        <Textarea rows={8} {...props.fields.frontText} />
-      </FormItem>
-      <FormItem col label="Back Text">
-        <Textarea rows={8} {...props.fields.backText} />
-      </FormItem>
-      <FormItem col label="Tags">
+      <section aria-labelledby={contentHeadingId} className="space-y-4">
+        <h2 id={contentHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Card content
+        </h2>
+        <FormItem col label="Front Text">
+          <Textarea rows={8} {...props.fields.frontText} />
+        </FormItem>
+        <FormItem col label="Back Text">
+          <Textarea rows={8} {...props.fields.backText} />
+        </FormItem>
+      </section>
+      <section
+        aria-labelledby={tagsHeadingId}
+        className="space-y-4 rounded-surface border border-border bg-surface-muted p-4"
+      >
+        <h2 id={tagsHeadingId} className="text-title font-semibold text-ink">
+          Tags
+        </h2>
         <TagList>
           {props.fields.tags.map(({ label, value, input }) => (
             <Tag className="mr-1 mb-1" primary small key={value} label={label} {...input} value={value} />
           ))}
         </TagList>
-      </FormItem>
-      <FormItem col label="Unique Key">
-        {props.card.uniqueKey ?? ""}
-      </FormItem>
-      <FormItem col label="id">
-        {props.card.id}
-      </FormItem>
-      <FormItem label="Created At">{props.card.createdAt}</FormItem>
-      <FormItem label="Last Seen At">
-        {props.card.lastSeenAt && new Date(props.card.lastSeenAt).toLocaleDateString()}
-      </FormItem>
+      </section>
+      <section aria-labelledby={metadataHeadingId} className="space-y-4">
+        <h2 id={metadataHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Metadata
+        </h2>
+        <FormItem col label="Unique Key">
+          {props.card.uniqueKey ?? ""}
+        </FormItem>
+        <FormItem col label="id">
+          {props.card.id}
+        </FormItem>
+        <FormItem label="Created At">{props.card.createdAt}</FormItem>
+        <FormItem label="Last Seen At">
+          {props.card.lastSeenAt && new Date(props.card.lastSeenAt).toLocaleDateString()}
+        </FormItem>
+      </section>
       <Button primary type="submit" {...(props.isSubmitting !== undefined ? { disabled: props.isSubmitting } : {})}>
         Save
       </Button>

--- a/src/features/card/components/templates/CardFormTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.spec.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { CardFormTemplate } from "@/features/card/components/templates/CardFormTemplate";
+import { createCard } from "@/test/factories";
+
+describe("CardFormTemplate", () => {
+  afterEach(cleanup);
+
+  it("composes feedback before the form in a bounded semantic editing surface", () => {
+    const view = render(
+      <CardFormTemplate
+        feedbackSlot={<div role="status">Saved</div>}
+        cardForm={{
+          card: createCard({ id: "card-123" }),
+          fields: {
+            frontText: { name: "frontText" },
+            backText: { name: "backText" },
+            tags: [],
+          },
+        }}
+      />
+    );
+
+    const heading = view.getByRole("heading", { level: 1, name: "Edit card" });
+    const surface = heading.parentElement;
+    const feedback = view.getByRole("status");
+    const form = view.container.querySelector("form");
+
+    expect(surface).toHaveClass(
+      "mx-auto",
+      "w-full",
+      "max-w-reading",
+      "rounded-surface",
+      "border",
+      "border-border",
+      "bg-surface",
+      "p-4",
+      "md:p-6"
+    );
+    expect(surface).toContainElement(feedback);
+    expect(surface).toContainElement(form);
+    expect(feedback.compareDocumentPosition(form as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/src/features/card/components/templates/CardFormTemplate.stories.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.stories.tsx
@@ -3,17 +3,24 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { INITIAL_VIEWPORTS } from "@/shared/storybook/storybookViewports";
 import type { CardFormFields } from "@/features/card/components/CardForm";
 import { CardFormTemplate as Template } from "@/features/card/components/templates/CardFormTemplate";
+import type { Option } from "@/shared/components/forms/Select";
 import * as fixture from "@/shared/storybook/fixture";
 
-const fields: CardFormFields = {
-  frontText: { value: fixture.card.default.frontText, onChange: () => undefined },
-  backText: { value: fixture.card.default.backText, onChange: () => undefined },
-  tags: fixture.form.options.default.map(({ label, value }) => ({
+const fieldsFor = (card: Card, options: Option[]): CardFormFields => ({
+  frontText: { value: card.frontText, onChange: () => undefined },
+  backText: { value: card.backText, onChange: () => undefined },
+  tags: options.map(({ label, value }) => ({
     label,
     value,
-    input: { name: "tags", value, checked: false, onChange: () => undefined },
+    input: { name: "tags", value, checked: card.tags.includes(value), onChange: () => undefined },
   })),
+});
+
+const longCard: Card = {
+  ...fixture.card.long,
+  tags: [...fixture.tags.toolong],
 };
+const longTagOptions = fixture.tags.toolong.map((tag) => ({ label: tag, value: tag }));
 
 const meta = {
   title: "Card/CardFormTemplate",
@@ -29,7 +36,7 @@ const meta = {
   args: {
     cardForm: {
       card: fixture.card.default,
-      fields,
+      fields: fieldsFor(fixture.card.default, [...fixture.form.options.default]),
     },
   },
 } satisfies Meta<typeof Template>;
@@ -39,7 +46,32 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const IphoneX: Story = {
+export const LongValues: Story = {
+  args: {
+    cardForm: {
+      card: longCard,
+      fields: fieldsFor(longCard, longTagOptions),
+    },
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    cardForm: {
+      card: fixture.card.default,
+      fields: fieldsFor(fixture.card.default, [...fixture.form.options.default]),
+      isSubmitting: true,
+    },
+  },
+};
+
+export const DarkReview: Story = {
+  ...LongValues,
+  globals: { theme: "dark" },
+};
+
+export const IphoneReview: Story = {
+  ...LongValues,
   parameters: {
     viewport: {
       defaultViewport: "iphonex",

--- a/src/features/card/components/templates/CardFormTemplate.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.tsx
@@ -11,8 +11,11 @@ export interface CardFormTemplateProps {
 export const CardFormTemplate: React.FC<CardFormTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
-      {props.feedbackSlot}
-      {props.cardForm != null && <CardForm {...props.cardForm} />}
+      <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
+        <h1 className="mb-section-gap break-words text-display font-bold text-ink">Edit card</h1>
+        {props.feedbackSlot}
+        {props.cardForm != null && <CardForm {...props.cardForm} />}
+      </section>
     </Layout>
   );
 };

--- a/src/features/deck/components/DeckForm.spec.tsx
+++ b/src/features/deck/components/DeckForm.spec.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { DeckForm, type DeckFormProps } from "@/features/deck/components/DeckForm";
+import { createDeck } from "@/test/factories";
+
+const createProps = (overrides: Partial<DeckFormProps> = {}): DeckFormProps => ({
+  deck: createDeck({
+    id: "deck-123",
+    name: "Japanese vocabulary",
+    url: "https://example.com/deck.csv",
+    category: "language",
+    convertToBr: true,
+    isPublic: true,
+    localMode: false,
+    createdAt: Date.UTC(2026, 0, 2),
+    updatedAt: Date.UTC(2026, 1, 3),
+  }),
+  fields: {
+    name: { name: "name", value: "Japanese vocabulary", onChange: vi.fn() },
+    convertToBr: { name: "convertToBr", checked: true, onChange: vi.fn() },
+    url: { name: "url", value: "https://example.com/deck.csv", onChange: vi.fn() },
+    isPublic: { name: "isPublic", checked: true, onChange: vi.fn() },
+    localMode: { name: "localMode", checked: false, onChange: vi.fn() },
+    category: {
+      name: "category",
+      value: "language",
+      options: [
+        { label: "Language", value: "language" },
+        { label: "Science", value: "science" },
+      ],
+      onChange: vi.fn(),
+    },
+  },
+  ...overrides,
+});
+
+describe("DeckForm", () => {
+  afterEach(cleanup);
+
+  it("groups deck details, availability, and metadata while preserving field values and callbacks", async () => {
+    const props = createProps();
+    const view = render(<DeckForm {...props} />);
+    const name = view.container.querySelector("input[name='name']") as HTMLInputElement;
+    const convertToBr = view.container.querySelector("input[name='convertToBr']") as HTMLInputElement;
+    const url = view.container.querySelector("input[name='url']") as HTMLInputElement;
+    const category = view.container.querySelector("select[name='category']") as HTMLSelectElement;
+
+    expect(view.getByRole("heading", { level: 2, name: "Deck details" })).toBeVisible();
+    expect(view.getByRole("heading", { level: 2, name: "Availability" })).toBeVisible();
+    expect(view.getByRole("heading", { level: 2, name: "Metadata" })).toBeVisible();
+    expect(name).toHaveValue("Japanese vocabulary");
+    expect(convertToBr).toBeChecked();
+    expect(url).toHaveValue("https://example.com/deck.csv");
+    expect(category).toHaveValue("language");
+    expect(view.getByText("deck-123")).toBeVisible();
+    expect(view.getByText(new Date(Date.UTC(2026, 0, 2)).toLocaleDateString())).toBeVisible();
+    expect(view.getByText(new Date(Date.UTC(2026, 1, 3)).toLocaleDateString())).toBeVisible();
+
+    fireEvent.change(name, { target: { value: "Updated deck" } });
+    await userEvent.click(convertToBr);
+    fireEvent.change(url, { target: { value: "https://example.com/updated.csv" } });
+    await userEvent.selectOptions(category, "science");
+
+    expect(props.fields.name.onChange).toHaveBeenCalledOnce();
+    expect(props.fields.convertToBr.onChange).toHaveBeenCalledOnce();
+    expect(props.fields.url.onChange).toHaveBeenCalledOnce();
+    expect(props.fields.category.onChange).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Public and Local Mode disabled with explicit unavailable help", () => {
+    const view = render(<DeckForm {...createProps()} />);
+
+    expect(view.container.querySelector("input[name='isPublic']")).toBeDisabled();
+    expect(view.container.querySelector("input[name='isPublic']")).toBeChecked();
+    expect(view.container.querySelector("input[name='localMode']")).toBeDisabled();
+    expect(view.container.querySelector("input[name='localMode']")).not.toBeChecked();
+    expect(view.getAllByText(/not available yet/i)).toHaveLength(2);
+  });
+
+  it("submits when idle and has no cancel action", async () => {
+    const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());
+    const view = render(<DeckForm {...createProps({ isSubmitting: false, onSubmit })} />);
+    const save = view.getByRole("button", { name: "Save" });
+
+    expect(save).toBeEnabled();
+    expect(view.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+    await userEvent.click(save);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("disables Save only while submitting", () => {
+    const view = render(<DeckForm {...createProps({ isSubmitting: true })} />);
+
+    expect(view.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+});

--- a/src/features/deck/components/DeckForm.spec.tsx
+++ b/src/features/deck/components/DeckForm.spec.tsx
@@ -80,6 +80,25 @@ describe("DeckForm", () => {
     expect(view.getAllByText(/not available yet/i)).toHaveLength(2);
   });
 
+  it("uses unique section heading relationships for each form instance", () => {
+    const view = render(
+      <>
+        <DeckForm {...createProps()} />
+        <DeckForm {...createProps()} />
+      </>
+    );
+    const sections = view.container.querySelectorAll("section[aria-labelledby]");
+    const labelledByIds = Array.from(sections, (section) => section.getAttribute("aria-labelledby"));
+
+    expect(sections).toHaveLength(6);
+    expect(new Set(labelledByIds).size).toBe(6);
+    for (const section of sections) {
+      const headingId = section.getAttribute("aria-labelledby");
+      expect(headingId).not.toBeNull();
+      expect(section.querySelector(`h2[id='${headingId}']`)).toBeInTheDocument();
+    }
+  });
+
   it("submits when idle and has no cancel action", async () => {
     const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());
     const view = render(<DeckForm {...createProps({ isSubmitting: false, onSubmit })} />);

--- a/src/features/deck/components/DeckForm.stories.tsx
+++ b/src/features/deck/components/DeckForm.stories.tsx
@@ -2,30 +2,43 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { DeckForm as Template, type DeckFormFields } from "@/features/deck/components/DeckForm";
 import * as fixture from "@/shared/storybook/fixture";
+import { INITIAL_VIEWPORTS } from "@/shared/storybook/storybookViewports";
 
-const fields: DeckFormFields = {
-  name: { defaultValue: fixture.deck.default.name },
-  convertToBr: { checked: Boolean(fixture.deck.default.convertToBr), onChange: () => undefined },
-  url: { ...(fixture.deck.default.url !== undefined ? { defaultValue: fixture.deck.default.url } : {}) },
-  isPublic: { checked: fixture.deck.default.isPublic, onChange: () => undefined },
-  localMode: { checked: Boolean(fixture.deck.default.localMode), onChange: () => undefined },
+const fieldsFor = (deck: Deck): DeckFormFields => ({
+  name: { value: deck.name, onChange: () => undefined },
+  convertToBr: { checked: Boolean(deck.convertToBr), onChange: () => undefined },
+  url: { value: deck.url ?? "", onChange: () => undefined },
+  isPublic: { checked: deck.isPublic, onChange: () => undefined },
+  localMode: { checked: Boolean(deck.localMode), onChange: () => undefined },
   category: {
-    value: fixture.deck.default.category,
+    value: deck.category,
     options: fixture.form.options.default,
     onChange: () => undefined,
   },
+});
+
+const longDeck: Deck = {
+  ...fixture.deck.tooLongName,
+  url: `https://example.com/${"deeply-nested/".repeat(12)}deck.csv`,
+  category: "value 3",
 };
 
 const meta = {
   title: "Deck/DeckForm",
   component: Template,
   tags: ["autodocs"],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: "desktop",
+    },
+  },
   argTypes: {
     onSubmit: { action: "onSubmit" },
   },
   args: {
     deck: fixture.deck.default,
-    fields,
+    fields: fieldsFor(fixture.deck.default),
   },
 } satisfies Meta<typeof Template>;
 
@@ -33,3 +46,21 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const LongValues: Story = {
+  args: { deck: longDeck, fields: fieldsFor(longDeck) },
+};
+
+export const Submitting: Story = {
+  args: { isSubmitting: true },
+};
+
+export const DarkReview: Story = {
+  ...LongValues,
+  globals: { theme: "dark" },
+};
+
+export const IphoneReview: Story = {
+  ...LongValues,
+  parameters: { viewport: { defaultViewport: "iphonex" } },
+};

--- a/src/features/deck/components/DeckForm.tsx
+++ b/src/features/deck/components/DeckForm.tsx
@@ -21,33 +21,51 @@ export interface DeckFormProps {
 export const DeckForm: React.FC<DeckFormProps> = (props) => {
   return (
     <Form {...(props.onSubmit !== undefined ? { onSubmit: props.onSubmit } : {})}>
-      <FormItem col label="Name">
-        <Input {...props.fields.name} />
-      </FormItem>
-      <FormItem label="Convert" extra="Convert two line breaks to one <br />">
-        <Switch {...props.fields.convertToBr} />
-      </FormItem>
-      <FormItem col label="URL">
-        <Input {...props.fields.url} />
-      </FormItem>
-      <FormItem label="Public">
-        <Switch disabled {...props.fields.isPublic} />
-      </FormItem>
-      <FormItem label="Local Mode">
-        <Switch disabled {...props.fields.localMode} />
-      </FormItem>
-      <FormItem col label="Category">
-        <Select empty {...props.fields.category} />
-      </FormItem>
-      <FormItem col label="id">
-        {props.deck.id}
-      </FormItem>
-      {Boolean(props.deck.createdAt) && (
-        <FormItem label="Created At">{new Date(props.deck.createdAt).toLocaleDateString()}</FormItem>
-      )}
-      {Boolean(props.deck.updatedAt) && (
-        <FormItem label="Updated At">{new Date(props.deck.updatedAt).toLocaleDateString()}</FormItem>
-      )}
+      <section aria-labelledby="deck-details-heading" className="space-y-4">
+        <h2 id="deck-details-heading" className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Deck details
+        </h2>
+        <FormItem col label="Name">
+          <Input {...props.fields.name} />
+        </FormItem>
+        <FormItem label="Convert" extra="Convert two line breaks to one <br />">
+          <Switch {...props.fields.convertToBr} />
+        </FormItem>
+        <FormItem col label="URL">
+          <Input {...props.fields.url} />
+        </FormItem>
+        <FormItem col label="Category">
+          <Select empty {...props.fields.category} />
+        </FormItem>
+      </section>
+      <section
+        aria-labelledby="deck-availability-heading"
+        className="space-y-4 rounded-surface border border-border bg-surface-muted p-4"
+      >
+        <h2 id="deck-availability-heading" className="text-title font-semibold text-ink">
+          Availability
+        </h2>
+        <FormItem label="Public" help="Public decks are not available yet.">
+          <Switch {...props.fields.isPublic} disabled />
+        </FormItem>
+        <FormItem label="Local Mode" help="Local Mode is not available yet.">
+          <Switch {...props.fields.localMode} disabled />
+        </FormItem>
+      </section>
+      <section aria-labelledby="deck-metadata-heading" className="space-y-4">
+        <h2 id="deck-metadata-heading" className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Metadata
+        </h2>
+        <FormItem col label="id">
+          {props.deck.id}
+        </FormItem>
+        {Boolean(props.deck.createdAt) && (
+          <FormItem label="Created At">{new Date(props.deck.createdAt).toLocaleDateString()}</FormItem>
+        )}
+        {Boolean(props.deck.updatedAt) && (
+          <FormItem label="Updated At">{new Date(props.deck.updatedAt).toLocaleDateString()}</FormItem>
+        )}
+      </section>
       <Button primary type="submit" {...(props.isSubmitting !== undefined ? { disabled: props.isSubmitting } : {})}>
         Save
       </Button>

--- a/src/features/deck/components/DeckForm.tsx
+++ b/src/features/deck/components/DeckForm.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react";
+import { useId } from "react";
 
 import { Button, Form, FormItem, Input, Select, Switch } from "@/shared/components";
 
@@ -19,10 +20,15 @@ export interface DeckFormProps {
 }
 
 export const DeckForm: React.FC<DeckFormProps> = (props) => {
+  const sectionHeadingIdPrefix = useId();
+  const detailsHeadingId = `${sectionHeadingIdPrefix}-deck-details-heading`;
+  const availabilityHeadingId = `${sectionHeadingIdPrefix}-deck-availability-heading`;
+  const metadataHeadingId = `${sectionHeadingIdPrefix}-deck-metadata-heading`;
+
   return (
     <Form {...(props.onSubmit !== undefined ? { onSubmit: props.onSubmit } : {})}>
-      <section aria-labelledby="deck-details-heading" className="space-y-4">
-        <h2 id="deck-details-heading" className="border-b border-border pb-2 text-title font-semibold text-ink">
+      <section aria-labelledby={detailsHeadingId} className="space-y-4">
+        <h2 id={detailsHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
           Deck details
         </h2>
         <FormItem col label="Name">
@@ -39,10 +45,10 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
         </FormItem>
       </section>
       <section
-        aria-labelledby="deck-availability-heading"
+        aria-labelledby={availabilityHeadingId}
         className="space-y-4 rounded-surface border border-border bg-surface-muted p-4"
       >
-        <h2 id="deck-availability-heading" className="text-title font-semibold text-ink">
+        <h2 id={availabilityHeadingId} className="text-title font-semibold text-ink">
           Availability
         </h2>
         <FormItem label="Public" help="Public decks are not available yet.">
@@ -52,8 +58,8 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           <Switch {...props.fields.localMode} disabled />
         </FormItem>
       </section>
-      <section aria-labelledby="deck-metadata-heading" className="space-y-4">
-        <h2 id="deck-metadata-heading" className="border-b border-border pb-2 text-title font-semibold text-ink">
+      <section aria-labelledby={metadataHeadingId} className="space-y-4">
+        <h2 id={metadataHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
           Metadata
         </h2>
         <FormItem col label="id">

--- a/src/features/deck/components/templates/DeckFormTemplate.spec.tsx
+++ b/src/features/deck/components/templates/DeckFormTemplate.spec.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { DeckFormTemplate } from "@/features/deck/components/templates/DeckFormTemplate";
+import { createDeck } from "@/test/factories";
+
+describe("DeckFormTemplate", () => {
+  afterEach(cleanup);
+
+  it("composes feedback before the form in a bounded semantic editing surface", () => {
+    const view = render(
+      <DeckFormTemplate
+        feedbackSlot={<div role="status">Saved</div>}
+        deckForm={{
+          deck: createDeck({ id: "deck-123" }),
+          fields: {
+            name: { name: "name" },
+            convertToBr: { name: "convertToBr" },
+            url: { name: "url" },
+            isPublic: { name: "isPublic" },
+            localMode: { name: "localMode" },
+            category: { name: "category", options: [] },
+          },
+        }}
+      />
+    );
+
+    const heading = view.getByRole("heading", { level: 1, name: "Edit deck" });
+    const surface = heading.parentElement;
+    const feedback = view.getByRole("status");
+    const form = view.container.querySelector("form");
+
+    expect(surface).toHaveClass(
+      "mx-auto",
+      "w-full",
+      "max-w-reading",
+      "rounded-surface",
+      "border",
+      "border-border",
+      "bg-surface",
+      "p-4",
+      "md:p-6"
+    );
+    expect(surface).toContainElement(feedback);
+    expect(surface).toContainElement(form);
+    expect(feedback.compareDocumentPosition(form as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/src/features/deck/components/templates/DeckFormTemplate.stories.tsx
+++ b/src/features/deck/components/templates/DeckFormTemplate.stories.tsx
@@ -5,17 +5,23 @@ import { DeckFormTemplate as Template } from "@/features/deck/components/templat
 import type { DeckFormFields } from "@/features/deck/components/DeckForm";
 import * as fixture from "@/shared/storybook/fixture";
 
-const fields: DeckFormFields = {
-  name: { defaultValue: fixture.deck.default.name },
-  convertToBr: { checked: Boolean(fixture.deck.default.convertToBr), onChange: () => undefined },
-  url: { ...(fixture.deck.default.url !== undefined ? { defaultValue: fixture.deck.default.url } : {}) },
-  isPublic: { checked: fixture.deck.default.isPublic, onChange: () => undefined },
-  localMode: { checked: Boolean(fixture.deck.default.localMode), onChange: () => undefined },
+const fieldsFor = (deck: Deck): DeckFormFields => ({
+  name: { value: deck.name, onChange: () => undefined },
+  convertToBr: { checked: Boolean(deck.convertToBr), onChange: () => undefined },
+  url: { value: deck.url ?? "", onChange: () => undefined },
+  isPublic: { checked: deck.isPublic, onChange: () => undefined },
+  localMode: { checked: Boolean(deck.localMode), onChange: () => undefined },
   category: {
-    value: fixture.deck.default.category,
+    value: deck.category,
     options: fixture.form.options.default,
     onChange: () => undefined,
   },
+});
+
+const longDeck: Deck = {
+  ...fixture.deck.tooLongName,
+  url: `https://example.com/${"deeply-nested/".repeat(12)}deck.csv`,
+  category: "value 3",
 };
 
 const meta = {
@@ -32,7 +38,7 @@ const meta = {
   args: {
     deckForm: {
       deck: fixture.deck.default,
-      fields,
+      fields: fieldsFor(fixture.deck.default),
     },
   },
 } satisfies Meta<typeof Template>;
@@ -42,7 +48,23 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const LongValues: Story = {
+  args: { deckForm: { deck: longDeck, fields: fieldsFor(longDeck) } },
+};
+
+export const Submitting: Story = {
+  args: {
+    deckForm: { deck: fixture.deck.default, fields: fieldsFor(fixture.deck.default), isSubmitting: true },
+  },
+};
+
+export const DarkReview: Story = {
+  ...LongValues,
+  globals: { theme: "dark" },
+};
+
 export const IphoneX: Story = {
+  ...LongValues,
   parameters: {
     viewport: {
       defaultViewport: "iphonex",

--- a/src/features/deck/components/templates/DeckFormTemplate.tsx
+++ b/src/features/deck/components/templates/DeckFormTemplate.tsx
@@ -11,8 +11,11 @@ export interface DeckFormTemplateProps {
 export const DeckFormTemplate: React.FC<DeckFormTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
-      {props.feedbackSlot}
-      {props.deckForm != null && <DeckForm {...props.deckForm} />}
+      <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
+        <h1 className="mb-section-gap break-words text-display font-bold text-ink">Edit deck</h1>
+        {props.feedbackSlot}
+        {props.deckForm != null && <DeckForm {...props.deckForm} />}
+      </section>
     </Layout>
   );
 };

--- a/src/features/import/components/templates/DeckImportTemplate.spec.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.spec.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DeckImportTemplate } from "@/features/import/components/templates/DeckImportTemplate";
+
+describe("DeckImportTemplate", () => {
+  afterEach(cleanup);
+
+  it("composes feedback before the import controls in a bounded semantic route surface", () => {
+    const view = render(
+      <DeckImportTemplate feedbackSlot={<div role="status">Import failed</div>} sampleText="front,back" />
+    );
+
+    const heading = view.getByRole("heading", { level: 1, name: "Import decks" });
+    const surface = heading.parentElement;
+    const feedback = view.getByRole("status");
+    const upload = view.container.querySelector<HTMLInputElement>("input[type='file']");
+
+    expect(surface).toHaveClass(
+      "mx-auto",
+      "w-full",
+      "max-w-reading",
+      "rounded-surface",
+      "border",
+      "border-border",
+      "bg-surface",
+      "p-4",
+      "md:p-6"
+    );
+    expect(surface).toContainElement(feedback);
+    expect(surface).toContainElement(upload);
+    expect(feedback.compareDocumentPosition(upload as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(view.getByRole("heading", { level: 2, name: "Choose a CSV file" })).toBeInTheDocument();
+    expect(view.getByRole("heading", { level: 2, name: "CSV format" })).toBeInTheDocument();
+    expect(view.getByRole("heading", { level: 2, name: "Sample" })).toBeInTheDocument();
+  });
+
+  it("passes a real file to the upload callback and disables upload while pending", () => {
+    const onChange = vi.fn();
+    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
+    const view = render(<DeckImportTemplate sampleText="front,back" onChange={onChange} />);
+    const input = view.container.querySelector("input[type='file']") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onChange).toHaveBeenCalledWith(file);
+    view.rerender(<DeckImportTemplate sampleText="front,back" onChange={onChange} pending />);
+    expect(view.container.querySelector("input[type='file']")).toBeDisabled();
+  });
+
+  it("explains the format and exposes the sample download and code surface", async () => {
+    const onDownloadSample = vi.fn();
+    const sampleText = "front,back,tag";
+    const view = render(<DeckImportTemplate sampleText={sampleText} onDownloadSample={onDownloadSample} />);
+
+    expect(
+      view.getByText("There are 3 columns without header: front text, back text, and tags (optional).")
+    ).toBeInTheDocument();
+    const code = view.container.querySelector("code");
+    expect(code).toHaveTextContent(sampleText);
+    const sampleSurface = code?.closest("[data-import-sample]");
+    expect(sampleSurface).toHaveClass(
+      "overflow-x-auto",
+      "rounded-surface",
+      "border",
+      "border-border",
+      "bg-surface-muted"
+    );
+
+    await userEvent.click(view.getByRole("button", { name: "Download CSV sample" }));
+
+    expect(onDownloadSample).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/import/components/templates/DeckImportTemplate.stories.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.stories.tsx
@@ -25,13 +25,28 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Empty: Story = {
+export const Pending: Story = {
   args: {
-    sampleText: "",
+    pending: true,
   },
 };
 
-export const IphoneX: Story = {
+export const LongSample: Story = {
+  args: {
+    sampleText: Array.from(
+      { length: 12 },
+      (_, index) => `A long front ${index + 1},A long back ${index + 1},tag-${index + 1}`
+    ).join("\n"),
+  },
+};
+
+export const DarkReview: Story = {
+  ...LongSample,
+  globals: { theme: "dark" },
+};
+
+export const IphoneReview: Story = {
+  ...LongSample,
   parameters: {
     viewport: {
       defaultViewport: "iphonex",

--- a/src/features/import/components/templates/DeckImportTemplate.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 import { AiOutlineCloudDownload } from "react-icons/ai";
-import { Upload, Description, Code, Title } from "@/shared/components";
+import { Button, Code, Description, Upload } from "@/shared/components";
 import { Layout, type LayoutProps } from "@/shared/components/layout/Layout";
 
 export const DeckImportTemplate: React.FC<{
@@ -13,30 +13,45 @@ export const DeckImportTemplate: React.FC<{
 }> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
-      {props.feedbackSlot}
-      <Title>Deck Upload</Title>
-      <Upload
-        className="my-2"
-        {...(props.pending !== undefined ? { disabled: props.pending } : {})}
-        {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
-      />
-      <Title>CSV File Format</Title>
-      <Description className="my-2">{`There are 3 columns without header: front text, back text, and tags (optional).`}</Description>
-      <div className="flex justify-start items-center">
-        <Title>CSV Sample</Title>
-        <button
-          type="button"
-          aria-label="Download CSV sample"
-          className="flex items-center cursor-pointer"
-          onClick={props.onDownloadSample}
-        >
-          <AiOutlineCloudDownload className="text-xl" size={24} />
-          <Description className="m-1 underline">{`download`}</Description>
-        </button>
-      </div>
-      <div className="overflow-scroll p-1 mt-2 shadow dark:shadow-gray-100">
-        <Code text={props.sampleText} category="csv" />
-      </div>
+      <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
+        <h1 className="mb-section-gap break-words text-display font-bold text-ink">Import decks</h1>
+        {props.feedbackSlot}
+        <div className="space-y-section-gap">
+          <section>
+            <h2 className="mb-3 break-words text-title font-bold text-ink">Choose a CSV file</h2>
+            <Upload
+              {...(props.pending !== undefined ? { disabled: props.pending } : {})}
+              {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
+            />
+          </section>
+          <section>
+            <h2 className="mb-2 break-words text-title font-bold text-ink">CSV format</h2>
+            <Description>{`There are 3 columns without header: front text, back text, and tags (optional).`}</Description>
+          </section>
+          <section>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h2 className="break-words text-title font-bold text-ink">Sample</h2>
+              <Button
+                variant="quiet"
+                size="sm"
+                {...(props.onDownloadSample !== undefined ? { onClick: props.onDownloadSample } : {})}
+              >
+                <AiOutlineCloudDownload aria-hidden="true" className="text-xl" size={24} />
+                <span aria-hidden="true" className="text-caption text-ink-muted underline">
+                  download
+                </span>
+                <span className="sr-only">Download CSV sample</span>
+              </Button>
+            </div>
+            <div
+              data-import-sample
+              className="overflow-x-auto rounded-surface border border-border bg-surface-muted p-2"
+            >
+              <Code text={props.sampleText} category="csv" />
+            </div>
+          </section>
+        </div>
+      </section>
     </Layout>
   );
 };

--- a/src/features/settings/components/ConfigForm.spec.tsx
+++ b/src/features/settings/components/ConfigForm.spec.tsx
@@ -1,0 +1,98 @@
+import { cleanup, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { ConfigForm, type ConfigFormFields, type ConfigFormProps } from "@/features/settings/components/ConfigForm";
+import { createConfig } from "@/test/factories";
+
+function createFields(): ConfigFormFields {
+  return {
+    showHeader: { name: "showHeader", checked: true, onChange: vi.fn() },
+    showSwipeButtonList: { name: "showSwipeButtonList", checked: false, onChange: vi.fn() },
+    showSwipeFeedback: { name: "showSwipeFeedback", checked: true, onChange: vi.fn() },
+    darkMode: { name: "darkMode", checked: false, onChange: vi.fn() },
+    localMode: { name: "localMode", checked: true, onChange: vi.fn() },
+    shuffled: { name: "shuffled", checked: false, onChange: vi.fn() },
+    useCardInterval: { name: "useCardInterval", checked: true, onChange: vi.fn() },
+    maxNumberOfCardsToLearn: { name: "maxNumberOfCardsToLearn", value: "24", min: 1, max: 100, onChange: vi.fn() },
+    defaultAutoPlay: { name: "defaultAutoPlay", checked: false, onChange: vi.fn() },
+    cardInterval: { name: "cardInterval", value: "7", min: 1, max: 60, onChange: vi.fn() },
+    githubAccessToken: { name: "githubAccessToken", value: "github-token", onChange: vi.fn() },
+  };
+}
+
+function createProps(overrides: Partial<ConfigFormProps> = {}): ConfigFormProps {
+  return {
+    config: createConfig(),
+    fields: createFields(),
+    maxNumberOfCardsToLearn: 24,
+    cardInterval: 7,
+    version: "1.2.3",
+    ...overrides,
+  };
+}
+
+describe("ConfigForm", () => {
+  afterEach(cleanup);
+
+  it("groups every auto-saved setting in semantic Calm Focus sections", () => {
+    const view = render(<ConfigForm {...createProps()} />);
+
+    expect(view.container.querySelector("form")).not.toBeInTheDocument();
+    for (const name of ["Account", "Layout", "Study", "Autoplay", "Metadata"]) {
+      const heading = view.getByRole("heading", { level: 2, name });
+      expect(heading.closest("section")).toHaveAttribute("aria-labelledby", heading.id);
+    }
+    expect(view.getByRole("heading", { level: 2, name: "Account" }).closest("section")).toHaveClass(
+      "rounded-surface",
+      "border",
+      "border-border",
+      "bg-surface-muted",
+      "p-4"
+    );
+    expect(view.getByText("Show Header")).toBeInTheDocument();
+    expect(view.queryByText("Show Heaer")).not.toBeInTheDocument();
+  });
+
+  it("preserves all switch, slider, token, and metadata values", () => {
+    const view = render(
+      <ConfigForm {...createProps({ identity: { uid: "user-123", displayName: "Settings User" }, isLoggedIn: true })} />
+    );
+
+    expect(view.container.querySelectorAll("input[type='checkbox']")).toHaveLength(8);
+    expect(view.container.querySelector("input[name='showHeader']")).toBeChecked();
+    expect(view.container.querySelector("input[name='localMode']")).toBeChecked();
+    expect(view.container.querySelector("input[name='useCardInterval']")).toBeChecked();
+    expect(view.container.querySelector("input[name='maxNumberOfCardsToLearn']")).toHaveValue("24");
+    expect(view.container.querySelector("input[name='cardInterval']")).toHaveValue("7");
+    expect(view.container.querySelector("input[name='githubAccessToken']")).toHaveValue("github-token");
+    expect(view.getByText("Max number of cards to learn: 24")).toBeInTheDocument();
+    expect(view.getByText("Interval: 7 sec")).toBeInTheDocument();
+    expect(view.getByText("1.2.3")).toBeInTheDocument();
+    expect(view.getByText("user-123")).toBeInTheDocument();
+  });
+
+  it("preserves logged-out login and logged-in logout behavior", async () => {
+    const onLogin = vi.fn();
+    const onLogout = vi.fn();
+    const view = render(<ConfigForm {...createProps({ onLogin })} />);
+
+    expect(view.getByText("Google Login")).toBeInTheDocument();
+    await userEvent.click(view.getByRole("button", { name: "Login" }));
+    expect(onLogin).toHaveBeenCalledOnce();
+
+    view.rerender(
+      <ConfigForm
+        {...createProps({
+          isLoggedIn: true,
+          identity: { uid: "user-123", displayName: "Settings User" },
+          onLogout,
+        })}
+      />
+    );
+    expect(view.getByText("Logged In As Settings User")).toBeInTheDocument();
+    await userEvent.click(view.getByRole("button", { name: "Logout" }));
+    expect(onLogout).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/settings/components/ConfigForm.spec.tsx
+++ b/src/features/settings/components/ConfigForm.spec.tsx
@@ -1,4 +1,6 @@
-import { cleanup, render } from "@testing-library/react";
+import type React from "react";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -71,6 +73,59 @@ describe("ConfigForm", () => {
     expect(view.getByText("Interval: 7 sec")).toBeInTheDocument();
     expect(view.getByText("1.2.3")).toBeInTheDocument();
     expect(view.getByText("user-123")).toBeInTheDocument();
+  });
+
+  it("forwards switch, slider, and token changes to their field callbacks", async () => {
+    let switchArguments: { name: string; checked: boolean } | undefined;
+    let sliderArguments: { name: string; value: string } | undefined;
+    let tokenArguments: { name: string; value: string } | undefined;
+    const showHeader = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+      switchArguments = { name: event.target.name, checked: event.target.checked };
+    });
+    const maxNumberOfCardsToLearn = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+      sliderArguments = { name: event.target.name, value: event.target.value };
+    });
+    const githubAccessToken = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+      tokenArguments = { name: event.target.name, value: event.target.value };
+    });
+    const fields = createFields();
+    fields.showHeader.onChange = showHeader;
+    fields.maxNumberOfCardsToLearn.onChange = maxNumberOfCardsToLearn;
+    fields.githubAccessToken.onChange = githubAccessToken;
+    const view = render(<ConfigForm {...createProps({ fields })} />);
+
+    await userEvent.click(view.container.querySelector("input[name='showHeader']") as HTMLInputElement);
+    fireEvent.change(view.container.querySelector("input[name='maxNumberOfCardsToLearn']") as HTMLInputElement, {
+      target: { value: "31" },
+    });
+    fireEvent.change(view.container.querySelector("input[name='githubAccessToken']") as HTMLInputElement, {
+      target: { value: "updated-token" },
+    });
+
+    expect(showHeader).toHaveBeenCalledOnce();
+    expect(switchArguments).toEqual({ name: "showHeader", checked: false });
+    expect(maxNumberOfCardsToLearn).toHaveBeenCalledOnce();
+    expect(sliderArguments).toEqual({ name: "maxNumberOfCardsToLearn", value: "31" });
+    expect(githubAccessToken).toHaveBeenCalledOnce();
+    expect(tokenArguments).toEqual({ name: "githubAccessToken", value: "updated-token" });
+  });
+
+  it("keeps section heading relationships unique across multiple instances", () => {
+    const view = render(
+      <>
+        <ConfigForm {...createProps()} />
+        <ConfigForm {...createProps()} />
+      </>
+    );
+    const headings = view.getAllByRole("heading", { level: 2 });
+    const headingIds = headings.map((heading) => heading.id);
+
+    expect(headings).toHaveLength(10);
+    expect(new Set(headingIds).size).toBe(10);
+    for (const heading of headings) {
+      expect(heading.closest("section")).toHaveAttribute("aria-labelledby", heading.id);
+      expect(document.getElementById(heading.id)).toBe(heading);
+    }
   });
 
   it("preserves logged-out login and logged-in logout behavior", async () => {

--- a/src/features/settings/components/ConfigForm.stories.tsx
+++ b/src/features/settings/components/ConfigForm.stories.tsx
@@ -27,6 +27,14 @@ const fields: ConfigFormFields = {
   githubAccessToken: { value: fixture.config.default.githubAccessToken, onChange: () => undefined },
 };
 
+const longFields: ConfigFormFields = {
+  ...fields,
+  githubAccessToken: {
+    value: "github_pat_story_token_with_an_intentionally_long_value_for_responsive_review_1234567890",
+    onChange: () => undefined,
+  },
+};
+
 const meta = {
   title: "Settings/ConfigForm",
   component: Template,
@@ -46,8 +54,34 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const LoggedOut: Story = {};
 
-export const Logout: Story = {
-  args: { isLoggedIn: true },
+export const LoggedIn: Story = {
+  args: {
+    isLoggedIn: true,
+    identity: { uid: "settings-user", displayName: "Settings User" },
+    version: "1.2.3",
+  },
+};
+
+export const LongContent: Story = {
+  args: {
+    isLoggedIn: true,
+    identity: {
+      uid: "settings-user-with-an-intentionally-long-identifier-for-responsive-review-1234567890",
+      displayName: "A settings user with an intentionally long display name for responsive review",
+    },
+    fields: longFields,
+    version: "2026.07.16-calm-focus-settings-presentation-long-metadata",
+  },
+};
+
+export const Dark: Story = {
+  ...LoggedIn,
+  globals: { theme: "dark" },
+};
+
+export const Mobile: Story = {
+  ...LongContent,
+  parameters: { viewport: { defaultViewport: "iphonex" } },
 };

--- a/src/features/settings/components/ConfigForm.tsx
+++ b/src/features/settings/components/ConfigForm.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
+import { useId } from "react";
 
-import { Button, Form, FormItem, Input, Section, Slider, Switch } from "@/shared/components";
+import { Button, Form, FormItem, Input, Slider, Switch } from "@/shared/components";
 
 export interface ConfigFormFields {
   showHeader: React.ComponentProps<typeof Switch>;
@@ -29,59 +30,91 @@ export interface ConfigFormProps {
 }
 
 export const ConfigForm: React.FC<ConfigFormProps> = (props) => {
+  const sectionHeadingIdPrefix = useId();
+  const accountHeadingId = `${sectionHeadingIdPrefix}-settings-account-heading`;
+  const layoutHeadingId = `${sectionHeadingIdPrefix}-settings-layout-heading`;
+  const studyHeadingId = `${sectionHeadingIdPrefix}-settings-study-heading`;
+  const autoplayHeadingId = `${sectionHeadingIdPrefix}-settings-autoplay-heading`;
+  const metadataHeadingId = `${sectionHeadingIdPrefix}-settings-metadata-heading`;
+
   return (
     <Form div>
-      <Section title="Settings" />
-      <FormItem label={props.isLoggedIn ? `Logged In As ${props.identity?.displayName ?? "no name"}` : "Google Login"}>
-        {props.isLoggedIn ? (
-          <Button small {...(props.onLogout !== undefined ? { onClick: props.onLogout } : {})}>
-            Logout
-          </Button>
-        ) : (
-          <Button primary small {...(props.onLogin !== undefined ? { onClick: props.onLogin } : {})}>
-            Login
-          </Button>
-        )}
-      </FormItem>
-      <Section title="Layout" />
-      <FormItem label="Show Heaer">
-        <Switch {...props.fields.showHeader} />
-      </FormItem>
-      <FormItem label="Show Button List">
-        <Switch {...props.fields.showSwipeButtonList} />
-      </FormItem>
-      <FormItem label="Show Swipe Feedback">
-        <Switch {...props.fields.showSwipeFeedback} />
-      </FormItem>
-      <FormItem label="Dark Mode">
-        <Switch {...props.fields.darkMode} />
-      </FormItem>
-      <FormItem label="Local Mode">
-        <Switch {...props.fields.localMode} />
-      </FormItem>
-      <Section title="Card" />
-      <FormItem label="Shuffle Cards">
-        <Switch {...props.fields.shuffled} />
-      </FormItem>
-      <FormItem label="Use Card Interval">
-        <Switch {...props.fields.useCardInterval} />
-      </FormItem>
-      <FormItem col label="Max Number" extra={`Max number of cards to learn: ${props.maxNumberOfCardsToLearn}`}>
-        <Slider {...props.fields.maxNumberOfCardsToLearn} />
-      </FormItem>
-      <Section title="Auto Play" />
-      <FormItem label="Auto Play Start">
-        <Switch {...props.fields.defaultAutoPlay} />
-      </FormItem>
-      <FormItem col label={`Interval: ${props.cardInterval} sec`}>
-        <Slider {...props.fields.cardInterval} />
-      </FormItem>
-      <Section title="Meta" />
-      <FormItem label="Version">{props.version}</FormItem>
-      <FormItem col label="Github Access Token">
-        <Input {...props.fields.githubAccessToken} />
-      </FormItem>
-      <FormItem label="User Id">{props.identity?.uid ?? ""}</FormItem>
+      <section
+        aria-labelledby={accountHeadingId}
+        className="space-y-4 rounded-surface border border-border bg-surface-muted p-4"
+      >
+        <h2 id={accountHeadingId} className="text-title font-semibold text-ink">
+          Account
+        </h2>
+        <FormItem
+          label={props.isLoggedIn ? `Logged In As ${props.identity?.displayName ?? "no name"}` : "Google Login"}
+        >
+          {props.isLoggedIn ? (
+            <Button small {...(props.onLogout !== undefined ? { onClick: props.onLogout } : {})}>
+              Logout
+            </Button>
+          ) : (
+            <Button primary small {...(props.onLogin !== undefined ? { onClick: props.onLogin } : {})}>
+              Login
+            </Button>
+          )}
+        </FormItem>
+      </section>
+      <section aria-labelledby={layoutHeadingId} className="space-y-4">
+        <h2 id={layoutHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Layout
+        </h2>
+        <FormItem label="Show Header">
+          <Switch {...props.fields.showHeader} />
+        </FormItem>
+        <FormItem label="Show Button List">
+          <Switch {...props.fields.showSwipeButtonList} />
+        </FormItem>
+        <FormItem label="Show Swipe Feedback">
+          <Switch {...props.fields.showSwipeFeedback} />
+        </FormItem>
+        <FormItem label="Dark Mode">
+          <Switch {...props.fields.darkMode} />
+        </FormItem>
+        <FormItem label="Local Mode">
+          <Switch {...props.fields.localMode} />
+        </FormItem>
+      </section>
+      <section aria-labelledby={studyHeadingId} className="space-y-4">
+        <h2 id={studyHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Study
+        </h2>
+        <FormItem label="Shuffle Cards">
+          <Switch {...props.fields.shuffled} />
+        </FormItem>
+        <FormItem label="Use Card Interval">
+          <Switch {...props.fields.useCardInterval} />
+        </FormItem>
+        <FormItem col label="Max Number" extra={`Max number of cards to learn: ${props.maxNumberOfCardsToLearn}`}>
+          <Slider {...props.fields.maxNumberOfCardsToLearn} />
+        </FormItem>
+      </section>
+      <section aria-labelledby={autoplayHeadingId} className="space-y-4">
+        <h2 id={autoplayHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Autoplay
+        </h2>
+        <FormItem label="Auto Play Start">
+          <Switch {...props.fields.defaultAutoPlay} />
+        </FormItem>
+        <FormItem col label={`Interval: ${props.cardInterval} sec`}>
+          <Slider {...props.fields.cardInterval} />
+        </FormItem>
+      </section>
+      <section aria-labelledby={metadataHeadingId} className="space-y-4">
+        <h2 id={metadataHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
+          Metadata
+        </h2>
+        <FormItem label="Version">{props.version}</FormItem>
+        <FormItem col label="Github Access Token">
+          <Input {...props.fields.githubAccessToken} />
+        </FormItem>
+        <FormItem label="User Id">{props.identity?.uid ?? ""}</FormItem>
+      </section>
     </Form>
   );
 };

--- a/src/features/settings/components/templates/ConfigFormTemplate.spec.tsx
+++ b/src/features/settings/components/templates/ConfigFormTemplate.spec.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { ConfigFormFields } from "@/features/settings/components/ConfigForm";
+import { ConfigFormTemplate } from "@/features/settings/components/templates/ConfigFormTemplate";
+import { createConfig } from "@/test/factories";
+
+const fields: ConfigFormFields = {
+  showHeader: { name: "showHeader" },
+  showSwipeButtonList: { name: "showSwipeButtonList" },
+  showSwipeFeedback: { name: "showSwipeFeedback" },
+  darkMode: { name: "darkMode" },
+  localMode: { name: "localMode" },
+  shuffled: { name: "shuffled" },
+  useCardInterval: { name: "useCardInterval" },
+  maxNumberOfCardsToLearn: { name: "maxNumberOfCardsToLearn", value: "10", onChange: () => undefined },
+  defaultAutoPlay: { name: "defaultAutoPlay" },
+  cardInterval: { name: "cardInterval", value: "5", onChange: () => undefined },
+  githubAccessToken: { name: "githubAccessToken" },
+};
+
+describe("ConfigFormTemplate", () => {
+  afterEach(cleanup);
+
+  it("composes the config form under one page heading in a bounded semantic surface", () => {
+    const view = render(
+      <ConfigFormTemplate
+        configForm={{
+          config: createConfig(),
+          fields,
+          maxNumberOfCardsToLearn: 10,
+          cardInterval: 5,
+        }}
+      />
+    );
+
+    const heading = view.getByRole("heading", { level: 1, name: "Settings" });
+    const surface = heading.parentElement;
+
+    expect(view.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(surface).toHaveClass(
+      "mx-auto",
+      "w-full",
+      "max-w-reading",
+      "rounded-surface",
+      "border",
+      "border-border",
+      "bg-surface",
+      "p-4",
+      "md:p-6"
+    );
+    expect(surface).toContainElement(view.getByRole("heading", { level: 2, name: "Account" }).closest("section"));
+  });
+});

--- a/src/features/settings/components/templates/ConfigFormTemplate.stories.tsx
+++ b/src/features/settings/components/templates/ConfigFormTemplate.stories.tsx
@@ -29,6 +29,14 @@ const fields: ConfigFormFields = {
   githubAccessToken: { value: fixture.config.default.githubAccessToken, onChange: () => undefined },
 };
 
+const longFields: ConfigFormFields = {
+  ...fields,
+  githubAccessToken: {
+    value: "github_pat_story_token_with_an_intentionally_long_value_for_responsive_review_1234567890",
+    onChange: () => undefined,
+  },
+};
+
 const meta = {
   title: "Settings/ConfigFormTemplate",
   component: Template,
@@ -54,22 +62,46 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const LoggedOut: Story = {};
 
-export const LongUserName: Story = {
+export const LoggedIn: Story = {
   args: {
     configForm: {
       isLoggedIn: true,
-      identity: { uid: "story-user", displayName: "this is a too long user name" },
-      config: fixture.config.longUserName,
+      identity: { uid: "settings-user", displayName: "Settings User" },
+      config: fixture.config.default,
       fields,
-      maxNumberOfCardsToLearn: fixture.config.longUserName.maxNumberOfCardsToLearn,
-      cardInterval: fixture.config.longUserName.cardInterval,
+      maxNumberOfCardsToLearn: fixture.config.default.maxNumberOfCardsToLearn,
+      cardInterval: fixture.config.default.cardInterval,
+      version: "1.2.3",
     },
   },
 };
 
-export const IphoneX: Story = {
+export const LongContent: Story = {
+  args: {
+    configForm: {
+      isLoggedIn: true,
+      identity: {
+        uid: "settings-user-with-an-intentionally-long-identifier-for-responsive-review-1234567890",
+        displayName: "A settings user with an intentionally long display name for responsive review",
+      },
+      config: fixture.config.longUserName,
+      fields: longFields,
+      maxNumberOfCardsToLearn: fixture.config.longUserName.maxNumberOfCardsToLearn,
+      cardInterval: fixture.config.longUserName.cardInterval,
+      version: "2026.07.16-calm-focus-settings-presentation-long-metadata",
+    },
+  },
+};
+
+export const Dark: Story = {
+  ...LoggedIn,
+  globals: { theme: "dark" },
+};
+
+export const Mobile: Story = {
+  ...LongContent,
   parameters: {
     viewport: {
       defaultViewport: "iphonex",

--- a/src/features/settings/components/templates/ConfigFormTemplate.tsx
+++ b/src/features/settings/components/templates/ConfigFormTemplate.tsx
@@ -10,7 +10,10 @@ export interface ConfigFormTemplateProps {
 export const ConfigFormTemplate: React.FC<ConfigFormTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
-      {props.configForm != null && <ConfigForm {...props.configForm} />}
+      <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
+        <h1 className="mb-section-gap break-words text-display font-bold text-ink">Settings</h1>
+        {props.configForm != null && <ConfigForm {...props.configForm} />}
+      </section>
     </Layout>
   );
 };

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -15,10 +15,15 @@ const utilityRoutePresentationFiles = [
   "features/settings/components/ConfigForm.tsx",
   "features/settings/components/templates/ConfigFormTemplate.tsx",
 ] as const;
-const modernizedUtilityRoutePresentationFiles = [
+const completedUtilityRoutePresentationFiles = [
   "features/deck/components/DeckForm.tsx",
   "features/deck/components/templates/DeckFormTemplate.tsx",
 ] as const satisfies readonly (typeof utilityRoutePresentationFiles)[number][];
+const completedUtilityRoutePresentationFileSet = new Set<string>(completedUtilityRoutePresentationFiles);
+const pendingUtilityRoutePresentationFiles = utilityRoutePresentationFiles.filter(
+  (relativePath) => !completedUtilityRoutePresentationFileSet.has(relativePath)
+);
+const pendingUtilityRoutePresentationFileSet = new Set<string>(pendingUtilityRoutePresentationFiles);
 const ownedPresentationFiles = [
   "shared/components/layout/Outer.tsx",
   "shared/components/layout/Main.tsx",
@@ -58,8 +63,11 @@ const ownedPresentationFiles = [
   "features/card/components/CardOverlay.tsx",
   "features/card/components/templates/CardListTemplate.tsx",
   "features/card/components/templates/CardViewTemplate.tsx",
-  ...modernizedUtilityRoutePresentationFiles,
+  ...utilityRoutePresentationFiles,
 ];
+const enforcedOwnedPresentationFiles = ownedPresentationFiles.filter(
+  (relativePath) => !pendingUtilityRoutePresentationFileSet.has(relativePath)
+);
 const semanticColorRoles = [
   "canvas",
   "surface",
@@ -232,8 +240,8 @@ describe("Calm Focus visual contract", () => {
     expect(reducedMotion).toContain("scroll-behavior:");
   });
 
-  it("keeps the owned presentation files free of raw Tailwind palette utilities", () => {
-    const violations = ownedPresentationFiles.flatMap((relativePath) =>
+  it("keeps completed owned presentation files free of raw Tailwind palette utilities", () => {
+    const violations = enforcedOwnedPresentationFiles.flatMap((relativePath) =>
       rawPaletteUtilities(readOwnedSource(relativePath)).map((utility) => `${relativePath}: ${utility}`)
     );
 
@@ -245,7 +253,7 @@ describe("Calm Focus visual contract", () => {
     expect(readOwnedSource("features/deck/components/TagFilter.tsx")).toMatch(/bg-surface/);
   });
 
-  it("registers utility routes and enforces semantic surfaces for modernized templates", () => {
+  it("registers utility routes and enforces semantic surfaces for completed templates", () => {
     expect(utilityRoutePresentationFiles).toEqual([
       "features/deck/components/DeckForm.tsx",
       "features/deck/components/templates/DeckFormTemplate.tsx",
@@ -255,8 +263,14 @@ describe("Calm Focus visual contract", () => {
       "features/settings/components/ConfigForm.tsx",
       "features/settings/components/templates/ConfigFormTemplate.tsx",
     ]);
+    expect(ownedPresentationFiles).toEqual(expect.arrayContaining(utilityRoutePresentationFiles));
+    expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(2));
+    expect(enforcedOwnedPresentationFiles).toEqual(expect.arrayContaining(completedUtilityRoutePresentationFiles));
+    for (const relativePath of pendingUtilityRoutePresentationFiles) {
+      expect(enforcedOwnedPresentationFiles).not.toContain(relativePath);
+    }
 
-    for (const relativePath of modernizedUtilityRoutePresentationFiles.filter((file) => file.includes("Template"))) {
+    for (const relativePath of completedUtilityRoutePresentationFiles.filter((file) => file.includes("Template"))) {
       expect(readOwnedSource(relativePath), relativePath).toMatch(/bg-surface(?:-elevated)?/);
     }
   });

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -20,6 +20,7 @@ const completedUtilityRoutePresentationFiles = [
   "features/deck/components/templates/DeckFormTemplate.tsx",
   "features/card/components/CardForm.tsx",
   "features/card/components/templates/CardFormTemplate.tsx",
+  "features/import/components/templates/DeckImportTemplate.tsx",
 ] as const satisfies readonly (typeof utilityRoutePresentationFiles)[number][];
 const completedUtilityRoutePresentationFileSet = new Set<string>(completedUtilityRoutePresentationFiles);
 const pendingUtilityRoutePresentationFiles = utilityRoutePresentationFiles.filter(
@@ -260,6 +261,14 @@ describe("Calm Focus visual contract", () => {
     expect(readOwnedSource("features/card/components/templates/CardFormTemplate.tsx")).toMatch(/bg-surface/);
   });
 
+  it("gives the import route a bounded semantic Calm Focus surface", () => {
+    const importTemplate = readOwnedSource("features/import/components/templates/DeckImportTemplate.tsx");
+
+    expect(importTemplate).toMatch(/max-w-reading/);
+    expect(importTemplate).toMatch(/border-border/);
+    expect(importTemplate).toMatch(/bg-surface/);
+  });
+
   it("registers utility routes and enforces semantic surfaces for completed templates", () => {
     expect(utilityRoutePresentationFiles).toEqual([
       "features/deck/components/DeckForm.tsx",
@@ -271,7 +280,7 @@ describe("Calm Focus visual contract", () => {
       "features/settings/components/templates/ConfigFormTemplate.tsx",
     ]);
     expect(ownedPresentationFiles).toEqual(expect.arrayContaining([...utilityRoutePresentationFiles]));
-    expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(4));
+    expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(5));
     expect(enforcedOwnedPresentationFiles).toEqual(expect.arrayContaining([...completedUtilityRoutePresentationFiles]));
     for (const relativePath of pendingUtilityRoutePresentationFiles) {
       expect(enforcedOwnedPresentationFiles).not.toContain(relativePath);

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -18,6 +18,8 @@ const utilityRoutePresentationFiles = [
 const completedUtilityRoutePresentationFiles = [
   "features/deck/components/DeckForm.tsx",
   "features/deck/components/templates/DeckFormTemplate.tsx",
+  "features/card/components/CardForm.tsx",
+  "features/card/components/templates/CardFormTemplate.tsx",
 ] as const satisfies readonly (typeof utilityRoutePresentationFiles)[number][];
 const completedUtilityRoutePresentationFileSet = new Set<string>(completedUtilityRoutePresentationFiles);
 const pendingUtilityRoutePresentationFiles = utilityRoutePresentationFiles.filter(
@@ -253,6 +255,11 @@ describe("Calm Focus visual contract", () => {
     expect(readOwnedSource("features/deck/components/TagFilter.tsx")).toMatch(/bg-surface/);
   });
 
+  it("gives the card editing surfaces semantic Calm Focus treatment", () => {
+    expect(readOwnedSource("features/card/components/CardForm.tsx")).toMatch(/bg-surface-muted/);
+    expect(readOwnedSource("features/card/components/templates/CardFormTemplate.tsx")).toMatch(/bg-surface/);
+  });
+
   it("registers utility routes and enforces semantic surfaces for completed templates", () => {
     expect(utilityRoutePresentationFiles).toEqual([
       "features/deck/components/DeckForm.tsx",
@@ -264,7 +271,7 @@ describe("Calm Focus visual contract", () => {
       "features/settings/components/templates/ConfigFormTemplate.tsx",
     ]);
     expect(ownedPresentationFiles).toEqual(expect.arrayContaining([...utilityRoutePresentationFiles]));
-    expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(2));
+    expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(4));
     expect(enforcedOwnedPresentationFiles).toEqual(expect.arrayContaining([...completedUtilityRoutePresentationFiles]));
     for (const relativePath of pendingUtilityRoutePresentationFiles) {
       expect(enforcedOwnedPresentationFiles).not.toContain(relativePath);

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -263,9 +263,9 @@ describe("Calm Focus visual contract", () => {
       "features/settings/components/ConfigForm.tsx",
       "features/settings/components/templates/ConfigFormTemplate.tsx",
     ]);
-    expect(ownedPresentationFiles).toEqual(expect.arrayContaining(utilityRoutePresentationFiles));
+    expect(ownedPresentationFiles).toEqual(expect.arrayContaining([...utilityRoutePresentationFiles]));
     expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(2));
-    expect(enforcedOwnedPresentationFiles).toEqual(expect.arrayContaining(completedUtilityRoutePresentationFiles));
+    expect(enforcedOwnedPresentationFiles).toEqual(expect.arrayContaining([...completedUtilityRoutePresentationFiles]));
     for (const relativePath of pendingUtilityRoutePresentationFiles) {
       expect(enforcedOwnedPresentationFiles).not.toContain(relativePath);
     }

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -6,6 +6,19 @@ const sourceRoot = path.resolve(process.cwd(), "src");
 const calmFocusStylesheet = "shared/styles/calm-focus.css";
 const storybookPreview = readFileSync(path.resolve(process.cwd(), ".storybook/preview.ts"), "utf8");
 const layoutStories = readFileSync(path.join(sourceRoot, "shared/components/layout/Layout.stories.tsx"), "utf8");
+const utilityRoutePresentationFiles = [
+  "features/deck/components/DeckForm.tsx",
+  "features/deck/components/templates/DeckFormTemplate.tsx",
+  "features/card/components/CardForm.tsx",
+  "features/card/components/templates/CardFormTemplate.tsx",
+  "features/import/components/templates/DeckImportTemplate.tsx",
+  "features/settings/components/ConfigForm.tsx",
+  "features/settings/components/templates/ConfigFormTemplate.tsx",
+] as const;
+const modernizedUtilityRoutePresentationFiles = [
+  "features/deck/components/DeckForm.tsx",
+  "features/deck/components/templates/DeckFormTemplate.tsx",
+] as const satisfies readonly (typeof utilityRoutePresentationFiles)[number][];
 const ownedPresentationFiles = [
   "shared/components/layout/Outer.tsx",
   "shared/components/layout/Main.tsx",
@@ -45,6 +58,7 @@ const ownedPresentationFiles = [
   "features/card/components/CardOverlay.tsx",
   "features/card/components/templates/CardListTemplate.tsx",
   "features/card/components/templates/CardViewTemplate.tsx",
+  ...modernizedUtilityRoutePresentationFiles,
 ];
 const semanticColorRoles = [
   "canvas",
@@ -229,5 +243,21 @@ describe("Calm Focus visual contract", () => {
   it("gives the deck filter surfaces semantic Calm Focus treatment", () => {
     expect(readOwnedSource("features/deck/components/DeckStartForm.tsx")).toMatch(/bg-surface/);
     expect(readOwnedSource("features/deck/components/TagFilter.tsx")).toMatch(/bg-surface/);
+  });
+
+  it("registers utility routes and enforces semantic surfaces for modernized templates", () => {
+    expect(utilityRoutePresentationFiles).toEqual([
+      "features/deck/components/DeckForm.tsx",
+      "features/deck/components/templates/DeckFormTemplate.tsx",
+      "features/card/components/CardForm.tsx",
+      "features/card/components/templates/CardFormTemplate.tsx",
+      "features/import/components/templates/DeckImportTemplate.tsx",
+      "features/settings/components/ConfigForm.tsx",
+      "features/settings/components/templates/ConfigFormTemplate.tsx",
+    ]);
+
+    for (const relativePath of modernizedUtilityRoutePresentationFiles.filter((file) => file.includes("Template"))) {
+      expect(readOwnedSource(relativePath), relativePath).toMatch(/bg-surface(?:-elevated)?/);
+    }
   });
 });

--- a/src/lib/calmFocusVisualContract.spec.ts
+++ b/src/lib/calmFocusVisualContract.spec.ts
@@ -21,6 +21,8 @@ const completedUtilityRoutePresentationFiles = [
   "features/card/components/CardForm.tsx",
   "features/card/components/templates/CardFormTemplate.tsx",
   "features/import/components/templates/DeckImportTemplate.tsx",
+  "features/settings/components/ConfigForm.tsx",
+  "features/settings/components/templates/ConfigFormTemplate.tsx",
 ] as const satisfies readonly (typeof utilityRoutePresentationFiles)[number][];
 const completedUtilityRoutePresentationFileSet = new Set<string>(completedUtilityRoutePresentationFiles);
 const pendingUtilityRoutePresentationFiles = utilityRoutePresentationFiles.filter(
@@ -269,6 +271,17 @@ describe("Calm Focus visual contract", () => {
     expect(importTemplate).toMatch(/bg-surface/);
   });
 
+  it("gives Settings semantic sections within a bounded Calm Focus surface", () => {
+    const configForm = readOwnedSource("features/settings/components/ConfigForm.tsx");
+    const configTemplate = readOwnedSource("features/settings/components/templates/ConfigFormTemplate.tsx");
+
+    expect(configForm).toMatch(/<section/);
+    expect(configForm).toMatch(/bg-surface-muted/);
+    expect(configTemplate).toMatch(/max-w-reading/);
+    expect(configTemplate).toMatch(/border-border/);
+    expect(configTemplate).toMatch(/bg-surface/);
+  });
+
   it("registers utility routes and enforces semantic surfaces for completed templates", () => {
     expect(utilityRoutePresentationFiles).toEqual([
       "features/deck/components/DeckForm.tsx",
@@ -280,7 +293,7 @@ describe("Calm Focus visual contract", () => {
       "features/settings/components/templates/ConfigFormTemplate.tsx",
     ]);
     expect(ownedPresentationFiles).toEqual(expect.arrayContaining([...utilityRoutePresentationFiles]));
-    expect(pendingUtilityRoutePresentationFiles).toEqual(utilityRoutePresentationFiles.slice(5));
+    expect(pendingUtilityRoutePresentationFiles).toEqual([]);
     expect(enforcedOwnedPresentationFiles).toEqual(expect.arrayContaining([...completedUtilityRoutePresentationFiles]));
     for (const relativePath of pendingUtilityRoutePresentationFiles) {
       expect(enforcedOwnedPresentationFiles).not.toContain(relativePath);


### PR DESCRIPTION
## Summary

- unify Deck and Card editing with shared Calm Focus form sections, bounded responsive surfaces, and explicit unavailable controls
- modernize CSV Import and Settings presentation while preserving upload, authentication, auto-save, persisted values, and existing handlers
- add focused component/template coverage, expanded Storybook states, Calm Focus ownership checks, and updated Import smoke expectations

## Impact

Utility routes now share a consistent page, section, field, help, control, metadata, and action hierarchy across light/dark and desktop/mobile layouts. This is a presentation-only change: form state ownership, persistence, authentication, synchronization, validation, and Import workflow behavior remain unchanged.

## Testing

- `direnv exec . make check` — 73 test files, 404 tests passed
- `direnv exec . make build` — app and Storybook builds passed
- `direnv exec . make e2e` — 16 tests passed

Closes #218