### PR TITLE
Add persistent Firestore cache read synchronization

### DIFF
--- a/src/action/firestore/card.ts
+++ b/src/action/firestore/card.ts
@@ -1,5 +1,4 @@
 import {
-  getFirestore,
   doc,
   updateDoc,
   setDoc,
@@ -13,10 +12,9 @@ import {
 } from "firebase/firestore";
 import { getTimestamp } from "@/action/firestore/mocked";
 import { buildCardCreateDto, buildCardUpdateDto, mapCardDocument, type CardDocument } from "@/action/firestore/dto";
+import { getDb } from "@/firestoreRuntime";
 
-const db = getFirestore();
-
-export const readAll = async (uid: string, firestore: Firestore = db): Promise<Card[]> => {
+export const readAll = async (uid: string, firestore: Firestore = getDb()): Promise<Card[]> => {
   const snapshot = await getDocs(query(collection(firestore, "card"), where("uid", "==", uid)));
   return snapshot.docs
     .map((document) => mapCardDocument(document.id, document.data() as CardDocument))
@@ -24,6 +22,7 @@ export const readAll = async (uid: string, firestore: Firestore = db): Promise<C
 };
 
 export const create = async (card: Card, createdAt?: number): Promise<string> => {
+  const db = getDb();
   if (createdAt == null) {
     createdAt = getTimestamp();
   }
@@ -33,6 +32,7 @@ export const create = async (card: Card, createdAt?: number): Promise<string> =>
 };
 
 export const upsert = async (card: Card): Promise<string> => {
+  const db = getDb();
   const timestamp = getTimestamp();
   const createdAt = card.createdAt > 0 ? card.createdAt : timestamp;
   const ref = doc(db, "card", card.id);
@@ -41,6 +41,7 @@ export const upsert = async (card: Card): Promise<string> => {
 };
 
 export const update = async (card: CardEdit) => {
+  const db = getDb();
   const ref = doc(db, "card", card.id);
   await updateDoc(ref, buildCardUpdateDto(card, getTimestamp()));
 };
@@ -56,6 +57,7 @@ export const bulkUpdate = async (cards: Card[]) => {
 };
 
 export const logicalRemove = async (id: string) => {
+  const db = getDb();
   const updatedAt = getTimestamp();
   const ref = doc(db, "card", id);
   await updateDoc(ref, { updatedAt, deletedAt: updatedAt });
@@ -63,11 +65,13 @@ export const logicalRemove = async (id: string) => {
 
 // used only for test
 export const remove = async (id: string) => {
+  const db = getDb();
   const ref = doc(db, "card", id);
   await deleteDoc(ref);
 };
 
 export const exists = async (id: string): Promise<boolean> => {
+  const db = getDb();
   const ref = doc(db, "card", id);
   try {
     const snapshot = await getDoc(ref);

--- a/src/action/firestore/deck.ts
+++ b/src/action/firestore/deck.ts
@@ -1,6 +1,5 @@
 import {
   where,
-  getFirestore,
   doc,
   updateDoc,
   query,
@@ -13,10 +12,9 @@ import {
 } from "firebase/firestore";
 import { getTimestamp } from "@/action/firestore/mocked";
 import { buildDeckCreateDto, buildDeckUpdateDto, mapDeckDocument, type DeckDocument } from "@/action/firestore/dto";
+import { getDb } from "@/firestoreRuntime";
 
-const db = getFirestore();
-
-export const readAll = async (uid: string, firestore: Firestore = db): Promise<Deck[]> => {
+export const readAll = async (uid: string, firestore: Firestore = getDb()): Promise<Deck[]> => {
   const snapshot = await getDocs(query(collection(firestore, "deck"), where("uid", "==", uid)));
   return snapshot.docs
     .map((document) => mapDeckDocument(document.id, document.data() as DeckDocument))
@@ -25,6 +23,7 @@ export const readAll = async (uid: string, firestore: Firestore = db): Promise<D
 
 export const create = async (deck: Deck): Promise<string> => {
   const createdAt = getTimestamp();
+  const db = getDb();
   const ref = doc(db, "deck", deck.id);
   await setDoc(ref, buildDeckCreateDto(deck, createdAt));
   return deck.id;
@@ -48,12 +47,14 @@ export const splitCards = <T>(cards: T[], max: number): T[][] => {
 };
 
 export const update = async (deck: DeckEdit) => {
+  const db = getDb();
   const ref = doc(db, "deck", deck.id);
   const updatedAt = getTimestamp();
   await updateDoc(ref, buildDeckUpdateDto(deck, updatedAt));
 };
 
 export const remove = async (deckId: string, uid: string) => {
+  const db = getDb();
   const q = query(collection(db, "card"), where("uid", "==", uid), where("deckId", "==", deckId));
   const snapshot = await getDocs(q);
   await Promise.all(
@@ -66,7 +67,7 @@ export const remove = async (deckId: string, uid: string) => {
 };
 
 export const exists = async (id: string): Promise<boolean> => {
-  const db = getFirestore();
+  const db = getDb();
   const ref = doc(db, "deck", id);
   try {
     const snapshot = await getDoc(ref);
@@ -81,7 +82,7 @@ export const exists = async (id: string): Promise<boolean> => {
 
 // for test
 export const removeAll = async () => {
-  const db = getFirestore();
+  const db = getDb();
   const q = query(collection(db, "deck"));
   const snapshot = await getDocs(q);
   for (const doc of snapshot.docs) await deleteDoc(doc.ref);

--- a/src/action/firestore/event.ts
+++ b/src/action/firestore/event.ts
@@ -1,10 +1,12 @@
-import { getFirestore, onSnapshot, where, collection, query } from "firebase/firestore";
+import { onSnapshot, where, collection, query } from "firebase/firestore";
 
 import { mapCardDocument, mapDeckDocument, type CardDocument, type DeckDocument } from "@/action/firestore/dto";
+import { getDb } from "@/firestoreRuntime";
 
 export interface RemoteSnapshotMetadata {
   size: number;
-  fromLocal: boolean;
+  fromCache: boolean;
+  hasPendingWrites: boolean;
 }
 
 export interface RemoteChange<T> {
@@ -30,7 +32,7 @@ const subscribeReads = <T extends RemoteEntity>(
   props: RemoteReadProps<T>,
   mapDocument: (id: string, data: Record<string, unknown>) => T
 ): Callback => {
-  const q = query(collection(getFirestore(), collectionName), where("uid", "==", props.uid));
+  const q = query(collection(getDb(), collectionName), where("uid", "==", props.uid));
   let initial = true;
   return onSnapshot(
     q,
@@ -39,7 +41,8 @@ const subscribeReads = <T extends RemoteEntity>(
       const changes = snapshot.docChanges();
       const metadata = {
         size: initial ? snapshot.docs.length : changes.length,
-        fromLocal: snapshot.metadata.hasPendingWrites,
+        fromCache: snapshot.metadata.fromCache,
+        hasPendingWrites: snapshot.metadata.hasPendingWrites,
       };
       if (initial) {
         initial = false;
@@ -61,9 +64,7 @@ const subscribeReads = <T extends RemoteEntity>(
           event.modified.push(item);
         }
       }
-      if (event.added.length > 0 || event.modified.length > 0 || event.removed.length > 0) {
-        props.onSnapshot({ type: "change", event, metadata });
-      }
+      props.onSnapshot({ type: "change", event, metadata });
     },
     props.onError
   );

--- a/src/action/firestore/eventAdapter.spec.ts
+++ b/src/action/firestore/eventAdapter.spec.ts
@@ -5,7 +5,7 @@ type TestChange = { type: "added" | "modified" | "removed"; doc: TestDocument };
 type TestSnapshot = {
   docs: TestDocument[];
   docChanges: () => TestChange[];
-  metadata: { hasPendingWrites: boolean };
+  metadata: { fromCache: boolean; hasPendingWrites: boolean };
 };
 
 const mocks = vi.hoisted(() => ({
@@ -16,7 +16,6 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("firebase/firestore", () => ({
-  getFirestore: vi.fn(() => "db"),
   collection: vi.fn((...parts: unknown[]) => parts),
   where: mocks.where,
   orderBy: vi.fn((...parts: unknown[]) => parts),
@@ -29,14 +28,19 @@ vi.mock("firebase/firestore", () => ({
     }
   ),
 }));
+vi.mock("@/firestoreRuntime", () => ({ getDb: () => "db" }));
 
 import { subscribeCardReads, subscribeDeckReads } from "@/action/firestore/event";
 
 const document = (id: string, data: Record<string, unknown>): TestDocument => ({ id, data: () => data });
-const snapshot = (docs: TestDocument[], changes: TestChange[] = [], hasPendingWrites = false): TestSnapshot => ({
+const snapshot = (
+  docs: TestDocument[],
+  changes: TestChange[] = [],
+  metadata: TestSnapshot["metadata"] = { fromCache: false, hasPendingWrites: false }
+): TestSnapshot => ({
   docs,
   docChanges: () => changes,
-  metadata: { hasPendingWrites },
+  metadata,
 });
 
 const deckDocument = (overrides: Record<string, unknown> = {}) => ({
@@ -90,7 +94,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenCalledWith({
       type: "replace",
       items: [],
-      metadata: { size: 0, fromLocal: false },
+      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
     });
   });
 
@@ -105,7 +109,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenCalledWith({
       type: "replace",
       items: [expect.objectContaining({ id: "deck-a", name: "Remote Deck", localMode: false })],
-      metadata: { size: 2, fromLocal: false },
+      metadata: { size: 2, fromCache: false, hasPendingWrites: false },
     });
   });
 
@@ -124,7 +128,7 @@ describe("Firestore remote-read subscriptions", () => {
           { type: "modified", doc: document("deck-deleted", deckDocument({ updatedAt: 5, deletedAt: 5 })) },
           { type: "removed", doc: document("deck-removed", deckDocument({ updatedAt: 6 })) },
         ],
-        true
+        { fromCache: true, hasPendingWrites: true }
       )
     );
 
@@ -135,7 +139,7 @@ describe("Firestore remote-read subscriptions", () => {
         modified: [expect.objectContaining({ id: "deck-modified" })],
         removed: ["deck-deleted", "deck-removed"],
       },
-      metadata: { size: 4, fromLocal: true },
+      metadata: { size: 4, fromCache: true, hasPendingWrites: true },
     });
   });
 
@@ -147,7 +151,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenLastCalledWith({
       type: "replace",
       items: [expect.objectContaining({ id: "card-a", nextSeeingAt: new Date(50) })],
-      metadata: { size: 1, fromLocal: false },
+      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
     });
 
     mocks.next?.(snapshot([], [{ type: "modified", doc: document("card-a", cardDocument({ frontText: "Updated" })) }]));
@@ -158,7 +162,22 @@ describe("Firestore remote-read subscriptions", () => {
         modified: [expect.objectContaining({ id: "card-a", frontText: "Updated" })],
         removed: [],
       },
-      metadata: { size: 1, fromLocal: false },
+      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
+    });
+  });
+
+  it("emits metadata-only snapshots so pending writes can become synced", () => {
+    const onSnapshot = vi.fn();
+    subscribeDeckReads({ uid: "uid-a", onSnapshot, onError: vi.fn() });
+    mocks.next?.(snapshot([], [], { fromCache: true, hasPendingWrites: true }));
+    onSnapshot.mockClear();
+
+    mocks.next?.(snapshot([], [], { fromCache: false, hasPendingWrites: false }));
+
+    expect(onSnapshot).toHaveBeenCalledWith({
+      type: "change",
+      event: { added: [], modified: [], removed: [] },
+      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
     });
   });
 

--- a/src/action/firestore/init.ts
+++ b/src/action/firestore/init.ts
@@ -1,11 +1,13 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
+import { initializeFirestoreRuntime } from "@/firestoreRuntime";
 
 initializeApp({
   projectId: "test",
 });
 
 const db = getFirestore();
+initializeFirestoreRuntime(db);
 connectFirestoreEmulator(db, import.meta.env.VITE_DB_HOST, parseInt(import.meta.env.VITE_DB_PORT, 10), {
   mockUserToken: { user_id: "uid" },
 });

--- a/src/action/firestore/mocked.ts
+++ b/src/action/firestore/mocked.ts
@@ -1,7 +1,8 @@
-import { getFirestore, doc, collection } from "firebase/firestore";
+import { doc, collection } from "firebase/firestore";
+import { getDb } from "@/firestoreRuntime";
 
-export const generateDeckId = (): string => doc(collection(getFirestore(), "deck")).id;
+export const generateDeckId = (): string => doc(collection(getDb(), "deck")).id;
 
-export const generateCardId = (): string => doc(collection(getFirestore(), "card")).id;
+export const generateCardId = (): string => doc(collection(getDb(), "card")).id;
 
 export const getTimestamp = () => Date.now();

--- a/src/firebase.spec.ts
+++ b/src/firebase.spec.ts
@@ -1,11 +1,29 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { connectAuthEmulator, getAuth } from "firebase/auth";
 import { initializeApp } from "firebase/app";
+import {
+  connectFirestoreEmulator,
+  getDocsFromCache,
+  initializeFirestore,
+  memoryLocalCache,
+  persistentLocalCache,
+  persistentSingleTabManager,
+  terminate,
+} from "firebase/firestore";
 
 const singletons = vi.hoisted(() => ({
   app: { name: "app" },
   auth: { currentUser: null },
+  db: { type: "firestore", _firestoreClient: { _offlineComponents: { kind: "persistent" } } },
 }));
+
+const stubAvailableWebLock = () => {
+  const request = vi.fn((_name: string, _options: object, callback: (lock: object) => Promise<void>) =>
+    callback({ name: "lock" })
+  );
+  vi.stubGlobal("navigator", { ...navigator, locks: { request } });
+  return request;
+};
 
 vi.mock("firebase/app", () => ({
   initializeApp: vi.fn(() => singletons.app),
@@ -17,25 +35,126 @@ vi.mock("firebase/auth", () => ({
 }));
 
 vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => "probe-collection"),
   connectFirestoreEmulator: vi.fn(),
-  getFirestore: vi.fn(() => ({})),
+  getDocsFromCache: vi.fn(async () => ({ docs: [] })),
+  initializeFirestore: vi.fn(() => singletons.db),
+  memoryLocalCache: vi.fn(() => "memory-cache"),
+  persistentLocalCache: vi.fn((settings) => ({ type: "persistent-cache", settings })),
+  persistentSingleTabManager: vi.fn(() => "single-tab-manager"),
+  query: vi.fn(() => "probe-query"),
+  terminate: vi.fn(async () => undefined),
 }));
 
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
   vi.resetModules();
+  singletons.db._firestoreClient._offlineComponents.kind = "persistent";
 });
 
 describe("Firebase singletons", () => {
-  it("exports one app and its stable auth instance", async () => {
-    const { app, auth } = await import("@/firebase");
+  it("exports one app with stable auth and Firestore instances", async () => {
+    const first = await import("@/firebase");
+    const second = await import("@/firebase");
 
-    expect(app).toBe(singletons.app);
-    expect(auth).toBe(singletons.auth);
+    expect(first.app).toBe(singletons.app);
+    expect(first.auth).toBe(singletons.auth);
+    expect(first.getDb()).toBe(singletons.db);
+    expect(second.getDb()).toBe(first.getDb());
     expect(initializeApp).toHaveBeenCalledTimes(1);
-    expect(getAuth).toHaveBeenCalledWith(app);
+    expect(getAuth).toHaveBeenCalledWith(singletons.app);
     expect(getAuth).toHaveBeenCalledTimes(1);
+    expect(initializeFirestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses persistent single-tab cache in production", async () => {
+    vi.stubEnv("PROD", true);
+    stubAvailableWebLock();
+
+    const firebase = await import("@/firebase");
+    await firebase.waitForFirestoreInitialization();
+
+    expect(persistentSingleTabManager).toHaveBeenCalledWith({});
+    expect(persistentLocalCache).toHaveBeenCalledWith({ tabManager: "single-tab-manager" });
+    expect(initializeFirestore).toHaveBeenCalledWith(singletons.app, {
+      localCache: { type: "persistent-cache", settings: { tabManager: "single-tab-manager" } },
+    });
+    expect(memoryLocalCache).not.toHaveBeenCalled();
+  });
+
+  it("uses injectable memory cache for tests and the emulator", async () => {
+    vi.stubEnv("PROD", false);
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_DB_HOST", "127.0.0.1");
+    vi.stubEnv("VITE_DB_PORT", "8080");
+
+    const { getDb } = await import("@/firebase");
+
+    expect(memoryLocalCache).toHaveBeenCalledTimes(1);
+    expect(initializeFirestore).toHaveBeenCalledWith(singletons.app, { localCache: "memory-cache" });
+    expect(connectFirestoreEmulator).toHaveBeenCalledWith(getDb(), "127.0.0.1", 8080);
+    expect(persistentLocalCache).not.toHaveBeenCalled();
+  });
+
+  it("exposes a blocking startup state instead of falling back when persistence initialization fails", async () => {
+    vi.stubEnv("PROD", true);
+    stubAvailableWebLock();
+    const failure = new Error("single-tab persistence unavailable");
+    vi.mocked(initializeFirestore).mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    const { getDb, getFirestoreInitializationState } = await import("@/firebase");
+
+    expect(getFirestoreInitializationState()).toEqual({ status: "blocked", error: failure });
+    expect(() => getDb()).toThrow(failure);
+    expect(memoryLocalCache).not.toHaveBeenCalled();
+  });
+
+  it("blocks startup when another tab owns the production lease", async () => {
+    vi.stubEnv("PROD", true);
+    const request = vi.fn((_name: string, _options: object, callback: (lock: object | null) => Promise<void>) =>
+      callback(null)
+    );
+    vi.stubGlobal("navigator", { ...navigator, locks: { request } });
+
+    const firebase = await import("@/firebase");
+
+    await expect(firebase.waitForFirestoreInitialization()).resolves.toEqual({
+      status: "blocked",
+      error: expect.objectContaining({ name: "FirestoreSingleTabLeaseError" }),
+    });
+    expect(() => firebase.getDb()).toThrow("another tab");
+    expect(memoryLocalCache).not.toHaveBeenCalled();
+  });
+
+  it("blocks startup when Firestore silently falls back to memory", async () => {
+    vi.stubEnv("PROD", true);
+    stubAvailableWebLock();
+    singletons.db._firestoreClient._offlineComponents.kind = "memory";
+
+    const firebase = await import("@/firebase");
+
+    await expect(firebase.waitForFirestoreInitialization()).resolves.toEqual({
+      status: "blocked",
+      error: expect.objectContaining({ name: "FirestorePersistenceUnavailableError" }),
+    });
+    expect(getDocsFromCache).toHaveBeenCalledTimes(1);
+    expect(terminate).toHaveBeenCalledWith(singletons.db);
+    expect(() => firebase.getDb()).toThrow("Memory fallback is disabled");
+  });
+
+  it("reports unsupported exclusive locks separately from tab contention", async () => {
+    vi.stubEnv("PROD", true);
+    vi.stubGlobal("navigator", { ...navigator, locks: undefined });
+
+    const firebase = await import("@/firebase");
+
+    await expect(firebase.waitForFirestoreInitialization()).resolves.toEqual({
+      status: "blocked",
+      error: expect.objectContaining({ name: "FirestoreSingleTabLeaseUnsupportedError" }),
+    });
   });
 
   it("connects auth to the configured emulator in dev mode", async () => {

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,27 @@
 import { initializeApp } from "firebase/app";
 import { connectAuthEmulator, getAuth } from "firebase/auth";
-import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
+import {
+  connectFirestoreEmulator,
+  initializeFirestore,
+  memoryLocalCache,
+  persistentLocalCache,
+  persistentSingleTabManager,
+  terminate,
+  type Firestore,
+} from "firebase/firestore";
+import {
+  blockFirestoreRuntime,
+  getDb,
+  getFirestoreInitializationState,
+  initializeFirestoreRuntime,
+  waitForFirestoreInitialization,
+} from "@/firestoreRuntime";
+import { verifyFirestorePersistence } from "@/firestorePersistenceProbe";
+import {
+  FirestoreSingleTabLeaseUnsupportedError,
+  startFirestoreSingleTabLease,
+  type FirestoreLockManager,
+} from "@/firestoreSingleTabLease";
 
 const projectId = import.meta.env.VITE_PROJECT_ID;
 const apiKey = import.meta.env.VITE_WEB_API_KEY;
@@ -14,15 +35,55 @@ export const app = initializeApp({
 });
 export const auth = getAuth(app);
 
+let initializedDb: Firestore | undefined;
+
+try {
+  const localCache = import.meta.env.PROD
+    ? persistentLocalCache({ tabManager: persistentSingleTabManager({}) })
+    : memoryLocalCache();
+  initializedDb = initializeFirestore(app, { localCache });
+  if (import.meta.env.PROD) {
+    const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
+    if (!locks) {
+      blockFirestoreRuntime(new FirestoreSingleTabLeaseUnsupportedError());
+    } else {
+      const lease = startFirestoreSingleTabLease(locks as unknown as FirestoreLockManager);
+      void lease.ready.then(async (state) => {
+        if (state.status === "blocked") {
+          blockFirestoreRuntime(state.error);
+          return;
+        }
+        try {
+          await verifyFirestorePersistence(initializedDb as Firestore);
+          initializeFirestoreRuntime(initializedDb as Firestore);
+        } catch (error) {
+          try {
+            await terminate(initializedDb as Firestore);
+          } catch {
+            // Preserve the persistence failure while releasing both leases best-effort.
+          }
+          lease.release();
+          blockFirestoreRuntime(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+    }
+  } else {
+    initializeFirestoreRuntime(initializedDb);
+  }
+} catch (error) {
+  blockFirestoreRuntime(error instanceof Error ? error : new Error(String(error)));
+}
+
+export { getDb, getFirestoreInitializationState, waitForFirestoreInitialization };
+
 if (import.meta.env.MODE === "dev") {
   const host = import.meta.env.VITE_AUTH_HOST;
   const port = import.meta.env.VITE_AUTH_PORT;
   connectAuthEmulator(auth, `http://${host}:${port}`);
 }
 
-if (import.meta.env.DEV) {
-  const db = getFirestore(app);
+if (import.meta.env.DEV && initializedDb) {
   const host = import.meta.env.VITE_DB_HOST;
   const port = import.meta.env.VITE_DB_PORT;
-  connectFirestoreEmulator(db, host, parseInt(port, 10));
+  connectFirestoreEmulator(initializedDb, host, parseInt(port, 10));
 }

--- a/src/firestorePersistenceProbe.spec.ts
+++ b/src/firestorePersistenceProbe.spec.ts
@@ -1,0 +1,34 @@
+import type { Firestore } from "firebase/firestore";
+import { describe, expect, it, vi } from "vitest";
+
+import { FirestorePersistenceUnavailableError, verifyFirestorePersistence } from "@/firestorePersistenceProbe";
+
+const firestoreWithCacheKind = (kind: string): Firestore =>
+  ({ _firestoreClient: { _offlineComponents: { kind } } }) as unknown as Firestore;
+
+describe("Firestore persistence probe", () => {
+  it("warms the local cache and accepts the initialized persistent provider", async () => {
+    const db = firestoreWithCacheKind("persistent");
+    const warmCache = vi.fn(async () => undefined);
+
+    await expect(verifyFirestorePersistence(db, warmCache)).resolves.toBeUndefined();
+
+    expect(warmCache).toHaveBeenCalledWith(db);
+  });
+
+  it("rejects the SDK's silent memory fallback", async () => {
+    const db = firestoreWithCacheKind("memory");
+
+    await expect(verifyFirestorePersistence(db, async () => undefined)).rejects.toBeInstanceOf(
+      FirestorePersistenceUnavailableError
+    );
+  });
+
+  it("propagates IndexedDB initialization errors", async () => {
+    const failure = new Error("IndexedDB schema failed");
+
+    await expect(
+      verifyFirestorePersistence(firestoreWithCacheKind("persistent"), async () => Promise.reject(failure))
+    ).rejects.toBe(failure);
+  });
+});

--- a/src/firestorePersistenceProbe.ts
+++ b/src/firestorePersistenceProbe.ts
@@ -1,0 +1,26 @@
+import { collection, getDocsFromCache, query, type Firestore } from "firebase/firestore";
+
+type InspectableFirestore = Firestore & {
+  _firestoreClient?: {
+    _offlineComponents?: { kind?: string };
+  };
+};
+
+type CacheWarmer = (db: Firestore) => Promise<unknown>;
+
+export class FirestorePersistenceUnavailableError extends Error {
+  constructor() {
+    super("Firestore persistent storage is unavailable. Memory fallback is disabled.");
+    this.name = "FirestorePersistenceUnavailableError";
+  }
+}
+
+const warmLocalCache: CacheWarmer = (db) => getDocsFromCache(query(collection(db, "__persistence_probe__")));
+
+export const verifyFirestorePersistence = async (db: Firestore, warmCache: CacheWarmer = warmLocalCache) => {
+  await warmCache(db);
+  // Firestore 10.x silently replaces a failed persistent provider with memory.
+  // Inspect the initialized provider so the app never exposes that fallback.
+  const cacheKind = (db as InspectableFirestore)._firestoreClient?._offlineComponents?.kind;
+  if (cacheKind !== "persistent") throw new FirestorePersistenceUnavailableError();
+};

--- a/src/firestoreRuntime.spec.ts
+++ b/src/firestoreRuntime.spec.ts
@@ -1,0 +1,45 @@
+import type { Firestore } from "firebase/firestore";
+import { describe, expect, it, vi } from "vitest";
+
+import { createFirestoreRuntime } from "@/firestoreRuntime";
+
+describe("Firestore runtime", () => {
+  it("keeps one injected instance and rejects a different duplicate initialization", () => {
+    const runtime = createFirestoreRuntime();
+    const db = { name: "first" } as unknown as Firestore;
+
+    runtime.initialize(db);
+    runtime.initialize(db);
+
+    expect(runtime.getDb()).toBe(db);
+    expect(runtime.getState()).toEqual({ status: "ready" });
+    expect(() => runtime.initialize({ name: "second" } as unknown as Firestore)).toThrow(
+      "Firestore runtime is already initialized"
+    );
+  });
+
+  it("waits until the injected Firestore instance is ready", async () => {
+    const runtime = createFirestoreRuntime();
+    const db = { name: "persistent" } as unknown as Firestore;
+    const onChange = vi.fn();
+    runtime.subscribe(onChange);
+
+    expect(runtime.getState()).toEqual({ status: "initializing" });
+    runtime.initialize(db);
+
+    await expect(runtime.waitForInitialization()).resolves.toEqual({ status: "ready" });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a blocking initialization error without allowing memory fallback", async () => {
+    const runtime = createFirestoreRuntime();
+    const error = new Error("persistent cache unavailable");
+
+    runtime.block(error);
+
+    expect(runtime.getState()).toEqual({ status: "blocked", error });
+    expect(() => runtime.getDb()).toThrow(error);
+    expect(() => runtime.initialize({} as Firestore)).toThrow(error);
+    await expect(runtime.waitForInitialization()).resolves.toEqual({ status: "blocked", error });
+  });
+});

--- a/src/firestoreRuntime.ts
+++ b/src/firestoreRuntime.ts
@@ -1,0 +1,58 @@
+import type { Firestore } from "firebase/firestore";
+
+export type FirestoreInitializationState =
+  | { status: "initializing" }
+  | { status: "ready" }
+  | { status: "blocked"; error: Error };
+
+export const createFirestoreRuntime = () => {
+  let db: Firestore | undefined;
+  let state: FirestoreInitializationState = { status: "initializing" };
+  let resolveInitialization: (state: FirestoreInitializationState) => void = () => undefined;
+  const listeners = new Set<Callback>();
+  const initialization = new Promise<FirestoreInitializationState>((resolve) => {
+    resolveInitialization = resolve;
+  });
+
+  return {
+    initialize: (nextDb: Firestore) => {
+      if (state.status === "blocked") throw state.error;
+      if (db && db !== nextDb) throw new Error("Firestore runtime is already initialized");
+      db = nextDb;
+      state = { status: "ready" };
+      resolveInitialization(state);
+      listeners.forEach((listener) => {
+        listener();
+      });
+    },
+    block: (error: Error) => {
+      if (state.status === "blocked") return;
+      db = undefined;
+      state = { status: "blocked", error };
+      resolveInitialization(state);
+      listeners.forEach((listener) => {
+        listener();
+      });
+    },
+    getDb: () => {
+      if (db) return db;
+      if (state.status === "blocked") throw state.error;
+      throw new Error("Firestore is not initialized");
+    },
+    getState: () => state,
+    waitForInitialization: () => initialization,
+    subscribe: (listener: Callback) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+};
+
+const firestoreRuntime = createFirestoreRuntime();
+
+export const initializeFirestoreRuntime = firestoreRuntime.initialize;
+export const blockFirestoreRuntime = firestoreRuntime.block;
+export const getDb = firestoreRuntime.getDb;
+export const getFirestoreInitializationState = firestoreRuntime.getState;
+export const waitForFirestoreInitialization = firestoreRuntime.waitForInitialization;
+export const subscribeFirestoreInitialization = firestoreRuntime.subscribe;

--- a/src/firestoreSingleTabLease.spec.ts
+++ b/src/firestoreSingleTabLease.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { type FirestoreLockManager, startFirestoreSingleTabLease } from "@/firestoreSingleTabLease";
+
+describe("Firestore single-tab lease", () => {
+  it("holds an exclusive Web Lock until explicitly released", async () => {
+    let lockRequest: Promise<void> | undefined;
+    const locks: FirestoreLockManager = {
+      request: vi.fn((_name, _options, callback): Promise<void> => {
+        const request = callback({ name: "tango-firestore" });
+        lockRequest = request;
+        return request;
+      }),
+    };
+
+    const lease = startFirestoreSingleTabLease(locks);
+
+    await expect(lease.ready).resolves.toEqual({ status: "ready" });
+    expect(locks.request).toHaveBeenCalledWith(
+      "tango-firestore-persistence",
+      { mode: "exclusive", ifAvailable: true },
+      expect.any(Function)
+    );
+    let settled = false;
+    void lockRequest?.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    lease.release();
+    await lockRequest;
+    expect(settled).toBe(true);
+  });
+
+  it("returns a dedicated blocker when another tab owns the lease", async () => {
+    const locks: FirestoreLockManager = {
+      request: vi.fn((_name, _options, callback) => callback(null)),
+    };
+
+    const lease = startFirestoreSingleTabLease(locks);
+
+    await expect(lease.ready).resolves.toEqual({
+      status: "blocked",
+      error: expect.objectContaining({ name: "FirestoreSingleTabLeaseError" }),
+    });
+  });
+
+  it("returns a blocker when the browser lock request fails", async () => {
+    const failure = new Error("Web Locks unavailable");
+    const locks: FirestoreLockManager = { request: vi.fn(async () => Promise.reject(failure)) };
+
+    const lease = startFirestoreSingleTabLease(locks);
+
+    await expect(lease.ready).resolves.toEqual({ status: "blocked", error: failure });
+  });
+});

--- a/src/firestoreSingleTabLease.ts
+++ b/src/firestoreSingleTabLease.ts
@@ -1,0 +1,53 @@
+export type FirestoreSingleTabLeaseState = { status: "ready" } | { status: "blocked"; error: Error };
+
+export interface FirestoreLockManager {
+  request: (
+    name: string,
+    options: { mode: "exclusive"; ifAvailable: true },
+    callback: (lock: object | null) => Promise<void>
+  ) => Promise<void>;
+}
+
+export class FirestoreSingleTabLeaseError extends Error {
+  constructor() {
+    super("Firestore offline storage is already open in another tab.");
+    this.name = "FirestoreSingleTabLeaseError";
+  }
+}
+
+export class FirestoreSingleTabLeaseUnsupportedError extends Error {
+  constructor() {
+    super("This browser cannot provide the exclusive lock required for persistent storage.");
+    this.name = "FirestoreSingleTabLeaseUnsupportedError";
+  }
+}
+
+export const startFirestoreSingleTabLease = (locks: FirestoreLockManager) => {
+  let release: Callback = () => undefined;
+  let resolveReady: (state: FirestoreSingleTabLeaseState) => void = () => undefined;
+  const ready = new Promise<FirestoreSingleTabLeaseState>((resolve) => {
+    resolveReady = resolve;
+  });
+
+  try {
+    void locks
+      .request("tango-firestore-persistence", { mode: "exclusive", ifAvailable: true }, async (lock) => {
+        if (!lock) {
+          resolveReady({ status: "blocked", error: new FirestoreSingleTabLeaseError() });
+          return;
+        }
+
+        resolveReady({ status: "ready" });
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      })
+      .catch((error) => {
+        resolveReady({ status: "blocked", error: error instanceof Error ? error : new Error(String(error)) });
+      });
+  } catch (error) {
+    resolveReady({ status: "blocked", error: error instanceof Error ? error : new Error(String(error)) });
+  }
+
+  return { ready, release: () => release() };
+};

--- a/src/query/firestoreSyncController.spec.ts
+++ b/src/query/firestoreSyncController.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFirestoreSyncController } from "@/query/firestoreSyncController";
+
+describe("Firestore sync controller", () => {
+  it("distinguishes cached, pending, and server-synced snapshots after both collections load", () => {
+    const controller = createFirestoreSyncController(["deck", "card"]);
+    const generation = controller.start("uid-a");
+
+    controller.observe("uid-a", generation, "deck", { fromCache: true, hasPendingWrites: false });
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-a", status: "loading" });
+
+    controller.observe("uid-a", generation, "card", { fromCache: false, hasPendingWrites: false });
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "cached" });
+
+    controller.observe("uid-a", generation, "deck", { fromCache: false, hasPendingWrites: false });
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "synced" });
+
+    controller.observe("uid-a", generation, "card", { fromCache: true, hasPendingWrites: true });
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "pending" });
+  });
+
+  it("ignores snapshots and errors from an old UID generation", () => {
+    const controller = createFirestoreSyncController(["deck", "card"]);
+    const oldGeneration = controller.start("uid-a");
+    const currentGeneration = controller.start("uid-b");
+
+    controller.observe("uid-a", oldGeneration, "deck", { fromCache: false, hasPendingWrites: false });
+    controller.fail("uid-a", oldGeneration, new Error("stale listener"));
+
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-b", status: "loading" });
+
+    controller.observe("uid-b", currentGeneration, "deck", { fromCache: false, hasPendingWrites: false });
+    controller.observe("uid-b", currentGeneration, "card", { fromCache: false, hasPendingWrites: false });
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-b", status: "ready", syncStatus: "synced" });
+  });
+
+  it("publishes listener errors and resets to idle when stopped", () => {
+    const controller = createFirestoreSyncController(["deck", "card"]);
+    const listener = vi.fn();
+    controller.subscribe(listener);
+    const generation = controller.start("uid-a");
+    const error = new Error("listener failed");
+
+    controller.fail("uid-a", generation, error);
+    expect(controller.getSnapshot()).toEqual({ uid: "uid-a", status: "error", error });
+
+    controller.stop("uid-a");
+    expect(controller.getSnapshot()).toEqual({ uid: null, status: "idle" });
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/query/firestoreSyncController.ts
+++ b/src/query/firestoreSyncController.ts
@@ -1,0 +1,73 @@
+export interface FirestoreSnapshotMetadata {
+  fromCache: boolean;
+  hasPendingWrites: boolean;
+}
+
+export type FirestoreSyncStatus = "cached" | "pending" | "synced";
+
+export type FirestoreSyncState =
+  | { uid: null; status: "idle" }
+  | { uid: string; status: "loading" }
+  | { uid: string; status: "ready"; syncStatus: FirestoreSyncStatus }
+  | { uid: string; status: "error"; error: Error };
+
+export const createFirestoreSyncController = <Collection extends string>(collections: readonly Collection[]) => {
+  let activeUid: string | undefined;
+  let generation = 0;
+  let state: FirestoreSyncState = { uid: null, status: "idle" };
+  let metadata = new Map<Collection, FirestoreSnapshotMetadata>();
+  const listeners = new Set<Callback>();
+
+  const setState = (next: FirestoreSyncState) => {
+    state = next;
+    listeners.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const isCurrent = (uid: string, currentGeneration: number) => activeUid === uid && generation === currentGeneration;
+
+  return {
+    start: (uid: string) => {
+      activeUid = uid;
+      metadata = new Map();
+      const currentGeneration = ++generation;
+      setState({ uid, status: "loading" });
+      return currentGeneration;
+    },
+    observe: (
+      uid: string,
+      currentGeneration: number,
+      collection: Collection,
+      nextMetadata: FirestoreSnapshotMetadata
+    ) => {
+      if (!isCurrent(uid, currentGeneration)) return;
+      metadata.set(collection, nextMetadata);
+      if (collections.some((name) => !metadata.has(name))) return;
+
+      const snapshots = collections.map((name) => metadata.get(name) as FirestoreSnapshotMetadata);
+      const syncStatus = snapshots.some((snapshot) => snapshot.hasPendingWrites)
+        ? "pending"
+        : snapshots.some((snapshot) => snapshot.fromCache)
+          ? "cached"
+          : "synced";
+      setState({ uid, status: "ready", syncStatus });
+    },
+    fail: (uid: string, currentGeneration: number, error: Error) => {
+      if (isCurrent(uid, currentGeneration)) setState({ uid, status: "error", error });
+    },
+    stop: (uid?: string) => {
+      if (uid && uid !== activeUid) return;
+      activeUid = undefined;
+      metadata = new Map();
+      generation += 1;
+      setState({ uid: null, status: "idle" });
+    },
+    isCurrent,
+    subscribe: (listener: Callback) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot: () => state,
+  };
+};

--- a/src/query/remoteReadController.spec.ts
+++ b/src/query/remoteReadController.spec.ts
@@ -10,16 +10,6 @@ import {
 } from "@/query/remoteReadController";
 import { createCard, createDeck } from "@/test/factories";
 
-const deferred = <T>() => {
-  let resolve: (value: T) => void = () => undefined;
-  let reject: (error: unknown) => void = () => undefined;
-  const promise = new Promise<T>((onResolve, onReject) => {
-    resolve = onResolve;
-    reject = onReject;
-  });
-  return { promise, resolve, reject };
-};
-
 const byId = <T extends { id: string }>(items: T[]) => Object.fromEntries(items.map((item) => [item.id, item]));
 
 const createHarness = () => {
@@ -30,8 +20,6 @@ const createHarness = () => {
   const cardUnsubscribes: ReturnType<typeof vi.fn>[] = [];
   const dependencies: RemoteReadDependencies = {
     client,
-    readDecks: vi.fn(async () => []),
-    readCards: vi.fn(async () => []),
     subscribeDecks: vi.fn((props) => {
       deckSubscriptions.push(props);
       const unsubscribe = vi.fn();
@@ -60,59 +48,89 @@ const createHarness = () => {
 describe("remote read controller", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("loads both collections before attaching exactly one listener for each", async () => {
+  it("attaches one listener per collection and becomes ready from cached initial snapshots", async () => {
     const harness = createHarness();
     const deck = createDeck({ id: "deck-a", localMode: false });
     const card = createCard({ id: "card-a", deckId: deck.id });
-    vi.mocked(harness.dependencies.readDecks).mockResolvedValue([deck]);
-    vi.mocked(harness.dependencies.readCards).mockResolvedValue([card]);
 
     const first = harness.controller.start("uid-a");
     const strictModeReplay = harness.controller.start("uid-a");
     await Promise.all([first, strictModeReplay]);
 
-    expect(harness.dependencies.readDecks).toHaveBeenCalledTimes(1);
-    expect(harness.dependencies.readCards).toHaveBeenCalledTimes(1);
     expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(1);
     expect(harness.dependencies.subscribeCards).toHaveBeenCalledTimes(1);
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "loading" });
+
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [deck],
+      metadata: { size: 1, fromCache: true, hasPendingWrites: false },
+    });
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "loading" });
+    harness.cardSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [card],
+      metadata: { size: 1, fromCache: true, hasPendingWrites: false },
+    });
+
     expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual(byId([deck]));
     expect(harness.client.getQueryData(firestoreKeys.cards("uid-a"))).toEqual(byId([card]));
-    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready" });
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "cached" });
   });
 
-  it("applies replacement and delta snapshots to Query", async () => {
+  it("applies delta snapshots and publishes pending then server-synced metadata", async () => {
     const harness = createHarness();
-    const deck = createDeck({ id: "deck-a", localMode: false });
-    vi.mocked(harness.dependencies.readDecks).mockResolvedValue([deck]);
     await harness.controller.start("uid-a");
 
     harness.deckSubscriptions[0]?.onSnapshot({
       type: "replace",
       items: [],
-      metadata: { size: 0, fromLocal: false },
+      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
+    });
+    harness.cardSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [],
+      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
     });
 
     expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual({});
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "synced" });
 
     const added = createDeck({ id: "deck-added", localMode: false });
     harness.deckSubscriptions[0]?.onSnapshot({
       type: "change",
       event: { added: [added], modified: [], removed: [] },
-      metadata: { size: 1, fromLocal: false },
+      metadata: { size: 1, fromCache: true, hasPendingWrites: true },
     });
 
     expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual(byId([added]));
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "pending" });
+
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "change",
+      event: { added: [], modified: [], removed: [] },
+      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
+    });
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready", syncStatus: "synced" });
   });
 
   it("forces one refetch and reconnect, then retains data on a terminal listener error", async () => {
     const harness = createHarness();
     const deck = createDeck({ id: "deck-a", localMode: false });
-    vi.mocked(harness.dependencies.readDecks).mockResolvedValue([deck]);
     await harness.controller.start("uid-a");
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [deck],
+      metadata: { size: 1, fromCache: true, hasPendingWrites: false },
+    });
+    harness.cardSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [],
+      metadata: { size: 0, fromCache: true, hasPendingWrites: false },
+    });
 
     harness.deckSubscriptions[0]?.onError(new Error("first listener failure"));
     await vi.waitFor(() => expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(2));
-    expect(harness.dependencies.readDecks).toHaveBeenCalledTimes(2);
     expect(harness.deckUnsubscribes[0]).toHaveBeenCalledTimes(1);
     expect(harness.cardUnsubscribes[0]).toHaveBeenCalledTimes(1);
 
@@ -122,7 +140,6 @@ describe("remote read controller", () => {
       expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "error", error: terminalError })
     );
 
-    expect(harness.dependencies.readDecks).toHaveBeenCalledTimes(2);
     expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toEqual(byId([deck]));
   });
 
@@ -136,34 +153,40 @@ describe("remote read controller", () => {
 
     await harness.controller.retry();
 
-    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "ready" });
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-a", status: "loading" });
     expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(3);
     harness.deckSubscriptions[2]?.onError(new Error("new automatic recovery"));
     await vi.waitFor(() => expect(harness.dependencies.subscribeDecks).toHaveBeenCalledTimes(4));
   });
 
-  it("prevents delayed work for an old UID from mutating Query or listeners", async () => {
+  it("prevents snapshots from an old UID generation from mutating Query or sync state", async () => {
     const harness = createHarness();
-    const decksA = deferred<Deck[]>();
-    const cardsA = deferred<Card[]>();
     const deckB = createDeck({ id: "deck-b", uid: "uid-b", localMode: false });
     const cardB = createCard({ id: "card-b", uid: "uid-b", deckId: deckB.id });
-    vi.mocked(harness.dependencies.readDecks).mockImplementation((uid) =>
-      uid === "uid-a" ? decksA.promise : Promise.resolve([deckB])
-    );
-    vi.mocked(harness.dependencies.readCards).mockImplementation((uid) =>
-      uid === "uid-a" ? cardsA.promise : Promise.resolve([cardB])
-    );
 
-    const startA = harness.controller.start("uid-a");
+    await harness.controller.start("uid-a");
     await harness.controller.start("uid-b");
-    decksA.resolve([createDeck({ id: "deck-a", uid: "uid-a", localMode: false })]);
-    cardsA.resolve([createCard({ id: "card-a", uid: "uid-a" })]);
-    await startA;
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [createDeck({ id: "deck-a", uid: "uid-a", localMode: false })],
+      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
+    });
+    harness.cardSubscriptions[0]?.onError(new Error("stale listener"));
+    harness.deckSubscriptions[1]?.onSnapshot({
+      type: "replace",
+      items: [deckB],
+      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
+    });
+    harness.cardSubscriptions[1]?.onSnapshot({
+      type: "replace",
+      items: [cardB],
+      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
+    });
 
     expect(harness.client.getQueryData(firestoreKeys.decks("uid-a"))).toBeUndefined();
     expect(harness.client.getQueryData(firestoreKeys.cards("uid-a"))).toBeUndefined();
-    expect(harness.dependencies.subscribeDecks).not.toHaveBeenCalledWith(expect.objectContaining({ uid: "uid-a" }));
-    expect(harness.dependencies.subscribeCards).not.toHaveBeenCalledWith(expect.objectContaining({ uid: "uid-a" }));
+    expect(harness.client.getQueryData(firestoreKeys.decks("uid-b"))).toEqual(byId([deckB]));
+    expect(harness.client.getQueryData(firestoreKeys.cards("uid-b"))).toEqual(byId([cardB]));
+    expect(harness.controller.getSnapshot()).toEqual({ uid: "uid-b", status: "ready", syncStatus: "synced" });
   });
 });

--- a/src/query/remoteReadController.ts
+++ b/src/query/remoteReadController.ts
@@ -2,6 +2,7 @@ import type { QueryClient, QueryKey } from "@tanstack/react-query";
 
 import type { RemoteSnapshot } from "@/action/firestore/event";
 import { firestoreKeys } from "@/query/firestoreKeys";
+import { createFirestoreSyncController, type FirestoreSyncState } from "@/query/firestoreSyncController";
 
 export type RemoteById<T> = Record<string, T | undefined>;
 
@@ -11,15 +12,10 @@ export interface RemoteSubscriptionProps<T> {
   onError: (error: Error) => void;
 }
 
-export type RemoteReadState =
-  | { uid: null; status: "idle" }
-  | { uid: string; status: "loading" | "ready" }
-  | { uid: string; status: "error"; error: Error };
+export type RemoteReadState = FirestoreSyncState;
 
 export interface RemoteReadDependencies {
   client: QueryClient;
-  readDecks: (uid: string) => Promise<Deck[]>;
-  readCards: (uid: string) => Promise<Card[]>;
   subscribeDecks: (props: RemoteSubscriptionProps<Deck>) => Callback;
   subscribeCards: (props: RemoteSubscriptionProps<Card>) => Callback;
   applyChange: <T extends { id: string }>(
@@ -32,24 +28,12 @@ const toById = <T extends { id: string }>(items: T[]): RemoteById<T> =>
   Object.fromEntries(items.map((item) => [item.id, item]));
 
 export const createRemoteReadController = (dependencies: RemoteReadDependencies) => {
+  const syncController = createFirestoreSyncController(["deck", "card"] as const);
   let activeUid: string | undefined;
-  let generation = 0;
   let automaticRecoveries = 0;
-  let recovering = false;
   let unsubscribeDeck: Callback | undefined;
   let unsubscribeCard: Callback | undefined;
   let currentStart: Promise<void> | undefined;
-  let state: RemoteReadState = { uid: null, status: "idle" };
-  const listeners = new Set<Callback>();
-
-  const setState = (next: RemoteReadState) => {
-    state = next;
-    listeners.forEach((listener) => {
-      listener();
-    });
-  };
-
-  const isCurrent = (uid: string, currentGeneration: number) => activeUid === uid && generation === currentGeneration;
 
   const stopListeners = () => {
     const subscriptions = [unsubscribeDeck, unsubscribeCard];
@@ -64,59 +48,29 @@ export const createRemoteReadController = (dependencies: RemoteReadDependencies)
     });
   };
 
-  const setCollection = <T extends { id: string }>(queryKey: QueryKey, items: T[]) => {
-    dependencies.client.setQueryData<RemoteById<T>>(queryKey, toById(items));
-  };
-
   const applySnapshot = <T extends { id: string }>(
     uid: string,
-    currentGeneration: number,
+    generation: number,
+    collection: "deck" | "card",
     queryKey: QueryKey,
     snapshot: RemoteSnapshot<T>
   ) => {
-    if (!isCurrent(uid, currentGeneration)) return;
+    if (!syncController.isCurrent(uid, generation)) return;
     const previous = dependencies.client.getQueryData<RemoteById<T>>(queryKey) ?? {};
     const next =
       snapshot.type === "replace" ? toById(snapshot.items) : dependencies.applyChange(previous, snapshot.event);
     dependencies.client.setQueryData(queryKey, next);
+    syncController.observe(uid, generation, collection, snapshot.metadata);
   };
 
-  const handleListenerError = async (uid: string, currentGeneration: number, error: Error) => {
-    if (!isCurrent(uid, currentGeneration) || recovering) return;
-    stopListeners();
-    if (automaticRecoveries >= 1) {
-      setState({ uid, status: "error", error });
-      return;
-    }
-
-    automaticRecoveries += 1;
-    recovering = true;
-    setState({ uid, status: "loading" });
-    try {
-      await loadAndSubscribe(uid, currentGeneration);
-    } catch (recoveryError) {
-      if (isCurrent(uid, currentGeneration)) {
-        setState({
-          uid,
-          status: "error",
-          error: recoveryError instanceof Error ? recoveryError : new Error(String(recoveryError)),
-        });
-      }
-    } finally {
-      recovering = false;
-    }
-  };
-
-  const attachListeners = (uid: string, currentGeneration: number) => {
-    const onError = (error: Error) => {
-      void handleListenerError(uid, currentGeneration, error);
-    };
+  const attachListeners = (uid: string, generation: number) => {
+    const onError = (error: Error) => handleListenerError(uid, generation, error);
     const nextDeckSubscription = dependencies.subscribeDecks({
       uid,
-      onSnapshot: (snapshot) => applySnapshot(uid, currentGeneration, firestoreKeys.decks(uid), snapshot),
+      onSnapshot: (snapshot) => applySnapshot(uid, generation, "deck", firestoreKeys.decks(uid), snapshot),
       onError,
     });
-    if (!isCurrent(uid, currentGeneration)) {
+    if (!syncController.isCurrent(uid, generation)) {
       nextDeckSubscription();
       return;
     }
@@ -124,10 +78,10 @@ export const createRemoteReadController = (dependencies: RemoteReadDependencies)
 
     const nextCardSubscription = dependencies.subscribeCards({
       uid,
-      onSnapshot: (snapshot) => applySnapshot(uid, currentGeneration, firestoreKeys.cards(uid), snapshot),
+      onSnapshot: (snapshot) => applySnapshot(uid, generation, "card", firestoreKeys.cards(uid), snapshot),
       onError,
     });
-    if (!isCurrent(uid, currentGeneration)) {
+    if (!syncController.isCurrent(uid, generation)) {
       nextCardSubscription();
       stopListeners();
       return;
@@ -135,36 +89,39 @@ export const createRemoteReadController = (dependencies: RemoteReadDependencies)
     unsubscribeCard = nextCardSubscription;
   };
 
-  async function loadAndSubscribe(uid: string, currentGeneration: number) {
-    const [decks, cards] = await Promise.all([dependencies.readDecks(uid), dependencies.readCards(uid)]);
-    if (!isCurrent(uid, currentGeneration)) return;
-
-    setCollection(firestoreKeys.decks(uid), decks);
-    setCollection(firestoreKeys.cards(uid), cards);
-    attachListeners(uid, currentGeneration);
-    if (isCurrent(uid, currentGeneration)) setState({ uid, status: "ready" });
-  }
-
   const begin = (uid: string, resetAutomaticRecoveries: boolean) => {
     stopListeners();
     activeUid = uid;
-    const currentGeneration = ++generation;
-    recovering = false;
     if (resetAutomaticRecoveries) automaticRecoveries = 0;
-    setState({ uid, status: "loading" });
+    const generation = syncController.start(uid);
 
-    const operation = loadAndSubscribe(uid, currentGeneration).catch((error) => {
-      if (isCurrent(uid, currentGeneration)) {
-        setState({ uid, status: "error", error: error instanceof Error ? error : new Error(String(error)) });
-      }
-      throw error;
-    });
-    currentStart = operation;
-    return operation;
+    try {
+      attachListeners(uid, generation);
+      currentStart = Promise.resolve();
+    } catch (error) {
+      const initializationError = error instanceof Error ? error : new Error(String(error));
+      stopListeners();
+      syncController.fail(uid, generation, initializationError);
+      currentStart = Promise.reject(initializationError);
+    }
+    return currentStart;
+  };
+
+  const handleListenerError = (uid: string, generation: number, error: Error) => {
+    if (!syncController.isCurrent(uid, generation)) return;
+    stopListeners();
+    if (automaticRecoveries >= 1) {
+      syncController.fail(uid, generation, error);
+      return;
+    }
+
+    automaticRecoveries += 1;
+    void begin(uid, false);
   };
 
   return {
     start: (uid: string) => {
+      const state = syncController.getSnapshot();
       if (activeUid === uid && (state.status === "loading" || state.status === "ready")) {
         return currentStart ?? Promise.resolve();
       }
@@ -175,17 +132,10 @@ export const createRemoteReadController = (dependencies: RemoteReadDependencies)
       if (uid && uid !== activeUid) return;
       stopListeners();
       activeUid = undefined;
-      generation += 1;
-      recovering = false;
       currentStart = undefined;
-      setState({ uid: null, status: "idle" });
+      syncController.stop(uid);
     },
-    subscribe: (listener: Callback) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
-    getSnapshot: () => state,
+    subscribe: syncController.subscribe,
+    getSnapshot: syncController.getSnapshot,
   };
 };

--- a/src/query/remoteReadSession.spec.ts
+++ b/src/query/remoteReadSession.spec.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteReadDependencies } from "@/query/remoteReadController";
+
+type InitializationState = { status: "ready" } | { status: "blocked"; error: Error };
 
 const mocks = vi.hoisted(() => ({
+  initializationState: { status: "ready" as const } as InitializationState,
+  dependencies: undefined as RemoteReadDependencies | undefined,
+  waitForInitialization: vi.fn<() => Promise<InitializationState>>(async () => ({ status: "ready" })),
   start: vi.fn(async () => undefined),
   stop: vi.fn(),
   retry: vi.fn(async () => undefined),
@@ -12,6 +18,12 @@ const mocks = vi.hoisted(() => ({
   subscribeCards: vi.fn(),
 }));
 
+vi.mock("@/firestoreRuntime", () => ({
+  getFirestoreInitializationState: () => mocks.initializationState,
+  subscribeFirestoreInitialization: vi.fn(() => () => undefined),
+  waitForFirestoreInitialization: mocks.waitForInitialization,
+}));
+
 vi.mock("@/action/firestore", () => ({
   deck: { readAll: mocks.readDecks },
   card: { readAll: mocks.readCards },
@@ -20,7 +32,8 @@ vi.mock("@/action/firestore", () => ({
 vi.mock("@/query/client", () => ({ queryClient: {} }));
 vi.mock("@/lib/realtimeChange", () => ({ applyRealtimeChange: vi.fn() }));
 vi.mock("@/query/remoteReadController", () => ({
-  createRemoteReadController: vi.fn(() => {
+  createRemoteReadController: vi.fn((dependencies: RemoteReadDependencies) => {
+    mocks.dependencies = dependencies;
     return {
       start: mocks.start,
       stop: mocks.stop,
@@ -34,7 +47,11 @@ vi.mock("@/query/remoteReadController", () => ({
 import { startRemoteReads, stopRemoteReads } from "@/query/remoteReadSession";
 
 describe("remote read session", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.initializationState = { status: "ready" };
+    mocks.waitForInitialization.mockResolvedValue({ status: "ready" });
+  });
 
   it("connects production gateways to the Query controller", async () => {
     await startRemoteReads("uid-a");
@@ -42,5 +59,31 @@ describe("remote read session", () => {
     expect(mocks.start).toHaveBeenCalledWith("uid-a");
     stopRemoteReads("uid-a");
     expect(mocks.stop).toHaveBeenCalledWith("uid-a");
+  });
+
+  it("does not start listeners when persistent cache initialization is blocked", async () => {
+    const error = new Error("another tab owns the cache");
+    mocks.initializationState = { status: "blocked", error };
+    mocks.waitForInitialization.mockResolvedValue({ status: "blocked", error });
+
+    await startRemoteReads("uid-a");
+
+    expect(mocks.start).not.toHaveBeenCalled();
+  });
+
+  it("does not start a stale UID after initialization finishes", async () => {
+    let finishInitialization: (state: { status: "ready" }) => void = () => undefined;
+    mocks.waitForInitialization.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishInitialization = resolve;
+      })
+    );
+
+    const starting = startRemoteReads("uid-a");
+    stopRemoteReads("uid-a");
+    finishInitialization({ status: "ready" });
+    await starting;
+
+    expect(mocks.start).not.toHaveBeenCalled();
   });
 });

--- a/src/query/remoteReadSession.ts
+++ b/src/query/remoteReadSession.ts
@@ -1,20 +1,39 @@
 import * as firestore from "@/action/firestore";
+import {
+  getFirestoreInitializationState,
+  subscribeFirestoreInitialization,
+  waitForFirestoreInitialization,
+} from "@/firestoreRuntime";
 import { applyRealtimeChange } from "@/lib/realtimeChange";
 import { queryClient } from "@/query/client";
 import { createRemoteReadController } from "@/query/remoteReadController";
 
 export const remoteReadController = createRemoteReadController({
   client: queryClient,
-  readDecks: firestore.deck.readAll,
-  readCards: firestore.card.readAll,
   subscribeDecks: firestore.event.subscribeDeckReads,
   subscribeCards: firestore.event.subscribeCardReads,
   applyChange: applyRealtimeChange,
 });
 
-export const startRemoteReads = (uid: string) => remoteReadController.start(uid);
+export const getRemoteReadBlocker = () => {
+  const state = getFirestoreInitializationState();
+  return state.status === "blocked" ? state.error : undefined;
+};
+export const subscribeRemoteReadBlocker = subscribeFirestoreInitialization;
 
-export const stopRemoteReads = (uid?: string) => remoteReadController.stop(uid);
+let requestedUid: string | undefined;
+
+export const startRemoteReads = async (uid: string) => {
+  requestedUid = uid;
+  const initialization = await waitForFirestoreInitialization();
+  if (initialization.status === "blocked" || requestedUid !== uid) return;
+  return remoteReadController.start(uid);
+};
+
+export const stopRemoteReads = (uid?: string) => {
+  if (!uid || requestedUid === uid) requestedUid = undefined;
+  remoteReadController.stop(uid);
+};
 
 export const retryRemoteReads = () => remoteReadController.retry();
 export const subscribeRemoteReadState = remoteReadController.subscribe;

--- a/src/query/useRemoteCollections.spec.tsx
+++ b/src/query/useRemoteCollections.spec.tsx
@@ -8,9 +8,11 @@ import { createCard, createDeck } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   uid: "uid-a",
-  state: { uid: "uid-a", status: "ready" } as
-    | { uid: string; status: "ready" | "loading" }
+  state: { uid: "uid-a", status: "ready", syncStatus: "synced" } as
+    | { uid: string; status: "ready"; syncStatus: "cached" | "pending" | "synced" }
+    | { uid: string; status: "loading" }
     | { uid: string; status: "error"; error: Error },
+  blocker: undefined as Error | undefined,
   rootState: undefined as unknown as RootState,
   retry: vi.fn(),
 }));
@@ -23,8 +25,10 @@ vi.mock("react-redux", () => ({
 }));
 vi.mock("@/query/remoteReadSession", () => ({
   subscribeRemoteReadState: () => () => undefined,
+  subscribeRemoteReadBlocker: () => () => undefined,
   getRemoteReadState: () => mocks.state,
   retryRemoteReads: mocks.retry,
+  getRemoteReadBlocker: () => mocks.blocker,
 }));
 
 import { useRemoteCollections } from "@/query/useRemoteCollections";
@@ -32,7 +36,8 @@ import { useRemoteCollections } from "@/query/useRemoteCollections";
 describe("useRemoteCollections", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.state = { uid: "uid-a", status: "ready" };
+    mocks.state = { uid: "uid-a", status: "ready", syncStatus: "synced" };
+    mocks.blocker = undefined;
   });
 
   it("merges Query remote data with Redux local-only data and lets local IDs win", () => {
@@ -64,6 +69,7 @@ describe("useRemoteCollections", () => {
     expect(result.current.cardsById).toEqual({ "local-card": localCard, "fresh-card": freshRemoteCard });
     expect(result.current.cardsByDeckId(freshRemote.id)).toEqual([freshRemoteCard]);
     expect(result.current.status).toBe("ready");
+    expect(result.current.syncStatus).toBe("synced");
   });
 
   it("exposes terminal state and Retry without dropping cached data", () => {
@@ -86,5 +92,40 @@ describe("useRemoteCollections", () => {
     expect(result.current.status).toBe("error");
     expect(result.current.error).toBe(error);
     expect(mocks.retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose Query data until authenticated and active UIDs match", () => {
+    const remoteDeck = createDeck({ id: "remote", localMode: false });
+    mocks.state = { uid: "uid-b", status: "ready", syncStatus: "synced" };
+    mocks.rootState = {
+      deck: { byId: {}, categories: [] },
+      card: { byId: {}, tags: [] },
+      config: {} as ConfigState,
+    };
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { remote: remoteDeck });
+    const QueryWrapper = createQueryWrapper(client);
+
+    const { result } = renderHook(useRemoteCollections, { wrapper: QueryWrapper });
+
+    expect(result.current.decks).toEqual([]);
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("exposes persistent cache initialization failures as blocking state", () => {
+    const blocker = new Error("another tab owns the cache");
+    mocks.blocker = blocker;
+    mocks.rootState = {
+      deck: { byId: {}, categories: [] },
+      card: { byId: {}, tags: [] },
+      config: {} as ConfigState,
+    };
+    const client = createTestQueryClient();
+    const QueryWrapper = createQueryWrapper(client);
+
+    const { result } = renderHook(useRemoteCollections, { wrapper: QueryWrapper });
+
+    expect(result.current.status).toBe("blocked");
+    expect(result.current.error).toBe(blocker);
   });
 });

--- a/src/query/useRemoteCollections.ts
+++ b/src/query/useRemoteCollections.ts
@@ -7,7 +7,13 @@ import { useAuth } from "@/auth/AuthContext";
 import { filterCardsForDeck } from "@/lib/study";
 import { firestoreKeys } from "@/query/firestoreKeys";
 import type { RemoteById, RemoteReadState } from "@/query/remoteReadController";
-import { getRemoteReadState, retryRemoteReads, subscribeRemoteReadState } from "@/query/remoteReadSession";
+import {
+  getRemoteReadBlocker,
+  getRemoteReadState,
+  retryRemoteReads,
+  subscribeRemoteReadBlocker,
+  subscribeRemoteReadState,
+} from "@/query/remoteReadSession";
 
 const definedEntries = <T>(items: Record<string, T | undefined>) =>
   Object.entries(items).filter((entry): entry is [string, T] => entry[1] != null);
@@ -18,6 +24,8 @@ export const useRemoteCollections = () => {
   const reduxDeckState = useSelector((state: RootState) => state.deck);
   const reduxCardState = useSelector((state: RootState) => state.card);
   const remoteState = useSyncExternalStore(subscribeRemoteReadState, getRemoteReadState, getRemoteReadState);
+  const blocker = useSyncExternalStore(subscribeRemoteReadBlocker, getRemoteReadBlocker, getRemoteReadBlocker);
+  const hasActiveUid = uid !== "" && remoteState.uid === uid;
   const remoteDeckQuery = useQuery<RemoteById<Deck>>({
     queryKey: firestoreKeys.decks(uid),
     queryFn: async () => ({}),
@@ -36,25 +44,32 @@ export const useRemoteCollections = () => {
     const localDeckIds = new Set(localDeckEntries.map(([id]) => id));
     const localCardEntries = definedEntries(reduxCards).filter(([, card]) => localDeckIds.has(card.deckId));
     const decksById = {
-      ...(remoteDeckQuery.data ?? {}),
+      ...(hasActiveUid ? (remoteDeckQuery.data ?? {}) : {}),
       ...Object.fromEntries(localDeckEntries),
     };
     const cardsById = {
-      ...(remoteCardQuery.data ?? {}),
+      ...(hasActiveUid ? (remoteCardQuery.data ?? {}) : {}),
       ...Object.fromEntries(localCardEntries),
     };
     const decks = definedEntries(decksById).map(([, deck]) => deck);
     const cards = definedEntries(cardsById).map(([, card]) => card);
     return { decksById, cardsById, decks, cards };
-  }, [reduxDeckState, reduxCardState, remoteDeckQuery.data, remoteCardQuery.data]);
+  }, [reduxDeckState, reduxCardState, remoteDeckQuery.data, remoteCardQuery.data, hasActiveUid]);
 
-  const status: RemoteReadState["status"] =
-    uid === "" ? "idle" : remoteState.uid === uid ? remoteState.status : "loading";
-  const error = remoteState.uid === uid && remoteState.status === "error" ? remoteState.error : undefined;
+  const status: RemoteReadState["status"] | "blocked" = blocker
+    ? "blocked"
+    : uid === ""
+      ? "idle"
+      : hasActiveUid
+        ? remoteState.status
+        : "loading";
+  const error = blocker ?? (hasActiveUid && remoteState.status === "error" ? remoteState.error : undefined);
+  const syncStatus = hasActiveUid && remoteState.status === "ready" ? remoteState.syncStatus : undefined;
 
   return {
     ...collections,
     status,
+    syncStatus,
     error,
     retry: retryRemoteReads,
     deckById: (id: string) => collections.decksById[id],

--- a/src/shared/components/feedback/RemoteReadBoundary.spec.tsx
+++ b/src/shared/components/feedback/RemoteReadBoundary.spec.tsx
@@ -28,6 +28,18 @@ describe("RemoteReadBoundary", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
+  it("blocks data access when another tab owns persistent offline storage", () => {
+    render(
+      <RemoteReadBoundary status="blocked" hasData onRetry={vi.fn()}>
+        cached content
+      </RemoteReadBoundary>
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain("Close other tabs or use a supported browser");
+    expect(screen.queryByText("cached content")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
   it("keeps cached content visible beside a terminal sync error", () => {
     render(
       <RemoteReadBoundary status="error" hasData onRetry={vi.fn()}>

--- a/src/shared/components/feedback/RemoteReadBoundary.tsx
+++ b/src/shared/components/feedback/RemoteReadBoundary.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { Button } from "@/shared/components/forms/Button";
 
 type RemoteReadBoundaryProps = {
-  status: "idle" | "loading" | "ready" | "error";
+  status: "idle" | "loading" | "ready" | "error" | "blocked";
   hasData: boolean;
   emptyLabel?: string;
   onRetry: () => void;
@@ -29,6 +29,16 @@ const ErrorNotice = ({ hasData, onRetry }: Pick<RemoteReadBoundaryProps, "hasDat
 );
 
 export const RemoteReadBoundary = (props: RemoteReadBoundaryProps) => {
+  if (props.status === "blocked") {
+    return (
+      <div
+        role="alert"
+        className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+      >
+        Offline storage is unavailable. Close other tabs or use a supported browser, then reload this page.
+      </div>
+    );
+  }
   if (props.status === "loading" && !props.hasData) return <Status>Loading…</Status>;
   if (props.status === "error" && !props.hasData) {
     return <ErrorNotice hasData={false} onRetry={props.onRetry} />;


### PR DESCRIPTION
## Summary

- configure production Firestore with persistent single-tab cache while keeping memory cache for tests and the emulator
- gate Firestore access behind an exclusive Web Lock and verify the initialized provider to prevent Firebase's silent memory fallback
- replace bootstrap reads with metadata-aware listeners and expose cached, pending, and synced states
- keep remote Query data hidden until the authenticated UID matches the active listener generation
- surface persistence and multi-tab blockers without exposing stale remote data

## Why

This implements the first stage of #280: the persistence and read-synchronization foundation. Later stages can build mutations, conflict handling, migration, and end-to-end coverage on top of this runtime.

## Impact

Production startup now requires verified IndexedDB persistence and exclusive-lock support. If persistence is unavailable or another tab owns the cache, remote reads stay blocked instead of falling back to memory. Test and emulator environments continue to use injectable memory-backed Firestore.

## Validation

- `make check`
- `make test-firestore`

Part of #280