### PR TITLE
Centralize remote collection mutation handling

### DIFF
--- a/src/query/cardMutationService.ts
+++ b/src/query/cardMutationService.ts
@@ -1,9 +1,8 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { isEqual } from "lodash";
 
 import { firestoreKeys } from "@/query/firestoreKeys";
-import type { RemoteById } from "@/query/remoteReadController";
 import { cardMutationLock, withMutationLocks } from "@/query/mutationLocks";
+import { runOptimisticMutation, toRemoteById, type RemoteById } from "@/query/remoteCollection";
 
 export interface CardMutationServiceDependencies {
   client: QueryClient;
@@ -23,8 +22,6 @@ export class CardBulkMutationError extends Error {
   }
 }
 
-const toById = (cards: Card[]): RemoteById<Card> => Object.fromEntries(cards.map((card) => [card.id, card]));
-
 export const createCardMutationService = (dependencies: CardMutationServiceDependencies) => {
   const cards = (uid: string) => dependencies.client.getQueryData<RemoteById<Card>>(firestoreKeys.cards(uid)) ?? {};
 
@@ -38,26 +35,15 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
     next: (previous: RemoteById<Card>) => RemoteById<Card>,
     write: () => Promise<T>
   ): Promise<T> =>
-    withMutationLocks(ids.map(cardMutationLock), async () => {
-      const previous = cards(uid);
-      const optimisticCards = next(previous);
-      replaceCards(uid, optimisticCards);
-      try {
-        return await write();
-      } catch (error) {
-        const current = cards(uid);
-        const rollback = { ...current };
-        ids.forEach((id) => {
-          const optimisticCard = optimisticCards[id];
-          if (!isEqual(current[id], optimisticCard)) return;
-          const previousCard = previous[id];
-          if (previousCard == null) delete rollback[id];
-          else rollback[id] = previousCard;
-        });
-        replaceCards(uid, rollback);
-        throw error;
-      }
-    });
+    withMutationLocks(ids.map(cardMutationLock), () =>
+      runOptimisticMutation({
+        targetIds: ids,
+        read: () => cards(uid),
+        replace: (cards) => replaceCards(uid, cards),
+        update: next,
+        mutation: write,
+      })
+    );
 
   return {
     create: (uid: string, card: Card) =>
@@ -94,7 +80,7 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
         upserts.map((card) => cardMutationLock(card.id)),
         async () => {
           const previous = cards(uid);
-          replaceCards(uid, { ...previous, ...toById(upserts) });
+          replaceCards(uid, { ...previous, ...toRemoteById(upserts) });
           const results = await Promise.allSettled(upserts.map(dependencies.upsertCard));
           const failedIds = results.flatMap((result, index) => {
             const card = upserts[index];
@@ -103,7 +89,7 @@ export const createCardMutationService = (dependencies: CardMutationServiceDepen
           if (failedIds.length === 0) return;
 
           const authoritative = await dependencies.readCards(uid);
-          replaceCards(uid, toById(authoritative));
+          replaceCards(uid, toRemoteById(authoritative));
           throw new CardBulkMutationError(failedIds, upserts.length);
         }
       ),

--- a/src/query/deckMutationService.ts
+++ b/src/query/deckMutationService.ts
@@ -1,9 +1,8 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { isEqual } from "lodash";
 
 import { firestoreKeys } from "@/query/firestoreKeys";
 import { cardMutationLock, deckMutationLock, withMutationLocks } from "@/query/mutationLocks";
-import type { RemoteById } from "@/query/remoteReadController";
+import { runOptimisticMutation, type RemoteById } from "@/query/remoteCollection";
 
 export interface DeckMutationServiceDependencies {
   client: QueryClient;
@@ -19,40 +18,41 @@ export const createDeckMutationService = (dependencies: DeckMutationServiceDepen
     dependencies.client.setQueryData(firestoreKeys.decks(uid), next);
   const setCards = (uid: string, next: RemoteById<Card>) =>
     dependencies.client.setQueryData(firestoreKeys.cards(uid), next);
+  const optimisticDeck = <T>(
+    uid: string,
+    id: DeckId,
+    update: (previous: RemoteById<Deck>) => RemoteById<Deck>,
+    mutation: () => Promise<T>
+  ) =>
+    withMutationLocks([deckMutationLock(id)], () =>
+      runOptimisticMutation({
+        targetIds: [id],
+        read: () => decks(uid),
+        replace: (decks) => setDecks(uid, decks),
+        update,
+        mutation,
+      })
+    );
 
   return {
     create: (uid: string, deck: Deck) =>
-      withMutationLocks([deckMutationLock(deck.id)], async () => {
-        const previous = decks(uid);
-        setDecks(uid, { ...previous, [deck.id]: deck });
-        try {
-          return await dependencies.createDeck(deck);
-        } catch (error) {
-          const current = decks(uid);
-          if (isEqual(current[deck.id], deck)) {
-            const rollback = { ...current };
-            if (previous[deck.id] == null) delete rollback[deck.id];
-            else rollback[deck.id] = previous[deck.id];
-            setDecks(uid, rollback);
-          }
-          throw error;
-        }
-      }),
+      optimisticDeck(
+        uid,
+        deck.id,
+        (previous) => ({ ...previous, [deck.id]: deck }),
+        () => dependencies.createDeck(deck)
+      ),
     update: (uid: string, patch: DeckEdit) =>
-      withMutationLocks([deckMutationLock(patch.id)], async () => {
-        const previous = decks(uid);
-        const currentDeck = previous[patch.id];
-        if (currentDeck == null) throw new Error(`Deck ${patch.id} is not available`);
-        const optimistic = { ...currentDeck, ...patch };
-        setDecks(uid, { ...previous, [patch.id]: optimistic });
-        try {
-          await dependencies.updateDeck(patch);
-        } catch (error) {
-          const current = decks(uid);
-          if (isEqual(current[patch.id], optimistic)) setDecks(uid, { ...current, [patch.id]: currentDeck });
-          throw error;
-        }
-      }),
+      optimisticDeck(
+        uid,
+        patch.id,
+        (previous) => {
+          const current = previous[patch.id];
+          if (current == null) throw new Error(`Deck ${patch.id} is not available`);
+          return { ...previous, [patch.id]: { ...current, ...patch } };
+        },
+        () => dependencies.updateDeck(patch)
+      ),
     remove: (uid: string, id: DeckId) => {
       const childIds = Object.values(cards(uid))
         .filter((card): card is Card => card?.deckId === id)

--- a/src/query/remoteCollection.ts
+++ b/src/query/remoteCollection.ts
@@ -1,0 +1,41 @@
+import { isEqual } from "lodash";
+
+export type RemoteById<T> = Record<string, T | undefined>;
+
+export const toRemoteById = <T extends { id: string }>(items: T[]): RemoteById<T> =>
+  Object.fromEntries(items.map((item) => [item.id, item]));
+
+interface OptimisticMutationOptions<T, Result> {
+  targetIds: string[];
+  read: () => RemoteById<T>;
+  replace: (next: RemoteById<T>) => void;
+  update: (previous: RemoteById<T>) => RemoteById<T>;
+  mutation: () => Promise<Result>;
+}
+
+export const runOptimisticMutation = async <T, Result>({
+  targetIds,
+  read,
+  replace,
+  update,
+  mutation,
+}: OptimisticMutationOptions<T, Result>): Promise<Result> => {
+  const previous = read();
+  const optimistic = update(previous);
+  replace(optimistic);
+
+  try {
+    return await mutation();
+  } catch (error) {
+    const current = read();
+    const rollback = { ...current };
+    targetIds.forEach((id) => {
+      if (!isEqual(current[id], optimistic[id])) return;
+      const previousItem = previous[id];
+      if (previousItem == null) delete rollback[id];
+      else rollback[id] = previousItem;
+    });
+    replace(rollback);
+    throw error;
+  }
+};

--- a/src/query/remoteReadController.ts
+++ b/src/query/remoteReadController.ts
@@ -3,8 +3,7 @@ import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import type { RemoteSnapshot } from "@/action/firestore/event";
 import { firestoreKeys } from "@/query/firestoreKeys";
 import { createFirestoreSyncController, type FirestoreSyncState } from "@/query/firestoreSyncController";
-
-export type RemoteById<T> = Record<string, T | undefined>;
+import { toRemoteById, type RemoteById } from "@/query/remoteCollection";
 
 export interface RemoteSubscriptionProps<T> {
   uid: string;
@@ -23,9 +22,6 @@ export interface RemoteReadDependencies {
     event: { added?: T[]; modified?: T[]; removed?: string[] }
   ) => RemoteById<T>;
 }
-
-const toById = <T extends { id: string }>(items: T[]): RemoteById<T> =>
-  Object.fromEntries(items.map((item) => [item.id, item]));
 
 export const createRemoteReadController = (dependencies: RemoteReadDependencies) => {
   const syncController = createFirestoreSyncController(["deck", "card"] as const);
@@ -58,7 +54,7 @@ export const createRemoteReadController = (dependencies: RemoteReadDependencies)
     if (!syncController.isCurrent(uid, generation)) return;
     const previous = dependencies.client.getQueryData<RemoteById<T>>(queryKey) ?? {};
     const next =
-      snapshot.type === "replace" ? toById(snapshot.items) : dependencies.applyChange(previous, snapshot.event);
+      snapshot.type === "replace" ? toRemoteById(snapshot.items) : dependencies.applyChange(previous, snapshot.event);
     dependencies.client.setQueryData(queryKey, next);
     syncController.observe(uid, generation, collection, snapshot.metadata);
   };

--- a/src/query/useRemoteCollections.ts
+++ b/src/query/useRemoteCollections.ts
@@ -6,7 +6,8 @@ import { uniq } from "lodash";
 import { useAuth } from "@/auth/AuthContext";
 import { filterCardsForDeck } from "@/lib/study";
 import { firestoreKeys } from "@/query/firestoreKeys";
-import type { RemoteById, RemoteReadState } from "@/query/remoteReadController";
+import type { RemoteById } from "@/query/remoteCollection";
+import type { RemoteReadState } from "@/query/remoteReadController";
 import {
   getRemoteReadBlocker,
   getRemoteReadState,


### PR DESCRIPTION
## Summary

- add shared helpers for remote collection indexing and optimistic mutation rollback
- reuse conflict-aware rollback behavior across Card and Deck mutation services
- decouple the remote collection type from the read controller

## Testing

- `make check`