### PR TITLE
Prevent stale app shell caching

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,6 +16,26 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
+    ],
     "rewrites": [
       {
         "source": "**",

--- a/src/lib/hostingConfig.spec.ts
+++ b/src/lib/hostingConfig.spec.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+interface HostingHeaderRule {
+  source: string;
+  headers: Array<{ key: string; value: string }>;
+}
+
+interface FirebaseConfig {
+  hosting: { headers?: HostingHeaderRule[] };
+}
+
+const firebaseConfig = JSON.parse(readFileSync(path.resolve(process.cwd(), "firebase.json"), "utf8")) as FirebaseConfig;
+
+describe("Firebase Hosting cache policy", () => {
+  it("revalidates app routes while caching fingerprinted assets", () => {
+    expect(firebaseConfig.hosting.headers).toEqual([
+      {
+        source: "**",
+        headers: [{ key: "Cache-Control", value: "no-cache, no-store" }],
+      },
+      {
+        source: "/assets/**",
+        headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- revalidate Firebase Hosting app-shell responses so deployments cannot leave browsers pointing at stale bundles
- keep fingerprinted files under /assets cached for one year with immutable semantics
- add a regression test for the Hosting cache policy

## Root cause

The deployed index.html was cached in browsers for one hour. After the Firestore initialization regression was fixed and redeployed, existing clients could continue loading the previous JavaScript bundle and remain on a blank page.

## Testing

- make check (77 test files, 420 tests)
- Firebase Hosting Emulator: / and a rewritten SPA route return Cache-Control: no-cache, no-store
- Firebase Hosting Emulator: /assets/index-*.js returns Cache-Control: public, max-age=31536000, immutable
- fresh production bundle renders the Decks screen without console errors