### PR TITLE
Restore Sample Deck for empty users

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,4 +62,4 @@ UI の依存方向は `App -> Page -> Container -> Template -> Component` です
 - 長期設定と学習セッションはそれぞれ Zustand store で管理し、設定は `tango-config`、学習状態は `tango-study` に永続化します。
 - Firebase Auth の runtime identity は Auth Context だけから参照し、LocalStorage の application state には保存しません。
 - `src/action/firestore` が Firestore との入出力を、`src/auth/AuthBootstrap.tsx` が認証に連動した購読 lifecycle を担当します。
-- `sample/build/output.json` のサンプルカードは Import 画面の明示操作で Firestore に追加します。
+- `sample/build/output.json` のサンプルカードは、サーバー同期後に Deck が0件なら自動で Firestore に追加します。Import 画面からの明示操作でも追加できます。

--- a/docs/summary/features.md
+++ b/docs/summary/features.md
@@ -75,7 +75,7 @@ Key files: `src/page/ConfigPage.tsx`, `src/features/settings/containers/ConfigCo
 ## Sample Deck
 
 - `sample/generate.py` が Python test files から card data を生成します。
-- Import 画面の Add sample deck 操作が `sample/build/output.json` を読み込み、通常の Firestore mutation で追加します。
+- サーバー同期後に Deck が0件なら `sample/build/output.json` を通常の Firestore mutation で自動追加します。Import 画面の Add sample deck 操作でも追加できます。
 - 同じ UID では決定的な sample deck ID を使うため、再実行しても duplicate deck を作りません。
 
 Key files: `sample/generate.py`, `src/features/import/hooks/useDeckImport.ts`, `src/features/import/containers/DeckImportContainer.tsx`

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -17,7 +17,7 @@ test("shows the deck list smoke screen", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByText("tango")).toBeVisible();
-  await expect(page.getByRole("status")).toHaveText("No decks yet.");
+  await expect(page.getByText("Sample Deck", { exact: true })).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });
 

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -52,6 +52,8 @@ vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
   useDeckMutations: () => ({ remove: vi.fn(), pending: false, error: null, retry: vi.fn() }),
 }));
 
+vi.mock("@/features/import/hooks/useSampleDeckBootstrap", () => ({ useSampleDeckBootstrap: vi.fn() }));
+
 import { DeckListContainer } from "@/features/deck/containers/DeckListContainer";
 
 describe("DeckListContainer", () => {

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -8,6 +8,7 @@ import { useActions } from "@/shared/hooks/useActions";
 import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
 import { useStudyStore } from "@/features/study/hooks/useStudyStore";
 import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
+import { useSampleDeckBootstrap } from "@/features/import/hooks/useSampleDeckBootstrap";
 import { useConfig } from "@/features/settings/hooks/useConfig";
 
 export const DeckListContainer: React.FC = () => {
@@ -17,6 +18,7 @@ export const DeckListContainer: React.FC = () => {
   const mutations = useDeckMutations();
   const decks = remote.decks;
   const studySession = useStudyStore((state) => state.session);
+  useSampleDeckBootstrap();
   useKey("s", actions.goToSettings);
   useKey("i", actions.goToImport);
 

--- a/src/features/import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -1,0 +1,76 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { StrictMode, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: { status: "authenticated", uid: "uid-a" } as { status: "authenticated"; uid: string } | { status: "loading" },
+  remote: {
+    status: "ready" as "idle" | "loading" | "ready" | "error" | "blocked",
+    syncStatus: "synced" as "cached" | "pending" | "synced" | undefined,
+    decks: [] as Deck[],
+  },
+  addSample: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock("@/auth/AuthContext", () => ({ useAuth: () => mocks.auth }));
+vi.mock("@/query/useRemoteCollections", () => ({ useRemoteCollections: () => mocks.remote }));
+vi.mock("@/features/import/hooks/useDeckImport", () => ({
+  useDeckImport: () => ({ addSample: mocks.addSample }),
+}));
+
+import {
+  createSampleDeckBootstrapController,
+  useSampleDeckBootstrap,
+} from "@/features/import/hooks/useSampleDeckBootstrap";
+
+const strictMode = ({ children }: { children: ReactNode }) => <StrictMode>{children}</StrictMode>;
+
+describe("sample Deck bootstrap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth = { status: "authenticated", uid: crypto.randomUUID() };
+    mocks.remote = { status: "ready", syncStatus: "synced", decks: [] };
+    mocks.addSample.mockResolvedValue(undefined);
+  });
+
+  it("adds the sample once for a server-synced empty user under StrictMode", async () => {
+    renderHook(useSampleDeckBootstrap, { wrapper: strictMode });
+
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+  });
+
+  it("waits for the server before treating an empty cache as an empty user", async () => {
+    mocks.remote.syncStatus = "cached";
+    const { rerender } = renderHook(useSampleDeckBootstrap);
+
+    expect(mocks.addSample).not.toHaveBeenCalled();
+    mocks.remote.syncStatus = "synced";
+    rerender();
+
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+  });
+
+  it("does not add the sample when the user already has a Deck", () => {
+    mocks.remote.decks = [{ id: "existing" } as Deck];
+
+    renderHook(useSampleDeckBootstrap);
+
+    expect(mocks.addSample).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent starts for one user", async () => {
+    const controller = createSampleDeckBootstrapController();
+    let finish!: () => void;
+    const addSample = vi.fn(() => new Promise<void>((resolve) => (finish = resolve)));
+
+    const first = controller.start("uid-a", addSample);
+    const second = controller.start("uid-a", addSample);
+
+    expect(first).toBe(second);
+    expect(addSample).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(addSample).toHaveBeenCalledOnce();
+    finish();
+    await first;
+  });
+});

--- a/src/features/import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/import/hooks/useSampleDeckBootstrap.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+
+import { useAuth } from "@/auth/AuthContext";
+import { useDeckImport } from "@/features/import/hooks/useDeckImport";
+import { useRemoteCollections } from "@/query/useRemoteCollections";
+
+type AddSample = () => Promise<unknown>;
+
+export const createSampleDeckBootstrapController = () => {
+  const completedUids = new Set<string>();
+  const pendingByUid = new Map<string, Promise<unknown>>();
+
+  return {
+    start: (uid: string, addSample: AddSample) => {
+      if (completedUids.has(uid)) return;
+      const pending = pendingByUid.get(uid);
+      if (pending != null) return pending;
+
+      const operation = Promise.resolve().then(addSample);
+      pendingByUid.set(uid, operation);
+      void operation.then(
+        () => {
+          pendingByUid.delete(uid);
+          completedUids.add(uid);
+        },
+        () => pendingByUid.delete(uid)
+      );
+      return operation;
+    },
+  };
+};
+
+const sampleDeckBootstrapController = createSampleDeckBootstrapController();
+
+export const useSampleDeckBootstrap = () => {
+  const auth = useAuth();
+  const remote = useRemoteCollections();
+  const deckImport = useDeckImport();
+  const uid = auth.status === "authenticated" ? auth.uid : "";
+
+  useEffect(() => {
+    if (uid === "" || remote.status !== "ready" || remote.syncStatus !== "synced" || remote.decks.length > 0) {
+      return;
+    }
+    void sampleDeckBootstrapController.start(uid, deckImport.addSample)?.catch(() => undefined);
+  }, [deckImport.addSample, remote.decks.length, remote.status, remote.syncStatus, uid]);
+};


### PR DESCRIPTION
## Summary

- add the bundled Sample Deck after the server confirms a user has no Decks
- avoid treating an empty cache as an empty account and deduplicate concurrent bootstraps
- cover the restored behavior with unit and browser smoke tests

## Testing

- `make check`
- `make e2e`