### PR TITLE
Redesign deck list for multiple study sessions

### DIFF
--- a/docs/superpowers/specs/2026-07-18-deck-list-ui-design.md
+++ b/docs/superpowers/specs/2026-07-18-deck-list-ui-design.md
@@ -99,6 +99,7 @@ interface PersistedStudyState {
 - `startStudy(deckId, cardOrderIds)`は対象デッキのセッションだけをindex 0で作成または置換し、`lastStudiedAt`を現在時刻にする。
 - `touchStudy(deckId)`はContinueまたは直接の学習画面表示時に対象セッションの`lastStudiedAt`だけを更新する。
 - `setCurrentIndex(deckId, currentIndex)`は対象セッションのindexと`lastStudiedAt`だけを更新する。
+- 次のindexが学習終了を示す`-1`になった場合は`setCurrentIndex`を呼ばず、対象セッションを直ちに削除して一覧へ戻す。無効なindexは永続化しない。
 - `removeStudy(deckId)`は対象デッキのセッションだけを削除する。
 - 認証解除などアプリ全体のリセットでは、すべてのセッションと一時UI状態を削除する。
 - route用selectorは`deckId`で該当セッションを直接返す。
@@ -109,7 +110,7 @@ interface PersistedStudyState {
 
 study storeの永続化versionを2から3へ上げる。
 
-- version 2の有効な単一`session`は、同じ`deckId`をキーにした` sessionsByDeckId`へ移す。
+- version 2の有効な単一`session`は、同じ`deckId`をキーにした`sessionsByDeckId`へ移す。
 - 移行したセッションの`lastStudiedAt`は`0`にする。移行直後は最大1件のため並び順に影響せず、次回のStartまたはContinueで実時刻へ更新される。
 - version 1も既存のsanitizerを経由して同じversion 3形式へ移す。
 - 不正なセッションはその要素だけを破棄し、有効な別セッションを巻き込まない。
@@ -123,7 +124,7 @@ study storeの永続化versionを2から3へ上げる。
 
 ### `DeckListContainer`
 
-remote collectionのデッキ・カードと、hydration済みの` sessionsByDeckId`を結合する。表示用データをStudyingとOther decksへ分割し、Studyingは最終学習時刻降順、Other decksは名前昇順にする。各デッキのカード総数もここで算出する。
+remote collectionのデッキ・カードと、hydration済みの`sessionsByDeckId`を結合する。表示用データをStudyingとOther decksへ分割し、Studyingは最終学習時刻降順、Other decksは名前昇順にする。各デッキのカード総数もここで算出する。
 
 LocalStorageのhydrationが終わるまではセクションを確定せず、全デッキが一度Other decksへ表示された後に移動するちらつきを防ぐ。
 

--- a/docs/superpowers/specs/2026-07-18-deck-list-ui-design.md
+++ b/docs/superpowers/specs/2026-07-18-deck-list-ui-design.md
@@ -1,0 +1,203 @@
+# デッキ一覧UI改善デザイン
+
+## 背景
+
+現行のデッキ一覧は、デッキごとに大きなカードを表示し、Study、Restart、Download、Edit、Deleteを同程度の強さで並べている。スマートフォンでは1画面に表示できるデッキ数が少なく、10件未満でも名前を見比べにくい。
+
+また、学習状態はZustandのstudy storeに単一の`session`として保存されているため、あるデッキの学習を開始すると別デッキの進捗を保持できない。改善後は複数デッキの学習を並行して保持し、一覧からそれぞれ再開できるようにする。
+
+## 目的
+
+- スマートフォンで10件未満のデッキを素早く見つけられるようにする。
+- 複数の学習中デッキを一覧上部にまとめ、各デッキを直接再開できるようにする。
+- デッキ名を縦に読みやすくし、管理操作の視覚的な優先度を下げる。
+- 既存の学習セッションを失わず、新しい複数セッション形式へ移行する。
+- 現行のCalm Focusトークン、ダークモード、レスポンシブ設計を維持する。
+
+## 非目標
+
+- 検索、フィルター、タブを追加しない。対象件数が10件未満のため、常設コントロールは過剰である。
+- 学習セッションをFirestoreへ同期しない。現行どおり端末内のLocalStorageだけに保存する。
+- Header、Import、Settings、デッキ内カード一覧の情報設計は変更しない。
+- 現在無効になっているReimport操作は有効化しない。
+
+## 採用したUI
+
+### ページ構成
+
+デッキをカードグリッドではなく、スマートフォンで読みやすい1列のコンパクトリストとして表示する。
+
+```text
+Decks                                      7 decks
+
+STUDYING                       3 decks · recent first
+┌──────────────────────────────────────────────┐
+│ Design Systems       Design  9 / 42 · 5m  ▶ ⋯│
+│ English Phrasal...   English 27 / 64 · 1d ▶ ⋯│
+│ AWS Certification   Tech   38 / 120 · 3d  ▶ ⋯│
+└──────────────────────────────────────────────┘
+
+OTHER DECKS                         4 decks · A–Z
+┌──────────────────────────────────────────────┐
+│ French Vocabulary   French  52 cards  Study ⋯│
+│ Japanese History    History 38 cards  Study ⋯│
+│ Mathematics Basics  Math    24 cards  Study ⋯│
+└──────────────────────────────────────────────┘
+```
+
+### Studyingセクション
+
+- 現在セッションを持つデッキを表示する。
+- `lastStudiedAt`の降順で並べる。
+- デッキ名、カテゴリ、`currentIndex + 1 / cardOrderIds.length`、最終学習時刻、進捗バーを表示する。
+- Continueボタンから対象デッキの既存セッションを再開する。
+- 0件の場合は見出しを含めて表示しない。
+
+### Other decksセクション
+
+- 現在セッションを持たないデッキを表示する。過去に学習済みでも、現在セッションがなければこのセクションに含める。
+- デッキ名の昇順で並べる。
+- デッキ名、カテゴリ、デッキ内のカード総数を表示する。
+- Studyボタンから既存の開始設定画面へ移動する。
+- 0件の場合は見出しを含めて表示しない。
+
+### 操作
+
+- デッキ名または行の主領域を押すと、既存のカード一覧へ移動する。
+- Continueは既存セッションの学習画面へ移動し、対象セッションの`lastStudiedAt`を更新する。
+- Studyは開始設定画面へ移動する。
+- 各行の「…」は`DeckActionsMenu`を開く。
+- メニューにはDownload、Edit、Deleteを表示する。
+- 学習中デッキだけRestartを追加し、開始設定画面から新しいセッションを作り直せるようにする。
+- Deleteは既存の確認を維持し、削除成功後に対象デッキのセッションも除去する。
+
+Headerのロゴ、ダークモード、Import、Settingsは現行どおり維持する。新しいフローティングボタンは追加しない。
+
+## 学習状態モデル
+
+### 永続化する状態
+
+単一の`session`を、デッキIDをキーにした`sessionsByDeckId`へ変更する。
+
+```ts
+interface StudySession {
+  deckId: DeckId;
+  cardOrderIds: CardId[];
+  currentIndex: number;
+  lastStudiedAt: number;
+}
+
+interface PersistedStudyState {
+  sessionsByDeckId: Partial<Record<DeckId, StudySession>>;
+}
+```
+
+`showBackText`、`autoPlay`、`lastSwipe`は現在表示中の学習画面だけが使う一時的なUI状態として、従来どおり永続化対象外にする。
+
+### Store操作
+
+- `startStudy(deckId, cardOrderIds)`は対象デッキのセッションだけをindex 0で作成または置換し、`lastStudiedAt`を現在時刻にする。
+- `touchStudy(deckId)`はContinueまたは直接の学習画面表示時に対象セッションの`lastStudiedAt`だけを更新する。
+- `setCurrentIndex(deckId, currentIndex)`は対象セッションのindexと`lastStudiedAt`だけを更新する。
+- `removeStudy(deckId)`は対象デッキのセッションだけを削除する。
+- 認証解除などアプリ全体のリセットでは、すべてのセッションと一時UI状態を削除する。
+- route用selectorは`deckId`で該当セッションを直接返す。
+
+セッション完了時は対象デッキのセッションだけを削除し、ほかのデッキの進捗を維持する。
+
+### LocalStorage移行
+
+study storeの永続化versionを2から3へ上げる。
+
+- version 2の有効な単一`session`は、同じ`deckId`をキーにした` sessionsByDeckId`へ移す。
+- 移行したセッションの`lastStudiedAt`は`0`にする。移行直後は最大1件のため並び順に影響せず、次回のStartまたはContinueで実時刻へ更新される。
+- version 1も既存のsanitizerを経由して同じversion 3形式へ移す。
+- 不正なセッションはその要素だけを破棄し、有効な別セッションを巻き込まない。
+- 有効条件は、`deckId`と全card IDが文字列、`cardOrderIds`が空でない、`currentIndex`が0以上かつ配列長未満、`lastStudiedAt`が有限の非負数であることとする。
+
+## コンポーネント境界
+
+### `studyStore`
+
+複数セッションの保存、対象デッキだけの更新、永続化移行、入力値のsanitizationを担当する。画面遷移やデッキ表示順は担当しない。
+
+### `DeckListContainer`
+
+remote collectionのデッキ・カードと、hydration済みの` sessionsByDeckId`を結合する。表示用データをStudyingとOther decksへ分割し、Studyingは最終学習時刻降順、Other decksは名前昇順にする。各デッキのカード総数もここで算出する。
+
+LocalStorageのhydrationが終わるまではセクションを確定せず、全デッキが一度Other decksへ表示された後に移動するちらつきを防ぐ。
+
+### `DeckListTemplate`
+
+受け取った2セクションを描画する。store、remote collection、画面遷移には依存しない。空のセクションは描画しない。
+
+### `DeckCard`
+
+既存の大きなカードをコンパクトな行へ変更する。表示データとcallbackだけを受け取り、学習状態の取得や並び替えは行わない。長いデッキ名は1行で省略し、主操作のタッチ領域を44px以上にする。
+
+### `DeckActionsMenu`
+
+管理操作をまとめる独立コンポーネントとする。トリガーに対象デッキ名を含むaria-labelを付け、キーボードで開閉・選択・終了できるようにする。Deleteはdanger表現を維持する。
+
+## データフロー
+
+1. Remote collectionからデッキとカードが読み込まれる。
+2. study storeのLocalStorage hydrationが完了する。
+3. `DeckListContainer`が各デッキにセッションとカード数を結合する。
+4. セッションありをStudying、なしをOther decksへ分割し、それぞれソートする。
+5. Continue時は対象セッションをtouchして`/deck/:id/study`へ移動する。
+6. StudyまたはRestart時は`/deck/:id/start`へ移動し、Start確定時に対象デッキのセッションだけを作成または置換する。
+7. swipe、controller、auto playはrouteの`deckId`に対応するセッションだけを更新する。
+8. 学習完了時は対象セッションを削除して一覧へ戻す。
+
+## エラーと整合性
+
+- persisted stateはセッション単位で検証し、壊れた要素だけを除去する。
+- Remote collection読込後に存在しないデッキのセッションを除去する。
+- セッションの現在カードが削除済みなどで学習を継続できない場合は、対象セッションだけを終了して一覧へ戻す。
+- card mutation失敗時のoptimistic rollbackは、対象デッキのindexと`lastStudiedAt`および既存の一時UI状態だけを戻す。別デッキのセッションは変更しない。
+- deck mutationのpending/error表示には既存の`RemoteMutationNotice`を使う。
+- 全デッキがない場合は既存の`RemoteReadBoundary`のempty表示を維持する。
+
+## アクセシビリティ
+
+- Continue、Study、メニュー、全メニュー項目をbuttonとして実装する。
+- アイコンだけの操作には対象デッキ名を含むaria-labelを付ける。
+- 行全体をクリック可能にする場合も、内部buttonの操作がカード一覧遷移を発火しないようイベントを分離する。
+- focus ring、色、danger表現は既存のCalm Focus tokenを使う。
+- 進捗は文字情報でも示し、色やバーだけに依存しない。
+- 44px以上のタッチ領域と、長いデッキ名でも操作を押し出さないレイアウトを維持する。
+
+## テスト方針
+
+### State unit tests
+
+- 2つ以上のセッションを開始し、両方が保持される。
+- index更新、touch、完了、削除が対象デッキだけに作用する。
+- version 1と2の有効な単一セッションがversion 3へ移行する。
+- 複数のpersisted sessionのうち、不正な要素だけが除去される。
+- store全体のclearだけが全セッションを削除する。
+
+### Presentation unit tests
+
+- Studyingが`lastStudiedAt`降順になる。
+- Other decksがデッキ名昇順になる。
+- セッション有無でデッキが正しいセクションへ一度だけ表示される。
+- 0件のセクション見出しを表示しない。
+- Continue、Study、Restart、Download、Edit、Deleteが正しいdeck IDを渡す。
+- 長い名前、進捗、カード数、相対時刻を表示する。
+- 操作メニューのaria-label、キーボード操作、focus、Deleteのdanger表現を検証する。
+
+### Stories and visual coverage
+
+- モバイル、デスクトップ、ダークモードを用意する。
+- すべてOther decks、すべてStudying、両方混在、長い名前、空一覧を用意する。
+
+### E2E
+
+- デッキAを開始し、別のデッキBを開始してもAの進捗が残る。
+- 一覧のStudyingにAとBが表示される。
+- Continueで各デッキの正しいカードとindexを再開する。
+- 一方を完了しても他方がStudyingに残る。
+
+実装完了前に`make check`を実行する。

--- a/e2e/deck-list.e2e.ts
+++ b/e2e/deck-list.e2e.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Page } from "@playwright/test";
+import { routeAnonymousAuth, seedConfig, seedDeckAndCards } from "./fixtures";
+
+const uid = "deck-list-e2e-user";
+
+const createDeck = (id: string, name: string) => ({
+  id,
+  name,
+  category: "English",
+  uid,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  scoreMax: null,
+  scoreMin: null,
+  isPublic: false,
+  selectedTags: [],
+  tagAndFilter: false,
+  convertToBr: false,
+});
+
+const createCard = (id: string, deckId: string, frontText: string) => ({
+  id,
+  deckId,
+  uid,
+  frontText,
+  backText: `${frontText} back`,
+  tags: [],
+  uniqueKey: id,
+  score: 0,
+  numberOfSeen: 0,
+  interval: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+});
+
+const deckA = createDeck("deck-list-e2e-a", "Deck A");
+const deckB = createDeck("deck-list-e2e-b", "Deck B");
+const cardsA = [
+  createCard("deck-list-e2e-a-1", deckA.id, "A first"),
+  createCard("deck-list-e2e-a-2", deckA.id, "A second"),
+];
+const cardsB = [createCard("deck-list-e2e-b-1", deckB.id, "B only")];
+
+const seedDecks = async (page: Page) => {
+  await routeAnonymousAuth(page, uid);
+  await seedConfig(page);
+  await Promise.all([seedDeckAndCards(deckA, cardsA), seedDeckAndCards(deckB, cardsB)]);
+};
+
+test.beforeEach(async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await seedDecks(page);
+  await page.exposeFunction("assertNoBrowserErrors", () => expect(errors).toEqual([]));
+});
+
+test("keeps independent progress for multiple studying decks", async ({ page }) => {
+  await page.goto(`/deck/${deckA.id}/start`);
+  await page.getByRole("button", { name: "Start to study 2 card(s) from 2" }).click();
+  await expect(page.getByText("A first")).toBeVisible();
+  await page.getByRole("button", { name: "Swipe up" }).click();
+  await expect(page.getByText("A second")).toBeVisible();
+
+  await page.goto(`/deck/${deckB.id}/start`);
+  await page.getByRole("button", { name: "Start to study 1 card(s) from 1" }).click();
+  await expect(page.getByText("B only")).toBeVisible();
+
+  await page.goto("/");
+  const studying = page.getByRole("region", { name: "Studying" });
+  await expect(studying.getByRole("button", { name: "Continue Deck A" })).toBeVisible();
+  await expect(studying.getByRole("button", { name: "Continue Deck B" })).toBeVisible();
+
+  await studying.getByRole("button", { name: "Continue Deck A" }).click();
+  await expect(page.getByText("A second")).toBeVisible();
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Continue Deck B" }).click();
+  await expect(page.getByText("B only")).toBeVisible();
+  await page.getByRole("button", { name: "Swipe up" }).click();
+
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole("button", { name: "Continue Deck A" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Continue Deck B" })).not.toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});

--- a/e2e/deck.e2e.ts
+++ b/e2e/deck.e2e.ts
@@ -39,9 +39,6 @@ const seedDeckSession = async (page: Page) => {
   await seedDeckAndCards(e2eDeck, [e2eCard]);
 };
 
-const deckCard = (page: Page, name: string) =>
-  page.getByText(name).locator("xpath=ancestor::div[contains(@class, 'rounded')][1]");
-
 test.beforeEach(async ({ page }) => {
   const errors: string[] = [];
   page.on("console", (message) => {
@@ -64,7 +61,7 @@ test("navigates from the deck list to the card list", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByText("E2E Deck")).toBeVisible();
-  await page.getByText("E2E Deck").click();
+  await page.getByRole("button", { name: "View E2E Deck" }).click();
 
   await expect(page).toHaveURL(new RegExp(`/deck/${e2eDeck.id}$`));
   await expect(page.getByText("apple")).toBeVisible();
@@ -74,7 +71,8 @@ test("navigates from the deck list to the card list", async ({ page }) => {
 test("saves deck edits and returns to the deck list", async ({ page }) => {
   await page.goto("/");
 
-  await deckCard(page, "E2E Deck").locator("svg").nth(1).click();
+  await page.getByRole("button", { name: "Open actions for E2E Deck" }).click();
+  await page.getByRole("menuitem", { name: "Edit" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${e2eDeck.id}/edit$`));
 
   await page.locator('input[name="name"]').fill("Updated E2E Deck");
@@ -89,7 +87,8 @@ test("deletes a deck from the deck list", async ({ page }) => {
   await page.goto("/");
 
   page.on("dialog", (dialog) => dialog.accept());
-  await deckCard(page, "E2E Deck").locator("svg").nth(2).click();
+  await page.getByRole("button", { name: "Open actions for E2E Deck" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
 
   await expect(page.getByText("E2E Deck")).not.toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -47,9 +47,6 @@ const getDocument = async (collection: "deck" | "card", id: string) => {
   return (await response.json()) as { fields: Record<string, { stringValue?: string }> };
 };
 
-const deckCard = (page: Page, name: string) =>
-  page.getByText(name, { exact: true }).locator("xpath=ancestor::div[contains(@class, 'rounded')][1]");
-
 const cardItem = (page: Page, frontText: string) =>
   page.getByText(frontText, { exact: true }).locator("xpath=ancestor::div[contains(@class, 'rounded')][1]");
 
@@ -170,7 +167,7 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
     .poll(async () => (await getDocument("deck", "remote-read-deck")).fields.name?.stringValue)
     .toBe("Updated Remote Query Deck");
 
-  await page.getByText("Updated Remote Query Deck").click();
+  await page.getByRole("button", { name: "View Updated Remote Query Deck" }).click();
   await expect(page.getByText("Remote Query Card")).toBeVisible();
 
   await page.goto("/card/remote-read-card/edit");
@@ -191,7 +188,8 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
   await expect(page.getByText("Updated Remote Query Card")).not.toBeVisible();
 
   await page.goto("/");
-  await deckCard(page, "Updated Remote Query Deck").locator("svg").nth(2).click();
+  await page.getByRole("button", { name: "Open actions for Updated Remote Query Deck" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
   await expect(page.getByText("Updated Remote Query Deck")).not.toBeVisible();
 
   const persistedEntityState = await page.evaluate(() => {

--- a/e2e/swipe.e2e.ts
+++ b/e2e/swipe.e2e.ts
@@ -127,15 +127,17 @@ test("updates study progress with a mastered deck swipe", async ({ page }) => {
 
   await expect(page.getByText("banana")).toBeVisible();
   await expect.poll(async () => persistedCard(e2eCards[0]?.id ?? "")).toMatchObject({ score: 1, numberOfSeen: 1 });
-  await expect.poll(async () => persistedStudyEnvelope(page)).toEqual({
+  await expect.poll(async () => persistedStudyEnvelope(page)).toMatchObject({
     state: {
-      session: {
-        deckId: e2eDeck.id,
-        cardOrderIds: e2eCards.map((card) => card.id),
-        currentIndex: 1,
+      sessionsByDeckId: {
+        [e2eDeck.id]: {
+          deckId: e2eDeck.id,
+          cardOrderIds: e2eCards.map((card) => card.id),
+          currentIndex: 1,
+        },
       },
     },
-    version: 2,
+    version: 3,
   });
   await expect.poll(async () => persistedStateBoundaries(page)).toEqual({
     rootDeck: false,

--- a/src/action/event.spec.ts
+++ b/src/action/event.spec.ts
@@ -28,7 +28,7 @@ describe("event action", () => {
     mocks.suspendAnonymousBootstrap.mockReturnValue(mocks.resumeAnonymousBootstrap);
     mocks.auth.currentUser = null;
     localStorage.clear();
-    studyStore.setState({ session: null, showBackText: false, autoPlay: false, lastSwipe: undefined });
+    studyStore.setState({ sessionsByDeckId: {}, showBackText: false, autoPlay: false, lastSwipe: undefined });
   });
 
   it("signs out before clearing Query and study state", async () => {
@@ -47,7 +47,7 @@ describe("event action", () => {
     await action.event.logout("uid-a");
 
     expect(operations).toEqual(["suspend", "sign-out", "cleanup-query", "resume"]);
-    expect(studyStore.getState().session).toBeNull();
+    expect(studyStore.getState().sessionsByDeckId).toEqual({});
     expect(localStorage.getItem(STUDY_STORAGE_KEY)).toBeNull();
   });
 
@@ -57,7 +57,7 @@ describe("event action", () => {
     await expect(action.event.logout("uid-a")).rejects.toThrow("sign-out failed");
 
     expect(mocks.cleanupFirestoreUid).not.toHaveBeenCalled();
-    expect(studyStore.getState().session).not.toBeNull();
+    expect(studyStore.getState().sessionsByDeckId).not.toEqual({});
   });
 
   it("clears study state after a Query cleanup failure", async () => {
@@ -65,7 +65,7 @@ describe("event action", () => {
     mocks.cleanupFirestoreUid.mockRejectedValue(new Error("cleanup failed"));
     await expect(action.event.logout("uid-a")).rejects.toThrow("cleanup failed");
 
-    expect(studyStore.getState().session).toBeNull();
+    expect(studyStore.getState().sessionsByDeckId).toEqual({});
   });
 
   it("publishes a linked Firebase user without persisting identity", async () => {

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DeckActionsMenu } from "@/features/deck/components/DeckActionsMenu";
+
+type ControlledMenuProps = Omit<React.ComponentProps<typeof DeckActionsMenu>, "open" | "onToggle" | "onClose">;
+
+const ControlledMenu: React.FC<ControlledMenuProps> = (props) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <DeckActionsMenu
+      {...props}
+      open={open}
+      onToggle={() => setOpen((value) => !value)}
+      onClose={() => setOpen(false)}
+    />
+  );
+};
+
+describe("DeckActionsMenu", () => {
+  afterEach(cleanup);
+
+  it("opens an accessible menu and routes each action", () => {
+    const actions = {
+      onRestart: vi.fn(),
+      onDownload: vi.fn(),
+      onEdit: vi.fn(),
+      onDelete: vi.fn(),
+    };
+    const view = render(<ControlledMenu deckName="Algebra" {...actions} />);
+
+    const trigger = view.getByRole("button", { name: "Open actions for Algebra" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(view.getByRole("menu", { name: "Actions for Algebra" })).toBeInTheDocument();
+    fireEvent.click(view.getByRole("menuitem", { name: "Restart" }));
+    expect(actions.onRestart).toHaveBeenCalledOnce();
+
+    fireEvent.click(trigger);
+    fireEvent.click(view.getByRole("menuitem", { name: "Download" }));
+    expect(actions.onDownload).toHaveBeenCalledOnce();
+
+    fireEvent.click(trigger);
+    fireEvent.click(view.getByRole("menuitem", { name: "Edit" }));
+    expect(actions.onEdit).toHaveBeenCalledOnce();
+
+    fireEvent.click(trigger);
+    const deleteItem = view.getByRole("menuitem", { name: "Delete" });
+    expect(deleteItem).toHaveClass("text-danger");
+    fireEvent.click(deleteItem);
+    expect(actions.onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("omits Restart for inactive decks", () => {
+    const view = render(<ControlledMenu deckName="History" />);
+
+    fireEvent.click(view.getByRole("button", { name: "Open actions for History" }));
+
+    expect(view.queryByRole("menuitem", { name: "Restart" })).not.toBeInTheDocument();
+    expect(view.getAllByRole("menuitem").map((item) => item.textContent)).toEqual(["Download", "Edit", "Delete"]);
+  });
+
+  it("supports arrow navigation and returns focus to the trigger on Escape", async () => {
+    const view = render(<ControlledMenu deckName="Design" onRestart={vi.fn()} />);
+    const trigger = view.getByRole("button", { name: "Open actions for Design" });
+
+    fireEvent.click(trigger);
+    const restart = view.getByRole("menuitem", { name: "Restart" });
+    const download = view.getByRole("menuitem", { name: "Download" });
+    await waitFor(() => expect(restart).toHaveFocus());
+
+    fireEvent.keyDown(restart, { key: "ArrowDown" });
+    expect(download).toHaveFocus();
+    fireEvent.keyDown(download, { key: "Escape" });
+
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/src/features/deck/components/DeckActionsMenu.tsx
+++ b/src/features/deck/components/DeckActionsMenu.tsx
@@ -1,0 +1,115 @@
+import type * as React from "react";
+import { AiOutlineCloudDownload, AiOutlineDelete, AiOutlineEdit, AiOutlineMore, AiOutlineReload } from "react-icons/ai";
+
+export interface DeckActionsMenuProps {
+  deckName: string;
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onRestart?: () => void;
+  onDownload?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+const itemClassName =
+  "flex min-h-touch w-full items-center gap-2 px-3 py-2 text-left text-body text-ink hover:bg-surface-muted focus-visible:bg-surface-muted focus-visible:outline-none";
+
+export const DeckActionsMenu: React.FC<DeckActionsMenuProps> = (props) => {
+  const focusTrigger = (menu: HTMLElement) => {
+    const trigger = menu.parentElement?.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
+    trigger?.focus();
+  };
+
+  const run = (action?: () => void) => (event: React.MouseEvent<HTMLButtonElement>) => {
+    const menu = event.currentTarget.parentElement;
+    action?.();
+    props.onClose();
+    if (menu != null) focusTrigger(menu);
+  };
+
+  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const root = event.currentTarget.parentElement;
+    props.onToggle();
+    if (!props.open) queueMicrotask(() => root?.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus());
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onClose();
+      focusTrigger(event.currentTarget);
+      return;
+    }
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+
+    event.preventDefault();
+    const items = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? items.length - 1
+          : event.key === "ArrowDown"
+            ? (currentIndex + 1) % items.length
+            : (currentIndex - 1 + items.length) % items.length;
+    items[nextIndex]?.focus();
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLFieldSetElement>) => {
+    if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) props.onClose();
+  };
+
+  return (
+    <fieldset
+      aria-label={`Deck actions for ${props.deckName}`}
+      className="relative min-w-0 shrink-0 border-0 p-0"
+      onBlur={handleBlur}
+    >
+      <button
+        type="button"
+        className="inline-flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+        aria-label={`Open actions for ${props.deckName}`}
+        aria-haspopup="menu"
+        aria-expanded={props.open}
+        onClick={handleToggle}
+      >
+        <AiOutlineMore aria-hidden="true" size={24} />
+      </button>
+
+      {props.open && (
+        <div
+          role="menu"
+          aria-label={`Actions for ${props.deckName}`}
+          className="absolute right-0 top-full z-20 min-w-40 rounded-control border border-border bg-surface py-1 shadow-elevated"
+          onKeyDown={handleMenuKeyDown}
+        >
+          {props.onRestart != null && (
+            <button type="button" role="menuitem" className={itemClassName} onClick={run(props.onRestart)}>
+              <AiOutlineReload aria-hidden="true" />
+              Restart
+            </button>
+          )}
+          <button type="button" role="menuitem" className={itemClassName} onClick={run(props.onDownload)}>
+            <AiOutlineCloudDownload aria-hidden="true" />
+            Download
+          </button>
+          <button type="button" role="menuitem" className={itemClassName} onClick={run(props.onEdit)}>
+            <AiOutlineEdit aria-hidden="true" />
+            Edit
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className={`${itemClassName} text-danger`}
+            onClick={run(props.onDelete)}
+          >
+            <AiOutlineDelete aria-hidden="true" />
+            Delete
+          </button>
+        </div>
+      )}
+    </fieldset>
+  );
+};

--- a/src/features/deck/components/DeckCard.spec.tsx
+++ b/src/features/deck/components/DeckCard.spec.tsx
@@ -1,118 +1,126 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DeckCard } from "@/features/deck/components/DeckCard";
-import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
+import * as React from "react";
 
-const deck = {
+import { DeckCard, type DeckCardProps } from "@/features/deck/components/DeckCard";
+import { createDeck } from "@/test/factories";
+
+const ControlledDeckCard: React.FC<DeckCardProps> = (props) => {
+  const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
+  return (
+    <DeckCard
+      {...props}
+      openMenuDeckId={openMenuDeckId}
+      onToggleMenu={(id) => setOpenMenuDeckId((value) => (value === id ? undefined : id))}
+      onCloseMenu={() => setOpenMenuDeckId(undefined)}
+    />
+  );
+};
+
+const deck = createDeck({
   id: "deck-id",
   name: "Deck name",
   category: "math",
-  isPublic: false,
-  url: "",
-} as Deck;
+  isPublic: true,
+});
 
 describe("DeckCard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-18T00:10:00Z"));
+  });
+
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
-  it("renders the active study progress and enables restart", () => {
-    const view = render(<DeckCard deck={deck} studyProgress={{ currentIndex: 1, cardCount: 3 }} />);
+  it("renders compact progress for an active deck", () => {
+    const view = render(
+      <DeckCard
+        deck={deck}
+        cardCount={8}
+        studyProgress={{
+          currentIndex: 1,
+          cardCount: 3,
+          lastStudiedAt: new Date("2026-07-18T00:05:00Z").getTime(),
+        }}
+      />
+    );
 
-    expect(view.getByText("studying 2 card(s) from 3")).toBeInTheDocument();
-    expect(view.getByRole("button", { name: "Continue" })).toBeInTheDocument();
-    expect(view.getByRole("button", { name: "Restart" })).toBeEnabled();
+    expect(view.getByText(deck.name)).toHaveClass("truncate");
+    expect(view.getByText("math")).toBeInTheDocument();
+    expect(view.getByLabelText("Public deck")).toBeInTheDocument();
+    const status = view.getByText("2 / 3 · 5m ago").parentElement;
+    const viewButton = view.getByRole("button", { name: "View Deck name" });
+    const progressbar = view.getByRole("progressbar", { name: "Progress for Deck name" });
+    expect(status).toHaveAttribute("id");
+    expect(viewButton).toHaveAttribute("aria-describedby", status?.id);
+    expect(viewButton).not.toContainElement(progressbar);
+    expect(progressbar).toHaveAttribute("aria-valuenow", "2");
+    expect(view.getByRole("button", { name: "Continue Deck name" })).toBeInTheDocument();
   });
 
-  it("hides study progress and disables restart without an active session", () => {
-    const view = render(<DeckCard deck={deck} />);
+  it("renders the card count and Study action for an inactive deck", () => {
+    const view = render(<ControlledDeckCard deck={deck} cardCount={8} />);
 
-    expect(view.queryByText(/studying/)).not.toBeInTheDocument();
-    expect(view.getByRole("button", { name: "Study" })).toBeInTheDocument();
-    expect(view.getByRole("button", { name: "Restart" })).toBeDisabled();
+    expect(view.getByText("8 cards")).toBeInTheDocument();
+    expect(view.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Study Deck name" })).toBeInTheDocument();
+
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Deck name" }));
+    expect(view.queryByRole("menuitem", { name: "Restart" })).not.toBeInTheDocument();
   });
 
-  it("routes active Continue and Restart actions without cross-wiring callbacks", () => {
+  it("passes the deck id to navigation and management actions", () => {
     const actions = {
       onClickName: vi.fn(),
+      onClickContinue: vi.fn(),
       onClickStudy: vi.fn(),
       onClickRestart: vi.fn(),
       onClickDownload: vi.fn(),
       onClickEdit: vi.fn(),
       onClickDelete: vi.fn(),
-      onClickReimport: vi.fn(),
     };
     const view = render(
-      <DeckCard
-        deck={{ ...deck, url: "https://example.com/deck" }}
-        studyProgress={{ currentIndex: 0, cardCount: 2 }}
+      <ControlledDeckCard
+        deck={deck}
+        cardCount={8}
+        studyProgress={{ currentIndex: 0, cardCount: 3, lastStudiedAt: Date.now() }}
         {...actions}
       />
     );
 
-    fireEvent.click(view.getByText(deck.name));
+    fireEvent.click(view.getByRole("button", { name: "View Deck name" }));
+    fireEvent.click(view.getByRole("button", { name: "Continue Deck name" }));
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Deck name" }));
+    fireEvent.click(view.getByRole("menuitem", { name: "Restart" }));
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Deck name" }));
+    fireEvent.click(view.getByRole("menuitem", { name: "Download" }));
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Deck name" }));
+    fireEvent.click(view.getByRole("menuitem", { name: "Edit" }));
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Deck name" }));
+    fireEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+
     expect(actions.onClickName).toHaveBeenCalledExactlyOnceWith(deck.id);
-
-    fireEvent.click(view.getByRole("button", { name: "Continue" }));
-    expect(actions.onClickRestart).toHaveBeenCalledExactlyOnceWith(deck.id);
+    expect(actions.onClickContinue).toHaveBeenCalledExactlyOnceWith(deck.id);
     expect(actions.onClickStudy).not.toHaveBeenCalled();
-
-    fireEvent.click(view.getByRole("button", { name: "Restart" }));
-    expect(actions.onClickStudy).toHaveBeenCalledExactlyOnceWith(deck.id);
-    expect(actions.onClickRestart).toHaveBeenCalledTimes(1);
-
-    const managementIcons = view.container.querySelectorAll("svg");
-    expect(managementIcons).toHaveLength(4);
-
-    fireEvent.click(managementIcons[0] as SVGElement);
+    expect(actions.onClickRestart).toHaveBeenCalledExactlyOnceWith(deck.id);
     expect(actions.onClickDownload).toHaveBeenCalledExactlyOnceWith(deck.id);
-
-    fireEvent.click(managementIcons[1] as SVGElement);
     expect(actions.onClickEdit).toHaveBeenCalledExactlyOnceWith(deck.id);
-
-    fireEvent.click(managementIcons[2] as SVGElement);
     expect(actions.onClickDelete).toHaveBeenCalledExactlyOnceWith(deck.id);
-
-    fireEvent.click(managementIcons[3] as SVGElement);
-    expect(actions.onClickReimport).toHaveBeenCalledExactlyOnceWith(deck.id);
   });
 
-  it("routes inactive Study to onClickStudy and keeps Restart inert", () => {
+  it("routes inactive Study without opening the row", () => {
+    const onClickName = vi.fn();
     const onClickStudy = vi.fn();
-    const onClickRestart = vi.fn();
-    const view = render(<DeckCard deck={deck} onClickStudy={onClickStudy} onClickRestart={onClickRestart} />);
+    const view = render(<DeckCard deck={deck} cardCount={1} onClickName={onClickName} onClickStudy={onClickStudy} />);
 
-    fireEvent.click(view.getByRole("button", { name: "Study" }));
+    fireEvent.click(view.getByRole("button", { name: "Study Deck name" }));
+
     expect(onClickStudy).toHaveBeenCalledExactlyOnceWith(deck.id);
-    expect(onClickRestart).not.toHaveBeenCalled();
-
-    fireEvent.click(view.getByRole("button", { name: "Restart" }));
-    expect(onClickRestart).not.toHaveBeenCalled();
-    expect(onClickStudy).toHaveBeenCalledTimes(1);
-  });
-
-  it("preserves the unwrapped management icon hooks and danger styling", () => {
-    const view = render(<DeckCard deck={deck} />);
-    const managementIcons = view.container.querySelectorAll("svg");
-    const deleteGlyph = managementIcons[2];
-
-    expect(managementIcons).toHaveLength(3);
-    for (const icon of managementIcons) expect(icon.parentElement?.tagName).toBe("DIV");
-    expect(deleteGlyph).toHaveClass("text-danger");
-    expect(deleteGlyph).not.toHaveAttribute("aria-label");
-  });
-
-  it("enables restart only for the deck that owns the active progress", () => {
-    const otherDeck = { ...deck, id: "other-deck", name: "Other deck" };
-    const view = render(
-      <DeckListTemplate decks={[deck, otherDeck]} studyProgress={{ deckId: deck.id, currentIndex: 1, cardCount: 3 }} />
-    );
-
-    const restartButtons = view.getAllByRole("button", { name: "Restart" });
-    expect(restartButtons[0]).toBeEnabled();
-    expect(restartButtons[1]).toBeDisabled();
-    expect(view.getAllByText(/studying/)).toHaveLength(1);
+    expect(onClickName).not.toHaveBeenCalled();
   });
 });

--- a/src/features/deck/components/DeckCard.stories.tsx
+++ b/src/features/deck/components/DeckCard.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   },
   args: {
     deck: fixture.deck.default,
+    cardCount: 24,
   },
 } satisfies Meta<typeof Template>;
 
@@ -31,6 +32,7 @@ export const WithStudyProgress: Story = {
     studyProgress: {
       currentIndex: 0,
       cardCount: 3,
+      lastStudiedAt: Date.now() - 5 * 60 * 1000,
     },
   },
 };

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -1,111 +1,127 @@
 import * as React from "react";
-import { Button, Card, Description, Tag, Title } from "@/shared/components";
-import { IconContext } from "react-icons";
-import {
-  AiOutlineCloud,
-  AiOutlineCloudDownload,
-  AiOutlineEdit,
-  AiOutlineDelete,
-  AiOutlineReload,
-} from "react-icons/ai";
+import { AiFillCaretRight, AiOutlineCloud } from "react-icons/ai";
 
-export interface DeckCardActions {
-  onClickName?: (id: string) => void;
-  onClickStudy?: (id: string) => void;
-  onClickRestart?: (id: string) => void;
-  onClickDownload?: (id: string) => void;
-  onClickEdit?: (id: string) => void;
-  onClickDelete?: (id: string) => void;
-  onClickReimport?: (id: string) => void;
-}
+import { DeckActionsMenu } from "@/features/deck/components/DeckActionsMenu";
 
-export interface StudyProgress {
+export interface DeckListStudyProgress {
   currentIndex: number;
   cardCount: number;
+  lastStudiedAt: number;
+}
+
+export interface DeckCardActions {
+  onClickName?: (id: DeckId) => void;
+  onClickContinue?: (id: DeckId) => void;
+  onClickStudy?: (id: DeckId) => void;
+  onClickRestart?: (id: DeckId) => void;
+  onClickDownload?: (id: DeckId) => void;
+  onClickEdit?: (id: DeckId) => void;
+  onClickDelete?: (id: DeckId) => void;
+  openMenuDeckId?: DeckId | undefined;
+  onToggleMenu?: (id: DeckId) => void;
+  onCloseMenu?: () => void;
 }
 
 export interface DeckCardProps extends DeckCardActions {
-  deck?: Deck;
-  studyProgress?: StudyProgress;
+  deck: Deck;
+  cardCount: number;
+  studyProgress?: DeckListStudyProgress;
 }
 
+const formatLastStudied = (timestamp: number): string => {
+  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (elapsedSeconds < 60) return "just now";
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 30) return `${elapsedDays}d ago`;
+  const elapsedMonths = Math.floor(elapsedDays / 30);
+  if (elapsedMonths < 12) return `${elapsedMonths}mo ago`;
+  return `${Math.floor(elapsedMonths / 12)}y ago`;
+};
+
+const primaryActionClassName =
+  "inline-flex min-h-touch shrink-0 items-center justify-center gap-1 rounded-control px-3 text-caption font-semibold transition-colors duration-fast ease-calm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
+
 export const DeckCard: React.FC<DeckCardProps> = (props) => {
-  const deck = props.deck;
-  if (deck == null) throw Error("invalid deck");
-  const id = deck.id;
-  const onClickName = React.useCallback(() => {
-    props.onClickName?.(id);
-  }, [id, props]);
-  const onClickStudy = React.useCallback(() => {
-    props.onClickStudy?.(id);
-  }, [id, props]);
-  const onClickRestart = React.useCallback(() => {
-    props.onClickRestart?.(id);
-  }, [id, props]);
-  const onClickDownload = React.useCallback(() => {
-    props.onClickDownload?.(id);
-  }, [id, props]);
-  const onClickEdit = React.useCallback(() => {
-    props.onClickEdit?.(id);
-  }, [id, props]);
-  const onClickDelete = React.useCallback(() => {
-    props.onClickDelete?.(id);
-  }, [id, props]);
-  const onClickReimport = React.useCallback(() => {
-    props.onClickReimport?.(id);
-  }, [id, props]);
+  const { deck, studyProgress } = props;
+  const active = studyProgress != null;
+  const progressValue = active ? studyProgress.currentIndex + 1 : 0;
+  const progressPercent = active ? Math.min(100, (progressValue / studyProgress.cardCount) * 100) : 0;
+  const withId = (action?: (id: DeckId) => void) => () => action?.(deck.id);
+  const statusId = React.useId();
+
   return (
-    <IconContext.Provider value={{ className: "text-2xl" }}>
-      <Card full className="px-4 pb-3 pt-4">
-        <div>
-          <div className="flex min-w-0 flex-wrap items-start gap-1">
-            <Title onClick={onClickName}>{deck.name}</Title>
-            <Tag className="mr-2 mb-2" round label={deck.category} hidden={!deck.category} />
-            {deck.isPublic && <AiOutlineCloud className="mt-1 shrink-0 text-ink-muted" size={24} />}
-          </div>
-          {props.studyProgress != null && (
-            <Description>
-              studying {props.studyProgress.currentIndex + 1} card(s) from {props.studyProgress.cardCount}
-            </Description>
+    <article className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0">
+      <div className="min-w-0 flex-1 px-1 py-1">
+        <button
+          type="button"
+          aria-label={`View ${deck.name}`}
+          aria-describedby={statusId}
+          className="flex w-full min-w-0 items-center gap-1.5 rounded-control text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          onClick={withId(props.onClickName)}
+        >
+          <span className="truncate text-body font-semibold text-ink">{deck.name}</span>
+          {deck.isPublic && (
+            <span role="img" aria-label="Public deck" className="shrink-0 text-ink-muted">
+              <AiOutlineCloud aria-hidden="true" size={16} />
+            </span>
           )}
-        </div>
+        </button>
 
-        <div className="mt-4">
-          <div className="flex flex-wrap gap-2">
-            <Button
-              variant="primary"
-              className="flex-1"
-              onClick={props.studyProgress == null ? onClickStudy : onClickRestart}
-            >
-              {props.studyProgress == null ? "Study" : "Continue"}
-            </Button>
-            <Button variant="quiet" className="flex-1" disabled={props.studyProgress == null} onClick={onClickStudy}>
-              Restart
-            </Button>
-          </div>
+        <span id={statusId} className="mt-1 flex min-w-0 items-center gap-2 text-caption text-ink-muted">
+          {deck.category !== "" && (
+            <span className="max-w-28 truncate rounded-pill bg-surface-muted px-2 py-0.5 text-xs font-medium text-ink">
+              {deck.category}
+            </span>
+          )}
+          <span className="truncate">
+            {active
+              ? `${progressValue} / ${studyProgress.cardCount} · ${formatLastStudied(studyProgress.lastStudiedAt)}`
+              : `${props.cardCount} ${props.cardCount === 1 ? "card" : "cards"}`}
+          </span>
+        </span>
 
-          <div className="mt-4 flex justify-center gap-1 border-t border-border pt-2">
-            <AiOutlineCloudDownload
-              className="size-touch rounded-control p-2 text-ink-muted hover:bg-surface-muted"
-              onClick={onClickDownload}
-            />
-            <AiOutlineEdit
-              className="size-touch rounded-control p-2 text-ink-muted hover:bg-surface-muted"
-              onClick={onClickEdit}
-            />
-            <AiOutlineDelete
-              className="size-touch rounded-control p-2 text-danger hover:bg-surface-muted"
-              onClick={onClickDelete}
-            />
-            {Boolean(deck.url) && (
-              <AiOutlineReload
-                className="size-touch rounded-control p-2 text-ink-muted hover:bg-surface-muted"
-                onClick={onClickReimport}
-              />
-            )}
-          </div>
-        </div>
-      </Card>
-    </IconContext.Provider>
+        {active && (
+          <span
+            role="progressbar"
+            aria-label={`Progress for ${deck.name}`}
+            aria-valuemin={0}
+            aria-valuemax={studyProgress.cardCount}
+            aria-valuenow={progressValue}
+            className="mt-2 block h-1 overflow-hidden rounded-pill bg-surface-muted"
+          >
+            <span className="block h-full rounded-pill bg-accent-primary" style={{ width: `${progressPercent}%` }} />
+          </span>
+        )}
+      </div>
+
+      <button
+        type="button"
+        aria-label={`${active ? "Continue" : "Study"} ${deck.name}`}
+        className={`${primaryActionClassName} ${
+          active
+            ? "bg-accent-primary text-ink-inverse hover:opacity-90"
+            : "border border-border bg-transparent text-ink hover:bg-surface-muted"
+        }`}
+        onClick={withId(active ? props.onClickContinue : props.onClickStudy)}
+      >
+        {active && <AiFillCaretRight aria-hidden="true" />}
+        <span>{active ? "Continue" : "Study"}</span>
+      </button>
+
+      <DeckActionsMenu
+        deckName={deck.name}
+        open={props.openMenuDeckId === deck.id}
+        onToggle={withId(props.onToggleMenu)}
+        onClose={() => props.onCloseMenu?.()}
+        {...(active ? { onRestart: withId(props.onClickRestart) } : {})}
+        onDownload={withId(props.onClickDownload)}
+        onEdit={withId(props.onClickEdit)}
+        onDelete={withId(props.onClickDelete)}
+      />
+    </article>
   );
 };

--- a/src/features/deck/components/templates/DeckListTemplate.spec.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.spec.tsx
@@ -1,22 +1,81 @@
-import { cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
+import { DeckListTemplate, type DeckListSections } from "@/features/deck/components/templates/DeckListTemplate";
+import { createDeck } from "@/test/factories";
+
+const activeDeck = createDeck({ id: "active", name: "Active deck", category: "math" });
+const otherDeck = createDeck({ id: "other", name: "Other deck", category: "history" });
+
+const sections: DeckListSections = {
+  studying: [
+    {
+      deck: activeDeck,
+      cardCount: 10,
+      studyProgress: { currentIndex: 1, cardCount: 4, lastStudiedAt: Date.now() },
+    },
+  ],
+  other: [{ deck: otherDeck, cardCount: 7 }],
+};
+
+const ControlledDeckList = () => {
+  const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
+  return (
+    <DeckListTemplate
+      sections={sections}
+      deckCard={{
+        openMenuDeckId,
+        onToggleMenu: (id) => setOpenMenuDeckId((value) => (value === id ? undefined : id)),
+        onCloseMenu: () => setOpenMenuDeckId(undefined),
+      }}
+    />
+  );
+};
 
 describe("DeckListTemplate", () => {
   afterEach(cleanup);
 
-  it("provides a clear page heading and preserves feedback content", () => {
-    const view = render(<DeckListTemplate decks={[]} feedbackSlot={<div role="status">Saved</div>} />);
+  it("renders the page count, feedback, and both compact sections", () => {
+    const view = render(<DeckListTemplate sections={sections} feedbackSlot={<div role="status">Saved</div>} />);
 
     expect(view.getByRole("heading", { level: 1, name: "Decks" })).toBeInTheDocument();
+    expect(view.getByText("2 decks")).toBeInTheDocument();
     expect(view.getByRole("status")).toHaveTextContent("Saved");
+
+    const studying = view.getByRole("region", { name: "Studying" });
+    expect(within(studying).getByText("1 deck · recent first")).toBeInTheDocument();
+    expect(within(studying).getByText(activeDeck.name)).toBeInTheDocument();
+
+    const other = view.getByRole("region", { name: "Other decks" });
+    expect(within(other).getByText("1 deck · A–Z")).toBeInTheDocument();
+    expect(within(other).getByText(otherDeck.name)).toBeInTheDocument();
+  });
+
+  it("omits empty sections", () => {
+    const view = render(<DeckListTemplate sections={{ studying: [], other: sections.other }} />);
+
+    expect(view.queryByRole("region", { name: "Studying" })).not.toBeInTheDocument();
+    expect(view.getByRole("region", { name: "Other decks" })).toBeInTheDocument();
+  });
+
+  it("opens one deck actions menu at a time", () => {
+    const view = render(<ControlledDeckList />);
+
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Active deck" }));
+    expect(view.getByRole("menu", { name: "Actions for Active deck" })).toBeInTheDocument();
+
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Other deck" }));
+    expect(view.queryByRole("menu", { name: "Actions for Active deck" })).not.toBeInTheDocument();
+    expect(view.getByRole("menu", { name: "Actions for Other deck" })).toBeInTheDocument();
   });
 
   it("does not introduce an empty-state message", () => {
-    const view = render(<DeckListTemplate decks={[]} />);
+    const view = render(<DeckListTemplate sections={{ studying: [], other: [] }} />);
 
+    expect(view.getByText("0 decks")).toBeInTheDocument();
+    expect(view.queryByRole("region")).not.toBeInTheDocument();
     expect(view.queryByText(/no decks/i)).not.toBeInTheDocument();
   });
 });

--- a/src/features/deck/components/templates/DeckListTemplate.stories.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.stories.tsx
@@ -1,8 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { INITIAL_VIEWPORTS } from "@/shared/storybook/storybookViewports";
-import { DeckListTemplate as Template } from "@/features/deck/components/templates/DeckListTemplate";
+import {
+  type DeckListItem,
+  type DeckListSections,
+  DeckListTemplate as Template,
+} from "@/features/deck/components/templates/DeckListTemplate";
 import * as fixture from "@/shared/storybook/fixture";
+import { INITIAL_VIEWPORTS } from "@/shared/storybook/storybookViewports";
+
+const otherItems = (decks: Deck[]): DeckListItem[] => decks.map((deck, index) => ({ deck, cardCount: 12 + index * 4 }));
+const studyingItems = (decks: Deck[]): DeckListItem[] =>
+  decks.map((deck, index) => ({
+    deck,
+    cardCount: 30 + index,
+    studyProgress: {
+      currentIndex: index + 1,
+      cardCount: 12 + index * 7,
+      lastStudiedAt: Date.now() - index * 24 * 60 * 60 * 1000,
+    },
+  }));
+
+const mixed: DeckListSections = {
+  studying: studyingItems(fixture.decks.default.slice(0, 3)),
+  other: otherItems(fixture.decks.default.slice(3)),
+};
+const longSections: DeckListSections = {
+  studying: studyingItems(fixture.decks.long.slice(0, 4)),
+  other: otherItems(fixture.decks.long.slice(4)),
+};
 
 const meta = {
   title: "Deck/DeckListTemplate",
@@ -16,7 +41,7 @@ const meta = {
     },
   },
   args: {
-    decks: fixture.decks.default,
+    sections: mixed,
   },
 } satisfies Meta<typeof Template>;
 
@@ -25,32 +50,24 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Inactive: Story = {};
+export const Inactive: Story = {
+  args: { sections: { studying: [], other: otherItems(fixture.decks.default) } },
+};
 
 export const WithStudyProgress: Story = {
-  args: {
-    studyProgress: {
-      deckId: "deck-1",
-      currentIndex: 0,
-      cardCount: 3,
-    },
-  },
+  args: { sections: { studying: studyingItems(fixture.decks.default), other: [] } },
 };
 
 export const Active: Story = WithStudyProgress;
 
 export const Empty: Story = {
-  args: {
-    decks: [],
-  },
+  args: { sections: { studying: [], other: [] } },
 };
 
 export const EmptyComposition: Story = Empty;
 
 export const Long: Story = {
-  args: {
-    decks: fixture.decks.long,
-  },
+  args: { sections: longSections },
 };
 
 export const IphoneX: Story = {
@@ -75,7 +92,5 @@ export const IphoneXLong: Story = {
       defaultViewport: "iphonex",
     },
   },
-  args: {
-    decks: fixture.decks.long,
-  },
+  args: { sections: longSections },
 };

--- a/src/features/deck/components/templates/DeckListTemplate.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.tsx
@@ -1,38 +1,74 @@
-import type * as React from "react";
-import { List } from "@/shared/components";
-import { Layout } from "@/shared/components/layout/Layout";
-import { DeckCard, type DeckCardActions, type StudyProgress } from "@/features/deck/components/DeckCard";
+import * as React from "react";
 
-export interface ActiveStudyProgress extends StudyProgress {
-  deckId: DeckId;
+import { DeckCard, type DeckCardActions, type DeckListStudyProgress } from "@/features/deck/components/DeckCard";
+import { Layout } from "@/shared/components/layout/Layout";
+
+export interface DeckListItem {
+  deck: Deck;
+  cardCount: number;
+  studyProgress?: DeckListStudyProgress;
+}
+
+export interface DeckListSections {
+  studying: DeckListItem[];
+  other: DeckListItem[];
 }
 
 export interface DeckListTemplateProps {
-  decks: Deck[];
+  sections: DeckListSections;
   layout?: React.ComponentProps<typeof Layout>;
   deckCard?: DeckCardActions;
-  studyProgress?: ActiveStudyProgress;
   feedbackSlot?: React.ReactNode;
 }
 
+const countLabel = (count: number) => `${count} ${count === 1 ? "deck" : "decks"}`;
+
+const DeckListSection: React.FC<{
+  title: string;
+  note: string;
+  items: DeckListItem[];
+  actions: DeckCardActions | undefined;
+}> = ({ title, note, items, actions }) => {
+  const headingId = React.useId();
+  if (items.length === 0) return null;
+
+  return (
+    <section aria-labelledby={headingId} className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between gap-3 px-1">
+        <h2 id={headingId} className="text-caption font-bold uppercase tracking-wide text-ink-muted">
+          {title}
+        </h2>
+        <span className="shrink-0 text-caption text-ink-muted">
+          {countLabel(items.length)} · {note}
+        </span>
+      </div>
+      <div className="rounded-surface border border-border bg-surface shadow-surface">
+        {items.map((item) => (
+          <DeckCard
+            key={item.deck.id}
+            deck={item.deck}
+            cardCount={item.cardCount}
+            {...(item.studyProgress != null ? { studyProgress: item.studyProgress } : {})}
+            {...actions}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
 export const DeckListTemplate: React.FC<DeckListTemplateProps> = (props) => {
+  const total = props.sections.studying.length + props.sections.other.length;
+
   return (
     <Layout showHeader {...props.layout}>
       {props.feedbackSlot}
-      <h1 className="break-words text-title font-bold text-ink">Decks</h1>
-      <List>
-        {props.decks?.map((deck) => {
-          const studyProgress = props.studyProgress?.deckId === deck.id ? props.studyProgress : undefined;
-          return (
-            <DeckCard
-              key={deck.id}
-              deck={deck}
-              {...(studyProgress !== undefined ? { studyProgress } : {})}
-              {...props.deckCard}
-            />
-          );
-        })}
-      </List>
+      <div className="flex items-baseline justify-between gap-3">
+        <h1 className="break-words text-title font-bold text-ink">Decks</h1>
+        <span className="shrink-0 text-caption text-ink-muted">{countLabel(total)}</span>
+      </div>
+      <DeckListSection title="Studying" note="recent first" items={props.sections.studying} actions={props.deckCard} />
+      <DeckListSection title="Other decks" note="A–Z" items={props.sections.other} actions={props.deckCard} />
     </Layout>
   );
 };

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -1,14 +1,18 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { studyStore } from "@/features/study/state/studyStore";
-import { createConfig, createDeck } from "@/test/factories";
+import { createCard, createConfig, createDeck } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   config: {} as ConfigState,
   decksById: {} as Record<DeckId, Deck>,
   cardsById: {} as Record<CardId, Card>,
+  hydrated: true,
+  pending: false,
+  remove: vi.fn(async (_deck: Deck) => undefined),
+  downloadData: vi.fn(),
   actions: {
     goToSettings: vi.fn(),
     goToImport: vi.fn(),
@@ -19,99 +23,165 @@ const mocks = vi.hoisted(() => ({
     goToView: vi.fn(),
     goToStudy: vi.fn(),
     goToStart: vi.fn(),
-    deckDownload: vi.fn(),
-    deckRemove: vi.fn(),
   },
 }));
 
 vi.mock("@/features/settings/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
-
-vi.mock("@/action", () => ({ deck: { downloadData: vi.fn() } }));
+vi.mock("@/features/study/hooks/useStudyHydrated", () => ({ useStudyHydrated: () => mocks.hydrated }));
+vi.mock("@/action", () => ({ deck: { downloadData: mocks.downloadData } }));
 vi.mock("@/query/useRemoteCollections", () => ({
   useRemoteCollections: () => {
-    const decksById = mocks.decksById;
+    const decks = Object.values(mocks.decksById);
+    const cards = Object.values(mocks.cardsById);
     return {
       status: "ready" as const,
       retry: vi.fn(),
-      decks: Object.values(decksById).filter((deck): deck is Deck => deck != null),
-      deckById: (id: string) => decksById[id],
-      cardsByDeckId: (id: string) => Object.values(mocks.cardsById).filter((card) => card.deckId === id),
+      decks,
+      cards,
+      deckById: (id: DeckId) => mocks.decksById[id],
+      cardsByDeckId: (id: DeckId) => cards.filter((card) => card.deckId === id),
     };
   },
 }));
-
-vi.mock("react-use", () => ({
-  useKey: vi.fn(),
-}));
-
-vi.mock("@/shared/hooks/useActions", () => ({
-  useActions: () => mocks.actions,
-}));
-
+vi.mock("react-use", () => ({ useKey: vi.fn() }));
+vi.mock("@/shared/hooks/useActions", () => ({ useActions: () => mocks.actions }));
 vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
-  useDeckMutations: () => ({ remove: vi.fn(), pending: false, error: null, retry: vi.fn() }),
+  useDeckMutations: () => ({ remove: mocks.remove, pending: mocks.pending, error: null, retry: vi.fn() }),
 }));
-
 vi.mock("@/features/import/hooks/useSampleDeckBootstrap", () => ({ useSampleDeckBootstrap: vi.fn() }));
 
 import { DeckListContainer } from "@/features/deck/containers/DeckListContainer";
 
 describe("DeckListContainer", () => {
-  const activeDeck = createDeck({
-    id: "active-deck",
-    name: "Active deck",
-    category: "math",
-    isPublic: false,
-    url: "",
-  });
-  const otherDeck = {
-    ...activeDeck,
-    id: "other-deck",
-    name: "Other deck",
-  };
+  const recentDeck = createDeck({ id: "recent", name: "Recent deck", category: "math" });
+  const oldDeck = createDeck({ id: "old", name: "Old deck", category: "design" });
+  const otherDeck = createDeck({ id: "other", name: "Alpha deck", category: "history" });
 
   beforeEach(() => {
     localStorage.clear();
-    mocks.decksById = { [activeDeck.id]: activeDeck, [otherDeck.id]: otherDeck };
-    mocks.cardsById = {};
+    vi.clearAllMocks();
+    mocks.hydrated = true;
+    mocks.pending = false;
     mocks.config = createConfig({ darkMode: false });
+    mocks.decksById = { [otherDeck.id]: otherDeck, [oldDeck.id]: oldDeck, [recentDeck.id]: recentDeck };
+    mocks.cardsById = {
+      "other-1": createCard({ id: "other-1", deckId: otherDeck.id }),
+      "other-2": createCard({ id: "other-2", deckId: otherDeck.id }),
+    };
     studyStore.setState({
-      session: {
-        deckId: activeDeck.id,
-        cardOrderIds: ["card-1", "card-2", "card-3"],
-        currentIndex: 1,
+      sessionsByDeckId: {
+        [oldDeck.id]: {
+          deckId: oldDeck.id,
+          cardOrderIds: ["old-1", "old-2"],
+          currentIndex: 0,
+          lastStudiedAt: 1000,
+        },
+        [recentDeck.id]: {
+          deckId: recentDeck.id,
+          cardOrderIds: ["recent-1", "recent-2", "recent-3"],
+          currentIndex: 1,
+          lastStudiedAt: 2000,
+        },
       },
+      showBackText: false,
+      autoPlay: false,
+      lastSwipe: undefined,
     });
   });
 
   afterEach(() => {
     cleanup();
-    studyStore.getState().resetStudy();
+    studyStore.setState({ sessionsByDeckId: {} });
+    vi.restoreAllMocks();
   });
 
-  it("renders progress only on the deck that owns the active session", () => {
+  it("renders every active deck in recent order and inactive decks by name", () => {
     const view = render(<DeckListContainer />);
 
-    expect(view.getByText("studying 2 card(s) from 3")).toBeInTheDocument();
-    const restartButtons = view.getAllByRole("button", { name: "Restart" });
-    expect(restartButtons[0]).toBeEnabled();
-    expect(restartButtons[1]).toBeDisabled();
+    const studying = view.getByRole("region", { name: "Studying" });
+    expect(
+      within(studying)
+        .getAllByRole("button", { name: /^View / })
+        .map((button) => button.getAttribute("aria-label"))
+    ).toEqual(["View Recent deck", "View Old deck"]);
+    expect(within(studying).getByText(/2 \/ 3/)).toBeInTheDocument();
+
+    const other = view.getByRole("region", { name: "Other decks" });
+    expect(within(other).getByRole("button", { name: "View Alpha deck" })).toBeInTheDocument();
+    expect(within(other).getByText("2 cards")).toBeInTheDocument();
   });
 
-  it("ignores legacy study fields when there is no current session", () => {
-    const legacyDeck = {
-      ...activeDeck,
-      currentIndex: 1,
-      cardOrderIds: ["card-1", "card-2"],
-    } satisfies Deck & { currentIndex: number; cardOrderIds: string[] };
-    mocks.decksById = { [legacyDeck.id]: legacyDeck, [otherDeck.id]: otherDeck };
-    studyStore.getState().resetStudy();
+  it("touches only the selected session before continuing", () => {
+    vi.spyOn(Date, "now").mockReturnValue(9000);
+    const view = render(<DeckListContainer />);
+
+    fireEvent.click(view.getByRole("button", { name: "Continue Recent deck" }));
+
+    expect(mocks.actions.goToStudy).toHaveBeenCalledExactlyOnceWith(recentDeck.id);
+    expect(studyStore.getState().sessionsByDeckId[recentDeck.id]?.lastStudiedAt).toBe(9000);
+    expect(studyStore.getState().sessionsByDeckId[oldDeck.id]?.lastStudiedAt).toBe(1000);
+  });
+
+  it("routes Study and Restart through the start screen", () => {
+    const view = render(<DeckListContainer />);
+
+    fireEvent.click(view.getByRole("button", { name: "Study Alpha deck" }));
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Recent deck" }));
+    fireEvent.click(view.getByRole("menuitem", { name: "Restart" }));
+
+    expect(mocks.actions.goToStart).toHaveBeenNthCalledWith(1, otherDeck.id);
+    expect(mocks.actions.goToStart).toHaveBeenNthCalledWith(2, recentDeck.id);
+  });
+
+  it("removes only the deleted deck session after the remote delete succeeds", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const view = render(<DeckListContainer />);
+
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Recent deck" }));
+    fireEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+
+    await waitFor(() => expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(recentDeck));
+    await waitFor(() => expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeUndefined());
+    expect(studyStore.getState().sessionsByDeckId[oldDeck.id]).toBeDefined();
+  });
+
+  it("waits for study hydration before classifying decks", () => {
+    mocks.hydrated = false;
+    const view = render(<DeckListContainer />);
+
+    expect(view.getByRole("status")).toHaveTextContent("Loading study progress");
+    expect(view.queryByRole("region", { name: "Other decks" })).not.toBeInTheDocument();
+
+    mocks.hydrated = true;
+    view.rerender(<DeckListContainer />);
+    expect(view.getByRole("region", { name: "Studying" })).toBeInTheDocument();
+  });
+
+  it("prunes sessions for decks that no longer exist", async () => {
+    studyStore.setState((state) => ({
+      sessionsByDeckId: {
+        ...state.sessionsByDeckId,
+        missing: { deckId: "missing", cardOrderIds: ["card"], currentIndex: 0, lastStudiedAt: 3000 },
+      },
+    }));
+
+    render(<DeckListContainer />);
+
+    await waitFor(() => expect(studyStore.getState().sessionsByDeckId.missing).toBeUndefined());
+    expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeDefined();
+  });
+
+  it("does not prune an optimistically removed deck session while deletion is pending", () => {
+    mocks.pending = true;
+    delete mocks.decksById[recentDeck.id];
 
     const view = render(<DeckListContainer />);
 
-    const restartButtons = view.getAllByRole("button", { name: "Restart" });
-    expect(restartButtons[0]).toBeDisabled();
-    expect(restartButtons[1]).toBeDisabled();
-    expect(view.queryByText(/studying/)).not.toBeInTheDocument();
+    expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeDefined();
+
+    mocks.pending = false;
+    mocks.decksById[recentDeck.id] = recentDeck;
+    view.rerender(<DeckListContainer />);
+    expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeDefined();
   });
 });

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -1,74 +1,96 @@
-import type * as React from "react";
+import * as React from "react";
 import { useKey } from "react-use";
 
 import * as action from "@/action";
+import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
+import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
+import { buildDeckListSections } from "@/features/deck/lib/buildDeckListSections";
+import { useSampleDeckBootstrap } from "@/features/import/hooks/useSampleDeckBootstrap";
+import { useConfig } from "@/features/settings/hooks/useConfig";
+import { useStudyHydrated } from "@/features/study/hooks/useStudyHydrated";
+import { useStudyStore } from "@/features/study/hooks/useStudyStore";
+import { studyStore } from "@/features/study/state/studyStore";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
 import { RemoteMutationNotice, RemoteReadBoundary } from "@/shared/components";
 import { useActions } from "@/shared/hooks/useActions";
-import { DeckListTemplate } from "@/features/deck/components/templates/DeckListTemplate";
-import { useStudyStore } from "@/features/study/hooks/useStudyStore";
-import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
-import { useSampleDeckBootstrap } from "@/features/import/hooks/useSampleDeckBootstrap";
-import { useConfig } from "@/features/settings/hooks/useConfig";
 
 export const DeckListContainer: React.FC = () => {
   const actions = useActions();
   const config = useConfig();
   const remote = useRemoteCollections();
   const mutations = useDeckMutations();
-  const decks = remote.decks;
-  const studySession = useStudyStore((state) => state.session);
+  const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
+  const sessionsByDeckId = useStudyStore((state) => state.sessionsByDeckId);
+  const hydrated = useStudyHydrated();
+  const sections = React.useMemo(
+    () => buildDeckListSections(remote.decks, remote.cards, sessionsByDeckId),
+    [remote.cards, remote.decks, sessionsByDeckId]
+  );
   useSampleDeckBootstrap();
   useKey("s", actions.goToSettings);
   useKey("i", actions.goToImport);
 
+  React.useEffect(() => {
+    if (!hydrated || mutations.pending || remote.status !== "ready") return;
+    const deckIds = new Set(remote.decks.map((deck) => deck.id));
+    for (const deckId of Object.keys(studyStore.getState().sessionsByDeckId)) {
+      if (!deckIds.has(deckId)) studyStore.getState().removeStudy(deckId);
+    }
+  }, [hydrated, mutations.pending, remote.decks, remote.status]);
+
   return (
     <RemoteReadBoundary
       status={remote.status}
-      hasData={decks.length > 0}
+      hasData={remote.decks.length > 0}
       emptyLabel="No decks yet."
       onRetry={remote.retry}
     >
-      <DeckListTemplate
-        decks={decks}
-        feedbackSlot={
-          <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
-        }
-        {...(studySession != null
-          ? {
-              studyProgress: {
-                deckId: studySession.deckId,
-                currentIndex: studySession.currentIndex,
-                cardCount: studySession.cardOrderIds.length,
-              },
-            }
-          : {})}
-        layout={{
-          headerProps: {
-            dark: config.darkMode,
-            onClickDarkMode: actions.setDarkMode,
-            onClickLogo: actions.goToTop,
-            onClickMenuItem: actions.goByMenu,
-          },
-        }}
-        deckCard={{
-          onClickEdit: actions.goToEdit,
-          onClickName: actions.goToView,
-          onClickRestart: actions.goToStudy,
-          onClickStudy: actions.goToStart,
-          onClickDownload: (id) => {
-            const deck = remote.deckById(id);
-            if (deck != null) action.deck.downloadData(deck, remote.cardsByDeckId(id));
-          },
-          onClickDelete: (id) => {
-            const deck = remote.deckById(id);
-            if (deck != null && window.confirm("Are you sure of removing this deck?")) {
-              void mutations.remove(deck).catch(() => undefined);
-            }
-          },
-          // onClickReimport: actions.deckReimport,
-        }}
-      />
+      {hydrated ? (
+        <DeckListTemplate
+          sections={sections}
+          feedbackSlot={
+            <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+          }
+          layout={{
+            headerProps: {
+              dark: config.darkMode,
+              onClickDarkMode: actions.setDarkMode,
+              onClickLogo: actions.goToTop,
+              onClickMenuItem: actions.goByMenu,
+            },
+          }}
+          deckCard={{
+            openMenuDeckId,
+            onToggleMenu: (id) => setOpenMenuDeckId((value) => (value === id ? undefined : id)),
+            onCloseMenu: () => setOpenMenuDeckId(undefined),
+            onClickEdit: actions.goToEdit,
+            onClickName: actions.goToView,
+            onClickContinue: (id) => {
+              studyStore.getState().touchStudy(id);
+              actions.goToStudy(id);
+            },
+            onClickRestart: actions.goToStart,
+            onClickStudy: actions.goToStart,
+            onClickDownload: (id) => {
+              const deck = remote.deckById(id);
+              if (deck != null) action.deck.downloadData(deck, remote.cardsByDeckId(id));
+            },
+            onClickDelete: (id) => {
+              const deck = remote.deckById(id);
+              if (deck != null && window.confirm("Are you sure of removing this deck?")) {
+                void mutations
+                  .remove(deck)
+                  .then(() => studyStore.getState().removeStudy(id))
+                  .catch(() => undefined);
+              }
+            },
+          }}
+        />
+      ) : (
+        <div role="status" className="py-10 text-center text-sm text-ink-muted">
+          Loading study progress…
+        </div>
+      )}
     </RemoteReadBoundary>
   );
 };

--- a/src/features/deck/lib/buildDeckListSections.spec.ts
+++ b/src/features/deck/lib/buildDeckListSections.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDeckListSections } from "@/features/deck/lib/buildDeckListSections";
+import type { StudySession } from "@/features/study/state/studyStore";
+import { createCard, createDeck } from "@/test/factories";
+
+describe("buildDeckListSections", () => {
+  it("puts active decks in recent order and inactive decks in name order", () => {
+    const decks = [
+      createDeck({ id: "other-z", name: "Zulu" }),
+      createDeck({ id: "active-old", name: "Bravo" }),
+      createDeck({ id: "other-a", name: "Alpha" }),
+      createDeck({ id: "active-new", name: "Charlie" }),
+    ];
+    const cards = [
+      createCard({ id: "card-1", deckId: "other-z" }),
+      createCard({ id: "card-2", deckId: "other-z" }),
+      createCard({ id: "card-3", deckId: "other-a" }),
+    ];
+    const sessionsByDeckId: Partial<Record<DeckId, StudySession>> = {
+      "active-old": {
+        deckId: "active-old",
+        cardOrderIds: ["old-1", "old-2"],
+        currentIndex: 0,
+        lastStudiedAt: 100,
+      },
+      "active-new": {
+        deckId: "active-new",
+        cardOrderIds: ["new-1", "new-2", "new-3"],
+        currentIndex: 1,
+        lastStudiedAt: 200,
+      },
+      missing: {
+        deckId: "missing",
+        cardOrderIds: ["missing-card"],
+        currentIndex: 0,
+        lastStudiedAt: 300,
+      },
+    };
+
+    const sections = buildDeckListSections(decks, cards, sessionsByDeckId);
+
+    expect(sections.studying.map((item) => item.deck.id)).toEqual(["active-new", "active-old"]);
+    expect(sections.studying[0]?.studyProgress).toEqual({
+      currentIndex: 1,
+      cardCount: 3,
+      lastStudiedAt: 200,
+    });
+    expect(sections.other.map((item) => item.deck.id)).toEqual(["other-a", "other-z"]);
+    expect(sections.other.map((item) => item.cardCount)).toEqual([1, 2]);
+  });
+
+  it("uses deck name as a stable tie breaker for equally recent sessions", () => {
+    const decks = [createDeck({ id: "b", name: "Beta" }), createDeck({ id: "a", name: "Alpha" })];
+    const session = (deckId: DeckId): StudySession => ({
+      deckId,
+      cardOrderIds: [`${deckId}-card`],
+      currentIndex: 0,
+      lastStudiedAt: 100,
+    });
+
+    const sections = buildDeckListSections(decks, [], { a: session("a"), b: session("b") });
+
+    expect(sections.studying.map((item) => item.deck.name)).toEqual(["Alpha", "Beta"]);
+    expect(sections.other).toEqual([]);
+  });
+});

--- a/src/features/deck/lib/buildDeckListSections.ts
+++ b/src/features/deck/lib/buildDeckListSections.ts
@@ -1,0 +1,43 @@
+import type { DeckListItem, DeckListSections } from "@/features/deck/components/templates/DeckListTemplate";
+import type { StudySession } from "@/features/study/state/studyStore";
+
+const compareNames = (left: DeckListItem, right: DeckListItem) => left.deck.name.localeCompare(right.deck.name);
+
+export const buildDeckListSections = (
+  decks: Deck[],
+  cards: Card[],
+  sessionsByDeckId: Partial<Record<DeckId, StudySession>>
+): DeckListSections => {
+  const cardCounts = new Map<DeckId, number>();
+  for (const card of cards) cardCounts.set(card.deckId, (cardCounts.get(card.deckId) ?? 0) + 1);
+
+  const studying: DeckListItem[] = [];
+  const other: DeckListItem[] = [];
+
+  for (const deck of decks) {
+    const session = sessionsByDeckId[deck.id];
+    const item: DeckListItem = {
+      deck,
+      cardCount: cardCounts.get(deck.id) ?? 0,
+      ...(session == null
+        ? {}
+        : {
+            studyProgress: {
+              currentIndex: session.currentIndex,
+              cardCount: session.cardOrderIds.length,
+              lastStudiedAt: session.lastStudiedAt,
+            },
+          }),
+    };
+    if (session == null) other.push(item);
+    else studying.push(item);
+  }
+
+  studying.sort(
+    (left, right) =>
+      (right.studyProgress?.lastStudiedAt ?? 0) - (left.studyProgress?.lastStudiedAt ?? 0) || compareNames(left, right)
+  );
+  other.sort(compareNames);
+
+  return { studying, other };
+};

--- a/src/features/study/containers/DeckSwiperContainer.spec.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -133,13 +133,13 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
     mocks.state = createState();
     mocks.hydrated = true;
     studyStore.setState({
-      session: null,
+      sessionsByDeckId: {},
       showBackText: false,
       autoPlay: false,
       lastSwipe: undefined,
     });
     studyStore.getState().startStudy(deck.id, [card.id, legacyCard.id]);
-    mocks.resetStudy.mockImplementation(() => studyStore.getState().resetStudy());
+    mocks.resetStudy.mockImplementation(() => studyStore.getState().removeStudy(deck.id));
   });
 
   afterEach(() => {
@@ -163,9 +163,30 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
     expect(mocks.useKey).toHaveBeenCalledWith(" ", mocks.toggleAutoPlay);
   });
 
+  it("updates the route session activity when the study screen opens", () => {
+    studyStore.setState((state) => {
+      const session = state.sessionsByDeckId[deck.id];
+      if (session == null) return state;
+      return {
+        sessionsByDeckId: {
+          ...state.sessionsByDeckId,
+          [deck.id]: { ...session, lastStudiedAt: 100 },
+        },
+      };
+    });
+    studyStore.setState({ showBackText: true, autoPlay: true, lastSwipe: "cardSwipeLeft" });
+    const now = vi.spyOn(Date, "now").mockReturnValue(9000);
+
+    render(<DeckSwiperContainer />);
+
+    expect(studyStore.getState().sessionsByDeckId[deck.id]?.lastStudiedAt).toBe(9000);
+    expect(studyStore.getState()).toMatchObject({ showBackText: false, autoPlay: false, lastSwipe: undefined });
+    now.mockRestore();
+  });
+
   it("renders Zustand back text and controlled auto-play", () => {
-    studyStore.setState({ showBackText: true, autoPlay: true });
     const view = render(<DeckSwiperContainer />);
+    act(() => studyStore.setState({ showBackText: true, autoPlay: true }));
 
     const code = view.container.querySelector("pre.typescript") as HTMLElement;
     expect(code).toHaveTextContent(card.backText);
@@ -188,7 +209,7 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
       cardOrderIds: [card.id],
     };
     mocks.state = createState(legacyDeck);
-    studyStore.getState().resetStudy();
+    studyStore.getState().removeStudy(deck.id);
     mocks.hydrated = false;
 
     const view = render(<DeckSwiperContainer />);
@@ -196,7 +217,7 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
     expect(view.getByRole("status")).toHaveTextContent("Study session unavailable.");
     expect(mocks.resetStudy).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
-    expect(studyStore.getState().session).toBeNull();
+    expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
 
     mocks.hydrated = true;
     view.rerender(<DeckSwiperContainer />);
@@ -205,10 +226,11 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
       expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
     });
     expect(mocks.resetStudy).toHaveBeenCalledOnce();
-    expect(studyStore.getState().session).toBeNull();
+    expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
   });
 
-  it("resets and exits when the active session belongs to another deck", async () => {
+  it("exits without removing a session that belongs to another deck", async () => {
+    studyStore.getState().removeStudy(deck.id);
     studyStore.getState().startStudy("other-deck", [card.id]);
 
     render(<DeckSwiperContainer />);
@@ -217,11 +239,11 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
       expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
     });
     expect(mocks.resetStudy).toHaveBeenCalledOnce();
-    expect(studyStore.getState().session).toBeNull();
+    expect(studyStore.getState().sessionsByDeckId["other-deck"]).toMatchObject({ deckId: "other-deck" });
   });
 
   it("resets and exits when no session or legacy candidate exists", async () => {
-    studyStore.getState().resetStudy();
+    studyStore.getState().removeStudy(deck.id);
 
     render(<DeckSwiperContainer />);
 
@@ -232,7 +254,14 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
   });
 
   it("resets and exits at a terminal session index", async () => {
-    studyStore.getState().setCurrentIndex(-1);
+    const session = studyStore.getState().sessionsByDeckId[deck.id];
+    if (session == null) throw new Error("Expected an active study session");
+    studyStore.setState((state) => ({
+      sessionsByDeckId: {
+        ...state.sessionsByDeckId,
+        [deck.id]: { ...session, currentIndex: -1 },
+      },
+    }));
 
     render(<DeckSwiperContainer />);
 

--- a/src/features/study/containers/DeckSwiperContainer.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.tsx
@@ -15,6 +15,7 @@ import { useStudyActions } from "@/features/study/hooks/useStudyActions";
 import { useStudyControllerState } from "@/features/study/hooks/useStudyControllerState";
 import { useStudyHydrated } from "@/features/study/hooks/useStudyHydrated";
 import { useStudyStore } from "@/features/study/hooks/useStudyStore";
+import { selectStudySessionForRoute, studyStore } from "@/features/study/state/studyStore";
 import { useActions } from "@/shared/hooks/useActions";
 import { useConfig } from "@/features/settings/hooks/useConfig";
 
@@ -26,12 +27,11 @@ export const DeckSwiperContainer: React.FC = () => {
   const config = useConfig();
   const remote = useRemoteCollections();
   const deck = remote.deckById(deckId);
-  const activeSession = useStudyStore((state) => state.session);
+  const session = useStudyStore(selectStudySessionForRoute(deckId));
   const showBackText = useStudyStore((state) => state.showBackText);
   const autoPlay = useStudyStore((state) => state.autoPlay);
   const hydrated = useStudyHydrated();
 
-  const session = activeSession?.deckId === deckId ? activeSession : null;
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
   const card = cardId == null ? undefined : remote.cardById(cardId);
@@ -60,6 +60,13 @@ export const DeckSwiperContainer: React.FC = () => {
   });
 
   const exitingDeck = React.useRef<DeckId>();
+  React.useEffect(() => {
+    if (!valid) return;
+    const state = studyStore.getState();
+    state.initializeStudyUi(config.defaultAutoPlay);
+    state.touchStudy(deckId);
+  }, [config.defaultAutoPlay, deckId, valid]);
+
   React.useEffect(() => {
     if (valid) {
       exitingDeck.current = undefined;

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -105,7 +105,7 @@ describe("useStudyActions", () => {
     mocks.pendingIds.clear();
     mocks.state = createState();
     studyStore.setState({
-      session: null,
+      sessionsByDeckId: {},
       showBackText: false,
       autoPlay: false,
       lastSwipe: undefined,
@@ -121,10 +121,13 @@ describe("useStudyActions", () => {
     studyStore.setState({ showBackText: true, lastSwipe: "cardSwipeLeft" });
     mocks.navigate.mockImplementationOnce(() => {
       expect(studyStore.getState()).toMatchObject({
-        session: {
-          deckId: deck.id,
-          cardOrderIds: [card1.id],
-          currentIndex: 0,
+        sessionsByDeckId: {
+          [deck.id]: {
+            deckId: deck.id,
+            cardOrderIds: [card1.id],
+            currentIndex: 0,
+            lastStudiedAt: 946684800000,
+          },
         },
         showBackText: false,
         autoPlay: true,
@@ -149,7 +152,8 @@ describe("useStudyActions", () => {
     });
 
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
-    expect(studyStore.getState().session?.deckId).toBe("deck-2");
+    expect(studyStore.getState().sessionsByDeckId["deck-2"]?.deckId).toBe("deck-2");
+    expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
     expect(studyStore.getState().lastSwipe).toBeUndefined();
   });
 
@@ -171,10 +175,13 @@ describe("useStudyActions", () => {
     };
     expect(mocks.cardUpdate).toHaveBeenCalledWith(patch);
     expect(studyStore.getState()).toMatchObject({
-      session: {
-        deckId: deck.id,
-        cardOrderIds: [card1.id, card2.id],
-        currentIndex: 1,
+      sessionsByDeckId: {
+        [deck.id]: {
+          deckId: deck.id,
+          cardOrderIds: [card1.id, card2.id],
+          currentIndex: 1,
+          lastStudiedAt: 946684800000,
+        },
       },
       lastSwipe: "cardSwipeRight",
       showBackText: false,
@@ -192,9 +199,31 @@ describe("useStudyActions", () => {
     });
 
     expect(studyStore.getState()).toMatchObject({
-      session: { currentIndex: 0 },
+      sessionsByDeckId: { [deck.id]: { currentIndex: 0 } },
       showBackText: true,
       lastSwipe: undefined,
+    });
+  });
+
+  it("does not roll back a newer same-index session update", async () => {
+    studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
+    let rejectWrite: ((error: Error) => void) | undefined;
+    mocks.cardUpdate.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectWrite = reject;
+      })
+    );
+    const { result } = renderHook(() => useStudyActions(deck.id));
+
+    const swipe = result.current.swipeRight();
+    vi.mocked(Date.now).mockReturnValue(946684800100);
+    act(() => studyStore.getState().touchStudy(deck.id));
+    rejectWrite?.(new Error("write failed"));
+    await act(async () => swipe);
+
+    expect(studyStore.getState().sessionsByDeckId[deck.id]).toMatchObject({
+      currentIndex: 1,
+      lastStudiedAt: 946684800100,
     });
   });
 
@@ -208,7 +237,7 @@ describe("useStudyActions", () => {
     });
 
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
-    expect(studyStore.getState().session?.currentIndex).toBe(0);
+    expect(studyStore.getState().sessionsByDeckId[deck.id]?.currentIndex).toBe(0);
   });
 
   it("keeps back text visible when the long-lived config allows it", async () => {
@@ -238,9 +267,10 @@ describe("useStudyActions", () => {
     expect(studyStore.getState()).toEqual(before);
   });
 
-  it("sets a terminal index for GoBack without a card or deck write", async () => {
+  it("removes only the route session for GoBack without a card write", async () => {
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
-    studyStore.getState().setCurrentIndex(1);
+    studyStore.getState().startStudy("deck-2", ["other-card"]);
+    studyStore.getState().setCurrentIndex(deck.id, 1);
     studyStore.setState({ showBackText: true });
     const { result } = renderHook(() => useStudyActions(deck.id));
 
@@ -250,10 +280,11 @@ describe("useStudyActions", () => {
 
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
     expect(studyStore.getState()).toMatchObject({
-      session: { currentIndex: -1 },
+      sessionsByDeckId: { "deck-2": { deckId: "deck-2" } },
       lastSwipe: "cardSwipeLeft",
       showBackText: true,
     });
+    expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
   });
 
   it("updates the session index and hides back text", () => {
@@ -265,7 +296,21 @@ describe("useStudyActions", () => {
       result.current.updateIndex(1);
     });
 
-    expect(studyStore.getState().session?.currentIndex).toBe(1);
+    expect(studyStore.getState().sessionsByDeckId[deck.id]?.currentIndex).toBe(1);
     expect(studyStore.getState().showBackText).toBe(false);
+  });
+
+  it("finishes only the route session after the final card", async () => {
+    studyStore.getState().startStudy(deck.id, [card1.id]);
+    studyStore.getState().startStudy("deck-2", ["other-card"]);
+    const { result } = renderHook(() => useStudyActions(deck.id));
+
+    await act(async () => {
+      await result.current.swipeRight();
+    });
+
+    expect(mocks.cardUpdate).toHaveBeenCalledOnce();
+    expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
+    expect(studyStore.getState().sessionsByDeckId["deck-2"]).toMatchObject({ deckId: "deck-2" });
   });
 });

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -30,6 +30,7 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
   const cards = remote.filteredCardsByDeckId(deckId, config);
   const cardsById = remote.cardsById;
   const cardMutations = useCardMutations();
+  const mutationTokenRef = React.useRef<symbol | undefined>(undefined);
 
   const start = React.useCallback(() => {
     const cardOrderIds = buildStudySession(cards, config);
@@ -42,15 +43,15 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
   const swipe = React.useCallback(
     async (direction: SwipeDirection): Promise<void> => {
       const state = studyStore.getState();
-      const session = state.session;
-      if (session == null || session.deckId !== deckId) return;
+      const session = state.sessionsByDeckId[deckId];
+      if (session == null) return;
 
       const swipeAction = resolveSwipeAction(config, direction);
       if (swipeAction === "DoNothing") return;
 
       if (swipeAction === "GoBack") {
         state.setLastSwipe(direction);
-        state.setCurrentIndex(-1);
+        state.removeStudy(deckId);
         return;
       }
 
@@ -71,14 +72,28 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
 
       const patch = buildStudyPatch(card, swipeAction, Date.now());
       const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
-      state.setCurrentIndex(nextIndex);
+      const mutationToken = Symbol();
+      mutationTokenRef.current = mutationToken;
+      if (nextIndex < 0) state.removeStudy(deckId);
+      else state.setCurrentIndex(deckId, nextIndex);
+      const optimisticSession = studyStore.getState().sessionsByDeckId[deckId];
       try {
         await cardMutations.update(patch);
       } catch {
         const current = studyStore.getState();
-        if (current.session?.deckId === deckId && current.session.currentIndex === nextIndex) {
-          studyStore.setState(previous);
+        const currentSession = current.sessionsByDeckId[deckId];
+        const changeStillCurrent =
+          mutationTokenRef.current === mutationToken &&
+          (nextIndex < 0 ? currentSession == null : currentSession === optimisticSession);
+        if (changeStillCurrent) {
+          studyStore.setState((state) => ({
+            sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
+            showBackText: previous.showBackText,
+            lastSwipe: previous.lastSwipe,
+          }));
         }
+      } finally {
+        if (mutationTokenRef.current === mutationToken) mutationTokenRef.current = undefined;
       }
     },
     [cardMutations, cardsById, config, deckId]
@@ -93,13 +108,13 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
       swipeRight: () => swipe("cardSwipeRight"),
       updateIndex: (currentIndex: number) => {
         const state = studyStore.getState();
-        if (state.session?.deckId !== deckId) return;
+        if (state.sessionsByDeckId[deckId] == null) return;
         state.hideBackText();
-        state.setCurrentIndex(currentIndex);
+        state.setCurrentIndex(deckId, currentIndex);
       },
       toggleShowBackText: () => studyStore.getState().toggleShowBackText(),
       toggleAutoPlay: () => studyStore.getState().toggleAutoPlay(),
-      resetStudy: () => studyStore.getState().resetStudy(),
+      resetStudy: () => studyStore.getState().removeStudy(deckId),
       pending: cardMutations.pending,
       error: cardMutations.error,
       retry: cardMutations.retry,

--- a/src/features/study/state/studyStore.spec.ts
+++ b/src/features/study/state/studyStore.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { STUDY_STORAGE_KEY, createStudyStore, selectStudySessionForRoute } from "@/features/study/state/studyStore";
 
@@ -20,239 +20,209 @@ const createVersionedStorage = (state: unknown, version: number) =>
     [STUDY_STORAGE_KEY]: JSON.stringify({ state, version }),
   });
 
-const createV1Storage = (state: unknown) => createVersionedStorage(state, 1);
-const createV2Storage = (state: unknown) => createVersionedStorage(state, 2);
+const callSetCurrentIndex = (store: ReturnType<typeof createStudyStore>, deckId: DeckId, currentIndex: number) => {
+  const setCurrentIndex = store.getState().setCurrentIndex as unknown as (id: DeckId, index: number) => void;
+  setCurrentIndex(deckId, currentIndex);
+};
 
-const malformedPersistedStates: Array<[string, unknown]> = [
-  ["a null root", null],
-  ["an array root", []],
-  ["a missing session", {}],
-  ["an array session", { session: [] }],
-  ["a non-string deck id", { session: { deckId: 1, cardOrderIds: ["card-1"], currentIndex: 0 } }],
-  ["a non-array card order", { session: { deckId: "deck-1", cardOrderIds: "card-1", currentIndex: 0 } }],
-  ["a non-string card id", { session: { deckId: "deck-1", cardOrderIds: ["card-1", 2], currentIndex: 0 } }],
-  ["a non-number index", { session: { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: "0" } }],
-  ["a non-finite index", { session: { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: null } }],
-];
+const callRemoveStudy = (store: ReturnType<typeof createStudyStore>, deckId: DeckId) => {
+  const removeStudy = Reflect.get(store.getState(), "removeStudy");
+  expect(removeStudy).toBeTypeOf("function");
+  (removeStudy as (id: DeckId) => void)(deckId);
+};
 
 describe("study store", () => {
-  it("starts a study session atomically at index zero", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps independent study sessions for multiple decks", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
     const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
 
     store.getState().startStudy("deck-1", ["card-1", "card-2"]);
+    vi.setSystemTime(2000);
+    store.getState().startStudy("deck-2", ["card-3"]);
 
-    expect(store.getState().session).toEqual({
-      deckId: "deck-1",
-      cardOrderIds: ["card-1", "card-2"],
-      currentIndex: 0,
+    expect(store.getState().sessionsByDeckId).toEqual({
+      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 0, lastStudiedAt: 1000 },
+      "deck-2": { deckId: "deck-2", cardOrderIds: ["card-3"], currentIndex: 0, lastStudiedAt: 2000 },
     });
   });
 
-  it("updates only the active session index", () => {
+  it("updates only the requested session and its last studied time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
+    store.getState().startStudy("deck-1", ["card-1", "card-2"]);
+    store.getState().startStudy("deck-2", ["card-3", "card-4"]);
+
+    vi.setSystemTime(3000);
+    callSetCurrentIndex(store, "deck-1", 1);
+
+    expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({ currentIndex: 1, lastStudiedAt: 3000 });
+    expect(store.getState().sessionsByDeckId["deck-2"]).toMatchObject({ currentIndex: 0, lastStudiedAt: 1000 });
+  });
+
+  it.each([-1, 2, 0.5])("does not persist an invalid session index: %s", (currentIndex) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
     const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
     store.getState().startStudy("deck-1", ["card-1", "card-2"]);
 
-    store.getState().setCurrentIndex(1);
+    vi.setSystemTime(3000);
+    callSetCurrentIndex(store, "deck-1", currentIndex);
 
-    expect(store.getState().session).toEqual({
-      deckId: "deck-1",
-      cardOrderIds: ["card-1", "card-2"],
-      currentIndex: 1,
+    expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({ currentIndex: 0, lastStudiedAt: 1000 });
+  });
+
+  it("touches only an existing requested session", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
+    store.getState().startStudy("deck-1", ["card-1"]);
+    const touchStudy = Reflect.get(store.getState(), "touchStudy");
+    expect(touchStudy).toBeTypeOf("function");
+
+    vi.setSystemTime(4000);
+    (touchStudy as (id: DeckId) => void)("deck-1");
+    (touchStudy as (id: DeckId) => void)("missing-deck");
+
+    expect(store.getState().sessionsByDeckId["deck-1"]?.lastStudiedAt).toBe(4000);
+    expect(store.getState().sessionsByDeckId).not.toHaveProperty("missing-deck");
+  });
+
+  it("removes only the requested session", () => {
+    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
+    store.getState().startStudy("deck-1", ["card-1"]);
+    store.getState().startStudy("deck-2", ["card-2"]);
+
+    callRemoveStudy(store, "deck-1");
+
+    expect(store.getState().sessionsByDeckId).toEqual({
+      "deck-2": expect.objectContaining({ deckId: "deck-2" }),
     });
   });
 
-  it("does not create a session when setting an index without one", () => {
-    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
-
-    store.getState().setCurrentIndex(1);
-
-    expect(store.getState().session).toBeNull();
-  });
-
-  it("resets the session", () => {
+  it("returns the session for the requested route deck", () => {
     const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
     store.getState().startStudy("deck-1", ["card-1"]);
+    store.getState().startStudy("deck-2", ["card-2"]);
 
-    store.getState().resetStudy();
-
-    expect(store.getState().session).toBeNull();
+    expect(selectStudySessionForRoute("deck-1")(store.getState())).toEqual(store.getState().sessionsByDeckId["deck-1"]);
+    expect(selectStudySessionForRoute("missing-deck")(store.getState())).toBeNull();
   });
 
-  it("returns a session only for its route deck", () => {
-    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
-    store.getState().startStudy("deck-1", ["card-1"]);
-
-    expect(selectStudySessionForRoute("deck-1")(store.getState())).toEqual(store.getState().session);
-    expect(selectStudySessionForRoute("deck-2")(store.getState())).toBeNull();
-  });
-
-  it("initializes transient UI state for a new study", () => {
+  it("initializes and toggles transient study UI state", () => {
     const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
     store.getState().toggleShowBackText();
     store.getState().setLastSwipe("cardSwipeLeft");
 
     store.getState().initializeStudyUi(true);
-
-    expect(store.getState()).toMatchObject({
-      showBackText: false,
-      autoPlay: true,
-      lastSwipe: undefined,
-    });
-  });
-
-  it("toggles transient study UI state", () => {
-    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
+    expect(store.getState()).toMatchObject({ showBackText: false, autoPlay: true, lastSwipe: undefined });
 
     store.getState().toggleShowBackText();
     store.getState().toggleAutoPlay();
     store.getState().setLastSwipe("cardSwipeRight");
-    expect(store.getState()).toMatchObject({
-      showBackText: true,
-      autoPlay: true,
-      lastSwipe: "cardSwipeRight",
-    });
+    expect(store.getState()).toMatchObject({ showBackText: true, autoPlay: false, lastSwipe: "cardSwipeRight" });
 
     store.getState().hideBackText();
     expect(store.getState().showBackText).toBe(false);
   });
 
-  it("writes exactly the session in a v2 persistence envelope", async () => {
+  it("persists exactly the session map in a v3 envelope", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
     const storage = createMemoryStorage();
     const store = createStudyStore({ storage, skipHydration: true });
     store.getState().startStudy("deck-1", ["card-1"]);
     store.getState().toggleShowBackText();
-    store.getState().toggleAutoPlay();
-    store.getState().setLastSwipe("cardSwipeLeft");
 
     expect(JSON.parse(storage.getItem(STUDY_STORAGE_KEY) ?? "{}")).toEqual({
       state: {
-        session: {
-          deckId: "deck-1",
-          cardOrderIds: ["card-1"],
-          currentIndex: 0,
+        sessionsByDeckId: {
+          "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
         },
       },
-      version: 2,
+      version: 3,
     });
 
     const restored = createStudyStore({ storage, skipHydration: true });
     await restored.persist.rehydrate();
-
     expect(restored.getState()).toMatchObject({
-      session: {
-        deckId: "deck-1",
-        cardOrderIds: ["card-1"],
-        currentIndex: 0,
+      sessionsByDeckId: {
+        "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
       },
       showBackText: false,
       autoPlay: false,
       lastSwipe: undefined,
     });
-    expect(restored.getState()).not.toHaveProperty("legacyMigratedDeckIds");
+    expect(restored.getState()).not.toHaveProperty("session");
   });
 
-  it("hydrates only a valid current v2 session while retaining transient state and methods", async () => {
-    const session = {
-      deckId: "deck-1",
-      cardOrderIds: ["card-1", "card-2"],
-      currentIndex: 1.5,
-    };
-    const storage = createV2Storage({
-      session: { ...session, unknownSessionMetadata: "drop" },
-      showBackText: true,
-      autoPlay: true,
-      lastSwipe: "cardSwipeLeft",
-      resetStudy: "broken",
-      unknownRootMetadata: "drop",
-    });
+  it("hydrates valid v3 sessions independently and drops unknown metadata", async () => {
+    const storage = createVersionedStorage(
+      {
+        sessionsByDeckId: {
+          "deck-1": {
+            deckId: "deck-1",
+            cardOrderIds: ["card-1", "card-2"],
+            currentIndex: 1,
+            lastStudiedAt: 1000,
+            unknownSessionMetadata: "drop",
+          },
+          broken: { deckId: "broken", cardOrderIds: [], currentIndex: 0, lastStudiedAt: 2000 },
+        },
+        showBackText: true,
+        unknownRootMetadata: "drop",
+      },
+      3
+    );
     const store = createStudyStore({ storage, skipHydration: true });
-    const resetStudy = store.getState().resetStudy;
 
     await store.persist.rehydrate();
 
-    expect(store.getState()).toMatchObject({
-      session,
-      showBackText: false,
-      autoPlay: false,
-      lastSwipe: undefined,
+    expect(store.getState().sessionsByDeckId).toEqual({
+      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 1000 },
     });
-    expect(store.getState().resetStudy).toBe(resetStudy);
     expect(store.getState()).not.toHaveProperty("unknownRootMetadata");
-    expect(store.getState().session).not.toHaveProperty("unknownSessionMetadata");
+    expect(store.getState().showBackText).toBe(false);
   });
 
-  it.each(malformedPersistedStates)("sanitizes current v2 state with %s", async (_label, state) => {
-    const storage = createV2Storage(state);
+  it.each([1, 2])("migrates a valid v%s session into the v3 map", async (version) => {
+    const storage = createVersionedStorage(
+      { session: { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1 } },
+      version
+    );
     const store = createStudyStore({ storage, skipHydration: true });
 
     await store.persist.rehydrate();
 
-    expect(store.getState().session).toBeNull();
-  });
-
-  it("sanitizes a non-finite numeric current v2 index", async () => {
-    const storage = createMemoryStorage({
-      [STUDY_STORAGE_KEY]:
-        '{"state":{"session":{"deckId":"deck-1","cardOrderIds":["card-1"],"currentIndex":1e400}},"version":2}',
+    expect(store.getState().sessionsByDeckId).toEqual({
+      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 0 },
     });
-    const store = createStudyStore({ storage, skipHydration: true });
-
-    await store.persist.rehydrate();
-
-    expect(store.getState().session).toBeNull();
-  });
-
-  it.each([
-    ["a negative index", -1],
-    ["a terminal index", 2],
-  ])("migrates a valid v1 session with %s and drops legacy markers", async (_label, currentIndex) => {
-    const session = {
-      deckId: "deck-1",
-      cardOrderIds: ["card-1", "card-2"],
-      currentIndex,
-    };
-    const storage = createV1Storage({
-      session,
-      legacyMigratedDeckIds: { "deck-1": true },
-      unknownMetadata: "drop",
-    });
-    const store = createStudyStore({ storage, skipHydration: true });
-
-    await store.persist.rehydrate();
-
-    expect(store.getState().session).toEqual(session);
-    expect(store.getState()).not.toHaveProperty("legacyMigratedDeckIds");
     expect(JSON.parse(storage.getItem(STUDY_STORAGE_KEY) ?? "{}")).toEqual({
-      state: { session },
-      version: 2,
+      state: {
+        sessionsByDeckId: {
+          "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 0 },
+        },
+      },
+      version: 3,
     });
   });
 
   it.each([
-    ...malformedPersistedStates,
-    ["a null session", { session: null }],
-  ])("falls back to a null session when v1 contains %s", async (_label, state) => {
-    const storage = createV1Storage(state);
+    ["a missing session", {}],
+    ["an empty card order", { session: { deckId: "deck-1", cardOrderIds: [], currentIndex: 0 } }],
+    ["a negative index", { session: { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: -1 } }],
+    ["a terminal index", { session: { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 1 } }],
+  ])("drops invalid legacy state with %s", async (_label, state) => {
+    const storage = createVersionedStorage(state, 2);
     const store = createStudyStore({ storage, skipHydration: true });
 
     await store.persist.rehydrate();
 
-    expect(store.getState().session).toBeNull();
-    expect(JSON.parse(storage.getItem(STUDY_STORAGE_KEY) ?? "{}")).toEqual({
-      state: { session: null },
-      version: 2,
-    });
-  });
-
-  it("rejects a non-finite numeric v1 index", async () => {
-    const storage = createMemoryStorage({
-      [STUDY_STORAGE_KEY]:
-        '{"state":{"session":{"deckId":"deck-1","cardOrderIds":["card-1"],"currentIndex":1e400}},"version":1}',
-    });
-    const store = createStudyStore({ storage, skipHydration: true });
-
-    await store.persist.rehydrate();
-
-    expect(store.getState().session).toBeNull();
+    expect(store.getState().sessionsByDeckId).toEqual({});
   });
 });

--- a/src/features/study/state/studyStore.ts
+++ b/src/features/study/state/studyStore.ts
@@ -7,10 +7,11 @@ export interface StudySession {
   deckId: DeckId;
   cardOrderIds: CardId[];
   currentIndex: number;
+  lastStudiedAt: number;
 }
 
 interface PersistedStudyState {
-  session: StudySession | null;
+  sessionsByDeckId: Partial<Record<DeckId, StudySession>>;
 }
 
 export interface StudyState extends PersistedStudyState {
@@ -18,8 +19,9 @@ export interface StudyState extends PersistedStudyState {
   autoPlay: boolean;
   lastSwipe?: SwipeDirection | undefined;
   startStudy: (deckId: DeckId, cardOrderIds: CardId[]) => void;
-  setCurrentIndex: (currentIndex: number) => void;
-  resetStudy: () => void;
+  touchStudy: (deckId: DeckId) => void;
+  setCurrentIndex: (deckId: DeckId, currentIndex: number) => void;
+  removeStudy: (deckId: DeckId) => void;
   initializeStudyUi: (defaultAutoPlay: boolean) => void;
   toggleShowBackText: () => void;
   toggleAutoPlay: () => void;
@@ -35,56 +37,109 @@ interface CreateStudyStoreOptions {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value != null && !Array.isArray(value);
 
-const sanitizePersistedStudyState = (persistedState: unknown): PersistedStudyState => {
-  if (!isRecord(persistedState) || !isRecord(persistedState.session)) {
-    return { session: null };
-  }
-
-  const { deckId, cardOrderIds, currentIndex } = persistedState.session;
+const sanitizeStudySession = (value: unknown, fallbackLastStudiedAt?: number): StudySession | undefined => {
+  if (!isRecord(value)) return undefined;
+  const { deckId, cardOrderIds, currentIndex } = value;
+  const lastStudiedAt = value.lastStudiedAt ?? fallbackLastStudiedAt;
   if (
     typeof deckId !== "string" ||
     !Array.isArray(cardOrderIds) ||
+    cardOrderIds.length === 0 ||
     !cardOrderIds.every((cardId) => typeof cardId === "string") ||
     typeof currentIndex !== "number" ||
-    !Number.isFinite(currentIndex)
+    !Number.isInteger(currentIndex) ||
+    currentIndex < 0 ||
+    currentIndex >= cardOrderIds.length ||
+    typeof lastStudiedAt !== "number" ||
+    !Number.isFinite(lastStudiedAt) ||
+    lastStudiedAt < 0
   ) {
-    return { session: null };
+    return undefined;
   }
 
   return {
-    session: {
-      deckId,
-      cardOrderIds: [...cardOrderIds],
-      currentIndex,
-    },
+    deckId,
+    cardOrderIds: [...cardOrderIds],
+    currentIndex,
+    lastStudiedAt,
   };
 };
 
-const migratePersistedStudyState = (persistedState: unknown, version: number): PersistedStudyState =>
-  version === 1 ? sanitizePersistedStudyState(persistedState) : { session: null };
+const sanitizePersistedStudyState = (persistedState: unknown): PersistedStudyState => {
+  if (!isRecord(persistedState) || !isRecord(persistedState.sessionsByDeckId)) {
+    return { sessionsByDeckId: {} };
+  }
+
+  const sessionsByDeckId: Partial<Record<DeckId, StudySession>> = {};
+  for (const [deckId, value] of Object.entries(persistedState.sessionsByDeckId)) {
+    const session = sanitizeStudySession(value);
+    if (session?.deckId === deckId) sessionsByDeckId[deckId] = session;
+  }
+  return { sessionsByDeckId };
+};
+
+const migratePersistedStudyState = (persistedState: unknown, version: number): PersistedStudyState => {
+  if (version !== 1 && version !== 2) return { sessionsByDeckId: {} };
+  if (!isRecord(persistedState)) return { sessionsByDeckId: {} };
+  const session = sanitizeStudySession(persistedState.session, 0);
+  return session == null ? { sessionsByDeckId: {} } : { sessionsByDeckId: { [session.deckId]: session } };
+};
 
 export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOptions = {}) => {
   const persistStorage = createJSONStorage<PersistedStudyState>(() => storage ?? localStorage);
   return createStore<StudyState>()(
     persist<StudyState, [], [], PersistedStudyState>(
       (set) => ({
-        session: null,
+        sessionsByDeckId: {},
         showBackText: false,
         autoPlay: false,
         lastSwipe: undefined,
         startStudy: (deckId, cardOrderIds) =>
-          set({
-            session: {
-              deckId,
-              cardOrderIds: [...cardOrderIds],
-              currentIndex: 0,
-            },
-          }),
-        setCurrentIndex: (currentIndex) =>
           set((state) => ({
-            session: state.session ? { ...state.session, currentIndex } : null,
+            sessionsByDeckId: {
+              ...state.sessionsByDeckId,
+              [deckId]: {
+                deckId,
+                cardOrderIds: [...cardOrderIds],
+                currentIndex: 0,
+                lastStudiedAt: Date.now(),
+              },
+            },
           })),
-        resetStudy: () => set({ session: null }),
+        touchStudy: (deckId) =>
+          set((state) => {
+            const session = state.sessionsByDeckId[deckId];
+            if (session == null) return state;
+            return {
+              sessionsByDeckId: {
+                ...state.sessionsByDeckId,
+                [deckId]: { ...session, lastStudiedAt: Date.now() },
+              },
+            };
+          }),
+        setCurrentIndex: (deckId, currentIndex) =>
+          set((state) => {
+            const session = state.sessionsByDeckId[deckId];
+            if (
+              session == null ||
+              !Number.isInteger(currentIndex) ||
+              currentIndex < 0 ||
+              currentIndex >= session.cardOrderIds.length
+            ) {
+              return state;
+            }
+            return {
+              sessionsByDeckId: {
+                ...state.sessionsByDeckId,
+                [deckId]: { ...session, currentIndex, lastStudiedAt: Date.now() },
+              },
+            };
+          }),
+        removeStudy: (deckId) =>
+          set((state) => {
+            const { [deckId]: _removed, ...sessionsByDeckId } = state.sessionsByDeckId;
+            return { sessionsByDeckId };
+          }),
         initializeStudyUi: (defaultAutoPlay) =>
           set({
             showBackText: false,
@@ -98,7 +153,7 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
       }),
       {
         name: STUDY_STORAGE_KEY,
-        version: 2,
+        version: 3,
         ...(persistStorage !== undefined ? { storage: persistStorage } : {}),
         ...(skipHydration !== undefined ? { skipHydration } : {}),
         migrate: migratePersistedStudyState,
@@ -106,7 +161,7 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
           ...currentState,
           ...sanitizePersistedStudyState(persistedState),
         }),
-        partialize: ({ session }) => ({ session }),
+        partialize: ({ sessionsByDeckId }) => ({ sessionsByDeckId }),
       }
     )
   );
@@ -116,7 +171,7 @@ export const studyStore = createStudyStore();
 
 export const clearStudyStore = async (): Promise<void> => {
   studyStore.setState({
-    session: null,
+    sessionsByDeckId: {},
     showBackText: false,
     autoPlay: false,
     lastSwipe: undefined,
@@ -125,4 +180,4 @@ export const clearStudyStore = async (): Promise<void> => {
 };
 
 export const selectStudySessionForRoute = (deckId: DeckId) => (state: StudyState) =>
-  state.session?.deckId === deckId ? state.session : null;
+  state.sessionsByDeckId[deckId] ?? null;


### PR DESCRIPTION
## Summary

- redesign the deck list as compact mobile-first Studying and Other decks sections
- support independent persisted progress for multiple studying decks with safe legacy migration
- move secondary deck actions into an accessible overflow menu
- add component, store, integration, Storybook, and multi-session E2E coverage
- document the approved interaction and state design

## Testing

- `direnv exec . make check` (418 unit tests passed)
- `direnv exec . make e2e` (16 E2E tests passed)