### PR TITLE
Fix deck action menu clicks

### DIFF
--- a/docs/superpowers/specs/2026-07-18-deck-actions-menu-fix-design.md
+++ b/docs/superpowers/specs/2026-07-18-deck-actions-menu-fix-design.md
@@ -1,0 +1,15 @@
+# Deck Actions Menu Fix
+
+## Problem
+
+The Deck list action menu closes from its `fieldset` blur handler whenever `FocusEvent.relatedTarget` is `null`. Browsers can report a null related target while pointer focus changes inside the menu. The menu is then unmounted before the pending click reaches Download, Edit, or Delete, so those actions do nothing.
+
+## Design
+
+Keep the existing menu structure and interaction model. Defer the blur decision until the browser has updated `document.activeElement`, then close only when focus is outside the menu root. This preserves outside-focus dismissal while allowing menu item clicks to finish when `relatedTarget` is unavailable.
+
+The change is limited to `DeckActionsMenu`; Deck list callbacks and mutation behavior remain unchanged.
+
+## Testing
+
+Add a regression test that opens the menu, simulates a blur with no related target while focus moves to each management item, and verifies Download, Edit, and Delete still invoke their callbacks. Preserve the existing keyboard navigation and Escape assertions. Run the focused tests and `make check` before publishing the PR.

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -100,8 +100,10 @@ describe("DeckActionsMenu", () => {
       const item = view.getByRole("menuitem", { name: label });
       await waitFor(() => expect(download).toHaveFocus());
 
-      download.blur();
-      item.focus();
+      await act(async () => {
+        download.blur();
+        item.focus();
+      });
       fireEvent.click(item);
 
       expect(action).toHaveBeenCalledOnce();

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -80,4 +80,31 @@ describe("DeckActionsMenu", () => {
     expect(view.queryByRole("menu")).not.toBeInTheDocument();
     expect(trigger).toHaveFocus();
   });
+
+  it("keeps management actions active when an ambiguous blur settles inside the menu", async () => {
+    const actions = {
+      onDownload: vi.fn(),
+      onEdit: vi.fn(),
+      onDelete: vi.fn(),
+    };
+    const view = render(<ControlledMenu deckName="Biology" {...actions} />);
+    const trigger = view.getByRole("button", { name: "Open actions for Biology" });
+
+    for (const [label, action] of [
+      ["Download", actions.onDownload],
+      ["Edit", actions.onEdit],
+      ["Delete", actions.onDelete],
+    ] as const) {
+      fireEvent.click(trigger);
+      const download = view.getByRole("menuitem", { name: "Download" });
+      const item = view.getByRole("menuitem", { name: label });
+      await waitFor(() => expect(download).toHaveFocus());
+
+      download.blur();
+      item.focus();
+      fireEvent.click(item);
+
+      expect(action).toHaveBeenCalledOnce();
+    }
+  });
 });

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -115,7 +115,7 @@ describe("DeckActionsMenu", () => {
       <>
         <button type="button">External focus target</button>
         <ControlledMenu deckName="Chemistry" />
-      </>,
+      </>
     );
     const trigger = view.getByRole("button", { name: "Open actions for Chemistry" });
     const externalTarget = view.getByRole("button", { name: "External focus target" });

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -109,4 +109,27 @@ describe("DeckActionsMenu", () => {
       expect(action).toHaveBeenCalledOnce();
     }
   });
+
+  it("closes when an ambiguous blur settles on an external element", async () => {
+    const view = render(
+      <>
+        <button type="button">External focus target</button>
+        <ControlledMenu deckName="Chemistry" />
+      </>,
+    );
+    const trigger = view.getByRole("button", { name: "Open actions for Chemistry" });
+    const externalTarget = view.getByRole("button", { name: "External focus target" });
+
+    fireEvent.click(trigger);
+    const download = view.getByRole("menuitem", { name: "Download" });
+    await waitFor(() => expect(download).toHaveFocus());
+
+    await act(async () => {
+      download.blur();
+      externalTarget.focus();
+    });
+
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    expect(externalTarget).toHaveFocus();
+  });
 });

--- a/src/features/deck/components/DeckActionsMenu.tsx
+++ b/src/features/deck/components/DeckActionsMenu.tsx
@@ -58,7 +58,12 @@ export const DeckActionsMenu: React.FC<DeckActionsMenuProps> = (props) => {
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLFieldSetElement>) => {
-    if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) props.onClose();
+    const root = event.currentTarget;
+    if (event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
+
+    queueMicrotask(() => {
+      if (!root.contains(document.activeElement)) props.onClose();
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- defer ambiguous menu blur dismissal until focus settles
- preserve Download, Edit, and Delete clicks inside the deck actions menu
- add regression coverage for internal and external focus transitions

## Testing
- make check (80 files, 424 tests)