### PR TITLE
Group shared Storybook components by responsibility

### DIFF
--- a/docs/superpowers/plans/2026-07-18-shared-storybook-groups.md
+++ b/docs/superpowers/plans/2026-07-18-shared-storybook-groups.md
@@ -1,0 +1,140 @@
+# Shared Storybook Groups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group shared component stories under `Content`, `Feedback`, `Forms`, and `Layout` in the Storybook sidebar.
+
+**Architecture:** Keep Storybook's existing explicit story titles and add the responsibility directory as the middle path segment. Protect the mapping with a filesystem-based Vitest contract that derives the expected Storybook title from each story's directory and filename.
+
+**Tech Stack:** TypeScript, Storybook 10, Vitest 4, Node.js filesystem APIs
+
+## Global Constraints
+
+- Preserve the existing `Shared` Storybook root.
+- Use exactly `Content`, `Feedback`, `Forms`, and `Layout` as second-level groups.
+- Change only stories under `src/shared/components`; feature stories and component implementations remain unchanged.
+- Run `make check` before publishing the pull request.
+
+---
+
+### Task 1: Group Shared Stories by Responsibility
+
+**Files:**
+- Create: `src/lib/storybookNavigation.spec.ts`
+- Modify: `src/shared/components/content/*.stories.tsx`
+- Modify: `src/shared/components/feedback/*.stories.tsx`
+- Modify: `src/shared/components/forms/*.stories.tsx`
+- Modify: `src/shared/components/layout/*.stories.tsx`
+- Test: `src/lib/storybookNavigation.spec.ts`
+
+**Interfaces:**
+- Consumes: story metadata with an explicit `title` string in each `*.stories.tsx` default export.
+- Produces: Storybook paths in the form `Shared/<Responsibility>/<Component>` and a contract that checks every shared story file.
+
+- [ ] **Step 1: Write the failing Storybook navigation contract**
+
+Create `src/lib/storybookNavigation.spec.ts`:
+
+```ts
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sharedComponentsRoot = path.resolve(process.cwd(), "src/shared/components");
+const storyGroups = {
+  content: "Content",
+  feedback: "Feedback",
+  forms: "Forms",
+  layout: "Layout",
+} as const;
+
+describe("Storybook navigation", () => {
+  for (const [directory, storybookGroup] of Object.entries(storyGroups)) {
+    it(`groups ${directory} stories under Shared/${storybookGroup}`, () => {
+      const groupDirectory = path.join(sharedComponentsRoot, directory);
+      const storyFiles = readdirSync(groupDirectory)
+        .filter((fileName) => fileName.endsWith(".stories.tsx"))
+        .sort();
+
+      const mismatches = storyFiles.flatMap((fileName) => {
+        const componentName = fileName.replace(/\.stories\.tsx$/, "");
+        const expectedTitle = `Shared/${storybookGroup}/${componentName}`;
+        const source = readFileSync(path.join(groupDirectory, fileName), "utf8");
+        return source.includes(`title: "${expectedTitle}"`)
+          ? []
+          : [`${directory}/${fileName}: expected ${expectedTitle}`];
+      });
+
+      expect(storyFiles.length).toBeGreaterThan(0);
+      expect(mismatches).toEqual([]);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the contract to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/lib/storybookNavigation.spec.ts
+```
+
+Expected: FAIL in all four generated tests because the current titles omit the responsibility group.
+
+- [ ] **Step 3: Add the responsibility segment to every shared story title**
+
+Apply these exact mappings while leaving all other story metadata and story implementations unchanged:
+
+```text
+src/shared/components/content/*.stories.tsx
+  Shared/<Component> -> Shared/Content/<Component>
+
+src/shared/components/feedback/*.stories.tsx
+  Shared/<Component> -> Shared/Feedback/<Component>
+
+src/shared/components/forms/*.stories.tsx
+  Shared/<Component> -> Shared/Forms/<Component>
+
+src/shared/components/layout/*.stories.tsx
+  Shared/<Component> -> Shared/Layout/<Component>
+```
+
+This covers 9 content stories, 2 feedback stories, 10 forms stories, and 6 layout stories.
+
+- [ ] **Step 4: Run the focused contract to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/lib/storybookNavigation.spec.ts
+```
+
+Expected: PASS with 1 test file and 4 tests.
+
+- [ ] **Step 5: Build Storybook**
+
+Run:
+
+```bash
+npm run build:storybook
+```
+
+Expected: PASS and generate a static Storybook build with no duplicate-title or metadata errors.
+
+- [ ] **Step 6: Run the repository checks**
+
+Run:
+
+```bash
+make check
+```
+
+Expected: PASS for sample build, formatting, linting, and unit tests.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add src/lib/storybookNavigation.spec.ts src/shared/components
+git commit -m "Group shared stories by responsibility"
+```

--- a/docs/superpowers/specs/2026-07-18-shared-storybook-groups-design.md
+++ b/docs/superpowers/specs/2026-07-18-shared-storybook-groups-design.md
@@ -1,0 +1,28 @@
+# Shared Storybook Groups Design
+
+## Goal
+
+Reflect the responsibility-based `src/shared/components` directory structure in the Storybook sidebar instead of listing every shared component directly under `Shared`.
+
+## Scope
+
+Update the explicit Storybook `title` in all 27 stories under `src/shared/components`:
+
+- `content` stories use `Shared/Content/<Component>`.
+- `feedback` stories use `Shared/Feedback/<Component>`.
+- `forms` stories use `Shared/Forms/<Component>`.
+- `layout` stories use `Shared/Layout/<Component>`.
+
+For example, `Shared/Card` becomes `Shared/Content/Card`, and `Shared/FullScreen` becomes `Shared/Layout/FullScreen`.
+
+Feature stories, component implementations, exports, and the source directory structure remain unchanged.
+
+## Implementation
+
+Keep each story's explicit `title` and insert its responsibility group as the middle Storybook path segment. This preserves the existing `Shared` root and component names while creating the four sidebar groups. No shared title helper or Storybook-wide automatic title configuration is needed.
+
+## Verification
+
+- Add a focused static contract test that reads shared story metadata and verifies every story title matches its containing responsibility group.
+- Build Storybook through the repository's existing checks to confirm the updated metadata is valid.
+- Run `make check` before publishing the pull request.

--- a/src/lib/storybookNavigation.spec.ts
+++ b/src/lib/storybookNavigation.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sharedComponentsRoot = path.resolve(process.cwd(), "src/shared/components");
+const storyGroups = {
+  content: "Content",
+  feedback: "Feedback",
+  forms: "Forms",
+  layout: "Layout",
+} as const;
+
+describe("Storybook navigation", () => {
+  for (const [directory, storybookGroup] of Object.entries(storyGroups)) {
+    it(`groups ${directory} stories under Shared/${storybookGroup}`, () => {
+      const groupDirectory = path.join(sharedComponentsRoot, directory);
+      const storyFiles = readdirSync(groupDirectory)
+        .filter((fileName) => fileName.endsWith(".stories.tsx"))
+        .sort();
+
+      const mismatches = storyFiles.flatMap((fileName) => {
+        const componentName = fileName.replace(/\.stories\.tsx$/, "");
+        const expectedTitle = `Shared/${storybookGroup}/${componentName}`;
+        const source = readFileSync(path.join(groupDirectory, fileName), "utf8");
+        return source.includes(`title: "${expectedTitle}"`)
+          ? []
+          : [`${directory}/${fileName}: expected ${expectedTitle}`];
+      });
+
+      expect(storyFiles.length).toBeGreaterThan(0);
+      expect(mismatches).toEqual([]);
+    });
+  }
+});

--- a/src/shared/components/content/Card.stories.tsx
+++ b/src/shared/components/content/Card.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Card as Template } from "@/shared/components/content/Card";
 
 const meta = {
-  title: "Shared/Card",
+  title: "Shared/Content/Card",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/content/Code.stories.tsx
+++ b/src/shared/components/content/Code.stories.tsx
@@ -4,7 +4,7 @@ import { Code as Template } from "@/shared/components/content/Code";
 import * as fixture from "@/shared/storybook/fixture";
 
 const meta = {
-  title: "Shared/Code",
+  title: "Shared/Content/Code",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/content/Description.stories.tsx
+++ b/src/shared/components/content/Description.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Description as Template } from "@/shared/components/content/Description";
 
 const meta = {
-  title: "Shared/Description",
+  title: "Shared/Content/Description",
   component: Template,
   tags: ["autodocs"],
 } satisfies Meta<typeof Template>;

--- a/src/shared/components/content/Logo.stories.tsx
+++ b/src/shared/components/content/Logo.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Logo as Template } from "@/shared/components/content/Logo";
 
 const meta = {
-  title: "Shared/Logo",
+  title: "Shared/Content/Logo",
   component: Template,
   tags: ["autodocs"],
   args: {},

--- a/src/shared/components/content/Math.stories.tsx
+++ b/src/shared/components/content/Math.stories.tsx
@@ -4,7 +4,7 @@ import { MathContent as Template } from "@/shared/components/content/Math";
 import * as fixture from "@/shared/storybook/fixture";
 
 const meta = {
-  title: "Shared/Math",
+  title: "Shared/Content/Math",
   component: Template,
   tags: ["autodocs"],
   args: {},

--- a/src/shared/components/content/Score.stories.tsx
+++ b/src/shared/components/content/Score.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Score as Template } from "@/shared/components/content/Score";
 
 const meta = {
-  title: "Shared/Score",
+  title: "Shared/Content/Score",
   component: Template,
   tags: ["autodocs"],
   args: {},

--- a/src/shared/components/content/Section.stories.tsx
+++ b/src/shared/components/content/Section.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Section as Template } from "@/shared/components/content/Section";
 
 const meta = {
-  title: "Shared/Section",
+  title: "Shared/Content/Section",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/content/TagList.stories.tsx
+++ b/src/shared/components/content/TagList.stories.tsx
@@ -5,7 +5,7 @@ import { TagList as Template } from "@/shared/components/content/TagList";
 import * as fixture from "@/shared/storybook/fixture";
 
 const meta = {
-  title: "Shared/TagList",
+  title: "Shared/Content/TagList",
   component: Template,
   tags: ["autodocs"],
 } satisfies Meta<typeof Template>;

--- a/src/shared/components/content/Title.stories.tsx
+++ b/src/shared/components/content/Title.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Title as Template } from "@/shared/components/content/Title";
 
 const meta = {
-  title: "Shared/Title",
+  title: "Shared/Content/Title",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/feedback/Feedback.stories.tsx
+++ b/src/shared/components/feedback/Feedback.stories.tsx
@@ -4,7 +4,7 @@ import { Feedback as Template } from "@/shared/components/feedback/Feedback";
 import { AiOutlineArrowUp } from "react-icons/ai";
 
 const meta = {
-  title: "Shared/Feedback",
+  title: "Shared/Feedback/Feedback",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/feedback/Overlay.stories.tsx
+++ b/src/shared/components/feedback/Overlay.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Overlay as Template } from "@/shared/components/feedback/Overlay";
 
 const meta = {
-  title: "Shared/Overlay",
+  title: "Shared/Feedback/Overlay",
   component: Template,
   tags: ["autodocs"],
   parameters: {

--- a/src/shared/components/forms/Button.stories.tsx
+++ b/src/shared/components/forms/Button.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Button as Template } from "@/shared/components/forms/Button";
 
 const meta = {
-  title: "Shared/Button",
+  title: "Shared/Forms/Button",
   component: Template,
   tags: ["autodocs"],
   argTypes: { onClick: { action: "onClick" } },

--- a/src/shared/components/forms/Form.stories.tsx
+++ b/src/shared/components/forms/Form.stories.tsx
@@ -20,7 +20,7 @@ const reviewForm = () => (
 );
 
 const meta = {
-  title: "Shared/Form",
+  title: "Shared/Forms/Form",
   component: Template,
   tags: ["autodocs"],
 } satisfies Meta<typeof Template>;

--- a/src/shared/components/forms/FormItem.stories.tsx
+++ b/src/shared/components/forms/FormItem.stories.tsx
@@ -8,7 +8,7 @@ import { Slider } from "@/shared/components/forms/Slider";
 import { Switch } from "@/shared/components/forms/Switch";
 
 const meta = {
-  title: "Shared/FormItem",
+  title: "Shared/Forms/FormItem",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/forms/Input.stories.tsx
+++ b/src/shared/components/forms/Input.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Input as Template } from "@/shared/components/forms/Input";
 
 const meta = {
-  title: "Shared/Input",
+  title: "Shared/Forms/Input",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/forms/Select.stories.tsx
+++ b/src/shared/components/forms/Select.stories.tsx
@@ -4,7 +4,7 @@ import { Select as Template } from "@/shared/components/forms/Select";
 import * as fixture from "@/shared/storybook/fixture";
 
 const meta = {
-  title: "Shared/Select",
+  title: "Shared/Forms/Select",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/forms/Slider.stories.tsx
+++ b/src/shared/components/forms/Slider.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Slider as Template } from "@/shared/components/forms/Slider";
 
 const meta = {
-  title: "Shared/Slider",
+  title: "Shared/Forms/Slider",
   component: Template,
   tags: ["autodocs"],
   args: {},

--- a/src/shared/components/forms/Switch.stories.tsx
+++ b/src/shared/components/forms/Switch.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Switch as Template } from "@/shared/components/forms/Switch";
 
 const meta = {
-  title: "Shared/Switch",
+  title: "Shared/Forms/Switch",
   component: Template,
   tags: ["autodocs"],
   args: {},

--- a/src/shared/components/forms/Tag.stories.tsx
+++ b/src/shared/components/forms/Tag.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Tag as Template } from "@/shared/components/forms/Tag";
 
 const meta = {
-  title: "Shared/Tag",
+  title: "Shared/Forms/Tag",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/shared/components/forms/Textarea.stories.tsx
+++ b/src/shared/components/forms/Textarea.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Textarea as Template } from "@/shared/components/forms/Textarea";
 
 const meta = {
-  title: "Shared/Textarea",
+  title: "Shared/Forms/Textarea",
   component: Template,
   tags: ["autodocs"],
   args: { rows: 4 },

--- a/src/shared/components/forms/Upload.stories.tsx
+++ b/src/shared/components/forms/Upload.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Upload as Template } from "@/shared/components/forms/Upload";
 
 const meta = {
-  title: "Shared/Upload",
+  title: "Shared/Forms/Upload",
   component: Template,
   tags: ["autodocs"],
   argTypes: {

--- a/src/shared/components/layout/FullScreen.stories.tsx
+++ b/src/shared/components/layout/FullScreen.stories.tsx
@@ -4,7 +4,7 @@ import { FullScreen as Template } from "@/shared/components/layout/FullScreen";
 import { Container } from "@/shared/storybook/Decorator";
 
 const meta = {
-  title: "Shared/FullScreen",
+  title: "Shared/Layout/FullScreen",
   component: Template,
   tags: ["autodocs"],
   parameters: {

--- a/src/shared/components/layout/Header.stories.tsx
+++ b/src/shared/components/layout/Header.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Header as Template } from "@/shared/components/layout/Header";
 
 const meta = {
-  title: "Shared/Header",
+  title: "Shared/Layout/Header",
   component: Template,
   tags: ["autodocs"],
   parameters: {

--- a/src/shared/components/layout/Layout.stories.tsx
+++ b/src/shared/components/layout/Layout.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Layout as Template } from "@/shared/components/layout/Layout";
 
 const meta = {
-  title: "Shared/Layout",
+  title: "Shared/Layout/Layout",
   component: Template,
   tags: ["autodocs"],
   parameters: {

--- a/src/shared/components/layout/List.stories.tsx
+++ b/src/shared/components/layout/List.stories.tsx
@@ -4,7 +4,7 @@ import { Card } from "@/shared/components/content/Card";
 import { List as Template } from "@/shared/components/layout/List";
 
 const meta = {
-  title: "Shared/List",
+  title: "Shared/Layout/List",
   component: Template,
   tags: ["autodocs"],
 } satisfies Meta<typeof Template>;

--- a/src/shared/components/layout/Main.stories.tsx
+++ b/src/shared/components/layout/Main.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Main as Template } from "@/shared/components/layout/Main";
 
 const meta = {
-  title: "Shared/Main",
+  title: "Shared/Layout/Main",
   component: Template,
   parameters: {
     layout: "fullscreen",

--- a/src/shared/components/layout/Outer.stories.tsx
+++ b/src/shared/components/layout/Outer.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Outer as Template } from "@/shared/components/layout/Outer";
 
 const meta = {
-  title: "Shared/Outer",
+  title: "Shared/Layout/Outer",
   component: Template,
   tags: ["autodocs"],
   parameters: {


### PR DESCRIPTION
## Summary

- group shared component stories under Content, Feedback, Forms, and Layout
- add a contract test that keeps Storybook titles aligned with source directories
- document the design and implementation plan

## Testing

- `npx vitest run src/lib/storybookNavigation.spec.ts`
- `npm run build:storybook`
- `make check`