### PR TITLE
Ignore Superpowers workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 
 # misc
 .DS_Store
+.superpowers/
 .worktrees/
 .env
 .env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Be simple.
 - Before editing files, fetch `origin/main`, then create a `git worktree` at `.worktrees/$BRANCH` from it.
 - Do not work directly on `main`.
+- Do not commit files ignored by `.gitignore`.
 - Write commit messages, pull request titles, and pull request descriptions in English.
 - If `gh` fails in the sandbox, rerun it outside the sandbox.
 - Before finishing non-documentation changes, run `make check`.


### PR DESCRIPTION
## Summary

- ignore the `.superpowers/` workspace directory
- document that files ignored by `.gitignore` must not be committed

## Testing

- `env -u COMPOSE_FILE make check`