### PR TITLE
Modernize the card list UI

### DIFF
--- a/e2e/card.e2e.ts
+++ b/e2e/card.e2e.ts
@@ -40,7 +40,9 @@ const seedCardSession = async (page: Page) => {
 };
 
 const cardItem = (page: Page, frontText: string) =>
-  page.getByText(frontText, { exact: true }).locator("xpath=ancestor::div[contains(@class, 'rounded')][1]");
+  page
+    .getByRole("button", { name: `View ${frontText}`, exact: true })
+    .locator("xpath=ancestor::article[1]");
 
 const expectScore = async (page: Page, frontText: string, score: number) => {
   await expect(cardItem(page, frontText).locator("span").filter({ hasText: new RegExp(`^${score}$`) })).toBeVisible();
@@ -73,7 +75,7 @@ test("shows cards for the deck", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
   await expect(page.getByText("apple")).toBeVisible();
-  await expect(cardItem(page, "apple").getByText("studied 0 time(s)")).toBeVisible();
+  await expect(cardItem(page, "apple").getByText("not studied yet")).toBeVisible();
   await expectScore(page, "apple", 0);
   await page.evaluate(() => window.assertNoBrowserErrors());
 });
@@ -81,7 +83,7 @@ test("shows cards for the deck", async ({ page }) => {
 test("opens and closes the card back text overlay", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
-  await page.getByText("apple").click();
+  await page.getByRole("button", { name: "View apple" }).click();
   await expect(page.getByText("りんご")).toBeVisible();
 
   await page.getByText("りんご").click();
@@ -92,7 +94,8 @@ test("opens and closes the card back text overlay", async ({ page }) => {
 test("saves card edits and returns to the card list", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
-  await cardItem(page, "apple").locator("svg").first().click();
+  await page.getByRole("button", { name: "Open actions for apple" }).click();
+  await page.getByRole("menuitem", { name: "Edit" }).click();
   await expect(page).toHaveURL(new RegExp(`/card/${e2eCard.id}/edit$`));
 
   await page.locator('textarea[name="frontText"]').fill("updated apple");
@@ -104,7 +107,7 @@ test("saves card edits and returns to the card list", async ({ page }) => {
   await expect(page.getByText("updated apple")).toBeVisible();
   await expect(cardItem(page, "updated apple").getByText("math")).toBeVisible();
 
-  await page.getByText("updated apple").click();
+  await page.getByRole("button", { name: "View updated apple" }).click();
   await expect(page.getByText("updated りんご")).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });
@@ -113,7 +116,8 @@ test("deletes a card from the card list", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
   page.on("dialog", (dialog) => dialog.accept());
-  await cardItem(page, "apple").locator("svg").nth(1).click();
+  await page.getByRole("button", { name: "Open actions for apple" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
 
   await expect(page.getByText("apple")).not.toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
@@ -122,9 +126,9 @@ test("deletes a card from the card list", async ({ page }) => {
 test("updates the card score with swipe gestures", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
-  const card = cardItem(page, "apple");
-  const box = await card.boundingBox();
-  if (box == null) throw new Error("Card bounding box is unavailable");
+  const swipeTarget = page.getByRole("button", { name: "View apple" });
+  const box = await swipeTarget.boundingBox();
+  if (box == null) throw new Error("Card swipe target bounding box is unavailable");
 
   const y = box.y + box.height / 2;
   await page.mouse.move(box.x + 20, y);

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -47,9 +47,6 @@ const getDocument = async (collection: "deck" | "card", id: string) => {
   return (await response.json()) as { fields: Record<string, { stringValue?: string }> };
 };
 
-const cardItem = (page: Page, frontText: string) =>
-  page.getByText(frontText, { exact: true }).locator("xpath=ancestor::div[contains(@class, 'rounded')][1]");
-
 const deckFields = (uid: string, name: string) => ({
   uid: field.string(uid),
   name: field.string(name),
@@ -184,7 +181,8 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
   await expect(page.getByText("Updated Remote Query Card")).toBeVisible();
 
   page.on("dialog", (dialog) => dialog.accept());
-  await cardItem(page, "Updated Remote Query Card").locator("svg").nth(1).click();
+  await page.getByRole("button", { name: "Open actions for Updated Remote Query Card" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
   await expect(page.getByText("Updated Remote Query Card")).not.toBeVisible();
 
   await page.goto("/");

--- a/src/features/card/components/Card.spec.tsx
+++ b/src/features/card/components/Card.spec.tsx
@@ -35,6 +35,15 @@ const swipe = (article: HTMLElement, from: number, to: number) => {
   fireEvent.mouseUp(document, { clientX: to, clientY: 0 });
 };
 
+const touchGesture = (target: HTMLElement, from: number, to: number) => {
+  const start = { identifier: 1, target, clientX: from, clientY: 24 };
+  const end = { identifier: 1, target, clientX: to, clientY: 24 };
+
+  fireEvent.touchStart(target, { touches: [start], targetTouches: [start], changedTouches: [start] });
+  fireEvent.touchMove(target, { touches: [end], targetTouches: [end], changedTouches: [end] });
+  fireEvent.touchEnd(target, { touches: [], targetTouches: [], changedTouches: [end] });
+};
+
 describe("Card", () => {
   afterEach(cleanup);
 
@@ -87,6 +96,64 @@ describe("Card", () => {
 
     expect(viewButton).not.toContainElement(studyText);
     expect(viewButton).not.toContainElement(tags);
+  });
+
+  it("covers the complete central region with View without owning its metadata", () => {
+    const view = render(<Card card={card} />);
+    const viewButton = view.getByRole("button", { name: "View A long front" });
+    const centralRegion = viewButton.parentElement;
+
+    expect(centralRegion).toHaveClass("relative", "min-h-touch");
+    expect(viewButton).toHaveClass("absolute", "inset-0");
+    expect(centralRegion).toContainElement(view.getByText("studied 7 times"));
+    expect(viewButton).not.toContainElement(view.getByText("studied 7 times"));
+  });
+
+  it("treats a swipe from View as only a swipe and allows a later View click", () => {
+    vi.useFakeTimers();
+    const goToView = vi.fn();
+    const onSwipedLeft = vi.fn();
+    const view = render(<Card card={card} goToView={goToView} onSwipedLeft={onSwipedLeft} />);
+    const viewButton = view.getByRole("button", { name: "View A long front" });
+
+    swipe(viewButton, 100, 0);
+    fireEvent.click(viewButton);
+    expect(onSwipedLeft).toHaveBeenCalledExactlyOnceWith(card.id);
+    expect(goToView).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+    fireEvent.click(viewButton);
+    expect(goToView).toHaveBeenCalledExactlyOnceWith(card.id);
+    vi.useRealTimers();
+  });
+
+  it("does not start swipe tracking from the actions menu trigger", () => {
+    const onSwipedLeft = vi.fn();
+    const view = render(<ControlledCard card={card} onSwipedLeft={onSwipedLeft} />);
+    const trigger = view.getByRole("button", { name: "Open actions for A long front" });
+
+    swipe(trigger, 100, 0);
+    fireEvent.click(trigger);
+
+    expect(onSwipedLeft).not.toHaveBeenCalled();
+    expect(view.getByRole("menu", { name: "Actions for A long front" })).toBeInTheDocument();
+  });
+
+  it("isolates complete touch sequences on the actions trigger while preserving its click", () => {
+    const onSwipedLeft = vi.fn();
+    const onSwipedRight = vi.fn();
+    const view = render(<ControlledCard card={card} onSwipedLeft={onSwipedLeft} onSwipedRight={onSwipedRight} />);
+    const trigger = view.getByRole("button", { name: "Open actions for A long front" });
+
+    touchGesture(trigger, 240, 80);
+    touchGesture(trigger, 80, 240);
+    touchGesture(trigger, 180, 184);
+
+    expect(onSwipedLeft).not.toHaveBeenCalled();
+    expect(onSwipedRight).not.toHaveBeenCalled();
+
+    fireEvent.click(trigger);
+    expect(view.getByRole("menu", { name: "Actions for A long front" })).toBeInTheDocument();
   });
 
   it("suppresses view, menu, and swipe actions while pending", () => {

--- a/src/features/card/components/Card.spec.tsx
+++ b/src/features/card/components/Card.spec.tsx
@@ -1,6 +1,8 @@
+import * as React from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { Card } from "@/features/card/components/Card";
 
 const card = {
@@ -12,37 +14,98 @@ const card = {
   tags: ["one", "two"],
 } as Card;
 
+const ControlledCard: React.FC<React.ComponentProps<typeof Card>> = (props) => {
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  return (
+    <Card
+      {...props}
+      menuOpen={menuOpen}
+      onToggleMenu={(id) => {
+        props.onToggleMenu?.(id);
+        setMenuOpen((value) => !value);
+      }}
+      onCloseMenu={() => setMenuOpen(false)}
+    />
+  );
+};
+
+const swipe = (article: HTMLElement, from: number, to: number) => {
+  fireEvent.mouseDown(article, { clientX: from, clientY: 0 });
+  fireEvent.mouseMove(document, { clientX: to, clientY: 0 });
+  fireEvent.mouseUp(document, { clientX: to, clientY: 0 });
+};
+
 describe("Card", () => {
   afterEach(cleanup);
 
-  it("preserves card metadata and routes view, edit, and delete with the card id", () => {
-    const goToView = vi.fn();
-    const goToEdit = vi.fn();
-    const onDelete = vi.fn();
-    const view = render(<Card card={card} goToView={goToView} goToEdit={goToEdit} onDelete={onDelete} />);
+  it("renders compact metadata and routes view, menu actions, and swipes by card id", () => {
+    const actions = {
+      goToView: vi.fn(),
+      goToEdit: vi.fn(),
+      onDelete: vi.fn(),
+      onSwipedLeft: vi.fn(),
+      onSwipedRight: vi.fn(),
+      onToggleMenu: vi.fn(),
+    };
+    const view = render(<ControlledCard card={card} {...actions} />);
+    const article = view.getByRole("article");
 
     expect(view.getByLabelText("Score 3, positive")).toBeInTheDocument();
-    expect(view.getByText("studied 7 time(s)")).toBeInTheDocument();
-    expect(view.getByText("one")).toBeInTheDocument();
-    const actionGlyphs = view.container.querySelectorAll("svg");
-    expect(view.container.querySelectorAll("button")).toHaveLength(0);
-    expect(actionGlyphs).toHaveLength(2);
-    expect(actionGlyphs[1]).toHaveClass("text-danger");
-    fireEvent.click(view.getByText("A long front"));
-    fireEvent.click(actionGlyphs[0] as Element);
-    fireEvent.click(actionGlyphs[1] as Element);
-    expect(goToView).toHaveBeenCalledExactlyOnceWith(card.id);
-    expect(goToEdit).toHaveBeenCalledExactlyOnceWith(card.id);
-    expect(onDelete).toHaveBeenCalledExactlyOnceWith(card.id);
+    expect(view.getByText("studied 7 times")).toBeInTheDocument();
+    expect(view.getByLabelText("Tags: one, two")).toHaveTextContent("onetwo");
+    fireEvent.click(view.getByRole("button", { name: "View A long front" }));
+    expect(actions.goToView).toHaveBeenCalledExactlyOnceWith(card.id);
+
+    const trigger = view.getByRole("button", { name: "Open actions for A long front" });
+    fireEvent.click(trigger);
+    expect(actions.onToggleMenu).toHaveBeenCalledExactlyOnceWith(card.id);
+    fireEvent.click(view.getByRole("menuitem", { name: "Edit" }));
+    expect(actions.goToEdit).toHaveBeenCalledExactlyOnceWith(card.id);
+    fireEvent.click(trigger);
+    fireEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+    expect(actions.onDelete).toHaveBeenCalledExactlyOnceWith(card.id);
+
+    swipe(article, 100, 0);
+    swipe(article, 0, 100);
+    expect(actions.onSwipedLeft).toHaveBeenCalledExactlyOnceWith(card.id);
+    expect(actions.onSwipedRight).toHaveBeenCalledExactlyOnceWith(card.id);
   });
 
-  it("suppresses actions while disabled and leaves onEdit unwired", () => {
-    const actions = { goToView: vi.fn(), goToEdit: vi.fn(), onDelete: vi.fn(), onEdit: vi.fn() };
-    const view = render(<Card card={card} disabled {...actions} />);
-    const actionGlyphs = view.container.querySelectorAll("svg");
-    fireEvent.click(view.getByText("A long front"));
-    fireEvent.click(actionGlyphs[0] as Element);
-    fireEvent.click(actionGlyphs[1] as Element);
+  it("uses explicit copy for unstudied and singular study counts", () => {
+    const view = render(<Card card={{ ...card, numberOfSeen: 0 }} />);
+    expect(view.getByText("not studied yet")).toBeInTheDocument();
+
+    view.rerender(<Card card={{ ...card, numberOfSeen: 1 }} />);
+    expect(view.getByText("studied 1 time")).toBeInTheDocument();
+  });
+
+  it("keeps study and tag metadata outside the View button", () => {
+    const view = render(<Card card={card} />);
+    const viewButton = view.getByRole("button", { name: "View A long front" });
+    const studyText = view.getByText("studied 7 times");
+    const tags = view.getByLabelText("Tags: one, two");
+
+    expect(viewButton).not.toContainElement(studyText);
+    expect(viewButton).not.toContainElement(tags);
+  });
+
+  it("suppresses view, menu, and swipe actions while pending", () => {
+    const actions = {
+      goToView: vi.fn(),
+      goToEdit: vi.fn(),
+      onDelete: vi.fn(),
+      onSwipedLeft: vi.fn(),
+      onSwipedRight: vi.fn(),
+      onToggleMenu: vi.fn(),
+    };
+    const view = render(<ControlledCard card={card} disabled {...actions} />);
+    const article = view.getByRole("article");
+
+    expect(article).toHaveAttribute("aria-busy", "true");
+    expect(view.getByRole("button", { name: "View A long front" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "Open actions for A long front" })).toBeDisabled();
+    swipe(article, 100, 0);
+    swipe(article, 0, 100);
     expect(Object.values(actions).every((action) => action.mock.calls.length === 0)).toBe(true);
   });
 });

--- a/src/features/card/components/Card.stories.tsx
+++ b/src/features/card/components/Card.stories.tsx
@@ -17,17 +17,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const LongText: Story = {
-  args: {
-    card: fixture.card.long,
-  },
+export const Unstudied: Story = {
+  args: { card: { ...fixture.card.default, numberOfSeen: 0, score: 0 } },
 };
 
-export const LongTags: Story = {
-  args: {
-    card: fixture.card.longTags,
-  },
-};
-
+export const LongText: Story = { args: { card: fixture.card.long } };
+export const LongTags: Story = { args: { card: fixture.card.longTags } };
+export const ActionsOpen: Story = { args: { menuOpen: true } };
+export const Pending: Story = { args: { disabled: true } };
 export const Mobile: Story = { parameters: { viewport: { defaultViewport: "iphonex" } } };
 export const Dark: Story = { globals: { theme: "dark" } };

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -1,73 +1,91 @@
-import * as React from "react";
-import { IconContext } from "react-icons";
-import { AiOutlineEdit, AiOutlineDelete } from "react-icons/ai";
-import { Card as Surface, Description, Score, Tag, TagList, Title } from "@/shared/components";
+import cx from "classnames";
+import type * as React from "react";
 import { useSwipeable } from "react-swipeable";
+
+import { CardActionsMenu } from "@/features/card/components/CardActionsMenu";
+import { Score } from "@/shared/components";
 
 export interface CardActionsProps {
   disabled?: boolean;
-  onSwipedLeft?: (id: string) => void;
-  onSwipedRight?: (id: string) => void;
-  onDelete?: (id: string) => void;
-  onEdit?: (id: string) => void;
-  goToEdit?: (id: string) => void;
-  goToView?: (id: string) => void;
+  onSwipedLeft?: (id: CardId) => void;
+  onSwipedRight?: (id: CardId) => void;
+  onDelete?: (id: CardId) => void;
+  goToEdit?: (id: CardId) => void;
+  goToView?: (id: CardId) => void;
+}
+
+export interface CardRowMenuProps {
+  menuOpen?: boolean;
+  onToggleMenu?: (id: CardId) => void;
+  onCloseMenu?: () => void;
 }
 
 export type CardProps = CardActionsProps;
 
-export const Card: React.FC<
-  {
-    className?: string;
-    card: Card;
-    filtered?: boolean;
-  } & CardActionsProps
-> = (props) => {
+const studiedText = (count: number) => {
+  if (count === 0) return "not studied yet";
+  return `studied ${count} ${count === 1 ? "time" : "times"}`;
+};
+
+export const Card: React.FC<{ className?: string; card: Card } & CardActionsProps & CardRowMenuProps> = (props) => {
   const id = props.card.id;
-  const goToView = React.useCallback(() => {
-    if (!props.disabled) props.goToView?.(id);
-  }, [id, props]);
-  const goToEdit = React.useCallback(() => {
-    if (!props.disabled) props.goToEdit?.(id);
-  }, [id, props]);
-  const onDelete = React.useCallback(() => {
-    if (!props.disabled) props.onDelete?.(id);
-  }, [id, props]);
-  const onSwipedLeft = React.useCallback(() => {
-    if (!props.disabled) props.onSwipedLeft?.(id);
-  }, [id, props]);
-  const onSwipedRight = React.useCallback(() => {
-    if (!props.disabled) props.onSwipedRight?.(id);
-  }, [id, props]);
+  const disabled = Boolean(props.disabled);
+  const withId = (action?: (id: CardId) => void) => () => {
+    if (!disabled) action?.(id);
+  };
   const handlers = useSwipeable({
-    onSwipedLeft,
-    onSwipedRight,
+    onSwipedLeft: withId(props.onSwipedLeft),
+    onSwipedRight: withId(props.onSwipedRight),
     trackMouse: true,
   });
+  const seenCount = props.card.numberOfSeen ?? 0;
+
   return (
-    <div className={props.className} {...handlers}>
-      <IconContext.Provider value={{ className: "text-2xl" }}>
-        <Surface full border className="gap-3 p-4" disabled={Boolean(props.filtered || props.disabled)}>
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <Score className="mr-1 shrink-0" score={props.card.score} />
-            <Description>studied {props.card.numberOfSeen ?? 0} time(s)</Description>
-            <TagList>
+    <article
+      {...handlers}
+      aria-busy={disabled}
+      className={cx(
+        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 sm:gap-3 sm:px-4",
+        disabled ? "bg-surface-muted" : "bg-surface",
+        props.className
+      )}
+    >
+      <Score className="shrink-0" score={props.card.score} />
+      <div className="flex min-w-0 flex-1 flex-col justify-center">
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label={`View ${props.card.frontText}`}
+          className="flex min-h-touch w-full items-center rounded-control px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed"
+          onClick={withId(props.goToView)}
+        >
+          <span className="w-full truncate text-body font-semibold text-ink">{props.card.frontText}</span>
+        </button>
+        <div className="mt-1 flex w-full min-w-0 items-center gap-2 text-caption text-ink-muted">
+          <span className="shrink-0">{studiedText(seenCount)}</span>
+          {props.card.tags.length > 0 && (
+            <fieldset
+              aria-label={`Tags: ${props.card.tags.join(", ")}`}
+              className="m-0 flex min-w-0 gap-1 overflow-hidden border-0 p-0"
+            >
               {props.card.tags.map((tag) => (
-                <Tag key={tag} small primary label={tag} />
+                <span key={tag} className="shrink-0 rounded-pill bg-surface-muted px-2 py-0.5 text-xs text-ink">
+                  {tag}
+                </span>
               ))}
-            </TagList>
-          </div>
-          <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end">
-            <Title className="max-w-reading flex-1 break-words" onClick={goToView}>
-              {props.card.frontText}
-            </Title>
-            <div className="flex shrink-0 gap-2 self-end">
-              <AiOutlineEdit className="text-ink" size={24} onClick={goToEdit} />
-              <AiOutlineDelete className="text-danger" size={24} onClick={onDelete} />
-            </div>
-          </div>
-        </Surface>
-      </IconContext.Provider>
-    </div>
+            </fieldset>
+          )}
+        </div>
+      </div>
+      <CardActionsMenu
+        cardText={props.card.frontText}
+        open={Boolean(props.menuOpen)}
+        disabled={disabled}
+        onToggle={withId(props.onToggleMenu)}
+        onClose={() => props.onCloseMenu?.()}
+        onEdit={withId(props.goToEdit)}
+        onDelete={withId(props.onDelete)}
+      />
+    </article>
   );
 };

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type * as React from "react";
+import * as React from "react";
 import { useSwipeable } from "react-swipeable";
 
 import { CardActionsMenu } from "@/features/card/components/CardActionsMenu";
@@ -30,12 +30,47 @@ const studiedText = (count: number) => {
 export const Card: React.FC<{ className?: string; card: Card } & CardActionsProps & CardRowMenuProps> = (props) => {
   const id = props.card.id;
   const disabled = Boolean(props.disabled);
+  const suppressViewClick = React.useRef(false);
+  const suppressViewClickTimer = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+  const menuBoundary = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(
+    () => () => {
+      if (suppressViewClickTimer.current !== undefined) clearTimeout(suppressViewClickTimer.current);
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    const boundary = menuBoundary.current;
+    if (boundary == null) return;
+
+    const stopSwipeTracking = (event: Event) => event.stopPropagation();
+    const boundaryEvents = ["mousedown", "touchstart", "touchmove", "touchend", "touchcancel"] as const;
+    for (const eventName of boundaryEvents) boundary.addEventListener(eventName, stopSwipeTracking);
+
+    return () => {
+      for (const eventName of boundaryEvents) boundary.removeEventListener(eventName, stopSwipeTracking);
+    };
+  }, []);
+
   const withId = (action?: (id: CardId) => void) => () => {
     if (!disabled) action?.(id);
   };
+  const withSwipeId = (action?: (id: CardId) => void) => () => {
+    if (disabled) return;
+
+    suppressViewClick.current = true;
+    if (suppressViewClickTimer.current !== undefined) clearTimeout(suppressViewClickTimer.current);
+    suppressViewClickTimer.current = setTimeout(() => {
+      suppressViewClick.current = false;
+      suppressViewClickTimer.current = undefined;
+    }, 0);
+    action?.(id);
+  };
   const handlers = useSwipeable({
-    onSwipedLeft: withId(props.onSwipedLeft),
-    onSwipedRight: withId(props.onSwipedRight),
+    onSwipedLeft: withSwipeId(props.onSwipedLeft),
+    onSwipedRight: withSwipeId(props.onSwipedRight),
     trackMouse: true,
   });
   const seenCount = props.card.numberOfSeen ?? 0;
@@ -51,25 +86,29 @@ export const Card: React.FC<{ className?: string; card: Card } & CardActionsProp
       )}
     >
       <Score className="shrink-0" score={props.card.score} />
-      <div className="flex min-w-0 flex-1 flex-col justify-center">
+      <div className="relative flex min-h-touch min-w-0 flex-1 flex-col justify-center rounded-control">
         <button
           type="button"
           disabled={disabled}
           aria-label={`View ${props.card.frontText}`}
-          className="flex min-h-touch w-full items-center rounded-control px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed"
-          onClick={withId(props.goToView)}
-        >
-          <span className="w-full truncate text-body font-semibold text-ink">{props.card.frontText}</span>
-        </button>
+          className="absolute inset-0 z-10 rounded-control text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed"
+          onClick={() => {
+            if (!disabled && !suppressViewClick.current) props.goToView?.(id);
+          }}
+        />
+        <span className="w-full truncate px-1 text-body font-semibold text-ink">{props.card.frontText}</span>
         <div className="mt-1 flex w-full min-w-0 items-center gap-2 text-caption text-ink-muted">
           <span className="shrink-0">{studiedText(seenCount)}</span>
           {props.card.tags.length > 0 && (
             <fieldset
               aria-label={`Tags: ${props.card.tags.join(", ")}`}
-              className="m-0 flex min-w-0 gap-1 overflow-hidden border-0 p-0"
+              className="m-0 flex min-w-0 max-w-full gap-1 overflow-hidden border-0 p-0"
             >
               {props.card.tags.map((tag) => (
-                <span key={tag} className="shrink-0 rounded-pill bg-surface-muted px-2 py-0.5 text-xs text-ink">
+                <span
+                  key={tag}
+                  className="max-w-full shrink-0 truncate rounded-pill bg-surface-muted px-2 py-0.5 text-xs text-ink"
+                >
                   {tag}
                 </span>
               ))}
@@ -77,15 +116,17 @@ export const Card: React.FC<{ className?: string; card: Card } & CardActionsProp
           )}
         </div>
       </div>
-      <CardActionsMenu
-        cardText={props.card.frontText}
-        open={Boolean(props.menuOpen)}
-        disabled={disabled}
-        onToggle={withId(props.onToggleMenu)}
-        onClose={() => props.onCloseMenu?.()}
-        onEdit={withId(props.goToEdit)}
-        onDelete={withId(props.onDelete)}
-      />
+      <div ref={menuBoundary} className="shrink-0">
+        <CardActionsMenu
+          cardText={props.card.frontText}
+          open={Boolean(props.menuOpen)}
+          disabled={disabled}
+          onToggle={withId(props.onToggleMenu)}
+          onClose={() => props.onCloseMenu?.()}
+          onEdit={withId(props.goToEdit)}
+          onDelete={withId(props.onDelete)}
+        />
+      </div>
     </article>
   );
 };

--- a/src/features/card/components/CardActionsMenu.spec.tsx
+++ b/src/features/card/components/CardActionsMenu.spec.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CardActionsMenu } from "@/features/card/components/CardActionsMenu";
+
+type ControlledMenuProps = Omit<React.ComponentProps<typeof CardActionsMenu>, "open" | "onToggle" | "onClose">;
+
+const ControlledMenu: React.FC<ControlledMenuProps> = (props) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <CardActionsMenu
+      {...props}
+      open={open}
+      onToggle={() => setOpen((value) => !value)}
+      onClose={() => setOpen(false)}
+    />
+  );
+};
+
+describe("CardActionsMenu", () => {
+  afterEach(cleanup);
+
+  it("renders edit and delete actions", () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const view = render(<ControlledMenu cardText="Binary search" onEdit={onEdit} onDelete={onDelete} />);
+
+    const trigger = view.getByRole("button", { name: "Open actions for Binary search" });
+    fireEvent.click(trigger);
+    expect(view.getByRole("group", { name: "Card actions for Binary search" })).toBeInTheDocument();
+    expect(view.getAllByRole("menuitem").map((item) => item.textContent)).toEqual(["Edit", "Delete"]);
+    fireEvent.click(view.getByRole("menuitem", { name: "Edit" }));
+    expect(onEdit).toHaveBeenCalledOnce();
+    fireEvent.click(trigger);
+    const deleteItem = view.getByRole("menuitem", { name: "Delete" });
+    expect(deleteItem).toHaveClass("text-danger");
+    fireEvent.click(deleteItem);
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("disables the trigger and hides an open menu", () => {
+    const view = render(
+      <CardActionsMenu cardText="Binary search" open disabled onToggle={vi.fn()} onClose={vi.fn()} />
+    );
+
+    expect(view.getByRole("button", { name: "Open actions for Binary search" })).toBeDisabled();
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/card/components/CardActionsMenu.tsx
+++ b/src/features/card/components/CardActionsMenu.tsx
@@ -1,0 +1,44 @@
+import type * as React from "react";
+import { AiOutlineDelete, AiOutlineEdit } from "react-icons/ai";
+import { ActionsMenu, type ActionsMenuItem } from "@/shared/components/forms/ActionsMenu";
+
+export interface CardActionsMenuProps {
+  cardText: string;
+  open: boolean;
+  disabled?: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export const CardActionsMenu: React.FC<CardActionsMenuProps> = (props) => {
+  const items: ActionsMenuItem[] = [
+    {
+      key: "edit",
+      label: "Edit",
+      icon: <AiOutlineEdit aria-hidden="true" />,
+      ...(props.onEdit !== undefined ? { onSelect: props.onEdit } : {}),
+    },
+    {
+      key: "delete",
+      label: "Delete",
+      icon: <AiOutlineDelete aria-hidden="true" />,
+      danger: true,
+      ...(props.onDelete !== undefined ? { onSelect: props.onDelete } : {}),
+    },
+  ];
+
+  return (
+    <ActionsMenu
+      groupLabel={`Card actions for ${props.cardText}`}
+      triggerLabel={`Open actions for ${props.cardText}`}
+      menuLabel={`Actions for ${props.cardText}`}
+      open={props.open}
+      {...(props.disabled !== undefined ? { disabled: props.disabled } : {})}
+      onToggle={props.onToggle}
+      onClose={props.onClose}
+      items={items}
+    />
+  );
+};

--- a/src/features/card/components/templates/CardListTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardListTemplate.spec.tsx
@@ -46,6 +46,26 @@ describe("CardListTemplate", () => {
     expect(view.getByText("score ≤ 3")).toBeInTheDocument();
   });
 
+  it("constrains a long unbroken selected tag without changing its text", () => {
+    const longTag = `tag-${"unbroken".repeat(30)}`;
+    const view = render(
+      <CardListTemplate cards={[card]} filter={{ scoreMin: null, scoreMax: null, selectedTags: [longTag] }} />
+    );
+    const chip = view.getByText(longTag);
+
+    expect(chip).toHaveTextContent(longTag);
+    expect(chip).toHaveClass("max-w-full", "truncate");
+  });
+
+  it("shows a token-styled decorative chevron for filter disclosure state", () => {
+    const view = render(<CardListTemplate cards={[card]} />);
+    const details = view.getByText("Filters").closest("details");
+    const chevron = details?.querySelector('[aria-hidden="true"]');
+
+    expect(details).toHaveClass("group");
+    expect(chevron).toHaveClass("text-ink-muted", "group-open:rotate-180");
+  });
+
   it("keeps only one menu open and removes it with a missing row", async () => {
     const view = render(<CardListTemplate cards={[card, otherCard]} />);
     fireEvent.click(view.getByRole("button", { name: "Open actions for Front" }));

--- a/src/features/card/components/templates/CardListTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardListTemplate.spec.tsx
@@ -35,8 +35,8 @@ describe("CardListTemplate", () => {
 
     expect(view.getByText("1 card")).toBeInTheDocument();
     expect(view.getByText("score -1–3 · 2 tags")).toBeInTheDocument();
-    expect(view.getByText("one")).toBeVisible();
-    expect(view.getByText("two")).toBeVisible();
+    expect(view.getByRole("list", { name: "Selected tags" })).toHaveTextContent("one");
+    expect(view.getByRole("list", { name: "Selected tags" })).toHaveTextContent("two");
     expect(view.getByText("Controls")).not.toBeVisible();
 
     view.rerender(<CardListTemplate cards={[card]} filter={{ scoreMin: -1, scoreMax: null, selectedTags: [] }} />);

--- a/src/features/card/components/templates/CardListTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardListTemplate.spec.tsx
@@ -1,21 +1,62 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { CardListTemplate } from "@/features/card/components/templates/CardListTemplate";
 import { createCard } from "@/test/factories";
 
 const card = createCard({ id: "card-id", frontText: "Front", backText: "Back", score: 0, tags: [] });
+const otherCard = createCard({ id: "other-id", frontText: "Other", backText: "Other back", tags: ["two"] });
 
 describe("CardListTemplate", () => {
   afterEach(cleanup);
-  it("preserves feedback and zero-card composition with a non-sticky filter boundary", () => {
+
+  it("renders the heading, zero count, collapsed no-filter summary, and feedback", () => {
     const view = render(
-      <CardListTemplate cards={[]} feedbackSlot={<div role="status">Saved</div>} filterSlot={<div>Filters</div>} />
+      <CardListTemplate cards={[]} feedbackSlot={<div role="status">Saved</div>} filterSlot={<div>Controls</div>} />
     );
+
+    expect(view.getByRole("heading", { level: 1, name: "Cards" })).toBeInTheDocument();
+    expect(view.getByText("0 cards")).toBeInTheDocument();
+    expect(view.getByText("No filters")).toBeInTheDocument();
+    expect(view.getByText("Filters").closest("details")).not.toHaveAttribute("open");
     expect(view.getByRole("status")).toHaveTextContent("Saved");
-    const details = view.getByText("filter").closest("details");
-    expect(details).not.toHaveClass("sticky");
     expect(view.queryByText(/no cards/i)).not.toBeInTheDocument();
+  });
+
+  it("formats score bounds, tag count, persistent chips, and singular card count", () => {
+    const view = render(
+      <CardListTemplate
+        cards={[card]}
+        filter={{ scoreMin: -1, scoreMax: 3, selectedTags: ["one", "two"] }}
+        filterSlot={<div>Controls</div>}
+      />
+    );
+
+    expect(view.getByText("1 card")).toBeInTheDocument();
+    expect(view.getByText("score -1–3 · 2 tags")).toBeInTheDocument();
+    expect(view.getByText("one")).toBeVisible();
+    expect(view.getByText("two")).toBeVisible();
+    expect(view.getByText("Controls")).not.toBeVisible();
+
+    view.rerender(<CardListTemplate cards={[card]} filter={{ scoreMin: -1, scoreMax: null, selectedTags: [] }} />);
+    expect(view.getByText("score ≥ -1")).toBeInTheDocument();
+
+    view.rerender(<CardListTemplate cards={[card]} filter={{ scoreMin: null, scoreMax: 3, selectedTags: [] }} />);
+    expect(view.getByText("score ≤ 3")).toBeInTheDocument();
+  });
+
+  it("keeps only one menu open and removes it with a missing row", async () => {
+    const view = render(<CardListTemplate cards={[card, otherCard]} />);
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Front" }));
+    expect(view.getByRole("menu", { name: "Actions for Front" })).toBeInTheDocument();
+
+    fireEvent.click(view.getByRole("button", { name: "Open actions for Other" }));
+    expect(view.queryByRole("menu", { name: "Actions for Front" })).not.toBeInTheDocument();
+    expect(view.getByRole("menu", { name: "Actions for Other" })).toBeInTheDocument();
+
+    view.rerender(<CardListTemplate cards={[card]} />);
+    await waitFor(() => expect(view.queryByRole("menu")).not.toBeInTheDocument());
   });
 
   it("preserves card display and overlay close callbacks", () => {
@@ -28,7 +69,8 @@ describe("CardListTemplate", () => {
         overlay={{ backText: { text: "Overlay back" }, onClose }}
       />
     );
-    fireEvent.click(view.getByText("Front"));
+
+    fireEvent.click(view.getByRole("button", { name: "View Front" }));
     expect(onShowCard).toHaveBeenCalledExactlyOnceWith(card);
     fireEvent.click(view.getByRole("button", { name: "Close card" }));
     expect(onClose).toHaveBeenCalledOnce();

--- a/src/features/card/components/templates/CardListTemplate.stories.tsx
+++ b/src/features/card/components/templates/CardListTemplate.stories.tsx
@@ -27,6 +27,8 @@ const longDeckStartForm: DeckStartFormProps = {
   tagFilterProps: { ...deckStartForm.tagFilterProps, tags: [...fixture.tags.toolong] },
 };
 
+const activeFilter = { scoreMax: 1, scoreMin: -1, selectedTags: ["tag 1", "tag 2"] };
+
 const meta = {
   title: "Card/CardListTemplate",
   component: Template,
@@ -40,6 +42,7 @@ const meta = {
   },
   args: {
     cards: fixture.cards.default,
+    filter: activeFilter,
     filterSlot: <DeckStartForm {...deckStartForm} />,
   },
 } satisfies Meta<typeof Template>;
@@ -70,22 +73,21 @@ export const CardView: Story = {
 
 export const DarkCardView: Story = { ...CardView, globals: { theme: "dark" } };
 
+export const Dark: Story = { globals: { theme: "dark" } };
+
+export const Pending: Story = {
+  args: { isCardPending: (id) => id === fixture.cards.default[0]?.id },
+};
+
 export const IphoneX: Story = {
-  parameters: {
-    viewport: {
-      defaultViewport: "iphonex",
-    },
-  },
+  parameters: { viewport: { defaultViewport: "iphonex" } },
 };
 
 export const IphoneXLong: Story = {
-  parameters: {
-    viewport: {
-      defaultViewport: "iphonex",
-    },
-  },
+  parameters: { viewport: { defaultViewport: "iphonex" } },
   args: {
     filterSlot: <DeckStartForm {...longDeckStartForm} />,
+    filter: { scoreMax: 1, scoreMin: -1, selectedTags: [...fixture.tags.toolong] },
     cards: fixture.cards.long,
   },
 };

--- a/src/features/card/components/templates/CardListTemplate.stories.tsx
+++ b/src/features/card/components/templates/CardListTemplate.stories.tsx
@@ -28,6 +28,11 @@ const longDeckStartForm: DeckStartFormProps = {
 };
 
 const activeFilter = { scoreMax: 1, scoreMin: -1, selectedTags: ["tag 1", "tag 2"] };
+const longUnbrokenTag =
+  "tag_this_is_one_genuinely_long_unbroken_value_that_must_never_force_the_mobile_card_list_beyond_the_viewport_width_even_when_it_keeps_going_0123456789";
+const longUnbrokenCards = fixture.cards.long.map((card, index) =>
+  index === 0 ? { ...card, tags: [longUnbrokenTag] } : card
+);
 
 const meta = {
   title: "Card/CardListTemplate",
@@ -87,7 +92,7 @@ export const IphoneXLong: Story = {
   parameters: { viewport: { defaultViewport: "iphonex" } },
   args: {
     filterSlot: <DeckStartForm {...longDeckStartForm} />,
-    filter: { scoreMax: 1, scoreMin: -1, selectedTags: [...fixture.tags.toolong] },
-    cards: fixture.cards.long,
+    filter: { scoreMax: 1, scoreMin: -1, selectedTags: [longUnbrokenTag] },
+    cards: longUnbrokenCards,
   },
 };

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -1,17 +1,25 @@
-import type * as React from "react";
-import { List, Overlay } from "@/shared/components";
-import { Layout, type LayoutProps } from "@/shared/components/layout/Layout";
+import * as React from "react";
+
 import { BackText, type BackTextProps } from "@/features/card/components/BackText";
 import { Card, type CardProps } from "@/features/card/components/Card";
+import { Overlay } from "@/shared/components";
+import { Layout, type LayoutProps } from "@/shared/components/layout/Layout";
 
 export interface CardListOverlayProps {
   backText: BackTextProps;
   onClose?: () => void;
 }
 
+export interface CardListFilterState {
+  scoreMax: number | null;
+  scoreMin: number | null;
+  selectedTags: string[];
+}
+
 export interface CardListTemplateProps {
   cards: Card[];
   layout?: LayoutProps;
+  filter?: CardListFilterState;
   filterSlot?: React.ReactNode;
   card?: CardProps;
   overlay?: CardListOverlayProps;
@@ -20,7 +28,59 @@ export interface CardListTemplateProps {
   isCardPending?: (id: CardId) => boolean;
 }
 
+const countLabel = (count: number) => `${count} ${count === 1 ? "card" : "cards"}`;
+
+const scoreRangeLabel = (filter: CardListFilterState) => {
+  if (filter.scoreMin != null && filter.scoreMax != null) return `score ${filter.scoreMin}–${filter.scoreMax}`;
+  if (filter.scoreMin != null) return `score ≥ ${filter.scoreMin}`;
+  if (filter.scoreMax != null) return `score ≤ ${filter.scoreMax}`;
+  return undefined;
+};
+
+const filterLabel = (filter: CardListFilterState) => {
+  const labels: string[] = [];
+  const score = scoreRangeLabel(filter);
+  if (score != null) labels.push(score);
+  if (filter.selectedTags.length > 0) {
+    labels.push(`${filter.selectedTags.length} ${filter.selectedTags.length === 1 ? "tag" : "tags"}`);
+  }
+  return labels.length > 0 ? labels.join(" · ") : "No filters";
+};
+
+const emptyFilter: CardListFilterState = { scoreMax: null, scoreMin: null, selectedTags: [] };
+
+const CardListRows: React.FC<Pick<CardListTemplateProps, "cards" | "card" | "onShowCard" | "isCardPending">> = (
+  props
+) => {
+  const [openMenuCardId, setOpenMenuCardId] = React.useState<CardId>();
+
+  return (
+    <div className="overflow-visible rounded-surface border border-border bg-surface shadow-surface">
+      {props.cards.map((card) => (
+        <Card
+          key={card.id}
+          card={card}
+          disabled={props.isCardPending?.(card.id) ?? false}
+          menuOpen={openMenuCardId === card.id}
+          onToggleMenu={(id) => setOpenMenuCardId((value) => (value === id ? undefined : id))}
+          onCloseMenu={() => setOpenMenuCardId(undefined)}
+          {...(props.card?.onSwipedLeft !== undefined ? { onSwipedLeft: props.card.onSwipedLeft } : {})}
+          {...(props.card?.onSwipedRight !== undefined ? { onSwipedRight: props.card.onSwipedRight } : {})}
+          {...(props.card?.onDelete !== undefined ? { onDelete: props.card.onDelete } : {})}
+          {...(props.card?.goToEdit !== undefined ? { goToEdit: props.card.goToEdit } : {})}
+          goToView={() => {
+            setOpenMenuCardId(undefined);
+            props.onShowCard?.(card);
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
 export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
+  const filter = props.filter ?? emptyFilter;
+
   return (
     <Layout showHeader {...props.layout}>
       {props.feedbackSlot}
@@ -34,24 +94,40 @@ export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
           <BackText {...props.overlay.backText} />
         </Overlay>
       )}
-      <details className="max-h-screen rounded-surface border border-border bg-surface-muted p-3">
-        <summary className="mb-1 cursor-pointer border-b border-border pb-1 font-semibold text-ink">filter</summary>
-        {props.filterSlot}
-      </details>
-      <List col1>
-        {props.cards?.map((c) => (
-          <Card
-            key={c.id}
-            card={c}
-            disabled={props.isCardPending?.(c.id) ?? false}
-            {...(props.card?.onSwipedLeft !== undefined ? { onSwipedLeft: props.card.onSwipedLeft } : {})}
-            {...(props.card?.onSwipedRight !== undefined ? { onSwipedRight: props.card.onSwipedRight } : {})}
-            {...(props.card?.onDelete !== undefined ? { onDelete: props.card.onDelete } : {})}
-            {...(props.card?.goToEdit !== undefined ? { goToEdit: props.card.goToEdit } : {})}
-            goToView={() => props.onShowCard?.(c)}
-          />
-        ))}
-      </List>
+
+      <div className="flex items-baseline justify-between gap-3">
+        <h1 className="break-words text-title font-bold text-ink">Cards</h1>
+        <span className="shrink-0 text-caption text-ink-muted">{countLabel(props.cards.length)}</span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <details className="rounded-surface border border-border bg-surface shadow-surface">
+          <summary className="flex min-h-touch cursor-pointer items-center justify-between gap-3 rounded-surface px-3 font-semibold text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus">
+            <span>Filters</span>
+            <span className="min-w-0 truncate text-caption font-medium text-ink-muted">{filterLabel(filter)}</span>
+          </summary>
+          <div className="border-t border-border p-3">{props.filterSlot}</div>
+        </details>
+        {filter.selectedTags.length > 0 && (
+          <ul className="flex list-none flex-wrap gap-1 px-1">
+            {filter.selectedTags.map((tag) => (
+              <li key={tag} className="rounded-pill bg-surface-muted px-2 py-1 text-xs font-medium text-ink">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {props.cards.length > 0 && (
+        <CardListRows
+          key={JSON.stringify(props.cards.map((card) => card.id))}
+          cards={props.cards}
+          {...(props.card !== undefined ? { card: props.card } : {})}
+          {...(props.onShowCard !== undefined ? { onShowCard: props.onShowCard } : {})}
+          {...(props.isCardPending !== undefined ? { isCardPending: props.isCardPending } : {})}
+        />
+      )}
     </Layout>
   );
 };

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { AiOutlineDown } from "react-icons/ai";
 
 import { BackText, type BackTextProps } from "@/features/card/components/BackText";
 import { Card, type CardProps } from "@/features/card/components/Card";
@@ -101,17 +102,27 @@ export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
       </div>
 
       <div className="flex flex-col gap-2">
-        <details className="rounded-surface border border-border bg-surface shadow-surface">
-          <summary className="flex min-h-touch cursor-pointer items-center justify-between gap-3 rounded-surface px-3 font-semibold text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus">
+        <details className="group rounded-surface border border-border bg-surface shadow-surface">
+          <summary className="flex min-h-touch cursor-pointer list-none items-center justify-between gap-3 rounded-surface px-3 font-semibold text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus [&::-webkit-details-marker]:hidden">
             <span>Filters</span>
-            <span className="min-w-0 truncate text-caption font-medium text-ink-muted">{filterLabel(filter)}</span>
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="min-w-0 truncate text-caption font-medium text-ink-muted">{filterLabel(filter)}</span>
+              <AiOutlineDown
+                aria-hidden="true"
+                className="shrink-0 text-ink-muted transition-transform group-open:rotate-180 motion-reduce:transition-none"
+                size={16}
+              />
+            </span>
           </summary>
           <div className="border-t border-border p-3">{props.filterSlot}</div>
         </details>
         {filter.selectedTags.length > 0 && (
-          <ul aria-label="Selected tags" className="flex list-none flex-wrap gap-1 px-1">
+          <ul aria-label="Selected tags" className="flex min-w-0 max-w-full list-none flex-wrap gap-1 px-1">
             {filter.selectedTags.map((tag) => (
-              <li key={tag} className="rounded-pill bg-surface-muted px-2 py-1 text-xs font-medium text-ink">
+              <li
+                key={tag}
+                className="max-w-full truncate rounded-pill bg-surface-muted px-2 py-1 text-xs font-medium text-ink"
+              >
                 {tag}
               </li>
             ))}

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -109,7 +109,7 @@ export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
           <div className="border-t border-border p-3">{props.filterSlot}</div>
         </details>
         {filter.selectedTags.length > 0 && (
-          <ul className="flex list-none flex-wrap gap-1 px-1">
+          <ul aria-label="Selected tags" className="flex list-none flex-wrap gap-1 px-1">
             {filter.selectedTags.map((tag) => (
               <li key={tag} className="rounded-pill bg-surface-muted px-2 py-1 text-xs font-medium text-ink">
                 {tag}

--- a/src/features/card/containers/CardListContainer.spec.tsx
+++ b/src/features/card/containers/CardListContainer.spec.tsx
@@ -212,7 +212,7 @@ describe("CardListContainer", () => {
 
     expect(view.queryByText(card.backText)).not.toBeInTheDocument();
 
-    await userEvent.click(view.getByText(card.frontText));
+    await userEvent.click(view.getByRole("button", { name: `View ${card.frontText}` }));
     expect(view.getByText(card.backText)).toBeVisible();
 
     await userEvent.click(view.getByText(card.backText));
@@ -224,7 +224,7 @@ describe("CardListContainer", () => {
     mocks.cards = [languageCard];
     const view = render(<CardListContainer />);
 
-    await userEvent.click(view.getByText(languageCard.frontText));
+    await userEvent.click(view.getByRole("button", { name: `View ${languageCard.frontText}` }));
 
     const code = view.container.querySelector("pre.typescript") as HTMLElement;
     expect(code).toHaveTextContent(languageCard.backText);

--- a/src/features/card/containers/CardListContainer.spec.tsx
+++ b/src/features/card/containers/CardListContainer.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -8,6 +8,12 @@ const mocks = vi.hoisted(() => ({
   config: { darkMode: false, useCardInterval: false } as ConfigState,
   deck: null as Deck | null,
   cards: [] as Card[],
+  filter: { scoreMax: null as number | null, scoreMin: null as number | null, selectedTags: [] as string[] },
+  pendingCardId: undefined as CardId | undefined,
+  pending: false,
+  error: null as unknown,
+  retry: vi.fn(),
+  goToCardEdit: vi.fn(),
   cardUpdateBy: vi.fn(),
   cardRemove: vi.fn(),
 }));
@@ -16,10 +22,10 @@ vi.mock("@/features/card/hooks/useCardMutations", () => ({
   useCardMutations: () => ({
     updateBy: mocks.cardUpdateBy,
     remove: mocks.cardRemove,
-    isPending: () => false,
-    pending: false,
-    error: null,
-    retry: vi.fn(),
+    isPending: (id: CardId) => id === mocks.pendingCardId,
+    pending: mocks.pending,
+    error: mocks.error,
+    retry: mocks.retry,
   }),
 }));
 
@@ -55,7 +61,7 @@ vi.mock("@/shared/hooks/useActions", () => ({
     goByMenu: vi.fn(),
     setDarkMode: vi.fn(),
     cardUpdateBy: vi.fn(() => vi.fn()),
-    goToCardEdit: vi.fn(),
+    goToCardEdit: mocks.goToCardEdit,
     cardRemove: vi.fn(),
   }),
 }));
@@ -66,15 +72,15 @@ vi.mock("@/features/deck/hooks/useDeckActions", () => ({
 
 vi.mock("@/features/deck/hooks/useDeckFilterState", () => ({
   useDeckFilterState: () => ({
-    scoreMax: null,
-    scoreMin: null,
+    scoreMax: mocks.filter.scoreMax,
+    scoreMin: mocks.filter.scoreMin,
     scoreMaxSwitchProps: { name: "scoreMaxSwitch" },
     scoreMinSwitchProps: { name: "scoreMinSwitch" },
     scoreMaxSliderProps: { name: "scoreMax" },
     scoreMinSliderProps: { name: "scoreMin" },
     tagFilterProps: {
       tags: [],
-      selectedTags: [],
+      selectedTags: mocks.filter.selectedTags,
       tagAndFilter: false,
       onClickFilter: vi.fn(),
       onClickAll: vi.fn(),
@@ -122,10 +128,83 @@ describe("CardListContainer", () => {
     mocks.deck = deck;
     mocks.cards = [card];
     mocks.config = { darkMode: false, useCardInterval: false } as ConfigState;
+    mocks.filter = { scoreMax: null, scoreMin: null, selectedTags: [] };
+    mocks.pendingCardId = undefined;
+    mocks.pending = false;
+    mocks.error = null;
+    mocks.retry.mockReset();
+    mocks.goToCardEdit.mockReset();
+    mocks.cardUpdateBy.mockReset().mockResolvedValue(undefined);
+    mocks.cardRemove.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the current score and tag filters in the collapsed summary", () => {
+    mocks.filter = { scoreMin: -2, scoreMax: 4, selectedTags: ["typescript"] };
+    const view = render(<CardListContainer />);
+
+    expect(view.getByRole("heading", { level: 1, name: "Cards" })).toBeInTheDocument();
+    expect(view.getByText("1 card")).toBeInTheDocument();
+    expect(view.getByText("score -2–4 · 1 tag")).toBeInTheDocument();
+    expect(view.getByLabelText("Selected tags")).toHaveTextContent("typescript");
+    expect(view.getByText("Filters").closest("details")).not.toHaveAttribute("open");
+  });
+
+  it("preserves Edit, Delete, and left/right swipe connections", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const view = render(<CardListContainer />);
+    const trigger = view.getByRole("button", { name: `Open actions for ${card.frontText}` });
+
+    await userEvent.click(trigger);
+    await userEvent.click(view.getByRole("menuitem", { name: "Edit" }));
+    expect(mocks.goToCardEdit).toHaveBeenCalledExactlyOnceWith(card.id);
+
+    await userEvent.click(trigger);
+    await userEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(mocks.cardRemove).toHaveBeenCalledExactlyOnceWith(card.id);
+
+    confirm.mockReturnValue(false);
+    await userEvent.click(trigger);
+    await userEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(mocks.cardRemove).toHaveBeenCalledOnce();
+
+    const article = view.getByRole("article");
+    fireEvent.mouseDown(article, { clientX: 100, clientY: 0 });
+    fireEvent.mouseMove(document, { clientX: 0, clientY: 0 });
+    fireEvent.mouseUp(document, { clientX: 0, clientY: 0 });
+    fireEvent.mouseDown(article, { clientX: 0, clientY: 0 });
+    fireEvent.mouseMove(document, { clientX: 100, clientY: 0 });
+    fireEvent.mouseUp(document, { clientX: 100, clientY: 0 });
+
+    expect(mocks.cardUpdateBy).toHaveBeenCalledTimes(2);
+    const decrement = mocks.cardUpdateBy.mock.calls[0]?.[1] as (value: Card) => Partial<Card>;
+    const increment = mocks.cardUpdateBy.mock.calls[1]?.[1] as (value: Card) => Partial<Card>;
+    expect(decrement(card)).toEqual({ score: -1 });
+    expect(increment(card)).toEqual({ score: 1 });
+  });
+
+  it("forwards pending, error, and retry state", async () => {
+    mocks.pending = true;
+    mocks.pendingCardId = card.id;
+    const view = render(<CardListContainer />);
+
+    expect(view.getByText("Saving…").closest('[role="status"]')).toHaveTextContent("Saving…");
+    expect(view.getByRole("button", { name: `View ${card.frontText}` })).toBeDisabled();
+    expect(view.getByRole("button", { name: `Open actions for ${card.frontText}` })).toBeDisabled();
+
+    mocks.pending = false;
+    mocks.pendingCardId = undefined;
+    mocks.error = new Error("write failed");
+    view.rerender(<CardListContainer />);
+    expect(view.getByRole("alert")).toHaveTextContent("Unable to save changes.");
+    await userEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(mocks.retry).toHaveBeenCalledOnce();
   });
 
   it("opens a selected card's back text and closes it through the overlay callback", async () => {

--- a/src/features/card/containers/CardListContainer.tsx
+++ b/src/features/card/containers/CardListContainer.tsx
@@ -31,6 +31,11 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
   return (
     <CardListTemplate
       cards={cards}
+      filter={{
+        scoreMax: deckStartForm.scoreMax,
+        scoreMin: deckStartForm.scoreMin,
+        selectedTags: deckStartForm.tagFilterProps.selectedTags ?? [],
+      }}
       filterSlot={<DeckStartForm {...deckStartForm} />}
       layout={{
         headerProps: {

--- a/src/features/deck/components/DeckActionsMenu.tsx
+++ b/src/features/deck/components/DeckActionsMenu.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
-import { AiOutlineCloudDownload, AiOutlineDelete, AiOutlineEdit, AiOutlineMore, AiOutlineReload } from "react-icons/ai";
+import { AiOutlineCloudDownload, AiOutlineDelete, AiOutlineEdit, AiOutlineReload } from "react-icons/ai";
+import { ActionsMenu, type ActionsMenuItem } from "@/shared/components/forms/ActionsMenu";
 
 export interface DeckActionsMenuProps {
   deckName: string;
@@ -12,109 +13,41 @@ export interface DeckActionsMenuProps {
   onDelete?: () => void;
 }
 
-const itemClassName =
-  "flex min-h-touch w-full items-center gap-2 px-3 py-2 text-left text-body text-ink hover:bg-surface-muted focus-visible:bg-surface-muted focus-visible:outline-none";
-
 export const DeckActionsMenu: React.FC<DeckActionsMenuProps> = (props) => {
-  const focusTrigger = (menu: HTMLElement) => {
-    const trigger = menu.parentElement?.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
-    trigger?.focus();
-  };
-
-  const run = (action?: () => void) => (event: React.MouseEvent<HTMLButtonElement>) => {
-    const menu = event.currentTarget.parentElement;
-    action?.();
-    props.onClose();
-    if (menu != null) focusTrigger(menu);
-  };
-
-  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
-    const root = event.currentTarget.parentElement;
-    props.onToggle();
-    if (!props.open) queueMicrotask(() => root?.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus());
-  };
-
-  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      props.onClose();
-      focusTrigger(event.currentTarget);
-      return;
-    }
-    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
-
-    event.preventDefault();
-    const items = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
-    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
-    const nextIndex =
-      event.key === "Home"
-        ? 0
-        : event.key === "End"
-          ? items.length - 1
-          : event.key === "ArrowDown"
-            ? (currentIndex + 1) % items.length
-            : (currentIndex - 1 + items.length) % items.length;
-    items[nextIndex]?.focus();
-  };
-
-  const handleBlur = (event: React.FocusEvent<HTMLFieldSetElement>) => {
-    const root = event.currentTarget;
-    if (event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
-
-    queueMicrotask(() => {
-      if (!root.contains(document.activeElement)) props.onClose();
-    });
-  };
+  const items: ActionsMenuItem[] = [
+    ...(props.onRestart != null
+      ? [{ key: "restart", label: "Restart", icon: <AiOutlineReload aria-hidden="true" />, onSelect: props.onRestart }]
+      : []),
+    {
+      key: "download",
+      label: "Download",
+      icon: <AiOutlineCloudDownload aria-hidden="true" />,
+      ...(props.onDownload !== undefined ? { onSelect: props.onDownload } : {}),
+    },
+    {
+      key: "edit",
+      label: "Edit",
+      icon: <AiOutlineEdit aria-hidden="true" />,
+      ...(props.onEdit !== undefined ? { onSelect: props.onEdit } : {}),
+    },
+    {
+      key: "delete",
+      label: "Delete",
+      icon: <AiOutlineDelete aria-hidden="true" />,
+      danger: true,
+      ...(props.onDelete !== undefined ? { onSelect: props.onDelete } : {}),
+    },
+  ];
 
   return (
-    <fieldset
-      aria-label={`Deck actions for ${props.deckName}`}
-      className="relative min-w-0 shrink-0 border-0 p-0"
-      onBlur={handleBlur}
-    >
-      <button
-        type="button"
-        className="inline-flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-        aria-label={`Open actions for ${props.deckName}`}
-        aria-haspopup="menu"
-        aria-expanded={props.open}
-        onClick={handleToggle}
-      >
-        <AiOutlineMore aria-hidden="true" size={24} />
-      </button>
-
-      {props.open && (
-        <div
-          role="menu"
-          aria-label={`Actions for ${props.deckName}`}
-          className="absolute right-0 top-full z-20 min-w-40 rounded-control border border-border bg-surface py-1 shadow-elevated"
-          onKeyDown={handleMenuKeyDown}
-        >
-          {props.onRestart != null && (
-            <button type="button" role="menuitem" className={itemClassName} onClick={run(props.onRestart)}>
-              <AiOutlineReload aria-hidden="true" />
-              Restart
-            </button>
-          )}
-          <button type="button" role="menuitem" className={itemClassName} onClick={run(props.onDownload)}>
-            <AiOutlineCloudDownload aria-hidden="true" />
-            Download
-          </button>
-          <button type="button" role="menuitem" className={itemClassName} onClick={run(props.onEdit)}>
-            <AiOutlineEdit aria-hidden="true" />
-            Edit
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className={`${itemClassName} text-danger`}
-            onClick={run(props.onDelete)}
-          >
-            <AiOutlineDelete aria-hidden="true" />
-            Delete
-          </button>
-        </div>
-      )}
-    </fieldset>
+    <ActionsMenu
+      groupLabel={`Deck actions for ${props.deckName}`}
+      triggerLabel={`Open actions for ${props.deckName}`}
+      menuLabel={`Actions for ${props.deckName}`}
+      open={props.open}
+      onToggle={props.onToggle}
+      onClose={props.onClose}
+      items={items}
+    />
   );
 };

--- a/src/lib/sharedComponentPublicApi.spec.ts
+++ b/src/lib/sharedComponentPublicApi.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import * as Shared from "@/shared/components";
-import type { HeaderProps, LayoutProps, Option } from "@/shared/components";
+import type { ActionsMenuItem, ActionsMenuProps, HeaderProps, LayoutProps, Option } from "@/shared/components";
 
 const components = {
+  ActionsMenu: Shared.ActionsMenu,
   Button: Shared.Button,
   Card: Shared.Card,
   Code: Shared.Code,
@@ -35,12 +36,34 @@ const components = {
 
 describe("shared component public API", () => {
   it("exports every component and named prop type from the root barrel", () => {
-    const acceptsTypes = (_header: HeaderProps, _layout: LayoutProps, _option: Option) => {
+    const acceptsTypes = (
+      _actionsMenu: ActionsMenuProps,
+      _actionsMenuItem: ActionsMenuItem,
+      _header: HeaderProps,
+      _layout: LayoutProps,
+      _option: Option
+    ) => {
+      void _actionsMenu;
+      void _actionsMenuItem;
       void _header;
       void _layout;
       void _option;
     };
-    acceptsTypes({}, {}, { label: "label", value: "value" });
+    acceptsTypes(
+      {
+        groupLabel: "Actions",
+        triggerLabel: "Open actions",
+        menuLabel: "Actions menu",
+        open: false,
+        onToggle: () => {},
+        onClose: () => {},
+        items: [{ key: "edit", label: "Edit", icon: null }],
+      },
+      { key: "edit", label: "Edit", icon: null },
+      {},
+      {},
+      { label: "label", value: "value" }
+    );
     expect(Object.values(components).every((component) => typeof component === "function")).toBe(true);
   });
 });

--- a/src/shared/components/forms/ActionsMenu.spec.tsx
+++ b/src/shared/components/forms/ActionsMenu.spec.tsx
@@ -71,6 +71,45 @@ describe("ActionsMenu", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("keeps menu items out of the Tab sequence and moves Tab to the next external control", async () => {
+    const view = render(
+      <>
+        <button type="button">Previous control</button>
+        <ControlledMenu {...labels} items={items()} />
+        <button type="button">Next control</button>
+      </>
+    );
+    fireEvent.click(view.getByRole("button", { name: labels.triggerLabel }));
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    const remove = view.getByRole("menuitem", { name: "Delete" });
+    await waitFor(() => expect(edit).toHaveFocus());
+
+    expect(edit).toHaveAttribute("tabindex", "-1");
+    expect(remove).toHaveAttribute("tabindex", "-1");
+    await act(async () => fireEvent.keyDown(edit, { key: "Tab" }));
+
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Next control" })).toHaveFocus();
+  });
+
+  it("moves Shift+Tab to the previous external control before the trigger", async () => {
+    const view = render(
+      <>
+        <button type="button">Previous control</button>
+        <ControlledMenu {...labels} items={items()} />
+        <button type="button">Next control</button>
+      </>
+    );
+    fireEvent.click(view.getByRole("button", { name: labels.triggerLabel }));
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    await waitFor(() => expect(edit).toHaveFocus());
+
+    await act(async () => fireEvent.keyDown(edit, { key: "Tab", shiftKey: true }));
+
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Previous control" })).toHaveFocus();
+  });
+
   it("keeps the menu open when an ambiguous blur settles inside", async () => {
     const view = render(<ControlledMenu {...labels} items={items()} />);
     fireEvent.click(view.getByRole("button", { name: labels.triggerLabel }));

--- a/src/shared/components/forms/ActionsMenu.spec.tsx
+++ b/src/shared/components/forms/ActionsMenu.spec.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ActionsMenu, type ActionsMenuItem } from "@/shared/components/forms/ActionsMenu";
+
+const items = (edit = vi.fn(), remove = vi.fn()): ActionsMenuItem[] => [
+  { key: "edit", label: "Edit", icon: <span aria-hidden="true">E</span>, onSelect: edit },
+  { key: "delete", label: "Delete", icon: <span aria-hidden="true">D</span>, danger: true, onSelect: remove },
+];
+
+type ControlledMenuProps = Omit<React.ComponentProps<typeof ActionsMenu>, "open" | "onToggle" | "onClose">;
+
+const ControlledMenu: React.FC<ControlledMenuProps> = (props) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <ActionsMenu {...props} open={open} onToggle={() => setOpen((value) => !value)} onClose={() => setOpen(false)} />
+  );
+};
+
+const labels = {
+  groupLabel: "Card actions for Binary search",
+  triggerLabel: "Open actions for Binary search",
+  menuLabel: "Actions for Binary search",
+};
+
+describe("ActionsMenu", () => {
+  afterEach(cleanup);
+
+  it("renders supplied labels and runs items before returning focus", async () => {
+    const edit = vi.fn();
+    const remove = vi.fn();
+    const view = render(<ControlledMenu {...labels} items={items(edit, remove)} />);
+    const trigger = view.getByRole("button", { name: labels.triggerLabel });
+
+    expect(view.getByRole("group", { name: labels.groupLabel })).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(trigger);
+    expect(view.getByRole("menu", { name: labels.menuLabel })).toBeInTheDocument();
+    fireEvent.click(view.getByRole("menuitem", { name: "Edit" }));
+    expect(edit).toHaveBeenCalledOnce();
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    fireEvent.click(trigger);
+    const deleteItem = view.getByRole("menuitem", { name: "Delete" });
+    expect(deleteItem).toHaveClass("text-danger");
+    fireEvent.click(deleteItem);
+    expect(remove).toHaveBeenCalledOnce();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("supports wrapping arrows, Home, End, and Escape", async () => {
+    const view = render(<ControlledMenu {...labels} items={items()} />);
+    const trigger = view.getByRole("button", { name: labels.triggerLabel });
+    fireEvent.click(trigger);
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    const remove = view.getByRole("menuitem", { name: "Delete" });
+
+    await waitFor(() => expect(edit).toHaveFocus());
+    fireEvent.keyDown(edit, { key: "ArrowUp" });
+    expect(remove).toHaveFocus();
+    fireEvent.keyDown(remove, { key: "Home" });
+    expect(edit).toHaveFocus();
+    fireEvent.keyDown(edit, { key: "End" });
+    expect(remove).toHaveFocus();
+    fireEvent.keyDown(remove, { key: "ArrowDown" });
+    expect(edit).toHaveFocus();
+    fireEvent.keyDown(edit, { key: "Escape" });
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("keeps the menu open when an ambiguous blur settles inside", async () => {
+    const view = render(<ControlledMenu {...labels} items={items()} />);
+    fireEvent.click(view.getByRole("button", { name: labels.triggerLabel }));
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    const remove = view.getByRole("menuitem", { name: "Delete" });
+    await waitFor(() => expect(edit).toHaveFocus());
+
+    await act(async () => {
+      edit.blur();
+      remove.focus();
+    });
+
+    expect(view.getByRole("menu", { name: labels.menuLabel })).toBeInTheDocument();
+    expect(remove).toHaveFocus();
+  });
+
+  it("closes when an ambiguous blur settles outside", async () => {
+    const view = render(
+      <>
+        <button type="button">External target</button>
+        <ControlledMenu {...labels} items={items()} />
+      </>
+    );
+    fireEvent.click(view.getByRole("button", { name: labels.triggerLabel }));
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    const external = view.getByRole("button", { name: "External target" });
+    await waitFor(() => expect(edit).toHaveFocus());
+
+    await act(async () => {
+      edit.blur();
+      external.focus();
+    });
+
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    expect(external).toHaveFocus();
+  });
+
+  it("disables the trigger and hides an open menu", () => {
+    const view = render(<ActionsMenu {...labels} items={items()} open disabled onToggle={vi.fn()} onClose={vi.fn()} />);
+
+    expect(view.getByRole("button", { name: labels.triggerLabel })).toBeDisabled();
+    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});

--- a/src/shared/components/forms/ActionsMenu.tsx
+++ b/src/shared/components/forms/ActionsMenu.tsx
@@ -1,0 +1,117 @@
+import type * as React from "react";
+import { AiOutlineMore } from "react-icons/ai";
+
+export interface ActionsMenuItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  danger?: boolean;
+  onSelect?: () => void;
+}
+
+export interface ActionsMenuProps {
+  groupLabel: string;
+  triggerLabel: string;
+  menuLabel: string;
+  open: boolean;
+  disabled?: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  items: ActionsMenuItem[];
+}
+
+const itemClassName =
+  "flex min-h-touch w-full items-center gap-2 px-3 py-2 text-left text-body text-ink hover:bg-surface-muted focus-visible:bg-surface-muted focus-visible:outline-none";
+
+const triggerClassName =
+  "inline-flex size-touch items-center justify-center rounded-control text-ink-muted hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed disabled:opacity-50";
+
+const menuClassName =
+  "absolute right-0 top-full z-20 min-w-40 rounded-control border border-border bg-surface py-1 shadow-elevated";
+
+export const ActionsMenu: React.FC<ActionsMenuProps> = (props) => {
+  const focusTrigger = (menu: HTMLElement) => {
+    const trigger = menu.parentElement?.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
+    trigger?.focus();
+  };
+
+  const run = (action?: () => void) => (event: React.MouseEvent<HTMLButtonElement>) => {
+    const menu = event.currentTarget.parentElement;
+    action?.();
+    props.onClose();
+    if (menu != null) focusTrigger(menu);
+  };
+
+  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const root = event.currentTarget.parentElement;
+    props.onToggle();
+    if (!props.open) queueMicrotask(() => root?.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus());
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onClose();
+      focusTrigger(event.currentTarget);
+      return;
+    }
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+
+    event.preventDefault();
+    const items = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? items.length - 1
+          : event.key === "ArrowDown"
+            ? (currentIndex + 1) % items.length
+            : (currentIndex - 1 + items.length) % items.length;
+    items[nextIndex]?.focus();
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLFieldSetElement>) => {
+    const root = event.currentTarget;
+    if (event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
+
+    queueMicrotask(() => {
+      if (!root.contains(document.activeElement)) props.onClose();
+    });
+  };
+
+  const isOpen = props.open && !props.disabled;
+
+  return (
+    <fieldset aria-label={props.groupLabel} className="relative min-w-0 shrink-0 border-0 p-0" onBlur={handleBlur}>
+      <button
+        type="button"
+        className={triggerClassName}
+        aria-label={props.triggerLabel}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        disabled={props.disabled}
+        onClick={handleToggle}
+      >
+        <AiOutlineMore aria-hidden="true" size={24} />
+      </button>
+
+      {isOpen && (
+        <div role="menu" aria-label={props.menuLabel} className={menuClassName} onKeyDown={handleMenuKeyDown}>
+          {props.items.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              role="menuitem"
+              className={item.danger ? `${itemClassName} text-danger` : itemClassName}
+              onClick={run(item.onSelect)}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </fieldset>
+  );
+};

--- a/src/shared/components/forms/ActionsMenu.tsx
+++ b/src/shared/components/forms/ActionsMenu.tsx
@@ -29,6 +29,26 @@ const triggerClassName =
 const menuClassName =
   "absolute right-0 top-full z-20 min-w-40 rounded-control border border-border bg-surface py-1 shadow-elevated";
 
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+const focusAdjacentToTrigger = (menu: HTMLElement, direction: -1 | 1) => {
+  const trigger = menu.parentElement?.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
+  if (trigger == null) return;
+
+  const focusable = Array.from(document.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+    (element) => element.tabIndex >= 0 && element.closest("[hidden], [inert]") == null
+  );
+  const triggerIndex = focusable.indexOf(trigger);
+  focusable[triggerIndex + direction]?.focus();
+};
+
 export const ActionsMenu: React.FC<ActionsMenuProps> = (props) => {
   const focusTrigger = (menu: HTMLElement) => {
     const trigger = menu.parentElement?.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
@@ -53,6 +73,13 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = (props) => {
       event.preventDefault();
       props.onClose();
       focusTrigger(event.currentTarget);
+      return;
+    }
+    if (event.key === "Tab") {
+      event.preventDefault();
+      const menu = event.currentTarget;
+      props.onClose();
+      focusAdjacentToTrigger(menu, event.shiftKey ? -1 : 1);
       return;
     }
     if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
@@ -103,6 +130,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = (props) => {
               key={item.key}
               type="button"
               role="menuitem"
+              tabIndex={-1}
               className={item.danger ? `${itemClassName} text-danger` : itemClassName}
               onClick={run(item.onSelect)}
             >

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,4 +1,5 @@
 export * from "@/shared/components/forms/Button";
+export * from "@/shared/components/forms/ActionsMenu";
 export * from "@/shared/components/content/Card";
 export * from "@/shared/components/content/Code";
 export * from "@/shared/components/content/Description";


### PR DESCRIPTION
## Summary

- Redesign the card list as compact, responsive rows with clearer primary and secondary actions.
- Add reusable accessible action menus, keyboard and focus handling, and safe swipe and click boundaries.
- Surface the live result count and active filter summary with removable filter chips.

## Testing

- `make check` (85 test files, 460 tests)
- `npm run build:storybook`