### PR TITLE
Fix deck list edit button timing

### DIFF
--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -110,6 +110,33 @@ describe("DeckActionsMenu", () => {
     }
   });
 
+  it("keeps Edit active when an ambiguous blur microtask runs before the click", async () => {
+    const onEdit = vi.fn();
+    const view = render(<ControlledMenu deckName="Biology" onEdit={onEdit} />);
+    const trigger = view.getByRole("button", { name: "Open actions for Biology" });
+
+    fireEvent.click(trigger);
+    const download = view.getByRole("menuitem", { name: "Download" });
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    await waitFor(() => expect(download).toHaveFocus());
+
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
+    try {
+      await act(async () => {
+        download.blur();
+        await Promise.resolve();
+      });
+      fireEvent.click(edit);
+
+      expect(onEdit).toHaveBeenCalledOnce();
+    } finally {
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+      vi.useRealTimers();
+    }
+  });
+
   it("closes when an ambiguous blur settles on an external element", async () => {
     const view = render(
       <>
@@ -129,7 +156,7 @@ describe("DeckActionsMenu", () => {
       externalTarget.focus();
     });
 
-    expect(view.queryByRole("menu")).not.toBeInTheDocument();
+    await waitFor(() => expect(view.queryByRole("menu")).not.toBeInTheDocument());
     expect(externalTarget).toHaveFocus();
   });
 });

--- a/src/features/deck/components/DeckActionsMenu.tsx
+++ b/src/features/deck/components/DeckActionsMenu.tsx
@@ -61,9 +61,9 @@ export const DeckActionsMenu: React.FC<DeckActionsMenuProps> = (props) => {
     const root = event.currentTarget;
     if (event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
 
-    queueMicrotask(() => {
-      if (!root.contains(document.activeElement)) props.onClose();
-    });
+    setTimeout(() => {
+      if (root.isConnected && !root.contains(document.activeElement)) props.onClose();
+    }, 0);
   };
 
   return (

--- a/src/shared/components/forms/ActionsMenu.spec.tsx
+++ b/src/shared/components/forms/ActionsMenu.spec.tsx
@@ -19,6 +19,27 @@ const ControlledMenu: React.FC<ControlledMenuProps> = (props) => {
   );
 };
 
+const SharedOpenMenus: React.FC = () => {
+  const [openMenu, setOpenMenu] = React.useState<"first" | "second" | null>(null);
+  const menu = (id: "first" | "second") => ({
+    ...labels,
+    groupLabel: `${id} ${labels.groupLabel}`,
+    triggerLabel: `Open ${id} actions`,
+    menuLabel: `${id} ${labels.menuLabel}`,
+    items: items(),
+    open: openMenu === id,
+    onToggle: () => setOpenMenu((current) => (current === id ? null : id)),
+    onClose: () => setOpenMenu(null),
+  });
+
+  return (
+    <>
+      <ActionsMenu {...menu("first")} />
+      <ActionsMenu {...menu("second")} />
+    </>
+  );
+};
+
 const labels = {
   groupLabel: "Card actions for Binary search",
   triggerLabel: "Open actions for Binary search",
@@ -148,6 +169,46 @@ describe("ActionsMenu", () => {
       act(() => {
         vi.runOnlyPendingTimers();
       });
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a newly opened sibling menu open after a stale blur timer runs", async () => {
+    const view = render(<SharedOpenMenus />);
+    fireEvent.click(view.getByRole("button", { name: "Open first actions" }));
+    const firstEdit = view.getByRole("menuitem", { name: "Edit" });
+    await waitFor(() => expect(firstEdit).toHaveFocus());
+
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
+    try {
+      await act(async () => {
+        firstEdit.blur();
+        fireEvent.click(view.getByRole("button", { name: "Open second actions" }));
+      });
+
+      const secondMenu = view.getByRole("menu", { name: `second ${labels.menuLabel}` });
+      expect(secondMenu).toBeInTheDocument();
+      act(() => vi.runOnlyPendingTimers());
+      expect(secondMenu).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not close after its root unmounts during an ambiguous blur", async () => {
+    const onClose = vi.fn();
+    const view = render(<ActionsMenu {...labels} items={items()} open onToggle={vi.fn()} onClose={onClose} />);
+    const edit = view.getByRole("menuitem", { name: "Edit" });
+    edit.focus();
+
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
+    try {
+      act(() => edit.blur());
+      view.unmount();
+      act(() => vi.runOnlyPendingTimers());
+
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
       vi.useRealTimers();
     }
   });

--- a/src/shared/components/forms/ActionsMenu.tsx
+++ b/src/shared/components/forms/ActionsMenu.tsx
@@ -101,9 +101,12 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = (props) => {
   const handleBlur = (event: React.FocusEvent<HTMLFieldSetElement>) => {
     const root = event.currentTarget;
     if (event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
+    const menu = root.querySelector<HTMLElement>('[role="menu"]');
 
     setTimeout(() => {
-      if (root.isConnected && !root.contains(document.activeElement)) props.onClose();
+      if (root.isConnected && menu?.isConnected && root.contains(menu) && !root.contains(document.activeElement)) {
+        props.onClose();
+      }
     }, 0);
   };
 


### PR DESCRIPTION
## Summary
- defer ambiguous action-menu blur dismissal until pending clicks complete
- scope deferred close to the same rendered menu instance so sibling menus stay open
- add regression coverage for Edit clicks, sibling-menu switching, and unmount cleanup

## Testing
- Focused Vitest: 5 files, 28 tests passed
- Playwright E2E: 16 tests passed
- make check: formatting, lint, 85 test files and 463 tests passed