### PR TITLE
Modernize the card editing page

### DIFF
--- a/docs/card-form-modernization-design.md
+++ b/docs/card-form-modernization-design.md
@@ -1,0 +1,107 @@
+# Card Form Modernization Design
+
+## Goal
+
+Modernize the card editing page so that editing the front and back feels focused, readable, and consistent with Tango's Calm Focus visual system. Preserve the existing card data model and save behavior.
+
+## Scope
+
+This change updates the presentation and interaction structure of the existing card editor. It does not add preview behavior, change Firestore data, or alter card mutation semantics.
+
+## Selected Direction
+
+Use a focused single-column layout. This direction keeps long card text readable, behaves consistently across desktop and mobile, and fits the existing bounded reading-width layout.
+
+The alternatives considered were:
+
+- A two-column front/back layout, which makes comparison easier but narrows long-form text fields and changes substantially with viewport width.
+- An editor-plus-preview layout, which adds useful visual feedback but requires new display behavior and expands the feature scope.
+
+## Page Structure
+
+The page uses the existing application header and a centered `max-w-reading` editing surface.
+
+The editing surface contains, in order:
+
+1. A `Back to cards` action that returns to the previous browser history entry.
+2. A `Card editor` eyebrow, `Edit card` heading, and short supporting description.
+3. Remote mutation feedback.
+4. A Front section with a short explanation and a large textarea.
+5. A Back section with a short explanation and a large textarea.
+6. A Tags section containing the existing selectable tags.
+7. A collapsed `Card information` disclosure containing the unique key, ID, creation date, and last-seen date.
+8. A footer action row with `Cancel` and `Save changes` aligned to the end.
+
+All interface copy remains in English to match the application. The layout remains a single column at every viewport size.
+
+## Components and Responsibilities
+
+### `CardFormContainer`
+
+- Continues to load the card and own mutation state.
+- Continues to navigate to the previous history entry after a successful save.
+- Provides the same previous-history navigation as the cancel action.
+- Preserves the current mutation error handling and retry notice.
+
+### `CardFormTemplate`
+
+- Owns page-level presentation: the bounded editing surface, back action, eyebrow, heading, and supporting description.
+- Passes editing behavior to `CardForm` without taking ownership of form state.
+
+### `CardForm`
+
+- Owns the semantic form structure for Front, Back, Tags, Card information, and footer actions.
+- Exposes an optional `onCancel` callback.
+- Uses the shared `Button`, `Form`, `FormItem`, `Tag`, `TagList`, and `Textarea` primitives.
+- Keeps unique section-heading relationships for accessibility.
+
+No new general-purpose shared component is required. The change follows the existing `DeckForm` and `DeckFormTemplate` presentation patterns without coupling the two features.
+
+## Interaction and Data Flow
+
+Field changes continue through `useCardFormState`. Submitting the form passes the updated card to `useCardMutations`, and a successful mutation returns to the previous history entry. Mutation failures remain on the page and are communicated by `RemoteMutationNotice`, which retains its retry behavior.
+
+Cancel and `Back to cards` both navigate to the previous browser history entry without submitting. No unsaved-changes confirmation is added.
+
+While a mutation is pending, the primary action is disabled and reads `Saving…`. When idle, it reads `Save changes`.
+
+## Metadata Presentation
+
+Card metadata is secondary to editing, so it is placed inside a collapsed disclosure. Labels use title case: `Unique key`, `ID`, `Created`, and `Last seen`. Unique key and ID rows are always shown; an absent unique key renders as an empty value. Created and Last seen rows are shown only when their timestamps exist, and their dates use the user's locale.
+
+## Accessibility
+
+- Front, Back, and Tags remain semantic sections associated with unique heading IDs.
+- The metadata disclosure uses native `details` and `summary` behavior.
+- Back, Cancel, and Save remain keyboard-accessible controls with visible focus treatment from the shared visual system.
+- Existing field names, values, and callbacks remain intact.
+- Touch targets continue to use the shared minimum touch size.
+
+## Error Handling
+
+- Remote read loading, missing-card, and retry states remain owned by `RemoteReadBoundary`.
+- Mutation errors remain owned by `RemoteMutationNotice`.
+- Cancel does not trigger a mutation.
+- Save navigation occurs only after a successful mutation.
+
+## Testing
+
+Update component and container tests to verify:
+
+- The new headings, descriptions, sections, and collapsed card information disclosure.
+- Existing field values and change callbacks.
+- Unique accessible heading relationships across multiple form instances.
+- The `Cancel` callback and form submission remain distinct.
+- `Save changes` is enabled while idle and `Saving…` is disabled while submitting.
+- The template renders its back action and composes mutation feedback before the form.
+- The container supplies previous-history navigation for cancel while preserving successful-save navigation and failure behavior.
+
+Run the focused Vitest tests during implementation and `make check` before finishing the non-documentation change.
+
+## Out of Scope
+
+- Live or rendered card preview.
+- Autosave or unsaved-change prompts.
+- Changes to tag options or card fields.
+- Firestore schema, mutation, or routing changes.
+- New visual tokens or global styling changes.

--- a/docs/card-form-modernization-plan.md
+++ b/docs/card-form-modernization-plan.md
@@ -1,0 +1,348 @@
+# Card Form Modernization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a focused, accessible single-column card editor that matches Tango's Calm Focus design and preserves existing card persistence behavior.
+
+**Architecture:** Keep server-state and navigation responsibilities in `CardFormContainer`, page-level framing in `CardFormTemplate`, and semantic fields and actions in `CardForm`. Add only an optional cancel callback; do not change the card model, routing, or mutation interfaces.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS 4, React Router, Vitest, Testing Library
+
+## Global Constraints
+
+- Keep all interface copy in English.
+- Keep the editor single-column at every viewport size.
+- Do not add card preview, autosave, unsaved-change prompts, new visual tokens, or Firestore changes.
+- Use shared form and layout primitives.
+- Preserve remote read and mutation retry behavior.
+- Run `make check` before finishing.
+
+---
+
+### Task 1: Modernize the card form
+
+**Files:**
+- Modify: `src/features/card/components/CardForm.spec.tsx`
+- Modify: `src/features/card/components/CardForm.tsx`
+
+**Interfaces:**
+- Consumes: existing `Card`, `Form`, `FormItem`, `Tag`, `TagList`, and `Textarea` interfaces.
+- Produces: `CardFormProps.onCancel?: () => void` and the existing `onSubmit` interface.
+
+- [ ] **Step 1: Write failing form presentation and interaction tests**
+
+Replace the existing presentation assertions with tests that require Front, Back, and Tags sections, a collapsed `Card information` disclosure, localized dates, separate Cancel and Save actions, and pending copy:
+
+```tsx
+expect(view.getByRole("heading", { level: 2, name: "Front" })).toBeVisible();
+expect(view.getByText("The prompt shown during study.")).toBeVisible();
+expect(view.getByRole("heading", { level: 2, name: "Back" })).toBeVisible();
+expect(view.getByText("The answer revealed after the prompt.")).toBeVisible();
+expect(view.getByRole("heading", { level: 2, name: "Tags" })).toBeVisible();
+expect(view.getByText("Organize this card for filtering and study sessions.")).toBeVisible();
+
+const disclosure = view.getByText("Card information").closest("details");
+expect(disclosure).not.toHaveAttribute("open");
+expect(view.getByText(new Date(createdAt).toLocaleDateString())).toBeInTheDocument();
+
+const onCancel = vi.fn();
+const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());
+const actions = render(<CardForm {...createProps({ isSubmitting: false, onCancel, onSubmit })} />);
+await userEvent.click(actions.getByRole("button", { name: "Cancel" }));
+expect(onCancel).toHaveBeenCalledOnce();
+expect(onSubmit).not.toHaveBeenCalled();
+await userEvent.click(actions.getByRole("button", { name: "Save changes" }));
+expect(onSubmit).toHaveBeenCalledOnce();
+
+const pending = render(<CardForm {...createProps({ isSubmitting: true })} />);
+expect(pending.getByRole("button", { name: "Saving…" })).toBeDisabled();
+```
+
+Update the unique heading test to expect six semantic sections across two form instances: Front, Back, and Tags per instance.
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run:
+
+```bash
+npm test -- src/features/card/components/CardForm.spec.tsx
+```
+
+Expected: FAIL because the current form exposes `Card content`, `Metadata`, and `Save`, and has no Cancel callback.
+
+- [ ] **Step 3: Implement the modernized form**
+
+Add `onCancel?: () => void` to `CardFormProps`. Replace the combined content section with focused sections using this presentation pattern:
+
+```tsx
+<section
+  aria-labelledby={frontHeadingId}
+  className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
+>
+  <div>
+    <h2 id={frontHeadingId} className="text-title font-semibold text-ink">Front</h2>
+    <p className="mt-1 text-caption text-ink-muted">The prompt shown during study.</p>
+  </div>
+  <FormItem col label="Front text">
+    <Textarea rows={8} {...props.fields.frontText} />
+  </FormItem>
+</section>
+```
+
+Use the same structure for Back with `The answer revealed after the prompt.` and `Back text`. Render Tags in a matching surface with `Organize this card for filtering and study sessions.`
+
+Replace Metadata with a native disclosure:
+
+```tsx
+<details className="rounded-surface border border-border bg-surface-muted p-4">
+  <summary className="flex min-h-touch cursor-pointer items-center font-semibold text-ink">
+    Card information
+  </summary>
+  <dl className="mt-4 grid gap-3 text-caption">
+    <div className="min-w-0">
+      <dt className="font-medium text-ink-muted">Unique key</dt>
+      <dd className="break-all text-ink">{props.card.uniqueKey ?? ""}</dd>
+    </div>
+    <div className="min-w-0">
+      <dt className="font-medium text-ink-muted">ID</dt>
+      <dd className="break-all text-ink">{props.card.id}</dd>
+    </div>
+    {Boolean(props.card.createdAt) && (
+      <div><dt className="font-medium text-ink-muted">Created</dt><dd className="text-ink">{new Date(props.card.createdAt).toLocaleDateString()}</dd></div>
+    )}
+    {Boolean(props.card.lastSeenAt) && (
+      <div><dt className="font-medium text-ink-muted">Last seen</dt><dd className="text-ink">{new Date(props.card.lastSeenAt).toLocaleDateString()}</dd></div>
+    )}
+  </dl>
+</details>
+```
+
+Finish with the shared footer pattern:
+
+```tsx
+<div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">
+  <Button
+    variant="quiet"
+    type="button"
+    {...(props.onCancel !== undefined ? { onClick: props.onCancel } : {})}
+  >
+    Cancel
+  </Button>
+  <Button variant="primary" type="submit" disabled={props.isSubmitting}>
+    {props.isSubmitting ? "Saving…" : "Save changes"}
+  </Button>
+</div>
+```
+
+- [ ] **Step 4: Run the focused test and confirm success**
+
+Run:
+
+```bash
+npm test -- src/features/card/components/CardForm.spec.tsx
+```
+
+Expected: all `CardForm` tests PASS.
+
+- [ ] **Step 5: Commit the form change**
+
+```bash
+git add src/features/card/components/CardForm.tsx src/features/card/components/CardForm.spec.tsx
+git commit -m "Modernize the card editing form"
+```
+
+---
+
+### Task 2: Modernize the card editor page frame
+
+**Files:**
+- Modify: `src/features/card/components/templates/CardFormTemplate.spec.tsx`
+- Modify: `src/features/card/components/templates/CardFormTemplate.tsx`
+
+**Interfaces:**
+- Consumes: `CardFormProps.onCancel?: () => void` from Task 1 and existing `LayoutProps`.
+- Produces: page-level `Back to cards` action using the same cancel callback.
+
+- [ ] **Step 1: Write a failing template test**
+
+Render the template with `onCancel` and assert the updated hierarchy and behavior:
+
+```tsx
+const onCancel = vi.fn();
+const view = render(<CardFormTemplate cardForm={{ ...cardFormProps, onCancel }} />);
+expect(view.getByText("Card editor")).toBeVisible();
+expect(view.getByRole("heading", { level: 1, name: "Edit card" })).toBeVisible();
+expect(view.getByText("Update the prompt, answer, and organization for this card.")).toBeVisible();
+await userEvent.click(view.getByRole("button", { name: "Back to cards" }));
+expect(onCancel).toHaveBeenCalledOnce();
+```
+
+Keep the existing bounded-surface and feedback-before-form assertions.
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run:
+
+```bash
+npm test -- src/features/card/components/templates/CardFormTemplate.spec.tsx
+```
+
+Expected: FAIL because the current template has no back action, eyebrow, or description.
+
+- [ ] **Step 3: Implement the page header**
+
+Import `AiOutlineArrowLeft`. Replace the lone heading with:
+
+```tsx
+<header className="mb-section-gap">
+  {props.cardForm?.onCancel != null && (
+    <button
+      type="button"
+      className="mb-4 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
+      onClick={props.cardForm.onCancel}
+    >
+      <AiOutlineArrowLeft aria-hidden="true" />
+      Back to cards
+    </button>
+  )}
+  <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Card editor</p>
+  <h1 className="mt-1 break-words text-display font-bold text-ink">Edit card</h1>
+  <p className="mt-2 text-body text-ink-muted">
+    Update the prompt, answer, and organization for this card.
+  </p>
+</header>
+```
+
+Keep feedback immediately before `CardForm` inside the existing bounded surface.
+
+- [ ] **Step 4: Run the focused test and confirm success**
+
+Run:
+
+```bash
+npm test -- src/features/card/components/templates/CardFormTemplate.spec.tsx
+```
+
+Expected: all `CardFormTemplate` tests PASS.
+
+- [ ] **Step 5: Commit the template change**
+
+```bash
+git add src/features/card/components/templates/CardFormTemplate.tsx src/features/card/components/templates/CardFormTemplate.spec.tsx
+git commit -m "Refine the card editor page header"
+```
+
+---
+
+### Task 3: Wire cancel navigation and verify the feature
+
+**Files:**
+- Modify: `src/features/card/containers/CardFormContainer.spec.tsx`
+- Modify: `src/features/card/containers/CardFormContainer.tsx`
+- Verify: all files changed by Tasks 1-3
+
+**Interfaces:**
+- Consumes: `CardFormProps.onCancel?: () => void` and React Router's `navigate(-1)`.
+- Produces: cancel and back controls that return to the previous history entry without invoking `cardUpdate`.
+
+- [ ] **Step 1: Write a failing cancel-navigation test**
+
+Add:
+
+```tsx
+it("returns to the previous page without saving when cancelled", async () => {
+  const view = render(<CardFormContainer />);
+
+  await userEvent.click(view.getByRole("button", { name: "Cancel" }));
+
+  expect(mocks.cardUpdate).not.toHaveBeenCalled();
+  expect(mocks.navigate).toHaveBeenCalledWith(-1);
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run:
+
+```bash
+npm test -- src/features/card/containers/CardFormContainer.spec.tsx
+```
+
+Expected: FAIL because the container does not provide `onCancel`.
+
+- [ ] **Step 3: Wire previous-history navigation**
+
+Add the callback to the existing state passed to the template:
+
+```tsx
+const goBack = () => void navigate(-1);
+
+const cardForm = useCardFormState({
+  card,
+  categoryOptions,
+  onSubmit: async (nextCard) => {
+    try {
+      await mutations.update(nextCard);
+      goBack();
+    } catch {
+      // The mutation notice owns error feedback and retry.
+    }
+  },
+});
+
+<CardFormTemplate
+  layout={{
+    headerProps: {
+      dark: config.darkMode,
+      onClickDarkMode: actions.setDarkMode,
+      onClickLogo: actions.goToTop,
+      onClickMenuItem: actions.goByMenu,
+    },
+  }}
+  feedbackSlot={
+    <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+  }
+  cardForm={{ ...cardForm, onCancel: goBack }}
+/>
+```
+
+- [ ] **Step 4: Run all focused card editor tests**
+
+Run:
+
+```bash
+npm test -- src/features/card/components/CardForm.spec.tsx src/features/card/components/templates/CardFormTemplate.spec.tsx src/features/card/containers/CardFormContainer.spec.tsx
+```
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 5: Format the changed source files**
+
+Run:
+
+```bash
+npx biome format --write src/features/card/components/CardForm.tsx src/features/card/components/CardForm.spec.tsx src/features/card/components/templates/CardFormTemplate.tsx src/features/card/components/templates/CardFormTemplate.spec.tsx src/features/card/containers/CardFormContainer.tsx src/features/card/containers/CardFormContainer.spec.tsx
+```
+
+Expected: Biome completes without errors.
+
+- [ ] **Step 6: Run repository verification**
+
+Run:
+
+```bash
+make check
+```
+
+Expected: sample build, formatting, lint, TypeScript checks, and unit tests all PASS.
+
+- [ ] **Step 7: Commit the navigation and plan**
+
+```bash
+git add docs/card-form-modernization-plan.md src/features/card/containers/CardFormContainer.tsx src/features/card/containers/CardFormContainer.spec.tsx
+git commit -m "Add card editor cancel navigation"
+```
+
+- [ ] **Step 8: Push and open a pull request**
+
+Push `codex/card-form-modernization` and create a ready pull request with an English title and description summarizing the focused editor layout, navigation behavior, accessibility, and `make check` result.

--- a/docs/card-form-modernization-plan.md
+++ b/docs/card-form-modernization-plan.md
@@ -110,7 +110,7 @@ Replace Metadata with a native disclosure:
     {Boolean(props.card.createdAt) && (
       <div><dt className="font-medium text-ink-muted">Created</dt><dd className="text-ink">{new Date(props.card.createdAt).toLocaleDateString()}</dd></div>
     )}
-    {Boolean(props.card.lastSeenAt) && (
+    {props.card.lastSeenAt != null && (
       <div><dt className="font-medium text-ink-muted">Last seen</dt><dd className="text-ink">{new Date(props.card.lastSeenAt).toLocaleDateString()}</dd></div>
     )}
   </dl>
@@ -128,7 +128,11 @@ Finish with the shared footer pattern:
   >
     Cancel
   </Button>
-  <Button variant="primary" type="submit" disabled={props.isSubmitting}>
+  <Button
+    variant="primary"
+    type="submit"
+    {...(props.isSubmitting !== undefined ? { disabled: props.isSubmitting } : {})}
+  >
     {props.isSubmitting ? "Saving…" : "Save changes"}
   </Button>
 </div>

--- a/src/features/card/components/CardForm.spec.tsx
+++ b/src/features/card/components/CardForm.spec.tsx
@@ -41,7 +41,7 @@ const createProps = (overrides: Partial<CardFormProps> = {}): CardFormProps => (
 describe("CardForm", () => {
   afterEach(cleanup);
 
-  it("groups card content, tags, and metadata while preserving values and callbacks", async () => {
+  it("groups front, back, tags, and card information while preserving values and callbacks", async () => {
     const props = createProps();
     const view = render(<CardForm {...props} />);
     const frontText = view.container.querySelector("textarea[name='frontText']") as HTMLTextAreaElement;
@@ -49,17 +49,21 @@ describe("CardForm", () => {
     const geography = view.container.querySelector("input[name='tags'][value='geography']") as HTMLInputElement;
     const travel = view.container.querySelector("input[name='tags'][value='travel']") as HTMLInputElement;
 
-    expect(view.getByRole("heading", { level: 2, name: "Card content" })).toBeVisible();
+    expect(view.getByRole("heading", { level: 2, name: "Front" })).toBeVisible();
+    expect(view.getByText("The prompt shown during study.")).toBeVisible();
+    expect(view.getByRole("heading", { level: 2, name: "Back" })).toBeVisible();
+    expect(view.getByText("The answer revealed after the prompt.")).toBeVisible();
     expect(view.getByRole("heading", { level: 2, name: "Tags" })).toBeVisible();
-    expect(view.getByRole("heading", { level: 2, name: "Metadata" })).toBeVisible();
+    expect(view.getByText("Organize this card for filtering and study sessions.")).toBeVisible();
+    expect(view.getByText("Card information").closest("details")).not.toHaveAttribute("open");
     expect(frontText).toHaveValue("What is the capital of Japan?");
     expect(backText).toHaveValue("Tokyo");
     expect(geography).toBeChecked();
     expect(travel).not.toBeChecked();
-    expect(view.getByText("japan-capital")).toBeVisible();
-    expect(view.getByText("card-123")).toBeVisible();
-    expect(view.getByText(String(createdAt))).toBeVisible();
-    expect(view.getByText(new Date(lastSeenAt).toLocaleDateString())).toBeVisible();
+    expect(view.getByText("japan-capital")).toBeInTheDocument();
+    expect(view.getByText("card-123")).toBeInTheDocument();
+    expect(view.getByText(new Date(createdAt).toLocaleDateString())).toBeInTheDocument();
+    expect(view.getByText(new Date(lastSeenAt).toLocaleDateString())).toBeInTheDocument();
 
     fireEvent.change(frontText, { target: { value: "Updated front" } });
     fireEvent.change(backText, { target: { value: "Updated back" } });
@@ -89,21 +93,28 @@ describe("CardForm", () => {
     }
   });
 
-  it("submits when idle and has no cancel action", async () => {
+  it("keeps cancel separate from submission while idle", async () => {
+    const onCancel = vi.fn();
     const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());
-    const view = render(<CardForm {...createProps({ isSubmitting: false, onSubmit })} />);
-    const save = view.getByRole("button", { name: "Save" });
+    const view = render(<CardForm {...createProps({ isSubmitting: false, onCancel, onSubmit })} />);
+    const cancel = view.getByRole("button", { name: "Cancel" });
+    const save = view.getByRole("button", { name: "Save changes" });
 
     expect(save).toBeEnabled();
-    expect(view.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+    await userEvent.click(cancel);
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
+
     await userEvent.click(save);
 
     expect(onSubmit).toHaveBeenCalledOnce();
   });
 
-  it("disables Save only while submitting", () => {
+  it("disables Save changes and shows pending copy only while submitting", () => {
     const view = render(<CardForm {...createProps({ isSubmitting: true })} />);
 
-    expect(view.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "Saving…" })).toBeDisabled();
+    expect(view.queryByRole("button", { name: "Save changes" })).not.toBeInTheDocument();
   });
 });

--- a/src/features/card/components/CardForm.tsx
+++ b/src/features/card/components/CardForm.tsx
@@ -18,59 +18,105 @@ export interface CardFormProps {
   card: Card;
   fields: CardFormFields;
   isSubmitting?: boolean;
+  onCancel?: () => void;
   onSubmit?: React.ComponentProps<typeof Form>["onSubmit"];
 }
 
 export const CardForm: React.FC<CardFormProps> = (props) => {
   const sectionHeadingIdPrefix = useId();
-  const contentHeadingId = `${sectionHeadingIdPrefix}-card-content-heading`;
+  const frontHeadingId = `${sectionHeadingIdPrefix}-card-front-heading`;
+  const backHeadingId = `${sectionHeadingIdPrefix}-card-back-heading`;
   const tagsHeadingId = `${sectionHeadingIdPrefix}-card-tags-heading`;
-  const metadataHeadingId = `${sectionHeadingIdPrefix}-card-metadata-heading`;
 
   return (
     <Form {...(props.onSubmit !== undefined ? { onSubmit: props.onSubmit } : {})}>
-      <section aria-labelledby={contentHeadingId} className="space-y-4">
-        <h2 id={contentHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
-          Card content
-        </h2>
-        <FormItem col label="Front Text">
+      <section
+        aria-labelledby={frontHeadingId}
+        className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
+      >
+        <div>
+          <h2 id={frontHeadingId} className="text-title font-semibold text-ink">
+            Front
+          </h2>
+          <p className="mt-1 text-caption text-ink-muted">The prompt shown during study.</p>
+        </div>
+        <FormItem col label="Front text">
           <Textarea rows={8} {...props.fields.frontText} />
         </FormItem>
-        <FormItem col label="Back Text">
+      </section>
+      <section
+        aria-labelledby={backHeadingId}
+        className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
+      >
+        <div>
+          <h2 id={backHeadingId} className="text-title font-semibold text-ink">
+            Back
+          </h2>
+          <p className="mt-1 text-caption text-ink-muted">The answer revealed after the prompt.</p>
+        </div>
+        <FormItem col label="Back text">
           <Textarea rows={8} {...props.fields.backText} />
         </FormItem>
       </section>
       <section
         aria-labelledby={tagsHeadingId}
-        className="space-y-4 rounded-surface border border-border bg-surface-muted p-4"
+        className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
       >
-        <h2 id={tagsHeadingId} className="text-title font-semibold text-ink">
-          Tags
-        </h2>
+        <div>
+          <h2 id={tagsHeadingId} className="text-title font-semibold text-ink">
+            Tags
+          </h2>
+          <p className="mt-1 text-caption text-ink-muted">Organize this card for filtering and study sessions.</p>
+        </div>
         <TagList>
           {props.fields.tags.map(({ label, value, input }) => (
             <Tag className="mr-1 mb-1" primary small key={value} label={label} {...input} value={value} />
           ))}
         </TagList>
       </section>
-      <section aria-labelledby={metadataHeadingId} className="space-y-4">
-        <h2 id={metadataHeadingId} className="border-b border-border pb-2 text-title font-semibold text-ink">
-          Metadata
-        </h2>
-        <FormItem col label="Unique Key">
-          {props.card.uniqueKey ?? ""}
-        </FormItem>
-        <FormItem col label="id">
-          {props.card.id}
-        </FormItem>
-        <FormItem label="Created At">{props.card.createdAt}</FormItem>
-        <FormItem label="Last Seen At">
-          {props.card.lastSeenAt && new Date(props.card.lastSeenAt).toLocaleDateString()}
-        </FormItem>
-      </section>
-      <Button primary type="submit" {...(props.isSubmitting !== undefined ? { disabled: props.isSubmitting } : {})}>
-        Save
-      </Button>
+      <details className="rounded-surface border border-border bg-surface-muted p-4">
+        <summary className="flex min-h-touch cursor-pointer items-center font-semibold text-ink">
+          Card information
+        </summary>
+        <dl className="mt-4 grid gap-3 text-caption">
+          <div className="min-w-0">
+            <dt className="font-medium text-ink-muted">Unique key</dt>
+            <dd className="break-all text-ink">{props.card.uniqueKey ?? ""}</dd>
+          </div>
+          <div className="min-w-0">
+            <dt className="font-medium text-ink-muted">ID</dt>
+            <dd className="break-all text-ink">{props.card.id}</dd>
+          </div>
+          {Boolean(props.card.createdAt) && (
+            <div>
+              <dt className="font-medium text-ink-muted">Created</dt>
+              <dd className="text-ink">{new Date(props.card.createdAt).toLocaleDateString()}</dd>
+            </div>
+          )}
+          {Boolean(props.card.lastSeenAt) && (
+            <div>
+              <dt className="font-medium text-ink-muted">Last seen</dt>
+              <dd className="text-ink">{new Date(props.card.lastSeenAt).toLocaleDateString()}</dd>
+            </div>
+          )}
+        </dl>
+      </details>
+      <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">
+        <Button
+          variant="quiet"
+          type="button"
+          {...(props.onCancel !== undefined ? { onClick: props.onCancel } : {})}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          type="submit"
+          {...(props.isSubmitting !== undefined ? { disabled: props.isSubmitting } : {})}
+        >
+          {props.isSubmitting ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
     </Form>
   );
 };

--- a/src/features/card/components/CardForm.tsx
+++ b/src/features/card/components/CardForm.tsx
@@ -93,7 +93,7 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
               <dd className="text-ink">{new Date(props.card.createdAt).toLocaleDateString()}</dd>
             </div>
           )}
-          {Boolean(props.card.lastSeenAt) && (
+          {props.card.lastSeenAt != null && (
             <div>
               <dt className="font-medium text-ink-muted">Last seen</dt>
               <dd className="text-ink">{new Date(props.card.lastSeenAt).toLocaleDateString()}</dd>
@@ -102,11 +102,7 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
         </dl>
       </details>
       <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">
-        <Button
-          variant="quiet"
-          type="button"
-          {...(props.onCancel !== undefined ? { onClick: props.onCancel } : {})}
-        >
+        <Button variant="quiet" type="button" {...(props.onCancel !== undefined ? { onClick: props.onCancel } : {})}>
           Cancel
         </Button>
         <Button

--- a/src/features/card/components/templates/CardFormTemplate.spec.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.spec.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 import { CardFormTemplate } from "@/features/card/components/templates/CardFormTemplate";
@@ -8,7 +9,8 @@ import { createCard } from "@/test/factories";
 describe("CardFormTemplate", () => {
   afterEach(cleanup);
 
-  it("composes feedback before the form in a bounded semantic editing surface", () => {
+  it("presents the card editor and composes feedback before the form", async () => {
+    const onCancel = vi.fn();
     const view = render(
       <CardFormTemplate
         feedbackSlot={<div role="status">Saved</div>}
@@ -19,15 +21,18 @@ describe("CardFormTemplate", () => {
             backText: { name: "backText" },
             tags: [],
           },
+          onCancel,
         }}
       />
     );
 
     const heading = view.getByRole("heading", { level: 1, name: "Edit card" });
-    const surface = heading.parentElement;
+    const surface = heading.closest("section");
     const feedback = view.getByRole("status");
     const form = view.container.querySelector("form");
 
+    expect(view.getByText("Card editor")).toBeVisible();
+    expect(view.getByText("Update the prompt, answer, and organization for this card.")).toBeVisible();
     expect(surface).toHaveClass(
       "mx-auto",
       "w-full",
@@ -42,5 +47,9 @@ describe("CardFormTemplate", () => {
     expect(surface).toContainElement(feedback);
     expect(surface).toContainElement(form);
     expect(feedback.compareDocumentPosition(form as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await userEvent.click(view.getByRole("button", { name: "Back to cards" }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/card/components/templates/CardFormTemplate.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.tsx
@@ -27,9 +27,7 @@ export const CardFormTemplate: React.FC<CardFormTemplateProps> = (props) => {
           )}
           <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Card editor</p>
           <h1 className="mt-1 break-words text-display font-bold text-ink">Edit card</h1>
-          <p className="mt-2 text-body text-ink-muted">
-            Update the prompt, answer, and organization for this card.
-          </p>
+          <p className="mt-2 text-body text-ink-muted">Update the prompt, answer, and organization for this card.</p>
         </header>
         {props.feedbackSlot}
         {props.cardForm != null && <CardForm {...props.cardForm} />}

--- a/src/features/card/components/templates/CardFormTemplate.tsx
+++ b/src/features/card/components/templates/CardFormTemplate.tsx
@@ -1,4 +1,6 @@
 import type * as React from "react";
+import { AiOutlineArrowLeft } from "react-icons/ai";
+
 import { Layout, type LayoutProps } from "@/components/layout/Layout";
 import { CardForm, type CardFormProps } from "@/features/card/components/CardForm";
 
@@ -12,7 +14,23 @@ export const CardFormTemplate: React.FC<CardFormTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
       <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
-        <h1 className="mb-section-gap break-words text-display font-bold text-ink">Edit card</h1>
+        <header className="mb-section-gap">
+          {props.cardForm?.onCancel != null && (
+            <button
+              type="button"
+              className="mb-4 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
+              onClick={props.cardForm.onCancel}
+            >
+              <AiOutlineArrowLeft aria-hidden="true" />
+              Back to cards
+            </button>
+          )}
+          <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Card editor</p>
+          <h1 className="mt-1 break-words text-display font-bold text-ink">Edit card</h1>
+          <p className="mt-2 text-body text-ink-muted">
+            Update the prompt, answer, and organization for this card.
+          </p>
+        </header>
         {props.feedbackSlot}
         {props.cardForm != null && <CardForm {...props.cardForm} />}
       </section>

--- a/src/features/card/containers/CardFormContainer.spec.tsx
+++ b/src/features/card/containers/CardFormContainer.spec.tsx
@@ -84,6 +84,15 @@ describe("CardFormContainer", () => {
     expect(mocks.navigate).toHaveBeenCalledWith(-1);
   });
 
+  it("returns to the previous page without saving when cancelled", async () => {
+    const view = render(<CardFormContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Cancel" }));
+
+    expect(mocks.cardUpdate).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledWith(-1);
+  });
+
   it("submits edited front and back text", async () => {
     const view = render(<CardFormContainer />);
     const frontText = view.container.querySelector("textarea[name='frontText']") as Element;

--- a/src/features/card/containers/CardFormContainer.tsx
+++ b/src/features/card/containers/CardFormContainer.tsx
@@ -16,13 +16,14 @@ const CardFormContent = ({ card }: { card: Card }) => {
   const navigate = useNavigate();
   const mutations = useCardMutations();
   const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
+  const goBack = () => void navigate(-1);
   const cardForm = useCardFormState({
     card,
     categoryOptions,
     onSubmit: async (nextCard) => {
       try {
         await mutations.update(nextCard);
-        void navigate(-1);
+        goBack();
       } catch {
         // The mutation notice owns error feedback and retry.
       }
@@ -42,7 +43,7 @@ const CardFormContent = ({ card }: { card: Card }) => {
       feedbackSlot={
         <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
       }
-      cardForm={cardForm}
+      cardForm={{ ...cardForm, onCancel: goBack }}
     />
   );
 };


### PR DESCRIPTION
## Summary
- present front, back, and tags as focused single-column editing sections
- add a card information disclosure and consistent back and cancel actions
- preserve save and retry behavior with pending-state copy and accessibility coverage

## Testing
- make check