### PR TITLE
Open Storybook from mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -46,7 +46,7 @@ run = "env -u VITE_PROJECT_ID -u VITE_WEB_API_KEY -u VITE_DB_HOST -u VITE_DB_POR
 [tasks.storybook]
 alias = "s"
 depends = ["build-sample"]
-run = "npm run storybook -- --no-open"
+run = "npm run storybook"
 
 [tasks.test]
 alias = "t"


### PR DESCRIPTION
## Summary

- Remove Storybook's `--no-open` override from the mise task.
- Keep the existing `s` alias and Storybook's standard file watching and browser updates.

## Why

`mise s` previously disabled Storybook's default browser opening behavior. Letting `storybook dev` use its defaults makes the command open Storybook while continuing to watch source files.

## Validation

- Confirmed `mise tasks info storybook` and `mise tasks info s` both resolve to `npm run storybook`.
- Started Storybook 10.4.6 and confirmed it reached the ready state.
- Ran `env -u COMPOSE_FILE make check` (85 test files, 464 tests passed).
