### PR TITLE
Keep study swipe saving silent

### DIFF
--- a/docs/20260718-study-silent-saving-design.md
+++ b/docs/20260718-study-silent-saving-design.md
@@ -1,0 +1,71 @@
+# Silent Study Swipe Saving Design
+
+## Context
+
+The study screen advances to the next card optimistically before the Card mutation completes. While the mutation is pending, `RemoteMutationNotice` currently inserts `Saving…` above the card inside the fullscreen layout. Fast writes therefore mount and unmount a visible status element in quick succession, producing a flash and a layout shift even though the swipe itself has already succeeded locally.
+
+The current presentation disables swipe controls while a mutation is pending, but keyboard callbacks still reach the study action directly. The intended single-mutation guard and the current optimistic rollback behavior are both required.
+
+## Goals
+
+- Keep successful study swipes visually uninterrupted.
+- Keep one study Card mutation in flight at a time.
+- Preserve the existing rollback, error message, and retry behavior when a write fails.
+- Preserve the current pending feedback on screens other than study.
+
+## Non-goals
+
+- Allow consecutive swipes while earlier Card writes are pending.
+- Introduce a global loading store.
+- Change the Card mutation, optimistic cache, or study session state flow.
+- Add delayed saving feedback or timers.
+
+## Decision
+
+Add an optional `showPending` prop to `RemoteMutationNotice`. It defaults to `true`, so existing consumers continue to show `Saving…`. The study screen passes `showPending={false}`.
+
+`RemoteMutationNotice` continues to prioritize an error over pending presentation. A study mutation failure therefore still renders the existing alert and Retry action even when pending feedback is hidden.
+
+This keeps the policy at the screen boundary: shared mutation state remains unchanged, while the study screen chooses a silent success path appropriate for its optimistic interaction.
+
+## Data Flow
+
+1. A swipe validates that no study Card mutation token is active.
+2. The study session advances optimistically to the next Card.
+3. The Card mutation sets `pending` while the remote write runs.
+4. Study swipe buttons and handlers remain disabled, but no saving status element is mounted.
+5. On success, the pending guard is removed without another visible transition.
+6. On failure, the existing logic restores the prior study session and card face, and `RemoteMutationNotice` renders the error alert with Retry.
+
+## Components
+
+### `RemoteMutationNotice`
+
+- Accept `showPending?: boolean`.
+- Continue showing errors regardless of `showPending`.
+- Show `Saving…` only when `pending` is true and `showPending` is not false.
+
+### `DeckSwiperContainer`
+
+- Pass `showPending={false}` to `RemoteMutationNotice`.
+- Continue using `studyActions.pending` to disable swipe buttons and omit swipe handlers.
+- Leave mutation and study state management unchanged.
+
+### `useStudyActions`
+
+- Use the existing mutation token as a synchronous in-flight guard before processing a swipe.
+- Ignore touch, overlay, button, or keyboard swipe calls until the current Card mutation settles.
+- Keep the existing optimistic advance and conditional rollback logic unchanged.
+
+## Accessibility
+
+Failed saves remain exposed through the existing alert semantics and Retry button. The intentionally silent successful save removes a transient live status announcement. During the pending interval, buttons remain disabled, touch and overlay handlers remain omitted, and the study action guard rejects keyboard swipe calls.
+
+## Testing
+
+- Verify that `RemoteMutationNotice` shows pending feedback by default.
+- Verify that `showPending={false}` suppresses `Saving…` while pending.
+- Verify that an error and Retry remain visible when `showPending={false}`.
+- Verify that the study screen does not render `Saving…` while pending and continues to disable swipe actions.
+- Verify that a second swipe is ignored while the first Card mutation is unresolved.
+- Run `make check` because implementation changes will affect application code.

--- a/src/components/feedback/RemoteMutationNotice.spec.tsx
+++ b/src/components/feedback/RemoteMutationNotice.spec.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import { RemoteMutationNotice } from "@/components/feedback/RemoteMutationNotice";
+
+describe("RemoteMutationNotice", () => {
+  it("shows pending feedback by default", () => {
+    const view = render(<RemoteMutationNotice pending error={null} onRetry={vi.fn()} />);
+
+    expect(view.getByRole("status")).toHaveTextContent("Saving…");
+  });
+
+  it("hides pending feedback when requested", () => {
+    const view = render(<RemoteMutationNotice pending error={null} onRetry={vi.fn()} showPending={false} />);
+
+    expect(view.queryByRole("status")).not.toBeInTheDocument();
+    expect(view.queryByText("Saving…")).not.toBeInTheDocument();
+  });
+
+  it("keeps the error and Retry action when pending feedback is hidden", () => {
+    const onRetry = vi.fn();
+    const view = render(
+      <RemoteMutationNotice pending={false} error={new Error("write failed")} onRetry={onRetry} showPending={false} />
+    );
+
+    expect(view.getByRole("alert")).toHaveTextContent("Unable to save changes.");
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/feedback/RemoteMutationNotice.tsx
+++ b/src/components/feedback/RemoteMutationNotice.tsx
@@ -1,6 +1,13 @@
 import { Button } from "@/components/forms/Button";
 
-export const RemoteMutationNotice = (props: { pending: boolean; error: unknown; onRetry: () => void }) => {
+interface RemoteMutationNoticeProps {
+  pending: boolean;
+  error: unknown;
+  onRetry: () => void;
+  showPending?: boolean;
+}
+
+export const RemoteMutationNotice = (props: RemoteMutationNoticeProps) => {
   if (props.error != null) {
     return (
       <div role="alert" className="my-2 flex items-center justify-between rounded border border-red-300 p-2 text-sm">
@@ -11,9 +18,10 @@ export const RemoteMutationNotice = (props: { pending: boolean; error: unknown; 
       </div>
     );
   }
-  return props.pending ? (
+  if (!props.pending || props.showPending === false) return null;
+  return (
     <div role="status" className="my-2 text-sm text-gray-500">
       Saving…
     </div>
-  ) : null;
+  );
 };

--- a/src/features/study/containers/DeckSwiperContainer.spec.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.spec.tsx
@@ -18,6 +18,9 @@ const mocks = vi.hoisted(() => ({
   swipeRight: vi.fn(),
   updateIndex: vi.fn(),
   resetStudy: vi.fn(),
+  pending: false,
+  error: null as unknown,
+  retry: vi.fn(),
   hydrated: true,
   toggleShowHeader: vi.fn(),
   toggleShowSwipeButtonList: vi.fn(),
@@ -59,6 +62,9 @@ vi.mock("@/features/study/hooks/useStudyActions", () => ({
     toggleShowBackText: mocks.toggleShowBackText,
     toggleAutoPlay: mocks.toggleAutoPlay,
     resetStudy: mocks.resetStudy,
+    pending: mocks.pending,
+    error: mocks.error,
+    retry: mocks.retry,
   }),
 }));
 
@@ -133,6 +139,8 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
     mocks.params.id = deck.id;
     mocks.state = createState();
     mocks.hydrated = true;
+    mocks.pending = false;
+    mocks.error = null;
     window.history.replaceState(null, document.title, document.location.href);
     studyStore.setState({
       sessionsByDeckId: {},
@@ -163,6 +171,17 @@ describe("DeckSwiperContainer with DeckSwiperTemplate", () => {
     expect(mocks.useKey).toHaveBeenCalledWith("ArrowRight", mocks.swipeRight);
     expect(mocks.useKey).toHaveBeenCalledWith("Enter", mocks.toggleShowBackText);
     expect(mocks.useKey).toHaveBeenCalledWith(" ", mocks.toggleAutoPlay);
+  });
+
+  it("keeps pending study saves silent while disabling swipe controls", () => {
+    mocks.pending = true;
+
+    const view = render(<DeckSwiperContainer />);
+
+    expect(view.queryByText("Saving…")).not.toBeInTheDocument();
+    for (const name of ["Swipe up", "Swipe down", "Swipe left", "Swipe right"]) {
+      expect(view.getByRole("button", { name })).toBeDisabled();
+    }
   });
 
   it("installs one back-navigation guard when StrictMode replays the effect", () => {

--- a/src/features/study/containers/DeckSwiperContainer.tsx
+++ b/src/features/study/containers/DeckSwiperContainer.tsx
@@ -138,7 +138,12 @@ export const DeckSwiperContainer: React.FC = () => {
         },
       }}
       feedbackSlot={
-        <RemoteMutationNotice pending={studyActions.pending} error={studyActions.error} onRetry={studyActions.retry} />
+        <RemoteMutationNotice
+          pending={studyActions.pending}
+          error={studyActions.error}
+          onRetry={studyActions.retry}
+          showPending={false}
+        />
       }
       frontTextSlot={
         <FrontText

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -240,6 +240,31 @@ describe("useStudyActions", () => {
     expect(studyStore.getState().sessionsByDeckId[deck.id]?.currentIndex).toBe(0);
   });
 
+  it("blocks a second swipe while the first Card write is unresolved", async () => {
+    studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
+    let finishWrite: () => void = () => undefined;
+    mocks.cardUpdate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishWrite = resolve;
+        })
+    );
+    const { result } = renderHook(() => useStudyActions(deck.id));
+
+    const firstSwipe = result.current.swipeRight();
+    await act(async () => {
+      await result.current.swipeRight();
+    });
+
+    expect(mocks.cardUpdate).toHaveBeenCalledOnce();
+    expect(studyStore.getState().sessionsByDeckId[deck.id]?.currentIndex).toBe(1);
+
+    await act(async () => {
+      finishWrite();
+      await firstSwipe;
+    });
+  });
+
   it("keeps back text visible when the long-lived config allows it", async () => {
     mocks.state = createState(createConfig({ hideBodyWhenCardChanged: false }));
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -42,6 +42,7 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
 
   const swipe = React.useCallback(
     async (direction: SwipeDirection): Promise<void> => {
+      if (mutationTokenRef.current !== undefined) return;
       const state = studyStore.getState();
       const session = state.sessionsByDeckId[deckId];
       if (session == null) return;


### PR DESCRIPTION
## Summary

- keep study swipes visually uninterrupted by suppressing short-lived pending feedback
- preserve default mutation feedback and failed-save retry behavior
- block a second study swipe until the active Card write settles

## Testing

- make check