### PR TITLE
Fix study back text visibility

### DIFF
--- a/docs/study-back-text-visibility-design.md
+++ b/docs/study-back-text-visibility-design.md
@@ -1,0 +1,52 @@
+# Study Back Text Visibility Design
+
+## Goal
+
+Make the study card's back text visually readable after it is revealed while preserving the existing swipe controls and centered-overlay backdrop behavior.
+
+## Root Cause
+
+The study back view renders four shared `Overlay` instances for the left, right, top, and bottom swipe actions. Every `Overlay` currently adds a fixed, full-viewport, 70% canvas-colored pseudo-element. The four pseudo-elements stack above the back text, repeatedly tinting the page until the text is effectively invisible even though it remains present and visible in the DOM.
+
+## Selected Direction
+
+Apply the backdrop classes only when `Overlay` uses the `center` position. Center overlays represent modal reading surfaces and retain the dimmed backdrop. Edge overlays represent swipe targets, so they keep their position, size, surface, focus, and click behavior without adding a viewport-wide backdrop.
+
+The alternatives considered were:
+
+- Override the backdrop only in the study template. This would limit the immediate change, but it would preserve an unsafe default for every non-center `Overlay` consumer.
+- Replace the study swipe overlays with a new component. This would make the distinction explicit, but it would duplicate existing positioning and interaction behavior for a one-class behavioral difference.
+
+## Components and Responsibilities
+
+### `Overlay`
+
+- Continues to own shared positioning, surface, focus, accessibility, and click interaction.
+- Adds the fixed pseudo-element backdrop only for `position="center"`.
+- Keeps all existing edge dimensions and inset classes unchanged.
+
+### `DeckSwiperTemplate`
+
+- Continues to compose four edge overlays around the revealed back text.
+- Requires no API or markup change because edge-overlay semantics are corrected in the shared component.
+
+## Interaction and Data Flow
+
+Clicking the study front text continues to toggle `showBackText` in the study store. When the back view renders, its four swipe targets remain interactive and the back text remains beneath them in the existing layout. Removing the edge backdrops changes only visual stacking; it does not change study state, swipe actions, card data, routing, or remote writes.
+
+## Error Handling
+
+No new runtime error path is introduced. Existing remote-read and mutation feedback remains unchanged. The correction is limited to conditional class composition in `Overlay`.
+
+## Testing
+
+Extend `Overlay.spec.tsx` so each edge position verifies that it does not receive the full-screen backdrop class, while the existing center-overlay assertion continues to verify that the backdrop remains present. Run the focused test before and after the implementation to demonstrate the regression and fix, then run `make check`.
+
+Use the study page in a browser to confirm that revealed back text is visually readable and that all four swipe controls remain available.
+
+## Out of Scope
+
+- Changes to back-text content or syntax highlighting.
+- Changes to swipe behavior, dimensions, or keyboard controls.
+- New overlay props or new study-specific components.
+- Firestore, persistence, routing, or card schema changes.

--- a/docs/study-back-text-visibility-plan.md
+++ b/docs/study-back-text-visibility-plan.md
@@ -1,0 +1,118 @@
+# Study Back Text Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep revealed study back text readable by preventing edge swipe overlays from adding full-viewport backdrops.
+
+**Architecture:** Correct the shared `Overlay` position contract instead of special-casing the study template. Center overlays retain their existing backdrop, while left, right, top, and bottom overlays retain their positioning and interactions without the backdrop pseudo-element.
+
+**Tech Stack:** React 19, TypeScript, classnames, Tailwind CSS 4, Vitest, Testing Library, Storybook
+
+## Global Constraints
+
+- Preserve the public `Overlay` props and all existing position values.
+- Keep the center-overlay backdrop unchanged.
+- Keep edge-overlay dimensions, positioning, focus, accessibility, and click behavior unchanged.
+- Do not change study state, swipe actions, card data, routing, persistence, or remote writes.
+- Keep comments and commit messages in English.
+- Do not commit ignored files.
+- Run `make check` before finishing.
+
+---
+
+### Task 1: Restrict the overlay backdrop to center content
+
+**Files:**
+- Modify: `src/components/feedback/Overlay.spec.tsx`
+- Modify: `src/components/feedback/Overlay.tsx`
+
+**Interfaces:**
+- Consumes: `Overlay`'s existing `position: "left" | "right" | "top" | "bottom" | "center"` prop.
+- Produces: a class contract where only `position="center"` includes `before:bg-canvas/70` and its fixed pseudo-element classes.
+
+- [ ] **Step 1: Write the failing edge-overlay regression assertion**
+
+Update the existing position-contract test to retain its position checks and reject the full-screen backdrop on every edge:
+
+```tsx
+it.each([
+  ["left", "inset-y-0", "left-0"],
+  ["right", "inset-y-0", "right-0"],
+  ["top", "inset-x-0", "top-0"],
+  ["bottom", "inset-x-0", "bottom-0"],
+] as const)("retains the %s position contract", (position, insetClass, edgeClass) => {
+  render(<Overlay position={position}>Overlay</Overlay>);
+  const overlay = screen.getByText("Overlay");
+
+  expect(overlay).toHaveClass(insetClass, edgeClass);
+  expect(overlay).not.toHaveClass("before:bg-canvas/70");
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/components/feedback/Overlay.spec.tsx
+```
+
+Expected: FAIL for the left, right, top, and bottom cases because each edge currently includes `before:bg-canvas/70`.
+
+- [ ] **Step 3: Apply the minimal class-composition fix**
+
+Keep the shared surface and focus classes unchanged, and make the backdrop conditional:
+
+```tsx
+className={cx(
+  "absolute z-10 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control bg-surface-elevated text-ink shadow-elevated",
+  props.position === "center" &&
+    "before:pointer-events-none before:fixed before:inset-0 before:-z-10 before:bg-canvas/70",
+  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2",
+  ["left", "right"].includes(props.position) && "w-20",
+  ["top", "bottom"].includes(props.position) && "h-10",
+  props.position === "center" && "inset-0",
+  props.position === "left" && "inset-y-0 left-0",
+  props.position === "right" && "inset-y-0 right-0",
+  props.position === "top" && "inset-x-0 top-0",
+  props.position === "bottom" && "inset-x-0 bottom-0",
+  props.className
+)}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/components/feedback/Overlay.spec.tsx
+```
+
+Expected: all six `Overlay` tests PASS.
+
+- [ ] **Step 5: Run repository verification**
+
+Run:
+
+```bash
+make check
+```
+
+Expected: sample build, formatting, lint, TypeScript checks, and unit tests all exit successfully.
+
+- [ ] **Step 6: Verify the study back view visually**
+
+Start Storybook:
+
+```bash
+npm run storybook -- --host 127.0.0.1 --port 6006
+```
+
+Open the `Study/DeckSwiperTemplate` `BackTextCode` story. Confirm that the back text is readable and that the four edge swipe controls remain present. Also open the `Shared/Feedback/Overlay` `Center` story and confirm that the center backdrop remains present.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add src/components/feedback/Overlay.spec.tsx src/components/feedback/Overlay.tsx
+git commit -m "Fix study back text visibility"
+```

--- a/src/components/feedback/Overlay.spec.tsx
+++ b/src/components/feedback/Overlay.spec.tsx
@@ -28,7 +28,10 @@ describe("shared overlay surface", () => {
     ["bottom", "inset-x-0", "bottom-0"],
   ] as const)("retains the %s position contract", (position, insetClass, edgeClass) => {
     render(<Overlay position={position}>Overlay</Overlay>);
-    expect(screen.getByText("Overlay")).toHaveClass(insetClass, edgeClass);
+    const overlay = screen.getByText("Overlay");
+
+    expect(overlay).toHaveClass(insetClass, edgeClass);
+    expect(overlay).not.toHaveClass("before:bg-canvas/70");
   });
 
   it("retains click, accessible name, custom class, and shared focus appearance", () => {

--- a/src/components/feedback/Overlay.tsx
+++ b/src/components/feedback/Overlay.tsx
@@ -16,7 +16,8 @@ export const Overlay: React.FC<{
       {...(props.onClick !== undefined && props.ariaLabel !== undefined ? { "aria-label": props.ariaLabel } : {})}
       className={cx(
         "absolute z-10 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control bg-surface-elevated text-ink shadow-elevated",
-        "before:pointer-events-none before:fixed before:inset-0 before:-z-10 before:bg-canvas/70",
+        props.position === "center" &&
+          "before:pointer-events-none before:fixed before:inset-0 before:-z-10 before:bg-canvas/70",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2",
         ["left", "right"].includes(props.position) && "w-20",
         ["top", "bottom"].includes(props.position) && "h-10",


### PR DESCRIPTION
## Summary

- keep full-screen backdrops limited to center overlays
- preserve edge swipe controls while making revealed study back text readable
- add regression coverage for every edge overlay position

## Testing

- `direnv exec . make check` (87 test files, 475 tests)
- Storybook: `Study/DeckSwiperTemplate / BackTextCode`
- Storybook: `Shared/Feedback/Overlay / Center`