### PR TITLE
Validate config and edit forms with Zod

### DIFF
--- a/docs/zod-form-validation-design.md
+++ b/docs/zod-form-validation-design.md
@@ -1,0 +1,91 @@
+# Zod Form Validation Design
+
+## Background
+
+Deck and Card editing currently pass React Hook Form values directly to their mutation hooks. TypeScript describes the expected values, but it does not validate browser input at runtime. Empty required text and malformed Deck source URLs can therefore reach remote writes, and the forms do not display field-level errors.
+
+PR #322 already introduces Zod for persisted application configuration. The same dependency should validate Deck and Card edit forms without expanding this change into Firestore document or CSV validation.
+
+## Goals
+
+- Validate Deck and Card edit values before calling mutations.
+- Require a non-blank Deck name.
+- Accept an empty Deck source URL or a valid absolute URL.
+- Require non-blank Card front and back text without trimming valid content.
+- Display validation messages directly below the relevant fields.
+- Mark invalid controls with `aria-invalid`.
+- Preserve existing entity metadata, mutation behavior, retry feedback, and navigation.
+
+## Non-goals
+
+- Do not validate Firestore documents, CSV imports, Deck study filters, or persisted study state.
+- Do not change Deck, Card, or storage data models.
+- Do not change mutation retry or remote error handling.
+- Do not redesign the forms or add validation to fields that are not editable on these screens.
+
+## Considered approaches
+
+### A. React Hook Form Zod resolver (selected)
+
+Connect feature-owned Zod schemas to React Hook Form through `@hookform/resolvers/zod`. React Hook Form blocks invalid submissions and exposes field errors through its existing `formState`. This keeps validation, error display, and submission behavior in the form boundary.
+
+### B. Manual parsing in submit handlers
+
+Call `safeParse` inside each `handleSubmit` callback and translate Zod issues into React Hook Form errors. This avoids another dependency, but duplicates error mapping and bypasses the resolver integration designed for this use case.
+
+### C. Mutation-boundary validation
+
+Parse Deck and Card updates in their mutation hooks. This protects non-form callers, but it reports errors as remote mutation failures rather than actionable field feedback and broadens the issue beyond editing screens.
+
+## Component boundaries
+
+### Deck form schema
+
+Create a schema under `src/features/deck/lib` for the editable Deck fields: `name`, `category`, `url`, and `convertToBr`. The name schema trims surrounding whitespace and requires at least one character. The URL schema accepts `undefined`, an empty string, or a valid absolute URL.
+
+Infer the form-value type from the schema. `DeckFormContainer` initializes only these editable values, connects the schema with `zodResolver`, and merges validated values into the original Deck before calling `updateAndGoToList`. Metadata that is not rendered as an input cannot be removed or rewritten by form parsing.
+
+### Card form schema
+
+Create a schema under `src/features/card/lib` for `frontText`, `backText`, and `tags`. Front and back text must each contain at least one non-whitespace character, but the schema preserves the submitted text so Markdown, code indentation, and intentional surrounding whitespace are not transformed. Tags remain an array of strings.
+
+Infer the form-value type from the schema. `useCardFormState` initializes only editable values, connects the resolver, and merges validated values into the original Card before invoking its submit callback.
+
+### Error presentation
+
+Extend Deck and Card form props with optional field-error messages. Their presentation components pass each message to the existing `FormItem.error` surface. Extend shared `Input` and `Textarea` props to forward `aria-invalid`, and set it only for fields with validation errors.
+
+The forms continue to use the existing mutation notice for remote failures. Validation errors remain local and do not set mutation error state.
+
+## Data flow
+
+1. The container or hook selects editable defaults from the current entity.
+2. React Hook Form collects browser values and runs the Zod resolver on submit.
+3. Invalid values populate `formState.errors`; React Hook Form does not call the valid-submit callback.
+4. Presentation components show messages below the matching fields and mark controls invalid.
+5. Valid values are merged into the original Deck or Card.
+6. Existing mutation and navigation logic runs unchanged.
+
+## Validation messages
+
+- Blank Deck name: `Deck name is required.`
+- Malformed non-empty Deck URL: `Enter a valid URL.`
+- Blank Card front text: `Front text is required.`
+- Blank Card back text: `Back text is required.`
+
+## Testing strategy
+
+- Add Deck container tests proving that a blank name and malformed URL show the expected messages and do not call `updateAndGoToList`.
+- Add Card container tests proving that blank front and back text show the expected messages and do not call the Card mutation or navigate.
+- Preserve the existing valid-submit tests to prove that entity metadata is retained when editable values are merged.
+- Add focused shared-control coverage for forwarding `aria-invalid` if existing component tests do not already exercise it.
+- Run the focused Deck/Card tests during the red-green cycle.
+- Run `make check` before committing the implementation.
+
+## Completion criteria
+
+- Deck and Card edit forms use Zod through the React Hook Form resolver.
+- Invalid values display the specified field messages and never reach mutation hooks.
+- Valid edits retain all non-editable entity fields.
+- Existing remote error and navigation behavior remains unchanged.
+- `make check` passes.

--- a/docs/zod-form-validation-plan.md
+++ b/docs/zod-form-validation-plan.md
@@ -1,0 +1,372 @@
+# Zod Form Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate Deck and Card edit forms with Zod, show accessible field errors, and block invalid remote writes.
+
+**Architecture:** Keep schemas inside their owning features and connect them to React Hook Form through `zodResolver`. Each form manages only editable values and merges validated output into the original entity before using the existing mutation path. Shared controls only gain native `aria-invalid` forwarding.
+
+**Tech Stack:** TypeScript 5.9, React 19, React Hook Form 7, Zod 4.4, `@hookform/resolvers`, Vitest, Testing Library.
+
+## Global Constraints
+
+- Deck name is non-blank; surrounding whitespace is removed from the submitted name.
+- Deck URL is `undefined`, empty, or a valid absolute URL.
+- Card front and back text each contain a non-whitespace character, but their submitted content is not trimmed.
+- Invalid forms do not call mutations or navigate.
+- Existing Deck, Card, Firestore, CSV, storage, retry, and remote-error behavior remains unchanged.
+- Validation copy is exactly `Deck name is required.`, `Enter a valid URL.`, `Front text is required.`, and `Back text is required.`.
+- Run `make check` before completion.
+
+---
+
+### Task 1: Forward Invalid State Through Shared Text Controls
+
+**Files:**
+- Modify: `src/components/forms/TextControl.spec.tsx`
+- Modify: `src/components/forms/Input.tsx`
+- Modify: `src/components/forms/Textarea.tsx`
+
+**Interfaces:**
+- Consumes: React's native `aria-invalid` value.
+- Produces: `Input` and `Textarea` props accepting `"aria-invalid"?: React.AriaAttributes["aria-invalid"]` and forwarding it to the native element.
+
+- [ ] **Step 1: Write the failing control test**
+
+Add this test inside `describe("shared text controls")`:
+
+```tsx
+it("forwards invalid state to native text controls", () => {
+  const view = render(
+    <>
+      <Input aria-invalid />
+      <Textarea aria-invalid />
+    </>
+  );
+
+  for (const control of view.container.querySelectorAll("input, textarea")) {
+    expect(control).toHaveAttribute("aria-invalid", "true");
+  }
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `npm run test:unit -- src/components/forms/TextControl.spec.tsx`
+
+Expected: FAIL because neither native control has `aria-invalid`.
+
+- [ ] **Step 3: Forward the prop in both controls**
+
+Add this property to each inline prop type:
+
+```ts
+"aria-invalid"?: React.AriaAttributes["aria-invalid"];
+```
+
+Destructure it as `"aria-invalid": ariaInvalid`, then pass it to the native element:
+
+```tsx
+aria-invalid={ariaInvalid}
+```
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run: `npm run test:unit -- src/components/forms/TextControl.spec.tsx`
+
+Expected: PASS for all shared text-control tests.
+
+- [ ] **Step 5: Commit the shared control change**
+
+```bash
+git add src/components/forms/TextControl.spec.tsx src/components/forms/Input.tsx src/components/forms/Textarea.tsx
+git commit -m "Forward invalid text control state"
+```
+
+---
+
+### Task 2: Validate Deck Edits
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Create: `src/features/deck/lib/deckFormSchema.ts`
+- Modify: `src/features/deck/containers/DeckFormContainer.tsx`
+- Modify: `src/features/deck/containers/DeckFormContainer.spec.tsx`
+- Modify: `src/features/deck/components/DeckForm.tsx`
+
+**Interfaces:**
+- Produces: `deckFormSchema` and `DeckFormValues = z.infer<typeof deckFormSchema>`.
+- Consumes: `zodResolver(deckFormSchema)` in `useForm<DeckFormValues>`.
+- Produces: `DeckFormProps.errors?: { name?: string; url?: string }`.
+- Preserves: `updateAndGoToList({ ...deck, ...values })` receives a complete `Deck`.
+
+- [ ] **Step 1: Write the failing Deck validation test**
+
+Add a test to `DeckFormContainer.spec.tsx`:
+
+```tsx
+it("blocks a blank name and malformed URL", async () => {
+  const view = render(<DeckFormContainer />);
+  const name = view.container.querySelector("input[name='name']") as Element;
+  const url = view.container.querySelector("input[name='url']") as Element;
+
+  await userEvent.clear(name);
+  await userEvent.type(name, "   ");
+  await userEvent.type(url, "not-a-url");
+  await userEvent.click(view.getByRole("button", { name: /save/i }));
+
+  expect(view.getByText("Deck name is required.")).toBeInTheDocument();
+  expect(view.getByText("Enter a valid URL.")).toBeInTheDocument();
+  expect(name).toHaveAttribute("aria-invalid", "true");
+  expect(url).toHaveAttribute("aria-invalid", "true");
+  expect(mocks.updateAndGoToList).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the Deck test and verify RED**
+
+Run: `npm run test:unit -- src/features/deck/containers/DeckFormContainer.spec.tsx`
+
+Expected: FAIL because the mutation is called and no validation messages appear.
+
+- [ ] **Step 3: Add the React Hook Form resolver dependency**
+
+Run: `npm install @hookform/resolvers`
+
+Expected: `package.json` and `package-lock.json` record the resolver as a production dependency.
+
+- [ ] **Step 4: Create the Deck form schema**
+
+Create `src/features/deck/lib/deckFormSchema.ts`:
+
+```ts
+import * as z from "zod";
+
+export const deckFormSchema = z.object({
+  name: z.string().trim().min(1, "Deck name is required."),
+  category: z.string(),
+  url: z.union([z.literal(""), z.url("Enter a valid URL.")]).optional(),
+  convertToBr: z.boolean(),
+});
+
+export type DeckFormValues = z.infer<typeof deckFormSchema>;
+```
+
+- [ ] **Step 5: Connect DeckFormContainer to the resolver**
+
+Import `zodResolver`, `deckFormSchema`, and `DeckFormValues`. Replace the full-entity form with editable defaults:
+
+```ts
+const { formState, handleSubmit, register } = useForm<DeckFormValues>({
+  defaultValues: {
+    name: deck.name,
+    category: deck.category,
+    url: deck.url,
+    convertToBr: deck.convertToBr,
+  },
+  resolver: zodResolver(deckFormSchema),
+});
+```
+
+Pass errors and merge validated output:
+
+```ts
+errors: {
+  name: formState.errors.name?.message,
+  url: formState.errors.url?.message,
+},
+onSubmit: handleSubmit((values) => deckActions.updateAndGoToList({ ...deck, ...values })),
+```
+
+- [ ] **Step 6: Render Deck field errors**
+
+Add `errors?: { name?: string; url?: string }` to `DeckFormProps`. Render the affected fields as:
+
+```tsx
+<FormItem col label="Name" error={props.errors?.name}>
+  <Input {...props.fields.name} aria-invalid={props.errors?.name != null || undefined} />
+</FormItem>
+```
+
+```tsx
+<FormItem col label="Source URL" error={props.errors?.url}>
+  <Input {...props.fields.url} aria-invalid={props.errors?.url != null || undefined} />
+</FormItem>
+```
+
+- [ ] **Step 7: Run the Deck tests and verify GREEN**
+
+Run: `npm run test:unit -- src/features/deck/containers/DeckFormContainer.spec.tsx src/features/deck/components/DeckForm.spec.tsx`
+
+Expected: PASS for Deck form container and presentation tests.
+
+- [ ] **Step 8: Commit Deck validation**
+
+```bash
+git add package.json package-lock.json src/features/deck/lib/deckFormSchema.ts src/features/deck/containers/DeckFormContainer.tsx src/features/deck/containers/DeckFormContainer.spec.tsx src/features/deck/components/DeckForm.tsx
+git commit -m "Validate deck edits with Zod"
+```
+
+---
+
+### Task 3: Validate Card Edits
+
+**Files:**
+- Create: `src/features/card/lib/cardFormSchema.ts`
+- Modify: `src/features/card/hooks/useCardFormState.ts`
+- Modify: `src/features/card/containers/CardFormContainer.spec.tsx`
+- Modify: `src/features/card/components/CardForm.tsx`
+
+**Interfaces:**
+- Produces: `cardFormSchema` and `CardFormValues = z.infer<typeof cardFormSchema>`.
+- Consumes: `zodResolver(cardFormSchema)` in `useForm<CardFormValues>`.
+- Produces: `CardFormProps.errors?: { frontText?: string; backText?: string }`.
+- Preserves: `onSubmit?.({ ...card, ...values })` receives a complete `Card`.
+
+- [ ] **Step 1: Write the failing Card validation test**
+
+Add a test to `CardFormContainer.spec.tsx`:
+
+```tsx
+it("blocks blank front and back text", async () => {
+  const view = render(<CardFormContainer />);
+  const frontText = view.container.querySelector("textarea[name='frontText']") as Element;
+  const backText = view.container.querySelector("textarea[name='backText']") as Element;
+
+  await userEvent.clear(frontText);
+  await userEvent.type(frontText, "   ");
+  await userEvent.clear(backText);
+  await userEvent.type(backText, "   ");
+  await userEvent.click(view.getByRole("button", { name: /save/i }));
+
+  expect(view.getByText("Front text is required.")).toBeInTheDocument();
+  expect(view.getByText("Back text is required.")).toBeInTheDocument();
+  expect(frontText).toHaveAttribute("aria-invalid", "true");
+  expect(backText).toHaveAttribute("aria-invalid", "true");
+  expect(mocks.cardUpdate).not.toHaveBeenCalled();
+  expect(mocks.navigate).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the Card test and verify RED**
+
+Run: `npm run test:unit -- src/features/card/containers/CardFormContainer.spec.tsx`
+
+Expected: FAIL because the mutation and navigation run and no validation messages appear.
+
+- [ ] **Step 3: Create the Card form schema**
+
+Create `src/features/card/lib/cardFormSchema.ts`:
+
+```ts
+import * as z from "zod";
+
+const requiredCardText = (message: string) =>
+  z.string().refine((value) => value.trim().length > 0, { message });
+
+export const cardFormSchema = z.object({
+  frontText: requiredCardText("Front text is required."),
+  backText: requiredCardText("Back text is required."),
+  tags: z.array(z.string()),
+});
+
+export type CardFormValues = z.infer<typeof cardFormSchema>;
+```
+
+- [ ] **Step 4: Connect useCardFormState to the resolver**
+
+Use editable defaults and merge validated values into the original Card:
+
+```ts
+const { formState, handleSubmit, register } = useForm<CardFormValues>({
+  defaultValues: {
+    frontText: card.frontText,
+    backText: card.backText,
+    tags: card.tags,
+  },
+  resolver: zodResolver(cardFormSchema),
+});
+```
+
+Return errors and update submission:
+
+```ts
+errors: {
+  frontText: formState.errors.frontText?.message,
+  backText: formState.errors.backText?.message,
+},
+onSubmit: handleSubmit((values) => onSubmit?.({ ...card, ...values })),
+```
+
+- [ ] **Step 5: Render Card field errors**
+
+Add `errors?: { frontText?: string; backText?: string }` to `CardFormProps`. Render both affected `FormItem` and `Textarea` pairs using the same pattern as Deck:
+
+```tsx
+<FormItem col label="Front text" error={props.errors?.frontText}>
+  <Textarea
+    rows={8}
+    {...props.fields.frontText}
+    aria-invalid={props.errors?.frontText != null || undefined}
+  />
+</FormItem>
+```
+
+Use `backText` and `Back text` for the second field.
+
+- [ ] **Step 6: Run the Card tests and verify GREEN**
+
+Run: `npm run test:unit -- src/features/card/containers/CardFormContainer.spec.tsx src/features/card/components/CardForm.spec.tsx`
+
+Expected: PASS for Card form container and presentation tests.
+
+- [ ] **Step 7: Commit Card validation**
+
+```bash
+git add src/features/card/lib/cardFormSchema.ts src/features/card/hooks/useCardFormState.ts src/features/card/containers/CardFormContainer.spec.tsx src/features/card/components/CardForm.tsx
+git commit -m "Validate card edits with Zod"
+```
+
+---
+
+### Task 4: Verify and Publish the PR Update
+
+**Files:**
+- Modify: `docs/zod-form-validation-plan.md` only if implementation discoveries require exact plan corrections.
+
+**Interfaces:**
+- Consumes: all committed changes from Tasks 1-3.
+- Produces: an updated `codex/issue-313-zod-config` remote branch and PR #322.
+
+- [ ] **Step 1: Run repository verification**
+
+Run: `make check`
+
+Expected: sample build, formatting, TypeScript, ESLint, Biome, and all unit tests pass.
+
+- [ ] **Step 2: Review the complete branch diff**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git status --short --branch
+```
+
+Expected: no whitespace errors, only Issue #313 config/form validation and its design/plan documents, and a clean worktree.
+
+- [ ] **Step 3: Push the branch**
+
+Run: `git push origin codex/issue-313-zod-config`
+
+Expected: the remote branch advances to the final local commit.
+
+- [ ] **Step 4: Update PR #322**
+
+Update the PR summary to include Deck and Card form validation and retain `Closes #313`. Keep the PR in draft state unless the user explicitly requests ready-for-review.
+
+- [ ] **Step 5: Verify remote PR metadata**
+
+Confirm PR #322 targets `main`, uses head `codex/issue-313-zod-config`, contains all new commits, and remains mergeable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "remark-math": "^6.0.0",
         "sass": "^1.101.0",
         "uuid": "^14.0.1",
+        "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -18939,7 +18940,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tango-web",
       "version": "2.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "@tailwindcss/postcss": "^4.3.2",
         "@tanstack/react-query": "^5.101.2",
         "@types/file-saver": "^2.0.7",
@@ -2553,6 +2554,18 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -5236,6 +5249,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build-storybook": "npm run build:storybook"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@tailwindcss/postcss": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",
     "@types/file-saver": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "remark-math": "^6.0.0",
     "sass": "^1.101.0",
     "uuid": "^14.0.1",
+    "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/src/components/forms/FormItem.tsx
+++ b/src/components/forms/FormItem.tsx
@@ -4,6 +4,8 @@ import { Description } from "@/components/content/Description";
 
 export const FormItem: React.FC<{
   label: string;
+  inputId?: string;
+  errorId?: string;
   extra?: string;
   help?: string;
   error?: string;
@@ -13,13 +15,26 @@ export const FormItem: React.FC<{
 }> = (props) => (
   <div className="w-full min-w-0">
     <div className={cx("flex gap-2", props.col && "flex-col md:flex-row")}>
-      <div className="min-w-0 basis-full break-words text-body font-medium text-ink md:basis-48 md:shrink-0">
-        {props.label}
-      </div>
+      {props.inputId !== undefined ? (
+        <label
+          htmlFor={props.inputId}
+          className="min-w-0 basis-full break-words text-body font-medium text-ink md:basis-48 md:shrink-0"
+        >
+          {props.label}
+        </label>
+      ) : (
+        <div className="min-w-0 basis-full break-words text-body font-medium text-ink md:basis-48 md:shrink-0">
+          {props.label}
+        </div>
+      )}
       <div className="min-w-0 flex-1 break-words text-ink-muted md:text-right">{props.text ?? props.children}</div>
     </div>
     {props.extra != null && <Description label={props.extra} />}
     {props.help != null && <Description label={props.help} />}
-    {props.error != null && <div className="text-caption font-medium text-danger">{props.error}</div>}
+    {props.error != null && (
+      <div id={props.errorId} className="text-caption font-medium text-danger">
+        {props.error}
+      </div>
+    )}
   </div>
 );

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -11,6 +11,7 @@ export const Input: React.FC<{
   disabled?: boolean;
   readOnly?: boolean;
   required?: boolean;
+  "aria-invalid"?: React.AriaAttributes["aria-invalid"];
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -25,6 +26,7 @@ export const Input: React.FC<{
   disabled,
   readOnly,
   required,
+  "aria-invalid": ariaInvalid,
   placeholder,
   onChange,
   onBlur,
@@ -41,6 +43,7 @@ export const Input: React.FC<{
       disabled={disabled}
       readOnly={readOnly}
       required={required}
+      aria-invalid={ariaInvalid}
       placeholder={placeholder}
       onChange={onChange}
       onBlur={onBlur}

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -12,6 +12,7 @@ export const Input: React.FC<{
   readOnly?: boolean;
   required?: boolean;
   "aria-invalid"?: React.AriaAttributes["aria-invalid"];
+  "aria-describedby"?: React.AriaAttributes["aria-describedby"];
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -27,6 +28,7 @@ export const Input: React.FC<{
   readOnly,
   required,
   "aria-invalid": ariaInvalid,
+  "aria-describedby": ariaDescribedBy,
   placeholder,
   onChange,
   onBlur,
@@ -44,6 +46,7 @@ export const Input: React.FC<{
       readOnly={readOnly}
       required={required}
       aria-invalid={ariaInvalid}
+      aria-describedby={ariaDescribedBy}
       placeholder={placeholder}
       onChange={onChange}
       onBlur={onBlur}

--- a/src/components/forms/TextControl.spec.tsx
+++ b/src/components/forms/TextControl.spec.tsx
@@ -94,6 +94,19 @@ describe("shared text controls", () => {
     expect(onBlur).toHaveBeenCalledOnce();
   });
 
+  it("forwards invalid state to native text controls", () => {
+    const view = render(
+      <>
+        <Input aria-invalid />
+        <Textarea aria-invalid />
+      </>
+    );
+
+    for (const control of view.container.querySelectorAll("input, textarea")) {
+      expect(control).toHaveAttribute("aria-invalid", "true");
+    }
+  });
+
   it("styles input states with semantic Calm Focus roles", () => {
     render(
       <Input

--- a/src/components/forms/Textarea.tsx
+++ b/src/components/forms/Textarea.tsx
@@ -10,6 +10,7 @@ export const Textarea: React.FC<{
   disabled?: boolean;
   readOnly?: boolean;
   required?: boolean;
+  "aria-invalid"?: React.AriaAttributes["aria-invalid"];
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
@@ -23,6 +24,7 @@ export const Textarea: React.FC<{
   disabled,
   readOnly,
   required,
+  "aria-invalid": ariaInvalid,
   placeholder,
   onChange,
   onBlur,
@@ -37,6 +39,7 @@ export const Textarea: React.FC<{
       disabled={disabled}
       readOnly={readOnly}
       required={required}
+      aria-invalid={ariaInvalid}
       placeholder={placeholder}
       onChange={onChange}
       onBlur={onBlur}

--- a/src/components/forms/Textarea.tsx
+++ b/src/components/forms/Textarea.tsx
@@ -2,6 +2,7 @@ import type * as React from "react";
 import cx from "classnames";
 
 export const Textarea: React.FC<{
+  id?: string;
   className?: string;
   rows?: number;
   name?: string;
@@ -11,11 +12,13 @@ export const Textarea: React.FC<{
   readOnly?: boolean;
   required?: boolean;
   "aria-invalid"?: React.AriaAttributes["aria-invalid"];
+  "aria-describedby"?: React.AriaAttributes["aria-describedby"];
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
   ref?: React.Ref<HTMLTextAreaElement>;
 }> = ({
+  id,
   className,
   rows,
   name,
@@ -25,6 +28,7 @@ export const Textarea: React.FC<{
   readOnly,
   required,
   "aria-invalid": ariaInvalid,
+  "aria-describedby": ariaDescribedBy,
   placeholder,
   onChange,
   onBlur,
@@ -33,6 +37,7 @@ export const Textarea: React.FC<{
   return (
     <textarea
       ref={ref}
+      id={id}
       name={name}
       value={value}
       defaultValue={defaultValue}
@@ -40,6 +45,7 @@ export const Textarea: React.FC<{
       readOnly={readOnly}
       required={required}
       aria-invalid={ariaInvalid}
+      aria-describedby={ariaDescribedBy}
       placeholder={placeholder}
       onChange={onChange}
       onBlur={onBlur}

--- a/src/features/card/components/CardForm.spec.tsx
+++ b/src/features/card/components/CardForm.spec.tsx
@@ -93,6 +93,19 @@ describe("CardForm", () => {
     }
   });
 
+  it("associates validation errors with their named controls", () => {
+    const view = render(
+      <CardForm
+        {...createProps({
+          errors: { frontText: "Front text is required.", backText: "Back text is required." },
+        })}
+      />
+    );
+
+    expect(view.getByRole("textbox", { name: "Front text" })).toHaveAccessibleDescription("Front text is required.");
+    expect(view.getByRole("textbox", { name: "Back text" })).toHaveAccessibleDescription("Back text is required.");
+  });
+
   it("keeps cancel separate from submission while idle", async () => {
     const onCancel = vi.fn();
     const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());

--- a/src/features/card/components/CardForm.tsx
+++ b/src/features/card/components/CardForm.tsx
@@ -44,7 +44,11 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">The prompt shown during study.</p>
         </div>
-        <FormItem col label="Front text" error={props.errors?.frontText}>
+        <FormItem
+          col
+          label="Front text"
+          {...(props.errors?.frontText !== undefined ? { error: props.errors.frontText } : {})}
+        >
           <Textarea rows={8} {...props.fields.frontText} aria-invalid={props.errors?.frontText != null || undefined} />
         </FormItem>
       </section>
@@ -58,7 +62,11 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">The answer revealed after the prompt.</p>
         </div>
-        <FormItem col label="Back text" error={props.errors?.backText}>
+        <FormItem
+          col
+          label="Back text"
+          {...(props.errors?.backText !== undefined ? { error: props.errors.backText } : {})}
+        >
           <Textarea rows={8} {...props.fields.backText} aria-invalid={props.errors?.backText != null || undefined} />
         </FormItem>
       </section>

--- a/src/features/card/components/CardForm.tsx
+++ b/src/features/card/components/CardForm.tsx
@@ -17,6 +17,10 @@ export interface CardFormFields {
 export interface CardFormProps {
   card: Card;
   fields: CardFormFields;
+  errors?: {
+    frontText?: string;
+    backText?: string;
+  };
   isSubmitting?: boolean;
   onCancel?: () => void;
   onSubmit?: React.ComponentProps<typeof Form>["onSubmit"];
@@ -40,8 +44,8 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">The prompt shown during study.</p>
         </div>
-        <FormItem col label="Front text">
-          <Textarea rows={8} {...props.fields.frontText} />
+        <FormItem col label="Front text" error={props.errors?.frontText}>
+          <Textarea rows={8} {...props.fields.frontText} aria-invalid={props.errors?.frontText != null || undefined} />
         </FormItem>
       </section>
       <section
@@ -54,8 +58,8 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">The answer revealed after the prompt.</p>
         </div>
-        <FormItem col label="Back text">
-          <Textarea rows={8} {...props.fields.backText} />
+        <FormItem col label="Back text" error={props.errors?.backText}>
+          <Textarea rows={8} {...props.fields.backText} aria-invalid={props.errors?.backText != null || undefined} />
         </FormItem>
       </section>
       <section

--- a/src/features/card/components/CardForm.tsx
+++ b/src/features/card/components/CardForm.tsx
@@ -31,6 +31,10 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
   const frontHeadingId = `${sectionHeadingIdPrefix}-card-front-heading`;
   const backHeadingId = `${sectionHeadingIdPrefix}-card-back-heading`;
   const tagsHeadingId = `${sectionHeadingIdPrefix}-card-tags-heading`;
+  const frontInputId = `${sectionHeadingIdPrefix}-card-front-text`;
+  const frontErrorId = `${frontInputId}-error`;
+  const backInputId = `${sectionHeadingIdPrefix}-card-back-text`;
+  const backErrorId = `${backInputId}-error`;
 
   return (
     <Form {...(props.onSubmit !== undefined ? { onSubmit: props.onSubmit } : {})}>
@@ -47,9 +51,17 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
         <FormItem
           col
           label="Front text"
+          inputId={frontInputId}
+          errorId={frontErrorId}
           {...(props.errors?.frontText !== undefined ? { error: props.errors.frontText } : {})}
         >
-          <Textarea rows={8} {...props.fields.frontText} aria-invalid={props.errors?.frontText != null || undefined} />
+          <Textarea
+            rows={8}
+            {...props.fields.frontText}
+            id={frontInputId}
+            aria-invalid={props.errors?.frontText != null || undefined}
+            aria-describedby={props.errors?.frontText !== undefined ? frontErrorId : undefined}
+          />
         </FormItem>
       </section>
       <section
@@ -65,9 +77,17 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
         <FormItem
           col
           label="Back text"
+          inputId={backInputId}
+          errorId={backErrorId}
           {...(props.errors?.backText !== undefined ? { error: props.errors.backText } : {})}
         >
-          <Textarea rows={8} {...props.fields.backText} aria-invalid={props.errors?.backText != null || undefined} />
+          <Textarea
+            rows={8}
+            {...props.fields.backText}
+            id={backInputId}
+            aria-invalid={props.errors?.backText != null || undefined}
+            aria-describedby={props.errors?.backText !== undefined ? backErrorId : undefined}
+          />
         </FormItem>
       </section>
       <section

--- a/src/features/card/containers/CardFormContainer.spec.tsx
+++ b/src/features/card/containers/CardFormContainer.spec.tsx
@@ -120,6 +120,25 @@ describe("CardFormContainer", () => {
     expect(mocks.cardUpdate).toHaveBeenCalledWith({ ...card, tags: ["math"] });
   });
 
+  it("blocks blank front and back text", async () => {
+    const view = render(<CardFormContainer />);
+    const frontText = view.container.querySelector("textarea[name='frontText']") as Element;
+    const backText = view.container.querySelector("textarea[name='backText']") as Element;
+
+    await userEvent.clear(frontText);
+    await userEvent.type(frontText, "   ");
+    await userEvent.clear(backText);
+    await userEvent.type(backText, "   ");
+    await userEvent.click(view.getByRole("button", { name: /save/i }));
+
+    expect(view.getByText("Front text is required.")).toBeInTheDocument();
+    expect(view.getByText("Back text is required.")).toBeInTheDocument();
+    expect(frontText).toHaveAttribute("aria-invalid", "true");
+    expect(backText).toHaveAttribute("aria-invalid", "true");
+    expect(mocks.cardUpdate).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
   it("does not navigate when the Card write fails", async () => {
     mocks.cardUpdate.mockRejectedValueOnce(new Error("write failed"));
     const view = render(<CardFormContainer />);

--- a/src/features/card/containers/CardFormContainer.spec.tsx
+++ b/src/features/card/containers/CardFormContainer.spec.tsx
@@ -99,15 +99,15 @@ describe("CardFormContainer", () => {
     const backText = view.container.querySelector("textarea[name='backText']") as Element;
 
     await userEvent.clear(frontText);
-    await userEvent.type(frontText, "UPDATED FRONT");
+    await userEvent.type(frontText, " UPDATED FRONT ");
     await userEvent.clear(backText);
-    await userEvent.type(backText, "UPDATED BACK");
+    await userEvent.type(backText, " UPDATED BACK ");
     await userEvent.click(view.getByRole("button", { name: /save/i }));
 
     expect(mocks.cardUpdate).toHaveBeenCalledWith({
       ...card,
-      frontText: "UPDATED FRONT",
-      backText: "UPDATED BACK",
+      frontText: " UPDATED FRONT ",
+      backText: " UPDATED BACK ",
     });
   });
 

--- a/src/features/card/hooks/useCardFormState.ts
+++ b/src/features/card/hooks/useCardFormState.ts
@@ -33,8 +33,8 @@ export const useCardFormState = ({ card, categoryOptions, onSubmit }: UseCardFor
       })),
     },
     errors: {
-      frontText: formState.errors.frontText?.message,
-      backText: formState.errors.backText?.message,
+      ...(formState.errors.frontText?.message !== undefined ? { frontText: formState.errors.frontText.message } : {}),
+      ...(formState.errors.backText?.message !== undefined ? { backText: formState.errors.backText.message } : {}),
     },
     isSubmitting: formState.isSubmitting,
     onSubmit: handleSubmit((values) => onSubmit?.({ ...card, ...values })),

--- a/src/features/card/hooks/useCardFormState.ts
+++ b/src/features/card/hooks/useCardFormState.ts
@@ -1,7 +1,9 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
 import type { Option } from "@/components/forms/Select";
 import type { CardFormProps } from "@/features/card/components/CardForm";
+import { cardFormSchema, type CardFormValues } from "@/features/card/lib/cardFormSchema";
 
 export interface UseCardFormStateOptions {
   card: Card;
@@ -10,7 +12,14 @@ export interface UseCardFormStateOptions {
 }
 
 export const useCardFormState = ({ card, categoryOptions, onSubmit }: UseCardFormStateOptions): CardFormProps => {
-  const { formState, handleSubmit, register } = useForm<Card>({ defaultValues: card });
+  const { formState, handleSubmit, register } = useForm<CardFormValues>({
+    defaultValues: {
+      frontText: card.frontText,
+      backText: card.backText,
+      tags: card.tags,
+    },
+    resolver: zodResolver(cardFormSchema),
+  });
 
   return {
     card,
@@ -23,7 +32,11 @@ export const useCardFormState = ({ card, categoryOptions, onSubmit }: UseCardFor
         input: { ...register("tags"), value },
       })),
     },
+    errors: {
+      frontText: formState.errors.frontText?.message,
+      backText: formState.errors.backText?.message,
+    },
     isSubmitting: formState.isSubmitting,
-    onSubmit: handleSubmit((data) => onSubmit?.(data)),
+    onSubmit: handleSubmit((values) => onSubmit?.({ ...card, ...values })),
   };
 };

--- a/src/features/card/lib/cardFormSchema.ts
+++ b/src/features/card/lib/cardFormSchema.ts
@@ -1,0 +1,11 @@
+import * as z from "zod";
+
+const requiredCardText = (message: string) => z.string().refine((value) => value.trim().length > 0, { message });
+
+export const cardFormSchema = z.object({
+  frontText: requiredCardText("Front text is required."),
+  backText: requiredCardText("Back text is required."),
+  tags: z.array(z.string()),
+});
+
+export type CardFormValues = z.infer<typeof cardFormSchema>;

--- a/src/features/deck/components/DeckForm.spec.tsx
+++ b/src/features/deck/components/DeckForm.spec.tsx
@@ -91,6 +91,15 @@ describe("DeckForm", () => {
     }
   });
 
+  it("associates validation errors with their named controls", () => {
+    const view = render(
+      <DeckForm {...createProps({ errors: { name: "Deck name is required.", url: "Enter a valid URL." } })} />
+    );
+
+    expect(view.getByRole("textbox", { name: "Name" })).toHaveAccessibleDescription("Deck name is required.");
+    expect(view.getByRole("textbox", { name: "Source URL" })).toHaveAccessibleDescription("Enter a valid URL.");
+  });
+
   it("submits or cancels from the action row", async () => {
     const onSubmit = vi.fn((event?: React.FormEvent) => event?.preventDefault());
     const onCancel = vi.fn();

--- a/src/features/deck/components/DeckForm.tsx
+++ b/src/features/deck/components/DeckForm.tsx
@@ -13,6 +13,10 @@ export interface DeckFormFields {
 export interface DeckFormProps {
   deck: Deck;
   fields: DeckFormFields;
+  errors?: {
+    name?: string;
+    url?: string;
+  };
   isSubmitting?: boolean;
   onCancel?: () => void;
   onSubmit?: React.ComponentProps<typeof Form>["onSubmit"];
@@ -35,8 +39,8 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Name and organize this deck.</p>
         </div>
-        <FormItem col label="Name">
-          <Input {...props.fields.name} />
+        <FormItem col label="Name" error={props.errors?.name}>
+          <Input {...props.fields.name} aria-invalid={props.errors?.name != null || undefined} />
         </FormItem>
         <FormItem col label="Category">
           <Select empty {...props.fields.category} />
@@ -52,8 +56,8 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Control the source and how imported text is displayed.</p>
         </div>
-        <FormItem col label="Source URL">
-          <Input {...props.fields.url} />
+        <FormItem col label="Source URL" error={props.errors?.url}>
+          <Input {...props.fields.url} aria-invalid={props.errors?.url != null || undefined} />
         </FormItem>
         <FormItem label="Convert line breaks" help="Convert two line breaks to one <br />.">
           <Switch {...props.fields.convertToBr} aria-label="Convert line breaks" />

--- a/src/features/deck/components/DeckForm.tsx
+++ b/src/features/deck/components/DeckForm.tsx
@@ -39,7 +39,7 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Name and organize this deck.</p>
         </div>
-        <FormItem col label="Name" error={props.errors?.name}>
+        <FormItem col label="Name" {...(props.errors?.name !== undefined ? { error: props.errors.name } : {})}>
           <Input {...props.fields.name} aria-invalid={props.errors?.name != null || undefined} />
         </FormItem>
         <FormItem col label="Category">
@@ -56,7 +56,7 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Control the source and how imported text is displayed.</p>
         </div>
-        <FormItem col label="Source URL" error={props.errors?.url}>
+        <FormItem col label="Source URL" {...(props.errors?.url !== undefined ? { error: props.errors.url } : {})}>
           <Input {...props.fields.url} aria-invalid={props.errors?.url != null || undefined} />
         </FormItem>
         <FormItem label="Convert line breaks" help="Convert two line breaks to one <br />.">

--- a/src/features/deck/components/DeckForm.tsx
+++ b/src/features/deck/components/DeckForm.tsx
@@ -26,6 +26,10 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
   const sectionHeadingIdPrefix = useId();
   const basicHeadingId = `${sectionHeadingIdPrefix}-deck-basic-heading`;
   const importHeadingId = `${sectionHeadingIdPrefix}-deck-import-heading`;
+  const nameInputId = `${sectionHeadingIdPrefix}-deck-name`;
+  const nameErrorId = `${nameInputId}-error`;
+  const urlInputId = `${sectionHeadingIdPrefix}-deck-url`;
+  const urlErrorId = `${urlInputId}-error`;
 
   return (
     <Form {...(props.onSubmit !== undefined ? { onSubmit: props.onSubmit } : {})}>
@@ -39,8 +43,19 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Name and organize this deck.</p>
         </div>
-        <FormItem col label="Name" {...(props.errors?.name !== undefined ? { error: props.errors.name } : {})}>
-          <Input {...props.fields.name} aria-invalid={props.errors?.name != null || undefined} />
+        <FormItem
+          col
+          label="Name"
+          inputId={nameInputId}
+          errorId={nameErrorId}
+          {...(props.errors?.name !== undefined ? { error: props.errors.name } : {})}
+        >
+          <Input
+            {...props.fields.name}
+            id={nameInputId}
+            aria-invalid={props.errors?.name != null || undefined}
+            aria-describedby={props.errors?.name !== undefined ? nameErrorId : undefined}
+          />
         </FormItem>
         <FormItem col label="Category">
           <Select empty {...props.fields.category} />
@@ -56,8 +71,19 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Control the source and how imported text is displayed.</p>
         </div>
-        <FormItem col label="Source URL" {...(props.errors?.url !== undefined ? { error: props.errors.url } : {})}>
-          <Input {...props.fields.url} aria-invalid={props.errors?.url != null || undefined} />
+        <FormItem
+          col
+          label="Source URL"
+          inputId={urlInputId}
+          errorId={urlErrorId}
+          {...(props.errors?.url !== undefined ? { error: props.errors.url } : {})}
+        >
+          <Input
+            {...props.fields.url}
+            id={urlInputId}
+            aria-invalid={props.errors?.url != null || undefined}
+            aria-describedby={props.errors?.url !== undefined ? urlErrorId : undefined}
+          />
         </FormItem>
         <FormItem label="Convert line breaks" help="Convert two line breaks to one <br />.">
           <Switch {...props.fields.convertToBr} aria-label="Convert line breaks" />

--- a/src/features/deck/containers/DeckFormContainer.spec.tsx
+++ b/src/features/deck/containers/DeckFormContainer.spec.tsx
@@ -88,7 +88,7 @@ describe("DeckFormContainer", () => {
     const input = view.container.querySelector("input[name='name']") as Element;
 
     await userEvent.clear(input);
-    await userEvent.type(input, "UPDATED");
+    await userEvent.type(input, " UPDATED ");
     await userEvent.click(view.getByRole("button", { name: /save/i }));
 
     expect(mocks.updateAndGoToList).toHaveBeenCalledWith({ ...deck, name: "UPDATED" });

--- a/src/features/deck/containers/DeckFormContainer.spec.tsx
+++ b/src/features/deck/containers/DeckFormContainer.spec.tsx
@@ -124,6 +124,23 @@ describe("DeckFormContainer", () => {
     expect(mocks.updateAndGoToList).toHaveBeenCalledWith({ ...deck, category: "math" });
   });
 
+  it("blocks a blank name and malformed URL", async () => {
+    const view = render(<DeckFormContainer />);
+    const name = view.container.querySelector("input[name='name']") as Element;
+    const url = view.container.querySelector("input[name='url']") as Element;
+
+    await userEvent.clear(name);
+    await userEvent.type(name, "   ");
+    await userEvent.type(url, "not-a-url");
+    await userEvent.click(view.getByRole("button", { name: /save/i }));
+
+    expect(view.getByText("Deck name is required.")).toBeInTheDocument();
+    expect(view.getByText("Enter a valid URL.")).toBeInTheDocument();
+    expect(name).toHaveAttribute("aria-invalid", "true");
+    expect(url).toHaveAttribute("aria-invalid", "true");
+    expect(mocks.updateAndGoToList).not.toHaveBeenCalled();
+  });
+
   it("cancels without submitting", async () => {
     const view = render(<DeckFormContainer />);
 

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 
@@ -8,6 +9,7 @@ import { RemoteMutationNotice, RemoteReadBoundary } from "@/components";
 import { useActions } from "@/hooks/useActions";
 import { DeckFormTemplate } from "@/features/deck/components/templates/DeckFormTemplate";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
+import { deckFormSchema, type DeckFormValues } from "@/features/deck/lib/deckFormSchema";
 import { useConfig } from "@/hooks/useConfig";
 
 const DeckFormContent = ({ deck }: { deck: Deck }) => {
@@ -15,7 +17,15 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
   const actions = useActions();
   const deckActions = useDeckActions(deck.id);
   const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
-  const { formState, handleSubmit, register } = useForm<Deck>({ defaultValues: deck });
+  const { formState, handleSubmit, register } = useForm<DeckFormValues>({
+    defaultValues: {
+      name: deck.name,
+      category: deck.category,
+      url: deck.url,
+      convertToBr: deck.convertToBr,
+    },
+    resolver: zodResolver(deckFormSchema),
+  });
 
   return (
     <DeckFormTemplate
@@ -41,9 +51,13 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
             options: categoryOptions,
           },
         },
+        errors: {
+          name: formState.errors.name?.message,
+          url: formState.errors.url?.message,
+        },
         isSubmitting: formState.isSubmitting,
         onCancel: deckActions.goToList,
-        onSubmit: handleSubmit((data) => deckActions.updateAndGoToList(data)),
+        onSubmit: handleSubmit((values) => deckActions.updateAndGoToList({ ...deck, ...values })),
       }}
     />
   );

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -52,12 +52,14 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
           },
         },
         errors: {
-          name: formState.errors.name?.message,
-          url: formState.errors.url?.message,
+          ...(formState.errors.name?.message !== undefined ? { name: formState.errors.name.message } : {}),
+          ...(formState.errors.url?.message !== undefined ? { url: formState.errors.url.message } : {}),
         },
         isSubmitting: formState.isSubmitting,
         onCancel: deckActions.goToList,
-        onSubmit: handleSubmit((values) => deckActions.updateAndGoToList({ ...deck, ...values })),
+        onSubmit: handleSubmit((values) =>
+          deckActions.updateAndGoToList({ ...deck, ...values, url: values.url ?? "" })
+        ),
       }}
     />
   );

--- a/src/features/deck/lib/deckFormSchema.ts
+++ b/src/features/deck/lib/deckFormSchema.ts
@@ -1,0 +1,10 @@
+import * as z from "zod";
+
+export const deckFormSchema = z.object({
+  name: z.string().trim().min(1, "Deck name is required."),
+  category: z.string(),
+  url: z.union([z.literal(""), z.url("Enter a valid URL.")]).optional(),
+  convertToBr: z.boolean(),
+});
+
+export type DeckFormValues = z.infer<typeof deckFormSchema>;

--- a/src/lib/componentArchitecture.spec.ts
+++ b/src/lib/componentArchitecture.spec.ts
@@ -219,7 +219,11 @@ describe("component architecture", () => {
     expect(legacyImports, legacyImports.join("\n")).toEqual([]);
     expect(entityModeReferences, entityModeReferences.join("\n")).toEqual([]);
     expect(dependencyNames.filter((name) => legacyPackages.includes(name))).toEqual([]);
-    expect(sourceFilesUnder("store")).toEqual(["store/configStore.spec.ts", "store/configStore.ts"]);
+    expect(sourceFilesUnder("store")).toEqual([
+      "store/configSchema.ts",
+      "store/configStore.spec.ts",
+      "store/configStore.ts",
+    ]);
   });
 
   it("groups shared layout components", () => {

--- a/src/store/configSchema.ts
+++ b/src/store/configSchema.ts
@@ -1,0 +1,64 @@
+import * as z from "zod";
+
+export const defaultConfig: ConfigState = {
+  useCardInterval: false,
+  showSwipeButtonList: true,
+  showScoreSlider: false,
+  showHeader: true,
+  fullscreen: false,
+  maxNumberOfCardsToLearn: 10,
+  hideBodyWhenCardChanged: true,
+  sizeBackText: 0,
+  shuffled: false,
+  defaultAutoPlay: false,
+  cardInterval: 60,
+  keepBackTextViewed: false,
+  showSwipeFeedback: false,
+  cardSwipeUp: "GoToNextCardMastered",
+  cardSwipeDown: "GoToNextCardNotMastered",
+  cardSwipeLeft: "GoToPrevCard",
+  cardSwipeRight: "GoToNextCard",
+  darkMode: false,
+  selectedTags: [],
+  githubAccessToken: "",
+};
+
+const cardSwipeSchema = z.enum([
+  "DoNothing",
+  "GoBack",
+  "GoToPrevCard",
+  "GoToNextCard",
+  "GoToNextCardMastered",
+  "GoToNextCardNotMastered",
+  "GoToNextCardToggleMastered",
+]);
+
+const configSchema: z.ZodType<ConfigState> = z
+  .object({
+    useCardInterval: z.boolean().catch(defaultConfig.useCardInterval),
+    showSwipeButtonList: z.boolean().catch(defaultConfig.showSwipeButtonList),
+    showScoreSlider: z.boolean().catch(defaultConfig.showScoreSlider),
+    showHeader: z.boolean().catch(defaultConfig.showHeader),
+    fullscreen: z.boolean().catch(defaultConfig.fullscreen),
+    maxNumberOfCardsToLearn: z.number().catch(defaultConfig.maxNumberOfCardsToLearn),
+    hideBodyWhenCardChanged: z.boolean().catch(defaultConfig.hideBodyWhenCardChanged),
+    sizeBackText: z.number().catch(defaultConfig.sizeBackText),
+    shuffled: z.boolean().catch(defaultConfig.shuffled),
+    defaultAutoPlay: z.boolean().catch(defaultConfig.defaultAutoPlay),
+    cardInterval: z.number().catch(defaultConfig.cardInterval),
+    keepBackTextViewed: z.boolean().catch(defaultConfig.keepBackTextViewed),
+    showSwipeFeedback: z.boolean().catch(defaultConfig.showSwipeFeedback),
+    cardSwipeUp: cardSwipeSchema.catch(defaultConfig.cardSwipeUp),
+    cardSwipeDown: cardSwipeSchema.catch(defaultConfig.cardSwipeDown),
+    cardSwipeLeft: cardSwipeSchema.catch(defaultConfig.cardSwipeLeft),
+    cardSwipeRight: cardSwipeSchema.catch(defaultConfig.cardSwipeRight),
+    darkMode: z.boolean().catch(defaultConfig.darkMode),
+    selectedTags: z.array(z.string()).catch(defaultConfig.selectedTags),
+    githubAccessToken: z.string().catch(defaultConfig.githubAccessToken),
+  })
+  .catch(defaultConfig);
+
+const persistedConfigStateSchema = z.object({ config: configSchema }).catch({ config: defaultConfig });
+
+export const parsePersistedConfig = (persistedState: unknown): ConfigState =>
+  persistedConfigStateSchema.parse(persistedState).config;

--- a/src/store/configStore.spec.ts
+++ b/src/store/configStore.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { CONFIG_STORAGE_KEY, createConfigStore, defaultConfig } from "@/store/configStore";
 
-const createMemoryStorage = () => {
-  const values = new Map<string, string>();
+const createMemoryStorage = (initial: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initial));
   return {
     getItem: (name: string) => values.get(name) ?? null,
     setItem: (name: string, value: string) => values.set(name, value),
@@ -45,5 +45,40 @@ describe("config store", () => {
     expect(restored.getState().config).toEqual({ ...defaultConfig, darkMode: true });
     expect(restored.getState().updateConfig).toBeTypeOf("function");
     expect(restored.getState().toggleConfig).toBeTypeOf("function");
+  });
+
+  it("keeps valid persisted settings and replaces invalid values with current defaults", async () => {
+    const storage = createMemoryStorage({
+      [CONFIG_STORAGE_KEY]: JSON.stringify({
+        state: {
+          config: {
+            cardInterval: 15,
+            darkMode: "yes",
+            removedSetting: true,
+          },
+        },
+        version: 1,
+      }),
+    });
+    const store = createConfigStore({ storage, skipHydration: true });
+
+    await store.persist.rehydrate();
+
+    expect(store.getState().config).toEqual({
+      ...defaultConfig,
+      cardInterval: 15,
+    });
+    expect(store.getState().config).not.toHaveProperty("removedSetting");
+  });
+
+  it("uses current defaults when persisted config is not an object", async () => {
+    const storage = createMemoryStorage({
+      [CONFIG_STORAGE_KEY]: JSON.stringify({ state: { config: "invalid" }, version: 1 }),
+    });
+    const store = createConfigStore({ storage, skipHydration: true });
+
+    await store.persist.rehydrate();
+
+    expect(store.getState().config).toEqual(defaultConfig);
   });
 });

--- a/src/store/configStore.ts
+++ b/src/store/configStore.ts
@@ -1,30 +1,10 @@
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
+import { defaultConfig, parsePersistedConfig } from "@/store/configSchema";
+
+export { defaultConfig } from "@/store/configSchema";
 
 export const CONFIG_STORAGE_KEY = "tango-config";
-
-export const defaultConfig: ConfigState = {
-  useCardInterval: false,
-  showSwipeButtonList: true,
-  showScoreSlider: false,
-  showHeader: true,
-  fullscreen: false,
-  maxNumberOfCardsToLearn: 10,
-  hideBodyWhenCardChanged: true,
-  sizeBackText: 0,
-  shuffled: false,
-  defaultAutoPlay: false,
-  cardInterval: 60,
-  keepBackTextViewed: false,
-  showSwipeFeedback: false,
-  cardSwipeUp: "GoToNextCardMastered",
-  cardSwipeDown: "GoToNextCardNotMastered",
-  cardSwipeLeft: "GoToPrevCard",
-  cardSwipeRight: "GoToNextCard",
-  darkMode: false,
-  selectedTags: [],
-  githubAccessToken: "",
-};
 
 type BooleanConfigKey = {
   [Key in keyof ConfigState]: ConfigState[Key] extends boolean ? Key : never;
@@ -59,13 +39,10 @@ export const createConfigStore = ({ storage, skipHydration }: CreateConfigStoreO
         storage: persistStorage,
         ...(skipHydration !== undefined ? { skipHydration } : {}),
         partialize: ({ config }) => ({ config }),
-        merge: (persistedState, currentState) => {
-          const persistedConfig = (persistedState as PersistedConfigState | undefined)?.config;
-          return {
-            ...currentState,
-            config: { ...defaultConfig, ...persistedConfig },
-          };
-        },
+        merge: (persistedState, currentState) => ({
+          ...currentState,
+          config: parsePersistedConfig(persistedState),
+        }),
       }
     )
   );


### PR DESCRIPTION
## Summary

- add Zod and the React Hook Form Zod resolver as runtime dependencies
- validate persisted application config with field-level defaults while preserving the version-1 storage format
- validate Deck names and source URLs before updates
- validate Card front and back text before updates without trimming valid content
- block invalid mutations and navigation, preserve entity metadata, and associate field errors with accessible controls

## Testing

- `make check` (91 test files, 499 tests)

Closes #313