### PR TITLE
Publish Storybook to GitHub Pages

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy Storybook to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build:storybook
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: storybook-static/
+
+  deploy:
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ You can access to the page for **demo** here: https://tango-ts.web.app
 
 Demo data is stored in Firestore and may be **deleted** without notice.
 
+## Storybook
+
+Browse the latest Storybook at https://her0e1c1.github.io/tango/. Updates are published automatically from `main`.
+
 ## Development
 
 ### Setup for development


### PR DESCRIPTION
## Summary

- add a dedicated GitHub Pages workflow for Storybook
- deploy successful main builds with official Pages actions and least-privilege permissions
- document the published Storybook URL and automatic updates from main

## Testing

- Storybook 10.4.6 static build completed successfully in the Docker development environment
- verified storybook-static/index.html, iframe.html, and generated assets
- yamllint passed with GitHub Actions-compatible YAML rules
- make check passed: 91 test files and 499 tests

Closes #250