### PR TITLE
Preserve deck existence check failures

### DIFF
--- a/src/action/firestore/deck.exists.spec.ts
+++ b/src/action/firestore/deck.exists.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn(() => "deck-ref"),
+  getDoc: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  doc: mocks.doc,
+  getDoc: mocks.getDoc,
+}));
+vi.mock("@/firestoreRuntime", () => ({ getDb: () => "db" }));
+
+import { exists } from "./deck";
+
+describe("firestore/deck.exists", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([true, false])("returns the snapshot exists value %s", async (expected) => {
+    mocks.getDoc.mockResolvedValue({ exists: () => expected });
+
+    await expect(exists("deck-id")).resolves.toBe(expected);
+  });
+
+  it.each([
+    "unavailable",
+    "permission-denied",
+    "unauthenticated",
+  ])("rejects the original %s read error", async (code) => {
+    const error = Object.assign(new Error(code), { code });
+    mocks.getDoc.mockRejectedValue(error);
+
+    await expect(exists("deck-id")).rejects.toBe(error);
+  });
+});

--- a/src/action/firestore/deck.exists.spec.ts
+++ b/src/action/firestore/deck.exists.spec.ts
@@ -11,7 +11,7 @@ vi.mock("firebase/firestore", () => ({
 }));
 vi.mock("@/firestoreRuntime", () => ({ getDb: () => "db" }));
 
-import { exists } from "./deck";
+import { exists } from "@/action/firestore/deck";
 
 describe("firestore/deck.exists", () => {
   beforeEach(() => {

--- a/src/action/firestore/deck.spec.ts
+++ b/src/action/firestore/deck.spec.ts
@@ -62,8 +62,7 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     await firestore.deck.create(d);
     expect((await getDoc(doc(db, "deck", d.id))).exists()).toBeTruthy();
     await firestore.deck.remove(d.id, "uid");
-    // getDoc can not be called here because of permission error
-    expect(await firestore.deck.exists(d.id)).toBeFalsy();
+    await expect(firestore.deck.exists(d.id)).rejects.toMatchObject({ code: "permission-denied" });
   });
 
   describe("splitCards", () => {

--- a/src/action/firestore/deck.ts
+++ b/src/action/firestore/deck.ts
@@ -69,15 +69,8 @@ export const remove = async (deckId: string, uid: string) => {
 export const exists = async (id: string): Promise<boolean> => {
   const db = getDb();
   const ref = doc(db, "deck", id);
-  try {
-    const snapshot = await getDoc(ref);
-    if (snapshot.exists()) {
-      return true;
-    }
-  } catch (_) {
-    // ignore permission error if not exist
-  }
-  return false;
+  const snapshot = await getDoc(ref);
+  return snapshot.exists();
 };
 
 // for test


### PR DESCRIPTION
## Summary

- return the Firestore snapshot existence value only after a successful deck read
- propagate `unavailable`, permission, and authentication failures instead of treating them as a missing deck
- cover existing, missing, and rejected reads with focused tests

## Root cause and impact

`deck.exists()` caught every `getDoc()` error and returned `false`, so callers could not distinguish a confirmed missing document from an offline or authorization failure. Failed reads now remain retryable errors and cannot be interpreted as confirmed absence.

The legacy `removeFromLocal` reconciliation path described when the issue was opened was removed by #274 and #295. Current `main` has no local multi-deck deletion caller, so this PR hardens the remaining gateway contract without recreating obsolete reconciliation or duplicating the existing sync-error UI.

## Validation

- `direnv exec . make test-firestore` — 8 files, 66 tests passed
- `direnv exec . make check` — 91 files, 499 tests passed
- `git diff --check origin/main...HEAD`

Closes #252