### PR TITLE
Add CSV import preview and validation

### DIFF
--- a/src/action/deck.spec.ts
+++ b/src/action/deck.spec.ts
@@ -49,6 +49,17 @@ describe("deck action", () => {
         "CSV content must be a string or File"
       );
     });
+
+    it("keeps the bundled sample safe for identical re-imports", async () => {
+      const cards = await action.deck.parseCsv(C.CSV_SAMPLE_TEXT);
+
+      expect(cards).toHaveLength(3);
+      expect(cards.map((card) => card.uniqueKey)).toEqual([
+        "question-answer-example",
+        "hello-world-python",
+        "circle-area",
+      ]);
+    });
   });
 
   describe("download", () => {

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -64,6 +64,6 @@ export const CanMapping = (x: string): x is MAPPINGKEY => {
 export const CATEGORY: Category[] = ["raw", "markdown", "math"].concat(LANGUAGES);
 
 export const CSV_SAMPLE_TEXT = `\
-"Write a question in front text","Write the answer for it in back text"
-"hello word in python","print('hello world')","python"
-"What is the area of a circle with a radius of r?","$\\pi r^2$","math"`;
+"Write a question in front text","Write the answer for it in back text","","question-answer-example"
+"hello word in python","print('hello world')","python","hello-world-python"
+"What is the area of a circle with a radius of r?","$\\pi r^2$","math","circle-area"`;

--- a/src/features/import/components/deckImportTypes.ts
+++ b/src/features/import/components/deckImportTypes.ts
@@ -1,0 +1,45 @@
+export interface DeckImportRow {
+  rowNumber: number;
+  card: CardRaw;
+}
+
+export interface DeckImportIssue {
+  rowNumber?: number;
+  message: string;
+  context?: string;
+}
+
+export interface DeckImportAnalysis {
+  rows: DeckImportRow[];
+  skippedRows: number[];
+  issues: DeckImportIssue[];
+  invalidCount: number;
+}
+
+export type DeckImportAction = "create" | "update" | "unchanged";
+
+export interface DeckImportPlanRow extends DeckImportRow {
+  action: DeckImportAction;
+}
+
+export interface DeckImportPlan {
+  rows: DeckImportPlanRow[];
+  created: number;
+  updated: number;
+  unchanged: number;
+}
+
+export interface DeckImportPreview {
+  fileName: string;
+  deckName: string;
+  analysis: DeckImportAnalysis;
+  plan: DeckImportPlan;
+}
+
+export interface DeckImportResult {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  deckId: DeckId;
+}

--- a/src/features/import/components/templates/DeckImportTemplate.spec.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.spec.tsx
@@ -4,18 +4,44 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DeckImportTemplate } from "@/features/import/components/templates/DeckImportTemplate";
+import type { DeckImportPreview, DeckImportResult } from "@/features/import/components/deckImportTypes";
+
+const preview = {
+  fileName: "deck.csv",
+  deckName: "deck.csv",
+  analysis: {
+    rows: [
+      {
+        rowNumber: 1,
+        card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
+      },
+    ],
+    skippedRows: [2],
+    issues: [],
+    invalidCount: 0,
+  },
+  plan: {
+    rows: [
+      {
+        rowNumber: 1,
+        card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
+        action: "create",
+      },
+    ],
+    created: 1,
+    updated: 0,
+    unchanged: 0,
+  },
+} satisfies DeckImportPreview;
 
 describe("DeckImportTemplate", () => {
   afterEach(cleanup);
 
-  it("composes feedback before the import controls in a bounded semantic route surface", () => {
-    const view = render(
-      <DeckImportTemplate feedbackSlot={<div role="status">Import failed</div>} sampleText="front,back" />
-    );
+  it("composes a bounded semantic import route surface", () => {
+    const view = render(<DeckImportTemplate sampleText="front,back,,key" />);
 
     const heading = view.getByRole("heading", { level: 1, name: "Import decks" });
     const surface = heading.parentElement;
-    const feedback = view.getByRole("status");
     const upload = view.container.querySelector<HTMLInputElement>("input[type='file']");
 
     expect(surface).toHaveClass(
@@ -29,42 +55,38 @@ describe("DeckImportTemplate", () => {
       "p-4",
       "md:p-6"
     );
-    expect(surface).toContainElement(feedback);
     expect(surface).toContainElement(upload);
-    expect(feedback.compareDocumentPosition(upload as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(view.getByRole("heading", { level: 2, name: "Choose a CSV file" })).toBeInTheDocument();
     expect(view.getByRole("heading", { level: 2, name: "CSV format" })).toBeInTheDocument();
     expect(view.getByRole("heading", { level: 2, name: "Sample" })).toBeInTheDocument();
   });
 
-  it("passes a real file to the upload callback and disables upload while pending", () => {
+  it("passes a real file to the upload callback and disables upload while busy", () => {
     const onChange = vi.fn();
-    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
-    const view = render(<DeckImportTemplate sampleText="front,back" onChange={onChange} />);
+    const file = new File(["front,back,,key"], "deck.csv", { type: "text/csv" });
+    const view = render(<DeckImportTemplate sampleText="front,back,,key" onChange={onChange} />);
     const input = view.container.querySelector("input[type='file']") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [file] } });
 
     expect(onChange).toHaveBeenCalledWith(file);
-    view.rerender(<DeckImportTemplate sampleText="front,back" onChange={onChange} pending />);
+    view.rerender(<DeckImportTemplate sampleText="front,back,,key" onChange={onChange} pending />);
     expect(view.container.querySelector("input[type='file']")).toBeDisabled();
   });
 
-  it("explains the format and exposes sample add, download, and code controls", async () => {
+  it("documents uniqueKey and exposes sample add, download, and code controls", async () => {
     const onAddSample = vi.fn();
     const onDownloadSample = vi.fn();
-    const sampleText = "front,back,tag";
+    const sampleText = "front,back,tag,key";
     const view = render(
       <DeckImportTemplate sampleText={sampleText} onAddSample={onAddSample} onDownloadSample={onDownloadSample} />
     );
 
-    expect(
-      view.getByText("There are 3 columns without header: front text, back text, and tags (optional).")
-    ).toBeInTheDocument();
+    expect(view.getByText(/Four columns without a header/)).toHaveTextContent("uniqueKey");
+    expect(view.getByText(/uniqueKey is required/)).toBeInTheDocument();
     const code = view.container.querySelector("code");
     expect(code).toHaveTextContent(sampleText);
-    const sampleSurface = code?.closest("[data-import-sample]");
-    expect(sampleSurface).toHaveClass(
+    expect(code?.closest("[data-import-sample]")).toHaveClass(
       "overflow-x-auto",
       "rounded-surface",
       "border",
@@ -77,5 +99,90 @@ describe("DeckImportTemplate", () => {
 
     expect(onAddSample).toHaveBeenCalledOnce();
     expect(onDownloadSample).toHaveBeenCalledOnce();
+  });
+
+  it("shows validation, planned changes, row content, and waits for explicit import", async () => {
+    const onImport = vi.fn();
+    const view = render(<DeckImportTemplate sampleText="front,back,,key" preview={preview} onImport={onImport} />);
+
+    expect(view.getAllByText("deck.csv")).toHaveLength(2);
+    expect(view.getByText("1 valid")).toBeVisible();
+    expect(view.getByText("1 skipped")).toBeVisible();
+    expect(view.getByText("0 invalid")).toBeVisible();
+    expect(view.getByText("1 create")).toBeVisible();
+    expect(view.getByText("0 update")).toBeVisible();
+    expect(view.getByText("0 unchanged")).toBeVisible();
+    expect(view.getByRole("cell", { name: "front" })).toBeVisible();
+    expect(view.getByRole("cell", { name: "key-1" })).toBeVisible();
+    expect(onImport).not.toHaveBeenCalled();
+
+    await userEvent.click(view.getByRole("button", { name: "Import" }));
+
+    expect(onImport).toHaveBeenCalledOnce();
+  });
+
+  it("shows invalid row context and requires a corrected file", () => {
+    const invalidPreview: DeckImportPreview = {
+      ...preview,
+      analysis: {
+        rows: [],
+        skippedRows: [],
+        invalidCount: 1,
+        issues: [
+          {
+            rowNumber: 3,
+            message: "Expected 4 columns, found 2.",
+            context: '["front","back"]',
+          },
+        ],
+      },
+      plan: { rows: [], created: 0, updated: 0, unchanged: 0 },
+    };
+    const view = render(<DeckImportTemplate sampleText="front,back,,key" preview={invalidPreview} />);
+
+    const alert = view.getByRole("alert");
+    expect(alert).toHaveTextContent("Row 3");
+    expect(alert).toHaveTextContent("Expected 4 columns, found 2.");
+    expect(alert).toHaveTextContent('["front","back"]');
+    expect(view.getByRole("button", { name: "Import" })).toBeDisabled();
+    expect(view.getByText("Choose a corrected CSV file to continue.")).toBeVisible();
+  });
+
+  it("keeps success and partial failure results visible with recovery actions", async () => {
+    const onBack = vi.fn();
+    const onRetry = vi.fn();
+    const success = {
+      created: 2,
+      updated: 1,
+      skipped: 3,
+      failed: 0,
+      deckId: "deck",
+    } satisfies DeckImportResult;
+    const view = render(
+      <DeckImportTemplate sampleText="front,back,,key" result={success} onBack={onBack} onRetry={onRetry} />
+    );
+
+    expect(view.getByRole("status")).toHaveTextContent("Import complete");
+    expect(view.getByRole("status")).toHaveTextContent("2 created");
+    expect(view.getByRole("status")).toHaveTextContent("1 updated");
+    expect(view.getByRole("status")).toHaveTextContent("3 skipped");
+    await userEvent.click(view.getByRole("button", { name: "Back to decks" }));
+    expect(onBack).toHaveBeenCalledOnce();
+
+    view.rerender(
+      <DeckImportTemplate
+        sampleText="front,back,,key"
+        error={new Error("Card writes failed")}
+        partialResult={{ ...success, created: 1, failed: 1 }}
+        onBack={onBack}
+        onRetry={onRetry}
+      />
+    );
+    const alert = view.getByRole("alert");
+    expect(alert).toHaveTextContent("Import partially completed");
+    expect(alert).toHaveTextContent("1 created");
+    expect(alert).toHaveTextContent("1 failed");
+    await userEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/import/components/templates/DeckImportTemplate.stories.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.stories.tsx
@@ -2,7 +2,45 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import * as C from "@/constant";
 import { DeckImportTemplate as Template } from "@/features/import/components/templates/DeckImportTemplate";
+import type { DeckImportPreview } from "@/features/import/components/deckImportTypes";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
+
+const preview = {
+  fileName: "spanish-basics.csv",
+  deckName: "spanish-basics.csv",
+  analysis: {
+    rows: [
+      {
+        rowNumber: 1,
+        card: { frontText: "hello", backText: "hola", tags: ["greeting"], uniqueKey: "hello-es" },
+      },
+      {
+        rowNumber: 2,
+        card: { frontText: "goodbye", backText: "adiós", tags: ["greeting"], uniqueKey: "goodbye-es" },
+      },
+    ],
+    skippedRows: [3],
+    issues: [],
+    invalidCount: 0,
+  },
+  plan: {
+    rows: [
+      {
+        rowNumber: 1,
+        card: { frontText: "hello", backText: "hola", tags: ["greeting"], uniqueKey: "hello-es" },
+        action: "update",
+      },
+      {
+        rowNumber: 2,
+        card: { frontText: "goodbye", backText: "adiós", tags: ["greeting"], uniqueKey: "goodbye-es" },
+        action: "create",
+      },
+    ],
+    created: 1,
+    updated: 1,
+    unchanged: 0,
+  },
+} satisfies DeckImportPreview;
 
 const meta = {
   title: "Import/DeckImportTemplate",
@@ -25,9 +63,50 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const Preview: Story = {
+  args: { preview },
+};
+
+export const Invalid: Story = {
+  args: {
+    preview: {
+      ...preview,
+      analysis: {
+        rows: [],
+        skippedRows: [],
+        invalidCount: 1,
+        issues: [
+          {
+            rowNumber: 2,
+            message: "Expected 4 columns, found 3.",
+            context: '["goodbye","adiós","greeting"]',
+          },
+        ],
+      },
+      plan: { rows: [], created: 0, updated: 0, unchanged: 0 },
+    },
+  },
+};
+
 export const Pending: Story = {
   args: {
     pending: true,
+    preview,
+  },
+};
+
+export const Success: Story = {
+  args: {
+    preview,
+    result: { created: 1, updated: 1, skipped: 0, failed: 0, deckId: "spanish-basics" },
+  },
+};
+
+export const PartialFailure: Story = {
+  args: {
+    preview,
+    error: new Error("1 Card write failed"),
+    partialResult: { created: 1, updated: 0, skipped: 0, failed: 1, deckId: "spanish-basics" },
   },
 };
 
@@ -35,7 +114,7 @@ export const LongSample: Story = {
   args: {
     sampleText: Array.from(
       { length: 12 },
-      (_, index) => `A long front ${index + 1},A long back ${index + 1},tag-${index + 1}`
+      (_, index) => `A long front ${index + 1},A long back ${index + 1},tag-${index + 1},sample-${index + 1}`
     ).join("\n"),
   },
 };

--- a/src/features/import/components/templates/DeckImportTemplate.tsx
+++ b/src/features/import/components/templates/DeckImportTemplate.tsx
@@ -1,34 +1,254 @@
 import type * as React from "react";
 import { AiOutlineCloudDownload } from "react-icons/ai";
+
 import { Button, Code, Description, Upload } from "@/components";
 import { Layout, type LayoutProps } from "@/components/layout/Layout";
+import type { DeckImportPreview, DeckImportResult } from "@/features/import/components/deckImportTypes";
 
-export const DeckImportTemplate: React.FC<{
+interface DeckImportTemplateProps {
   onChange?: (file: File) => void;
   onAddSample?: () => void;
   onDownloadSample?: () => void;
+  onImport?: () => void;
+  onRetry?: () => void;
+  onBack?: () => void;
   sampleText: string;
   dark?: boolean;
   layout?: LayoutProps;
+  validating?: boolean;
   pending?: boolean;
-  feedbackSlot?: React.ReactNode;
-}> = (props) => {
+  preview?: DeckImportPreview;
+  result?: DeckImportResult;
+  partialResult?: DeckImportResult;
+  error?: unknown;
+}
+
+const resultCounts = (result: DeckImportResult) => (
+  <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption">
+    <li>{result.created} created</li>
+    <li>{result.updated} updated</li>
+    <li>{result.skipped} skipped</li>
+    {result.failed > 0 ? <li>{result.failed} failed</li> : null}
+  </ul>
+);
+
+interface ImportResultProps {
+  result: DeckImportResult | undefined;
+  partialResult: DeckImportResult | undefined;
+  error: unknown;
+  onRetry: (() => void) | undefined;
+  onBack: (() => void) | undefined;
+}
+
+const ImportResult = (props: ImportResultProps) => {
+  if (props.partialResult != null) {
+    return (
+      <section role="alert" className="rounded-surface border border-warning bg-surface-muted p-4 text-ink">
+        <h2 className="font-bold">Import partially completed</h2>
+        <p className="mt-1 text-caption text-ink-muted">
+          Successful rows are kept. Retry safely rechecks each uniqueKey before writing.
+        </p>
+        {resultCounts(props.partialResult)}
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button size="sm" {...(props.onRetry !== undefined ? { onClick: props.onRetry } : {})}>
+            Retry
+          </Button>
+          <Button variant="quiet" size="sm" {...(props.onBack !== undefined ? { onClick: props.onBack } : {})}>
+            Back to decks
+          </Button>
+        </div>
+      </section>
+    );
+  }
+  if (props.error != null) {
+    const message = props.error instanceof Error ? props.error.message : "The import could not be completed.";
+    return (
+      <section role="alert" className="rounded-surface border border-danger bg-surface-muted p-4 text-ink">
+        <h2 className="font-bold">Import failed</h2>
+        <p className="mt-1 break-words text-caption text-ink-muted">{message}</p>
+        <Button className="mt-3" size="sm" {...(props.onRetry !== undefined ? { onClick: props.onRetry } : {})}>
+          Retry
+        </Button>
+      </section>
+    );
+  }
+  if (props.result == null) return null;
+  return (
+    <section role="status" className="rounded-surface border border-success bg-surface-muted p-4 text-ink">
+      <h2 className="font-bold">Import complete</h2>
+      {resultCounts(props.result)}
+      <Button
+        className="mt-3"
+        variant="quiet"
+        size="sm"
+        {...(props.onBack !== undefined ? { onClick: props.onBack } : {})}
+      >
+        Back to decks
+      </Button>
+    </section>
+  );
+};
+
+interface ImportPreviewProps {
+  preview: DeckImportPreview | undefined;
+  pending: boolean | undefined;
+  validating: boolean | undefined;
+  onImport: (() => void) | undefined;
+}
+
+const ImportPreview = (props: ImportPreviewProps) => {
+  const preview = props.preview;
+  if (preview == null) return null;
+
+  const busy = props.pending === true || props.validating === true;
+  const canImport = preview.analysis.rows.length > 0 && preview.analysis.invalidCount === 0 && !busy;
+  const visibleRows = preview.plan.rows.slice(0, 10);
+  const hiddenRowCount = preview.plan.rows.length - visibleRows.length;
+
+  return (
+    <section aria-labelledby="import-preview-heading" className="space-y-4">
+      <div>
+        <h2 id="import-preview-heading" className="text-title font-bold text-ink">
+          Review import
+        </h2>
+        <p className="mt-1 break-words text-caption text-ink-muted">
+          Deck: <strong className="text-ink">{preview.deckName}</strong>
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-surface border border-border bg-surface-muted p-3">
+          <h3 className="font-semibold text-ink">Validation</h3>
+          <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption text-ink-muted">
+            <li>{preview.analysis.rows.length} valid</li>
+            <li>{preview.analysis.skippedRows.length} skipped</li>
+            <li>{preview.analysis.invalidCount} invalid</li>
+          </ul>
+        </div>
+        <div className="rounded-surface border border-border bg-surface-muted p-3">
+          <h3 className="font-semibold text-ink">Planned changes</h3>
+          <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption text-ink-muted">
+            <li>{preview.plan.created} create</li>
+            <li>{preview.plan.updated} update</li>
+            <li>{preview.plan.unchanged} unchanged</li>
+          </ul>
+        </div>
+      </div>
+
+      {preview.analysis.issues.length > 0 ? (
+        <div role="alert" className="rounded-surface border border-danger bg-surface-muted p-3 text-caption text-ink">
+          <h3 className="font-semibold">Fix these CSV rows</h3>
+          <ul className="mt-2 space-y-2">
+            {preview.analysis.issues.map((issue) => (
+              <li key={`${issue.rowNumber ?? "file"}-${issue.message}-${issue.context ?? ""}`}>
+                <span className="font-semibold">{issue.rowNumber == null ? "File" : `Row ${issue.rowNumber}`}:</span>{" "}
+                {issue.message}
+                {issue.context == null ? null : (
+                  <code className="mt-1 block overflow-x-auto whitespace-pre-wrap text-ink-muted">{issue.context}</code>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {visibleRows.length > 0 ? (
+        <div className="overflow-x-auto rounded-surface border border-border">
+          <table className="w-full min-w-max border-collapse text-left text-caption text-ink">
+            <thead className="bg-surface-muted">
+              <tr>
+                <th className="px-3 py-2">Row</th>
+                <th className="px-3 py-2">Action</th>
+                <th className="px-3 py-2">Front</th>
+                <th className="px-3 py-2">Back</th>
+                <th className="px-3 py-2">Tags</th>
+                <th className="px-3 py-2">uniqueKey</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleRows.map((row) => (
+                <tr key={row.rowNumber} className="border-t border-border">
+                  <td className="px-3 py-2">{row.rowNumber}</td>
+                  <td className="px-3 py-2 capitalize">{row.action}</td>
+                  <td className="max-w-64 break-words px-3 py-2">{row.card.frontText}</td>
+                  <td className="max-w-64 break-words px-3 py-2">{row.card.backText}</td>
+                  <td className="px-3 py-2">{row.card.tags.join(", ")}</td>
+                  <td className="px-3 py-2">{row.card.uniqueKey}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+      {hiddenRowCount > 0 ? (
+        <p className="text-caption text-ink-muted">{hiddenRowCount} more valid rows are not shown.</p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="primary"
+          disabled={!canImport}
+          loading={props.pending ?? false}
+          {...(props.onImport !== undefined ? { onClick: props.onImport } : {})}
+        >
+          Import
+        </Button>
+        {preview.analysis.invalidCount > 0 ? (
+          <p className="text-caption text-ink-muted">Choose a corrected CSV file to continue.</p>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export const DeckImportTemplate: React.FC<DeckImportTemplateProps> = (props) => {
+  const busy = props.pending === true || props.validating === true;
+
   return (
     <Layout showHeader {...props.layout}>
       <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
         <h1 className="mb-section-gap break-words text-display font-bold text-ink">Import decks</h1>
-        {props.feedbackSlot}
         <div className="space-y-section-gap">
+          {props.validating ? (
+            <p role="status" className="text-caption text-ink-muted">
+              Validating CSV…
+            </p>
+          ) : props.pending ? (
+            <p role="status" className="text-caption text-ink-muted">
+              Importing…
+            </p>
+          ) : null}
+          <ImportResult
+            result={props.result}
+            partialResult={props.partialResult}
+            error={props.error}
+            onRetry={props.onRetry}
+            onBack={props.onBack}
+          />
           <section>
             <h2 className="mb-3 break-words text-title font-bold text-ink">Choose a CSV file</h2>
             <Upload
-              {...(props.pending !== undefined ? { disabled: props.pending } : {})}
+              disabled={busy}
+              {...(props.preview !== undefined ? { fileName: props.preview.fileName } : {})}
               {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
             />
           </section>
+          <ImportPreview
+            preview={props.preview}
+            pending={props.pending}
+            validating={props.validating}
+            onImport={props.onImport}
+          />
           <section>
             <h2 className="mb-2 break-words text-title font-bold text-ink">CSV format</h2>
-            <Description>{`There are 3 columns without header: front text, back text, and tags (optional).`}</Description>
+            <div className="space-y-2">
+              <Description>
+                Four columns without a header: front text, back text, tags (optional), and uniqueKey.
+              </Description>
+              <Description>
+                uniqueKey is required. Keep it stable to update the same card and avoid duplicates when importing again.
+              </Description>
+            </div>
           </section>
           <section>
             <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
@@ -36,7 +256,7 @@ export const DeckImportTemplate: React.FC<{
               <div className="flex flex-wrap gap-2">
                 <Button
                   size="sm"
-                  {...(props.pending !== undefined ? { disabled: props.pending } : {})}
+                  disabled={busy}
                   {...(props.onAddSample !== undefined ? { onClick: props.onAddSample } : {})}
                 >
                   Add sample deck

--- a/src/features/import/containers/DeckImportContainer.spec.tsx
+++ b/src/features/import/containers/DeckImportContainer.spec.tsx
@@ -1,26 +1,41 @@
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { DeckImportPreview, DeckImportResult } from "@/features/import/components/deckImportTypes";
+
 const mocks = vi.hoisted(() => ({
-  importFile: vi.fn(),
+  selectFile: vi.fn(),
+  importPreview: vi.fn(),
   addSample: vi.fn(),
+  retry: vi.fn(),
   navigate: vi.fn(),
   deckDownloadCsvSampleText: vi.fn(),
   goToTop: vi.fn(),
   goToSettings: vi.fn(),
   useKey: vi.fn(),
+  preview: undefined as DeckImportPreview | undefined,
+  data: undefined as DeckImportResult | undefined,
+  partialResult: undefined as DeckImportResult | undefined,
+  pending: false,
+  validating: false,
+  error: null as unknown,
 }));
 
 vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
 vi.mock("@/features/import/hooks/useDeckImport", () => ({
   useDeckImport: () => ({
-    importFile: mocks.importFile,
+    selectFile: mocks.selectFile,
+    importPreview: mocks.importPreview,
     addSample: mocks.addSample,
-    pending: false,
-    error: null,
-    retry: vi.fn(),
+    retry: mocks.retry,
+    preview: mocks.preview,
+    data: mocks.data,
+    partialResult: mocks.partialResult,
+    pending: mocks.pending,
+    validating: mocks.validating,
+    error: mocks.error,
   }),
 }));
 
@@ -42,39 +57,88 @@ vi.mock("@/hooks/useActions", () => ({
 
 import { DeckImportContainer } from "@/features/import/containers/DeckImportContainer";
 
+const preview = {
+  fileName: "deck.csv",
+  deckName: "deck.csv",
+  analysis: {
+    rows: [
+      {
+        rowNumber: 1,
+        card: { frontText: "front", backText: "back", tags: [], uniqueKey: "key" },
+      },
+    ],
+    skippedRows: [],
+    issues: [],
+    invalidCount: 0,
+  },
+  plan: {
+    rows: [
+      {
+        rowNumber: 1,
+        card: { frontText: "front", backText: "back", tags: [], uniqueKey: "key" },
+        action: "create",
+      },
+    ],
+    created: 1,
+    updated: 0,
+    unchanged: 0,
+  },
+} satisfies DeckImportPreview;
+
 describe("DeckImportContainer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.importFile.mockResolvedValue({});
+    mocks.selectFile.mockResolvedValue(preview);
+    mocks.importPreview.mockResolvedValue({});
     mocks.addSample.mockResolvedValue({});
+    mocks.preview = undefined;
+    mocks.data = undefined;
+    mocks.partialResult = undefined;
+    mocks.pending = false;
+    mocks.validating = false;
+    mocks.error = null;
   });
 
-  afterEach(() => {
-    cleanup();
-  });
+  afterEach(cleanup);
 
-  it("wires CSV upload, sample download, and navigation shortcuts", async () => {
+  it("selects a CSV without importing or navigating automatically", async () => {
     const view = render(<DeckImportContainer />);
-    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
+    const file = new File(["front,back,,key"], "deck.csv", { type: "text/csv" });
 
     fireEvent.change(view.container.querySelector("input[type='file']") as Element, {
       target: { files: [file] },
     });
-    await userEvent.click(view.getByText("download"));
+    await userEvent.click(view.getByRole("button", { name: "Download CSV sample" }));
 
-    expect(mocks.importFile).toHaveBeenCalledWith(file);
-    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith(-1));
+    expect(mocks.selectFile).toHaveBeenCalledWith(file);
+    expect(mocks.importPreview).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
     expect(mocks.deckDownloadCsvSampleText).toHaveBeenCalledOnce();
     expect(mocks.useKey).toHaveBeenCalledWith("t", mocks.goToTop);
     expect(mocks.useKey).toHaveBeenCalledWith("s", mocks.goToSettings);
   });
 
-  it("adds the bundled sample through the import operation", async () => {
+  it("adds the bundled sample without navigating automatically", async () => {
     const view = render(<DeckImportContainer />);
 
     await userEvent.click(view.getByRole("button", { name: "Add sample deck" }));
 
     expect(mocks.addSample).toHaveBeenCalledOnce();
-    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith(-1));
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("imports the preview explicitly and navigates only from Back to decks", async () => {
+    mocks.preview = preview;
+    mocks.data = { created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" };
+    const view = render(<DeckImportContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Import" }));
+
+    expect(mocks.importPreview).toHaveBeenCalledOnce();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+
+    await userEvent.click(view.getByRole("button", { name: "Back to decks" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith(-1);
   });
 });

--- a/src/features/import/containers/DeckImportContainer.tsx
+++ b/src/features/import/containers/DeckImportContainer.tsx
@@ -5,7 +5,6 @@ import * as C from "@/constant";
 import { DeckImportTemplate } from "@/features/import/components/templates/DeckImportTemplate";
 import { useActions } from "@/hooks/useActions";
 import { useDeckImport } from "@/features/import/hooks/useDeckImport";
-import { RemoteMutationNotice } from "@/components";
 import { useConfig } from "@/hooks/useConfig";
 
 export const DeckImportContainer: React.FC = () => {
@@ -19,22 +18,23 @@ export const DeckImportContainer: React.FC = () => {
   return (
     <DeckImportTemplate
       onChange={(file) => {
-        void deckImport
-          .importFile(file)
-          .then(() => navigate(-1))
-          .catch(() => undefined);
+        void deckImport.selectFile(file).catch(() => undefined);
       }}
       onAddSample={() => {
-        void deckImport
-          .addSample()
-          .then(() => navigate(-1))
-          .catch(() => undefined);
+        void deckImport.addSample().catch(() => undefined);
       }}
+      onImport={() => {
+        void deckImport.importPreview().catch(() => undefined);
+      }}
+      onRetry={deckImport.retry}
+      onBack={() => navigate(-1)}
       onDownloadSample={actions.deckDownloadCsvSampleText}
+      validating={deckImport.validating}
       pending={deckImport.pending}
-      feedbackSlot={
-        <RemoteMutationNotice pending={deckImport.pending} error={deckImport.error} onRetry={deckImport.retry} />
-      }
+      {...(deckImport.preview !== undefined ? { preview: deckImport.preview } : {})}
+      {...(deckImport.data !== undefined ? { result: deckImport.data } : {})}
+      {...(deckImport.partialResult !== undefined ? { partialResult: deckImport.partialResult } : {})}
+      error={deckImport.error}
       dark={config.darkMode}
       sampleText={C.CSV_SAMPLE_TEXT}
       layout={{

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createQueryWrapper, createTestQueryClient } from "@/query/testUtils";
 import { createCard, createConfig, createDeck } from "@/test/factories";
-import type { DeckImportResult } from "@/features/import/hooks/useDeckImport";
+import type { DeckImportResult } from "@/features/import/components/deckImportTypes";
+import { CardBulkMutationError } from "@/query/cardMutationService";
 
 const mocks = vi.hoisted(() => ({
   config: {} as ConfigState,
@@ -52,19 +53,80 @@ describe("useDeckImport", () => {
     mocks.bulkUpsert.mockResolvedValue(undefined);
   });
 
-  it("awaits Deck creation and Card upsert as one import operation", async () => {
+  it("previews a file without writing until import is confirmed", async () => {
     const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
-    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
     let imported: DeckImportResult | undefined;
 
     await act(async () => {
-      imported = await result.current.importFile(file);
+      await result.current.selectFile(file);
     });
 
+    expect(result.current.preview).toMatchObject({
+      fileName: "deck.csv",
+      deckName: "deck.csv",
+      analysis: { invalidCount: 0 },
+      plan: { created: 1, updated: 0, unchanged: 0 },
+    });
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+
+    await act(async () => {
+      imported = await result.current.importPreview();
+    });
     expect(mocks.createDeck).toHaveBeenCalledOnce();
     expect(mocks.prepareDeck).toHaveBeenCalledWith({ name: "deck.csv" }, "uid-a");
     expect(mocks.bulkUpsert).toHaveBeenCalledWith([expect.objectContaining({ id: "card" })]);
     expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" });
+  });
+
+  it("keeps invalid files in preview without mutating state", async () => {
+    const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const file = new File(["front,back"], "invalid.csv", { type: "text/csv" });
+
+    await act(async () => {
+      await result.current.selectFile(file);
+    });
+
+    expect(result.current.preview).toMatchObject({
+      analysis: {
+        rows: [],
+        invalidCount: 1,
+        issues: [expect.objectContaining({ rowNumber: 1, message: "Expected 4 columns, found 2." })],
+      },
+    });
+    await expect(result.current.importPreview()).rejects.toThrow("Fix invalid CSV rows");
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("skips an identical CSV re-import by uniqueKey", async () => {
+    mocks.decks = [createDeck({ id: "deck", name: "deck.csv", uid: "uid-a" })];
+    mocks.cards = [
+      createCard({
+        id: "existing",
+        deckId: "deck",
+        frontText: "front",
+        backText: "back",
+        tags: [],
+        uniqueKey: "key",
+      }),
+    ];
+    const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+    let imported: DeckImportResult | undefined;
+
+    await act(async () => {
+      await result.current.selectFile(file);
+    });
+    await act(async () => {
+      imported = await result.current.importPreview();
+    });
+
+    expect(result.current.preview?.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+    expect(imported).toEqual({ created: 0, updated: 0, skipped: 1, failed: 0, deckId: "deck" });
   });
 
   it("adds the bundled sample with a stable per-user Deck id", async () => {
@@ -100,21 +162,47 @@ describe("useDeckImport", () => {
   });
 
   it("rejects a second import while the first is pending", async () => {
-    let finish!: (cards: CardRaw[]) => void;
-    mocks.parseCsv.mockReturnValueOnce(new Promise((resolve) => (finish = resolve)));
+    let finish!: () => void;
+    mocks.bulkUpsert.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));
     const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
-    const file = new File(["front,back"], "deck.csv", { type: "text/csv" });
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await act(async () => {
+      await result.current.selectFile(file);
+    });
 
     let first: Promise<DeckImportResult> | undefined;
     act(() => {
-      first = result.current.importFile(file);
+      first = result.current.importPreview();
     });
     await waitFor(() => expect(result.current.pending).toBe(true));
-    await expect(result.current.importFile(file)).rejects.toThrow("already running");
+    await expect(result.current.importPreview()).rejects.toThrow("already running");
     await act(async () => {
-      finish([]);
+      finish();
       await first;
     });
     expect(result.current.pending).toBe(false);
+  });
+
+  it("retains successful and failed counts after a partial Card write failure", async () => {
+    mocks.prepareCard.mockReturnValue(createCard({ id: "card", deckId: "deck", uniqueKey: "key" }));
+    mocks.bulkUpsert.mockRejectedValueOnce(new CardBulkMutationError(["card"], 1));
+    const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await act(async () => {
+      await result.current.selectFile(file);
+    });
+    await act(async () => {
+      await expect(result.current.importPreview()).rejects.toThrow("did not complete");
+    });
+
+    expect(result.current.partialResult).toEqual({
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      failed: 1,
+      deckId: "deck",
+    });
   });
 });

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -8,21 +8,35 @@ import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
 import { CardBulkMutationError } from "@/query/cardMutationService";
 import { useConfig } from "@/hooks/useConfig";
+import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/components/deckImportTypes";
+import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
 import sampleCards from "../../../../sample/build/output.json";
 
-export interface DeckImportResult {
-  created: number;
-  updated: number;
-  skipped: number;
-  failed: number;
-  deckId: DeckId;
-}
-
-type ImportRequest = { kind: "content"; name: string; content: string | File } | { kind: "sample" };
+type ImportRequest = { kind: "content"; name: string; rows: DeckImportRow[] } | { kind: "sample" };
 
 const SAMPLE_DECK_NAME = "Sample Deck";
 const SAMPLE_VERSION = 1;
 export const sampleDeckId = (uid: string): DeckId => `sample-v${SAMPLE_VERSION}-${uid}`;
+
+const rowsFromCards = (cards: CardRaw[]): DeckImportRow[] =>
+  cards.map((card, index) => ({ rowNumber: index + 1, card }));
+
+const partialResultFrom = (error: unknown): DeckImportResult | undefined => {
+  if (error == null || typeof error !== "object" || !("result" in error)) return undefined;
+  const result = error.result;
+  if (
+    result == null ||
+    typeof result !== "object" ||
+    !("created" in result) ||
+    !("updated" in result) ||
+    !("skipped" in result) ||
+    !("failed" in result) ||
+    !("deckId" in result)
+  ) {
+    return undefined;
+  }
+  return result as DeckImportResult;
+};
 
 export const useDeckImport = () => {
   const auth = useAuth();
@@ -32,6 +46,8 @@ export const useDeckImport = () => {
   const cardMutations = useCardMutations();
   const runningRef = useRef(false);
   const [running, setRunning] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [preview, setPreview] = useState<DeckImportPreview>();
   const lastRequest = useRef<ImportRequest>(undefined);
 
   const operation = useMutation({
@@ -41,8 +57,7 @@ export const useDeckImport = () => {
       if (uid === "") throw new Error("A confirmed user is required for imports");
       const name = request.kind === "sample" ? SAMPLE_DECK_NAME : request.name;
       const preferredDeckId = request.kind === "sample" ? sampleDeckId(uid) : undefined;
-      const rawCards =
-        request.kind === "sample" ? (sampleCards as CardRaw[]) : await action.deck.parseCsv(request.content);
+      const rows = request.kind === "sample" ? rowsFromCards(sampleCards as CardRaw[]) : request.rows;
       let deck = remote.decks.find((candidate) =>
         preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId
       );
@@ -54,29 +69,19 @@ export const useDeckImport = () => {
 
       const existing = remote.cardsByDeckId(deck.id);
       const byUniqueKey = new Map(existing.map((card) => [card.uniqueKey, card]));
+      const plan = buildDeckImportPlan(rows, existing);
       const upserts: Card[] = [];
       const createdIds = new Set<CardId>();
       const updatedIds = new Set<CardId>();
-      let created = 0;
-      let updated = 0;
-      let skipped = 0;
-      rawCards.forEach((raw) => {
-        const current = byUniqueKey.get(raw.uniqueKey);
-        if (current == null) {
-          const card = action.card.prepare(raw, deck);
+      plan.rows.forEach((row) => {
+        const current = byUniqueKey.get(row.card.uniqueKey);
+        if (row.action === "create") {
+          const card = action.card.prepare(row.card, deck);
           upserts.push(card);
           createdIds.add(card.id);
-          created += 1;
-        } else if (
-          current.frontText === raw.frontText &&
-          current.backText === raw.backText &&
-          current.tags.join("\0") === raw.tags.join("\0")
-        ) {
-          skipped += 1;
-        } else {
-          upserts.push({ ...current, ...raw });
+        } else if (row.action === "update" && current != null) {
+          upserts.push({ ...current, ...row.card });
           updatedIds.add(current.id);
-          updated += 1;
         }
       });
       try {
@@ -88,13 +93,19 @@ export const useDeckImport = () => {
           result: {
             created: [...createdIds].filter((id) => !failed.has(id)).length,
             updated: [...updatedIds].filter((id) => !failed.has(id)).length,
-            skipped,
+            skipped: plan.unchanged,
             failed: failed.size,
             deckId: deck.id,
           },
         });
       }
-      return { created, updated, skipped, failed: 0, deckId: deck.id };
+      return {
+        created: plan.created,
+        updated: plan.updated,
+        skipped: plan.unchanged,
+        failed: 0,
+        deckId: deck.id,
+      };
     },
   });
 
@@ -114,6 +125,43 @@ export const useDeckImport = () => {
     [operation]
   );
 
+  const selectFile = useCallback(
+    async (file: File) => {
+      if (runningRef.current) throw new Error("A Deck import is already running");
+      setValidating(true);
+      setPreview(undefined);
+      operation.reset();
+      try {
+        const analysis = await parseDeckImportCsv(file);
+        const deck = remote.decks.find((candidate) => candidate.name === file.name);
+        const existing = deck == null ? [] : remote.cardsByDeckId(deck.id);
+        const next = {
+          fileName: file.name,
+          deckName: file.name,
+          analysis,
+          plan: buildDeckImportPlan(analysis.rows, existing),
+        };
+        setPreview(next);
+        return next;
+      } finally {
+        setValidating(false);
+      }
+    },
+    [operation, remote]
+  );
+
+  const importPreview = useCallback(() => {
+    if (runningRef.current) return Promise.reject(new Error("A Deck import is already running"));
+    if (preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
+    if (preview.analysis.invalidCount > 0) {
+      return Promise.reject(new Error("Fix invalid CSV rows before importing"));
+    }
+    if (preview.analysis.rows.length === 0) {
+      return Promise.reject(new Error("The CSV file has no valid rows"));
+    }
+    return run({ kind: "content", name: preview.deckName, rows: preview.analysis.rows });
+  }, [preview, run]);
+
   const importUrl = useCallback(
     async (url: string, name?: string) => {
       const headers: Record<string, string> = {};
@@ -123,10 +171,11 @@ export const useDeckImport = () => {
       }
       const response = await fetch(url, { headers });
       if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
+      const cards = await action.deck.parseCsv(await response.text());
       return await run({
         kind: "content",
         name: name ?? url.split("/").pop() ?? "no name",
-        content: await response.text(),
+        rows: rowsFromCards(cards),
       });
     },
     [config.githubAccessToken, run]
@@ -138,16 +187,20 @@ export const useDeckImport = () => {
   }, [run]);
 
   return {
-    importFile: (file: File) => run({ kind: "content", name: file.name, content: file }),
+    selectFile,
+    importPreview,
     addSample: () => run({ kind: "sample" }),
     importUrl,
     reimport: (deck: Deck) => {
       if (deck.url == null || deck.url === "") return Promise.reject(new Error("Deck has no import URL"));
       return importUrl(deck.url, deck.name);
     },
+    preview,
+    validating,
     pending: operation.isPending || running,
     error: operation.error,
     data: operation.data,
+    partialResult: partialResultFrom(operation.error),
     retry,
   };
 };

--- a/src/features/import/lib/deckImportAnalysis.spec.ts
+++ b/src/features/import/lib/deckImportAnalysis.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
+import { createCard } from "@/test/factories";
+
+describe("parseDeckImportCsv", () => {
+  it("separates valid, skipped, and invalid rows with context", async () => {
+    const result = await parseDeckImportCsv(
+      '"front","back","tag","key-1"\n\n"missing","columns"\n"other","back","",""'
+    );
+
+    expect(result.rows).toEqual([
+      {
+        rowNumber: 1,
+        card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
+      },
+    ]);
+    expect(result.skippedRows).toEqual([2]);
+    expect(result.invalidCount).toBe(2);
+    expect(result.issues).toEqual([
+      {
+        rowNumber: 3,
+        message: "Expected 4 columns, found 2.",
+        context: '["missing","columns"]',
+      },
+      {
+        rowNumber: 4,
+        message: "uniqueKey is required.",
+        context: '["other","back","",""]',
+      },
+    ]);
+  });
+
+  it("rejects an empty file", async () => {
+    const result = await parseDeckImportCsv("");
+
+    expect(result.rows).toEqual([]);
+    expect(result.invalidCount).toBe(1);
+    expect(result.issues).toContainEqual({ message: "The CSV file is empty." });
+  });
+
+  it("reports duplicate unique keys with row context", async () => {
+    const result = await parseDeckImportCsv('"one","back","","same"\n"two","back","","same"');
+
+    expect(result.issues).toContainEqual({
+      rowNumber: 2,
+      message: 'uniqueKey "same" is duplicated in this file.',
+      context: '["two","back","","same"]',
+    });
+  });
+
+  it("reports CSV parse errors with row context", async () => {
+    const result = await parseDeckImportCsv('"one","back","","key"\n"unterminated');
+
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        rowNumber: 2,
+        context: expect.stringContaining("unterminated"),
+      }),
+    ]);
+  });
+});
+
+describe("buildDeckImportPlan", () => {
+  const rows = [
+    {
+      rowNumber: 1,
+      card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
+    },
+  ];
+
+  it("plans an initial import as a create", () => {
+    expect(buildDeckImportPlan(rows, [])).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
+  });
+
+  it("plans an identical re-import as unchanged", () => {
+    expect(buildDeckImportPlan(rows, [createCard(rows[0]?.card)])).toMatchObject({
+      created: 0,
+      updated: 0,
+      unchanged: 1,
+    });
+  });
+
+  it("plans changed content with the same unique key as an update", () => {
+    expect(
+      buildDeckImportPlan(rows, [createCard({ ...rows[0]?.card, frontText: "previous front", uniqueKey: "key-1" })])
+    ).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
+  });
+});

--- a/src/features/import/lib/deckImportAnalysis.ts
+++ b/src/features/import/lib/deckImportAnalysis.ts
@@ -1,0 +1,112 @@
+import * as Papa from "papaparse";
+
+import * as cardAction from "@/action/card";
+import type {
+  DeckImportAnalysis,
+  DeckImportIssue,
+  DeckImportPlan,
+  DeckImportPlanRow,
+  DeckImportRow,
+} from "@/features/import/components/deckImportTypes";
+
+const rowContext = (columns: string[]) => JSON.stringify(columns);
+
+const sameCardContent = (left: CardRaw, right: CardRaw) =>
+  left.frontText === right.frontText &&
+  left.backText === right.backText &&
+  left.tags.join("\0") === right.tags.join("\0");
+
+export const parseDeckImportCsv = async (content: string | File): Promise<DeckImportAnalysis> => {
+  const parsed = await new Promise<Papa.ParseResult<string[]>>((resolve, reject) => {
+    Papa.parse<string[]>(content, { delimiter: ",", complete: resolve, error: reject });
+  });
+  const rows: DeckImportRow[] = [];
+  const skippedRows: number[] = [];
+  const issues: DeckImportIssue[] = [];
+  const invalidRows = new Set<number>();
+  const parseErrorRows = new Set<number>();
+  const uniqueKeys = new Set<string>();
+  let fileIssueCount = 0;
+
+  parsed.errors.forEach((error) => {
+    if (error.row == null) {
+      fileIssueCount += 1;
+      issues.push({ message: error.message });
+      return;
+    }
+    const rowNumber = error.row + 1;
+    invalidRows.add(rowNumber);
+    parseErrorRows.add(error.row);
+    issues.push({
+      rowNumber,
+      message: error.message,
+      context: rowContext(parsed.data[error.row] ?? []),
+    });
+  });
+
+  parsed.data.forEach((columns, index) => {
+    const rowNumber = index + 1;
+    if (parseErrorRows.has(index)) return;
+    if (columns.every((column) => column.trim() === "")) {
+      skippedRows.push(rowNumber);
+      return;
+    }
+    if (columns.length !== 4) {
+      invalidRows.add(rowNumber);
+      issues.push({
+        rowNumber,
+        message: `Expected 4 columns, found ${columns.length}.`,
+        context: rowContext(columns),
+      });
+      return;
+    }
+
+    const card = cardAction.fromRow(columns);
+    card.uniqueKey = card.uniqueKey.trim();
+    if (card.uniqueKey === "") {
+      invalidRows.add(rowNumber);
+      issues.push({ rowNumber, message: "uniqueKey is required.", context: rowContext(columns) });
+      return;
+    }
+    if (uniqueKeys.has(card.uniqueKey)) {
+      invalidRows.add(rowNumber);
+      issues.push({
+        rowNumber,
+        message: `uniqueKey "${card.uniqueKey}" is duplicated in this file.`,
+        context: rowContext(columns),
+      });
+      return;
+    }
+
+    uniqueKeys.add(card.uniqueKey);
+    rows.push({ rowNumber, card });
+  });
+
+  if (rows.length === 0 && issues.length === 0) {
+    fileIssueCount += 1;
+    issues.push({ message: "The CSV file is empty." });
+  }
+
+  return {
+    rows,
+    skippedRows,
+    issues,
+    invalidCount: invalidRows.size + fileIssueCount,
+  };
+};
+
+export const buildDeckImportPlan = (rows: DeckImportRow[], existingCards: Card[]): DeckImportPlan => {
+  const existingByUniqueKey = new Map(existingCards.map((card) => [card.uniqueKey, card]));
+  const plannedRows = rows.map((row): DeckImportPlanRow => {
+    const existing = existingByUniqueKey.get(row.card.uniqueKey);
+    const plannedAction = existing == null ? "create" : sameCardContent(existing, row.card) ? "unchanged" : "update";
+    return { ...row, action: plannedAction };
+  });
+
+  return {
+    rows: plannedRows,
+    created: plannedRows.filter((row) => row.action === "create").length,
+    updated: plannedRows.filter((row) => row.action === "update").length,
+    unchanged: plannedRows.filter((row) => row.action === "unchanged").length,
+  };
+};


### PR DESCRIPTION
## Summary

- add side-effect-free CSV validation and create/update/unchanged preview before import
- document the four-column CSV contract and require a stable uniqueKey for idempotent re-imports
- keep success and partial-failure counts visible with explicit retry and back actions
- add focused tests for first import, identical re-import, invalid input, duplicate submission, and partial failure

## Validation

- `make check` (95 test files, 531 tests)
- Storybook visual QA for preview, invalid input, success, and partial failure states

Closes #207
Related to #203