### PR TITLE
Unify route and operation feedback

### DIFF
--- a/docs/20260719-route-operation-feedback-design.md
+++ b/docs/20260719-route-operation-feedback-design.md
@@ -164,4 +164,3 @@ Use test-driven development for every behavior change.
 - Study completion or onboarding behavior, which remains owned by #208.
 - Changes to Firebase auth providers, Firestore schema, query ownership, or mutation retry policy.
 - A new global notification queue or application workflow store.
-

--- a/docs/20260719-route-operation-feedback-design.md
+++ b/docs/20260719-route-operation-feedback-design.md
@@ -31,8 +31,8 @@ Extend the existing feedback boundary instead of introducing a new global workfl
 2. Gate the router on Firebase-confirmed auth state. Initializing and anonymous bootstrap display `Starting Tango…`; an auth failure displays a reload action. `AuthBootstrap` remains responsible for remote subscription lifecycle.
 3. Add a wildcard route and use the shared surface for unknown URLs. Missing Deck/Card containers pass a shared recovery surface into `RemoteReadBoundary` rather than returning a bare status string.
 4. Keep cached remote content mounted during listener failures. `RemoteReadBoundary` continues to own Retry and non-destructive sync-error behavior.
-5. Add a settings-owned account-operation hook for Login and Logout pending, failure, and retry state. Presentation receives pending and feedback props; it does not import Firebase or application actions.
-6. Prevent a second Deck mutation for the same Deck while one is active and disable that Deck row's actions until the operation settles.
+5. Add a settings-owned account-operation hook for Login and Logout pending, failure, and retry state. Its module-scope controller survives a Logout-driven Settings unmount, but feedback may cross at most one auth-generation handoff.
+6. Prevent a second Deck mutation for the same Deck while one is active, disable that Deck row's actions until the operation settles, and let the mutation hook own successful removal cleanup for both initial attempts and Retry.
 7. Add Storybook stories for route feedback, remote-read states, and mutation states, plus focused unit and browser tests for recovery paths.
 
 ## Alternatives Considered
@@ -81,10 +81,18 @@ This is the selected approach. It preserves current state ownership, adds only p
 ### Account operation hook
 
 - Lives with settings hooks and wraps the existing `login` and `logout` actions.
-- Stores only operation-local kind, pending state, last error, and the last failed operation for Retry.
+- Uses a module-scope controller so an in-flight Logout and its feedback survive the Settings unmount caused by sign-out.
+- Stores operation-local kind, pending state, last error, and the last failed operation for Retry. Failed-operation metadata distinguishes a full Logout that may still sign out from a cleanup continuation that cannot.
 - Ignores a repeated request while an account operation is already running.
 - Clears a previous error when a new attempt starts.
-- Does not alter the existing Firebase auth or cleanup lifecycle.
+- Resets stale settled feedback when Settings is left or the auth generation changes, except for one bounded handoff of a post-sign-out cleanup failure to the next Settings mount. StrictMode remounts do not duplicate or prematurely reset the operation.
+
+### Logout action
+
+- `src/action/event.ts` signs out before starting query and study cleanup.
+- Cleanup progress is phase-aware: Retry skips sign-out and any cleanup phase that already succeeded.
+- The study cleanup continuation records the state produced by clearing and does not clear again if a new auth generation has already created different study state.
+- A cleanup failure exposes its continuation on the error, while an ordinary sign-out failure retries the original full Logout.
 
 ### `ConfigForm`
 
@@ -96,6 +104,7 @@ This is the selected approach. It preserves current state ownership, adds only p
 
 - `useDeckMutations` tracks active Deck IDs before starting the asynchronous mutation.
 - A repeated mutation request for an active Deck ID is ignored.
+- Its optional latest-ref `onRemoveSuccess(deck)` callback belongs to the hook operation, so initial removal and Retry perform the same study cleanup even if the Deck list unmounts before success.
 - `DeckCard` receives entity-specific pending state, marks the row busy, and disables navigation and the actions menu for that Deck.
 - Other Deck rows remain usable.
 
@@ -122,16 +131,18 @@ This is the selected approach. It preserves current state ownership, adds only p
 ### Account operation
 
 1. The user selects Login or Logout.
-2. The settings hook records the operation as pending before calling the existing action.
+2. The module-scope settings controller records the operation as pending before calling the existing action and reuses its exact Promise for duplicate requests.
 3. The button becomes loading/disabled and the shared notice announces progress.
-4. Success clears local operation state. Failure keeps Settings mounted and displays Retry.
+4. Logout signs out first, then runs query and study cleanup. A cleanup Retry resumes only unfinished cleanup and cannot sign out again.
+5. A post-sign-out cleanup failure may cross the resulting auth-generation change once; a later Settings departure or unrelated generation clears it.
+6. Success clears local operation state. Failure keeps or restores Settings feedback with Retry.
 
 ### Deck deletion
 
 1. Confirmation remains required.
 2. The mutation hook marks the Deck ID active before calling the mutation service.
 3. The selected Deck row becomes busy and non-interactive.
-4. Success removes the associated study session. Failure preserves the row and displays a retryable deletion error.
+4. Every successful remove attempt invokes the hook-owned latest success callback and removes the associated study session. Failure does not run cleanup and displays a retryable deletion error.
 
 ## Error Handling
 
@@ -140,7 +151,8 @@ This is the selected approach. It preserves current state ownership, adds only p
 - Listener failure with cached data remains non-destructive and displays Retry beside current content.
 - Missing entity feedback is shown only after a successful read. Query/existence-check failures stay errors.
 - Login, Logout, save, import, and delete failures remain operation-local; they do not navigate away or clear user input.
-- Retry replays only the last failed operation owned by that hook.
+- Account Retry preserves whether the failed operation can still sign out; cleanup continuations never regain an auth handoff.
+- Deck Retry replays only the last failed mutation and owns the same remove-success cleanup as the initial attempt.
 
 ## Testing
 
@@ -150,8 +162,8 @@ Use test-driven development for every behavior change.
 - `App`: startup gating, auth failure Reload, normal routing, and wildcard route recovery.
 - `RemoteReadBoundary`: shared loading/error surface, cached non-destructive error, caller-provided not-found content, and Retry.
 - Missing Deck/Card containers: not-found appears only after a successful read and recovery actions are wired.
-- Account hook and Settings: pending blocks duplicate Login/Logout, failure remains visible, and Retry replays the failed operation.
-- Deck mutation and Deck card: same-Deck duplicates are blocked while other rows remain enabled.
+- Account hook, `action/event.ts`, `AuthLogout.integration.spec.tsx`, and Settings: pending blocks duplicates, StrictMode preserves exact Promise reuse, Logout phases resume safely, and cleanup feedback crosses only its allowed auth handoff.
+- Deck mutation and Deck card: same-Deck duplicates are blocked, other rows remain enabled, and a successful Retry runs study cleanup once after hook unmount.
 - Storybook: representative loading, initial error, cached sync error, not-found, mutation pending, and mutation failure stories.
 - Playwright: unknown route and missing Deck recovery routes.
 - Repository verification: `make check` is required before completion.

--- a/docs/20260719-route-operation-feedback-design.md
+++ b/docs/20260719-route-operation-feedback-design.md
@@ -1,0 +1,167 @@
+# Route and Operation Feedback Design
+
+## Goal
+
+Finish Issue #205 against the current application architecture so startup, unknown routes, missing Deck/Card entities, remote read failures, account operations, and Deck deletion never leave the user with an unexplained or repeatable action.
+
+## Current State
+
+The Issue #205 background predates the completed Redux removal and component-directory flattening. There is no longer a `PersistGate`, and shared feedback components now live under `src/components/feedback`.
+
+The current application already has two useful foundations:
+
+- `RemoteReadBoundary` shows initial loading, retryable read failures, and non-destructive sync failures.
+- `RemoteMutationNotice` shows mutation pending and failure states while edit forms remain mounted.
+
+The remaining gaps are:
+
+- auth startup and auth failure are not represented by the route UI;
+- unknown routes render no route element;
+- missing Deck/Card routes show plain text without Home or Back recovery;
+- Login and Logout do not prevent repeated actions or expose failures;
+- Deck deletion can be requested again while the first request is pending;
+- the shared route and operation states are not represented in Storybook;
+- focused route recovery and account-operation tests are absent.
+
+## Selected Direction
+
+Extend the existing feedback boundary instead of introducing a new global workflow store.
+
+1. Add a stateless shared `RouteFeedback` presentation component for full-route loading, error, and not-found surfaces. It owns semantic Calm Focus presentation and receives all labels and callbacks through props.
+2. Gate the router on Firebase-confirmed auth state. Initializing and anonymous bootstrap display `Starting Tango…`; an auth failure displays a reload action. `AuthBootstrap` remains responsible for remote subscription lifecycle.
+3. Add a wildcard route and use the shared surface for unknown URLs. Missing Deck/Card containers pass a shared recovery surface into `RemoteReadBoundary` rather than returning a bare status string.
+4. Keep cached remote content mounted during listener failures. `RemoteReadBoundary` continues to own Retry and non-destructive sync-error behavior.
+5. Add a settings-owned account-operation hook for Login and Logout pending, failure, and retry state. Presentation receives pending and feedback props; it does not import Firebase or application actions.
+6. Prevent a second Deck mutation for the same Deck while one is active and disable that Deck row's actions until the operation settles.
+7. Add Storybook stories for route feedback, remote-read states, and mutation states, plus focused unit and browser tests for recovery paths.
+
+## Alternatives Considered
+
+### Duplicate feedback in each route container
+
+Each container could render its own heading, explanatory copy, and buttons. This minimizes changes to shared components but would immediately create different copy and accessibility behavior for Deck, Card, startup, and unknown-route states.
+
+### Introduce a global application workflow store
+
+A global store could own auth, route, read, and mutation feedback. It would centralize every status but would duplicate TanStack Query, Auth Context, React Hook Form, and feature-hook ownership. It would also make unrelated operations overwrite one another.
+
+### Extend the existing shared boundaries
+
+This is the selected approach. It preserves current state ownership, adds only presentation and operation-local state, and lets each feature pass the relevant action through props.
+
+## Components and Responsibilities
+
+### `RouteFeedback`
+
+- Lives in `src/components/feedback` and remains stateless.
+- Renders a route-sized Calm Focus surface with a heading, optional description, and up to two actions.
+- Uses `role="status"` for loading and `role="alert"` for blocking failures.
+- Accepts callbacks through props and does not import React Router, Query, Auth, Firebase, stores, or feature modules.
+
+### `RemoteReadBoundary`
+
+- Uses `RouteFeedback` for initial loading, blocking storage failure, and initial read failure.
+- Preserves the inline error notice when cached route content exists.
+- Accepts caller-provided empty content for entity-specific not-found recovery.
+- Keeps the existing string fallback for ordinary empty collections such as an empty Deck list.
+
+### `App`
+
+- Reads `AuthState` and does not mount route content until a Firebase user is confirmed.
+- Shows startup feedback for `initializing` and `signedOut` states.
+- Shows blocking auth feedback with Reload for `error`.
+- Adds a `*` route whose small router-aware adapter passes Home and Back callbacks to `RouteFeedback`.
+
+### Missing entity containers
+
+- Deck and Card route containers continue to determine existence from `useRemoteCollections`.
+- When a successful read does not contain the requested entity, they provide `RouteFeedback` with entity-specific copy and Home/Back callbacks.
+- Deck existence read errors introduced by #325 remain errors and must not be relabeled as not-found.
+
+### Account operation hook
+
+- Lives with settings hooks and wraps the existing `login` and `logout` actions.
+- Stores only operation-local kind, pending state, last error, and the last failed operation for Retry.
+- Ignores a repeated request while an account operation is already running.
+- Clears a previous error when a new attempt starts.
+- Does not alter the existing Firebase auth or cleanup lifecycle.
+
+### `ConfigForm`
+
+- Receives account pending state and a feedback slot through props.
+- Sets the active Login or Logout button to loading/disabled while the operation is pending.
+- Keeps all settings controls and auto-save behavior available.
+
+### Deck deletion
+
+- `useDeckMutations` tracks active Deck IDs before starting the asynchronous mutation.
+- A repeated mutation request for an active Deck ID is ignored.
+- `DeckCard` receives entity-specific pending state, marks the row busy, and disables navigation and the actions menu for that Deck.
+- Other Deck rows remain usable.
+
+### `RemoteMutationNotice`
+
+- Keeps its current default save copy.
+- Accepts optional pending and error labels so account and deletion operations can use accurate language without creating another notice component.
+
+## Interaction and Data Flow
+
+### Startup
+
+1. `AuthProvider` starts in `initializing`.
+2. `App` renders `RouteFeedback` with `Starting Tango…` while `AuthContext` observes Firebase and completes anonymous bootstrap.
+3. Once authenticated, `App` mounts the router. Route containers then use `RemoteReadBoundary` for remote initial loading.
+4. If auth fails, route content stays unmounted and Reload restarts the application lifecycle.
+
+### Unknown or missing route
+
+1. React Router selects the wildcard route, or a feature container completes a read without finding its entity.
+2. The adapter/container passes appropriate copy plus Home and Back callbacks to `RouteFeedback`.
+3. Back uses browser history when available; Home always navigates to `/`.
+
+### Account operation
+
+1. The user selects Login or Logout.
+2. The settings hook records the operation as pending before calling the existing action.
+3. The button becomes loading/disabled and the shared notice announces progress.
+4. Success clears local operation state. Failure keeps Settings mounted and displays Retry.
+
+### Deck deletion
+
+1. Confirmation remains required.
+2. The mutation hook marks the Deck ID active before calling the mutation service.
+3. The selected Deck row becomes busy and non-interactive.
+4. Success removes the associated study session. Failure preserves the row and displays a retryable deletion error.
+
+## Error Handling
+
+- Auth startup failure is blocking because no confirmed UID may start reads or writes; Reload is the recovery action.
+- Initial remote read failure replaces route content with Retry because there is no authoritative content to show.
+- Listener failure with cached data remains non-destructive and displays Retry beside current content.
+- Missing entity feedback is shown only after a successful read. Query/existence-check failures stay errors.
+- Login, Logout, save, import, and delete failures remain operation-local; they do not navigate away or clear user input.
+- Retry replays only the last failed operation owned by that hook.
+
+## Testing
+
+Use test-driven development for every behavior change.
+
+- `RouteFeedback`: semantic role, copy, and Home/Back callbacks.
+- `App`: startup gating, auth failure Reload, normal routing, and wildcard route recovery.
+- `RemoteReadBoundary`: shared loading/error surface, cached non-destructive error, caller-provided not-found content, and Retry.
+- Missing Deck/Card containers: not-found appears only after a successful read and recovery actions are wired.
+- Account hook and Settings: pending blocks duplicate Login/Logout, failure remains visible, and Retry replays the failed operation.
+- Deck mutation and Deck card: same-Deck duplicates are blocked while other rows remain enabled.
+- Storybook: representative loading, initial error, cached sync error, not-found, mutation pending, and mutation failure stories.
+- Playwright: unknown route and missing Deck recovery routes.
+- Repository verification: `make check` is required before completion.
+
+## Out of Scope
+
+- A generic React exception boundary for unexpected programming errors.
+- CSV preview and validation, which remain owned by #207.
+- Empty Deck/filter onboarding guidance, which remains owned by #206.
+- Study completion or onboarding behavior, which remains owned by #208.
+- Changes to Firebase auth providers, Firestore schema, query ownership, or mutation retry policy.
+- A new global notification queue or application workflow store.
+

--- a/docs/20260719-route-operation-feedback-plan.md
+++ b/docs/20260719-route-operation-feedback-plan.md
@@ -1,0 +1,562 @@
+# Route and Operation Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete Issue #205 by giving startup, unknown routes, missing entities, remote reads, account operations, and Deck deletion consistent feedback and recovery behavior.
+
+**Architecture:** Extend the existing stateless feedback layer with a full-route `RouteFeedback` component, while keeping auth, Query, settings, and Deck mutation state in their current owners. Route adapters and feature containers pass labels and recovery callbacks through props; operation-local hooks own pending, failure, duplicate suppression, and Retry.
+
+**Tech Stack:** React 19, TypeScript 5, React Router 7, TanStack Query 5, Firebase Auth/Firestore, Vitest, Testing Library, Storybook 10, Playwright
+
+## Global Constraints
+
+- Work only in `.worktrees/agent/issue-205-feedback` on branch `agent/issue-205-feedback`, based on current `origin/main`.
+- Do not commit files ignored by `.gitignore`.
+- Write comments, commit messages, PR title, and PR description in English.
+- Follow strict TDD: add one focused failing test, observe the expected failure, add minimal production code, and observe the test pass before continuing.
+- Keep shared presentation components stateless and free of React Router, Query, Auth, Firebase, store, action, and feature imports.
+- Preserve the #325 contract: Deck existence-check failures are read errors, never not-found states.
+- Keep cached route content mounted during terminal sync errors.
+- Keep failed edit/account/delete operations on their current route and expose Retry without automatic mutation retry.
+- Before publishing, run `make check`; because this change adds Storybook and Playwright coverage, also run `make ci`.
+- The draft PR must use `Closes #205` and `Refs #203`.
+
+---
+
+### Task 1: Shared Route Feedback and Application Startup
+
+**Files:**
+- Create: `src/components/feedback/RouteFeedback.tsx`
+- Create: `src/components/feedback/RouteFeedback.spec.tsx`
+- Create: `src/components/feedback/RouteFeedback.stories.tsx`
+- Create: `src/components/feedback/RemoteReadBoundary.stories.tsx`
+- Create: `src/components/feedback/RemoteMutationNotice.stories.tsx`
+- Modify: `src/components/feedback/RemoteReadBoundary.tsx`
+- Modify: `src/components/feedback/RemoteReadBoundary.spec.tsx`
+- Modify: `src/components/feedback/RemoteMutationNotice.tsx`
+- Modify: `src/components/feedback/RemoteMutationNotice.spec.tsx`
+- Modify: `src/components/index.ts`
+- Modify: `src/lib/componentArchitecture.spec.ts`
+- Modify: `src/lib/sharedComponentPublicApi.spec.ts`
+- Modify: `src/App.tsx`
+- Modify: `src/App.spec.tsx`
+
+**Interfaces:**
+- Produces: `RouteFeedbackProps`, `RouteFeedbackAction`, and `RouteFeedback` from `@/components`.
+- Produces: `RemoteReadBoundaryProps.emptyContent?: React.ReactNode`.
+- Produces: `RemoteMutationNoticeProps.pendingLabel?: string` and `errorLabel?: string` while preserving `Saving…` and `Unable to save changes.` defaults.
+
+- [ ] **Step 1: Add failing `RouteFeedback` presentation tests**
+
+Create tests that render loading, error, and not-found examples. Require a level-one heading, optional description, `role="status"` for non-error tones, `role="alert"` for error, and primary/secondary `Button` callbacks. Use real `RouteFeedback` and callbacks; do not mock `Button` or `Layout`.
+
+Use this public shape:
+
+```tsx
+export type RouteFeedbackTone = "loading" | "error" | "not-found";
+
+export interface RouteFeedbackAction {
+  label: string;
+  onClick: () => void;
+  variant?: ButtonVariant;
+}
+
+export interface RouteFeedbackProps {
+  title: string;
+  description?: string;
+  tone?: RouteFeedbackTone;
+  primaryAction?: RouteFeedbackAction;
+  secondaryAction?: RouteFeedbackAction;
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/components/feedback/RouteFeedback.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because `RouteFeedback` does not exist.
+
+- [ ] **Step 3: Implement and export `RouteFeedback`**
+
+Render a `Layout` containing one centered section with semantic surface, border, spacing, and text-token classes. Use `role="alert"` only for `tone="error"`; use `role="status"` otherwise. Render the secondary quiet action before the primary action. Export the component and named prop types from `src/components/index.ts`. Update architecture/public-API tests so `RouteFeedback`, `RemoteReadBoundary`, and `RemoteMutationNotice` are included in the feedback group and root API.
+
+- [ ] **Step 4: Run the focused component and architecture tests and confirm GREEN**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/components/feedback/RouteFeedback.spec.tsx src/lib/componentArchitecture.spec.ts src/lib/sharedComponentPublicApi.spec.ts --no-file-parallelism
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing boundary and notice tests**
+
+Extend `RemoteReadBoundary.spec.tsx` to require:
+
+```tsx
+<RemoteReadBoundary
+  status="ready"
+  hasData={false}
+  emptyContent={<RouteFeedback title="Deck not found" tone="not-found" />}
+  onRetry={vi.fn()}
+>
+  content
+</RemoteReadBoundary>
+```
+
+The custom empty surface must render instead of the string fallback. Existing loading, initial error, blocked storage, cached sync-error, and ordinary empty-string tests must remain.
+
+Extend `RemoteMutationNotice.spec.tsx` to require custom `pendingLabel="Deleting deck…"` and `errorLabel="Unable to delete deck."`, while retaining default-copy tests.
+
+- [ ] **Step 6: Run the boundary tests and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/components/feedback/RemoteReadBoundary.spec.tsx src/components/feedback/RemoteMutationNotice.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because the new props are not supported.
+
+- [ ] **Step 7: Extend the existing feedback components**
+
+Add `emptyContent?: ReactNode` to `RemoteReadBoundary`. Use `RouteFeedback` for initial loading, initial error, and blocked storage; keep the existing inline `ErrorNotice` unchanged when `hasData` is true. For a successful empty read, render `emptyContent` when supplied and otherwise render a `RouteFeedback` using `emptyLabel ?? "No data yet."`.
+
+Add optional pending/error labels to `RemoteMutationNotice` and default them at render time:
+
+```tsx
+const pendingLabel = props.pendingLabel ?? "Saving…";
+const errorLabel = props.errorLabel ?? "Unable to save changes.";
+```
+
+- [ ] **Step 8: Run the boundary tests and confirm GREEN**
+
+Run the Step 6 command. Expected: PASS.
+
+- [ ] **Step 9: Add failing startup and wildcard route tests**
+
+Update the App test harness to mock `useAuth` with complete `AuthState` values. Require:
+
+- `initializing` and `signedOut` render `Starting Tango…` without route content;
+- `error` renders `Unable to start Tango` and calls an injected `reload` callback;
+- `authenticated` preserves normal route rendering;
+- an authenticated unknown URL renders `Page not found`, and `Go home` navigates to `/`.
+
+Define `App` as `React.FC<{ reload?: () => void }>` with the production default `() => window.location.reload()` so the test does not replace `window.location`.
+
+- [ ] **Step 10: Run the App test and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/App.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because App does not gate on auth or define a wildcard route.
+
+- [ ] **Step 11: Implement startup gating and wildcard recovery**
+
+Read auth state in `App`. Preserve the theme effect for every state. Before creating `BrowserRouter`, return:
+
+- `RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading"` for `initializing` and `signedOut`;
+- `RouteFeedback title="Unable to start Tango" description="Authentication could not be initialized." tone="error" primaryAction={{ label: "Reload", onClick: reload }}` for `error`.
+
+For authenticated state, render existing routes plus a `path="*"` adapter using `useNavigate`. Render `Page not found` with `Go back` calling `navigate(-1)` and `Go home` calling `navigate("/")`.
+
+- [ ] **Step 12: Run the App test and confirm GREEN**
+
+Run the Step 10 command. Expected: PASS.
+
+- [ ] **Step 13: Add representative Storybook states**
+
+Create autodocs stories under `Shared/Feedback` for:
+
+- Route loading, error with Reload, not-found with Home/Back, and dark mode;
+- remote initial loading, initial error, cached sync error with child content, blocked storage, and empty read;
+- mutation pending, custom deleting pending, default error, and custom account error.
+
+Use no-op Storybook action callbacks where interaction logging is unavailable.
+
+- [ ] **Step 14: Run all Task 1 focused tests and commit**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/App.spec.tsx src/components/feedback/RouteFeedback.spec.tsx src/components/feedback/RemoteReadBoundary.spec.tsx src/components/feedback/RemoteMutationNotice.spec.tsx src/lib/componentArchitecture.spec.ts src/lib/sharedComponentPublicApi.spec.ts --no-file-parallelism
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/App.tsx src/App.spec.tsx src/components src/lib/componentArchitecture.spec.ts src/lib/sharedComponentPublicApi.spec.ts
+git commit -m "Add shared route feedback"
+```
+
+---
+
+### Task 2: Missing Deck and Card Recovery
+
+**Files:**
+- Modify: `src/features/deck/containers/DeckFormContainer.tsx`
+- Modify: `src/features/deck/containers/DeckFormContainer.spec.tsx`
+- Modify: `src/features/card/containers/CardFormContainer.tsx`
+- Modify: `src/features/card/containers/CardFormContainer.spec.tsx`
+- Modify: `src/features/card/containers/CardListContainer.tsx`
+- Modify: `src/features/card/containers/CardViewContainer.tsx`
+- Modify: `src/features/study/containers/DeckStartContainer.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 `RouteFeedback` and `RemoteReadBoundaryProps.emptyContent`.
+- Produces: consistent `Deck not found` and `Card not found` Home/Back recovery on every non-study entity route.
+
+- [ ] **Step 1: Add failing representative missing-entity tests**
+
+In `DeckFormContainer.spec.tsx`, render a successful read with `mocks.deck = null`; require `Deck not found`, `Go home`, and `Go back`. Click both actions in separate renders and require `navigate("/")` and `navigate(-1)`. Extend the router mock with `useNavigate`.
+
+In `CardFormContainer.spec.tsx`, render with `mocks.card = null`; require `Card not found`, `Go home`, and `Go back`, and verify the same navigation calls.
+
+Keep invalid missing route params as thrown programming errors.
+
+- [ ] **Step 2: Run the representative tests and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/deck/containers/DeckFormContainer.spec.tsx src/features/card/containers/CardFormContainer.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because current empty output has no recovery actions.
+
+- [ ] **Step 3: Implement consistent recovery surfaces**
+
+For each listed container, call `useNavigate` unconditionally and replace the entity-specific `emptyLabel` with:
+
+```tsx
+emptyContent={
+  <RouteFeedback
+    title="Deck not found"
+    description="The requested deck is unavailable or has been removed."
+    tone="not-found"
+    primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+    secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+  />
+}
+```
+
+Use the Card equivalent: `Card not found` and `The requested card is unavailable or has been removed.` Preserve `status={remote.status}` so read errors, including #325 Deck existence failures, continue to win before the successful-empty branch.
+
+- [ ] **Step 4: Run the representative tests and confirm GREEN**
+
+Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Run all affected container tests and commit**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/deck/containers/DeckFormContainer.spec.tsx src/features/card/containers/CardFormContainer.spec.tsx src/features/card/containers/CardListContainer.spec.tsx src/features/study/containers/DeckStartContainer.spec.tsx --no-file-parallelism
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/features/deck/containers src/features/card/containers src/features/study/containers
+git commit -m "Add missing entity recovery"
+```
+
+---
+
+### Task 3: Account Operation Feedback
+
+**Files:**
+- Create: `src/features/settings/hooks/useAccountOperations.ts`
+- Create: `src/features/settings/hooks/useAccountOperations.spec.tsx`
+- Modify: `src/features/settings/hooks/useConfigFormState.ts`
+- Modify: `src/features/settings/hooks/useConfigFormState.spec.tsx`
+- Modify: `src/features/settings/containers/ConfigContainer.tsx`
+- Modify: `src/features/settings/containers/ConfigContainer.spec.tsx`
+- Modify: `src/features/settings/components/ConfigForm.tsx`
+- Modify: `src/features/settings/components/ConfigForm.spec.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 label-aware `RemoteMutationNotice`.
+- Produces: `useAccountOperations({ login, logout })` with `kind`, `pending`, `error`, `login`, `logout`, and `retry`.
+
+- [ ] **Step 1: Add failing hook tests**
+
+Use `renderHook` with deferred Promises. Require:
+
+- two Login calls before the first settles return the same in-flight Promise and invoke the action once;
+- Logout follows the same duplicate suppression;
+- failure sets `error`, preserves `kind`, and Retry invokes the failed operation again;
+- a new attempt clears the previous error and pending settles to false after success.
+
+Use this signature:
+
+```ts
+interface AccountOperationDependencies {
+  login: () => Promise<void>;
+  logout?: () => Promise<void>;
+}
+
+type AccountOperationKind = "login" | "logout";
+```
+
+- [ ] **Step 2: Run the hook test and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/settings/hooks/useAccountOperations.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because the hook does not exist.
+
+- [ ] **Step 3: Implement the account operation hook**
+
+Store the latest dependencies, one in-flight Promise, and the last failed `AccountOperationKind` in refs, plus render state `{ kind, pending, error }`. `run(kind)` is not declared `async`; it returns the existing Promise object while pending so duplicate callers share the same result. It chooses the latest `login` or `logout` dependency, clears errors before starting, records failure, rethrows it, and clears the in-flight ref in `finally`. `retry()` replays the last failed kind and returns `Promise<void>`; it resolves immediately when there is no failed operation.
+
+- [ ] **Step 4: Run the hook test and confirm GREEN**
+
+Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Add failing Settings presentation/container tests**
+
+Extend `UseConfigFormStateOptions` and `ConfigFormProps` expectations with:
+
+```tsx
+accountPending?: boolean;
+accountFeedback?: React.ReactNode;
+```
+
+Require the visible Login or Logout button to be loading, disabled, and `aria-busy` while pending, and require the feedback slot inside the Account section.
+
+In `ConfigContainer.spec.tsx`, mock `useAccountOperations` and require `ConfigContainer` to pass wrapped Login/Logout callbacks, pending state, and a `RemoteMutationNotice` with:
+
+- `Signing in…` / `Unable to sign in.` for login;
+- `Signing out…` / `Unable to sign out.` for logout;
+- Retry wired to the hook.
+
+- [ ] **Step 6: Run the Settings tests and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/settings/components/ConfigForm.spec.tsx src/features/settings/containers/ConfigContainer.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because Settings does not expose account operation state.
+
+- [ ] **Step 7: Wire account operation state into Settings**
+
+Call the hook unconditionally with the existing `actions.login` and an optional authenticated logout closure. Pass `() => void account.login().catch(() => undefined)` and the Logout equivalent into `useConfigFormState`. Pass `accountPending` and a `RemoteMutationNotice` feedback slot through `useConfigFormState`/`ConfigFormProps`; use the kind-specific labels above. Render the slot below the Account action row and set the active Button's `loading={accountPending}`.
+
+- [ ] **Step 8: Run all Task 3 tests and commit**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/settings/hooks/useAccountOperations.spec.tsx src/features/settings/components/ConfigForm.spec.tsx src/features/settings/containers/ConfigContainer.spec.tsx --no-file-parallelism
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/features/settings
+git commit -m "Add account operation feedback"
+```
+
+---
+
+### Task 4: Deck Deletion Guard and Browser Recovery Coverage
+
+**Files:**
+- Create: `src/features/deck/hooks/useDeckMutations.spec.tsx`
+- Modify: `src/features/deck/hooks/useDeckMutations.ts`
+- Modify: `src/features/deck/components/DeckCard.tsx`
+- Modify: `src/features/deck/components/DeckCard.spec.tsx`
+- Modify: `src/features/deck/components/DeckActionsMenu.tsx`
+- Modify: `src/features/deck/components/DeckActionsMenu.spec.tsx`
+- Modify: `src/features/deck/containers/DeckListContainer.tsx`
+- Modify: `src/features/deck/containers/DeckListContainer.spec.tsx`
+- Modify: `e2e/smoke.e2e.ts`
+
+**Interfaces:**
+- Consumes: Task 1 label-aware `RemoteMutationNotice` and Task 2 route recovery copy.
+- Produces: `useDeckMutations().isPending(id: DeckId): boolean` and same-Deck in-flight Promise reuse.
+
+- [ ] **Step 1: Add failing Deck mutation duplicate tests**
+
+Model `useDeckMutations.spec.tsx` after the existing Card mutation hook spec. Use a deferred Firestore update/remove Promise and a real test QueryClient. Require:
+
+- two same-Deck remove calls return the same Promise and call Firestore remove once;
+- `pending` and `isPending(deck.id)` are true while active and false after settlement;
+- a different Deck ID is not reported pending;
+- failure remains available through `error` and Retry repeats the failed operation once.
+
+- [ ] **Step 2: Run the hook test and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/deck/hooks/useDeckMutations.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because entity pending state and duplicate suppression do not exist.
+
+- [ ] **Step 3: Implement entity-scoped in-flight tracking**
+
+Keep `useMutation` and the existing service. Add a `Map<DeckId, Promise<void>>` ref and a rendered `Set<DeckId>` state. Before starting a mutation, return the Map's Promise for that Deck ID when present. Add the ID before awaiting `mutateAsync`; remove it in `finally`. Preserve `lastFailed` and existing Retry semantics. Return `pending: pendingDeckIds.size > 0` and `isPending: (id) => pendingDeckIds.has(id)`.
+
+- [ ] **Step 4: Run the hook test and confirm GREEN**
+
+Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Add failing busy Deck presentation tests**
+
+Extend `DeckCardActions` with `isPending?: (id: DeckId) => boolean`. Require a pending Deck card to:
+
+- set `aria-busy="true"` on the article;
+- disable View and Study/Continue;
+- pass `disabled` to `DeckActionsMenu`, whose trigger is disabled and whose menu cannot remain open.
+
+Require a non-pending Deck card to retain all current actions.
+
+- [ ] **Step 6: Run the Deck presentation tests and confirm RED**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/deck/components/DeckCard.spec.tsx src/features/deck/components/DeckActionsMenu.spec.tsx --no-file-parallelism
+```
+
+Expected: FAIL because pending state is not wired.
+
+- [ ] **Step 7: Wire pending state and accurate deletion copy**
+
+Compute pending from `props.isPending?.(deck.id) ?? false` in `DeckCard`; disable its three interactive entry points and set `aria-busy`. Add `disabled?: boolean` to `DeckActionsMenu` and forward it to `ActionsMenu`.
+
+In `DeckListContainer`, pass `isPending: mutations.isPending` through `deckCard` and render:
+
+```tsx
+<RemoteMutationNotice
+  pending={mutations.pending}
+  error={mutations.error}
+  onRetry={mutations.retry}
+  pendingLabel="Deleting deck…"
+  errorLabel="Unable to delete deck."
+/>
+```
+
+Update its hook mock in the container spec and require the selected pending row to be disabled while another row remains enabled.
+
+- [ ] **Step 8: Run the Deck tests and confirm GREEN**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/deck/hooks/useDeckMutations.spec.tsx src/features/deck/components/DeckCard.spec.tsx src/features/deck/components/DeckActionsMenu.spec.tsx src/features/deck/containers/DeckListContainer.spec.tsx --no-file-parallelism
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Add browser recovery tests**
+
+Extend `e2e/smoke.e2e.ts` with authenticated tests for:
+
+- `/unknown-route`: `Page not found` is visible and `Go home` returns to the Deck list;
+- `/deck/missing-deck`: `Deck not found` is visible and `Go home` returns to the Deck list;
+- `/card/missing-card`: `Card not found` is visible and `Go home` returns to the Deck list.
+
+Each case must call `window.assertNoBrowserErrors()` after recovery.
+
+- [ ] **Step 10: Run focused browser coverage and commit**
+
+Run:
+
+```bash
+COMPOSE_FILE=.devcontainer/compose.yaml:.devcontainer/compose.e2e.yaml docker compose up --wait --wait-timeout 120 --remove-orphans
+COMPOSE_FILE=.devcontainer/compose.yaml:.devcontainer/compose.e2e.yaml docker compose run --rm --remove-orphans --env CI --entrypoint npm dev exec -- playwright test e2e/smoke.e2e.ts
+```
+
+Expected: all smoke tests PASS.
+
+Commit:
+
+```bash
+git add src/features/deck e2e/smoke.e2e.ts
+git commit -m "Prevent duplicate Deck deletion"
+```
+
+---
+
+### Task 5: Repository Verification and Publication
+
+**Files:**
+- Verify all files changed since `origin/main`.
+
+**Interfaces:**
+- Consumes: Tasks 1–4.
+- Produces: a verified branch ready for a draft PR.
+
+- [ ] **Step 1: Re-read the design, plan, current diff, and status**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+```
+
+Compare every design requirement with the committed diff. Confirm there are no ignored or unrelated files.
+
+- [ ] **Step 2: Run the required lightweight gate**
+
+Run:
+
+```bash
+make check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run the full CI-equivalent gate**
+
+Run:
+
+```bash
+make ci
+```
+
+Expected: build, Storybook, formatting, lint, unit, Firestore, sample, and Playwright checks exit 0.
+
+- [ ] **Step 4: Request whole-branch code review**
+
+Review `origin/main...HEAD` against `docs/20260719-route-operation-feedback-design.md`. Fix every Critical or Important finding with focused tests and rerun the affected command. Rerun `make check` after fixes.
+
+- [ ] **Step 5: Verify GitHub prerequisites and publish**
+
+Run `gh --version`, `gh auth status`, and `git status --short --branch`. Push with tracking:
+
+```bash
+git push -u origin agent/issue-205-feedback
+```
+
+Create a draft PR targeting `main` with title `Unify route and operation feedback`. The body must summarize startup/route recovery, account/deletion feedback, Storybook/tests, include the actual verification commands, and end with:
+
+```markdown
+Closes #205
+Refs #203
+```

--- a/docs/20260719-route-operation-feedback-plan.md
+++ b/docs/20260719-route-operation-feedback-plan.md
@@ -82,7 +82,7 @@ Expected: FAIL because `RouteFeedback` does not exist.
 
 - [ ] **Step 3: Implement and export `RouteFeedback`**
 
-Render a `Layout` containing one centered section with semantic surface, border, spacing, and text-token classes. Use `role="alert"` only for `tone="error"`; use `role="status"` otherwise. Render the secondary quiet action before the primary action. Export the component and named prop types from `src/components/index.ts`. Update architecture/public-API tests so `RouteFeedback`, `RemoteReadBoundary`, and `RemoteMutationNotice` are included in the feedback group and root API.
+Render a `Layout` containing one centered section with semantic surface, border, spacing, and text-token classes. Use `role="alert"` only for `tone="error"`; use `role="status"` otherwise. Render the secondary quiet action before the primary action. Export the component and named prop types from `src/components/index.ts`. Update architecture/public-API tests so `RouteFeedback`, `RemoteReadBoundary`, and `RemoteMutationNotice` are included in the feedback group and root API. Create their Storybook files at this step with the minimal default states needed by the architecture contract; Step 13 expands those files with every representative state.
 
 - [ ] **Step 4: Run the focused component and architecture tests and confirm GREEN**
 

--- a/docs/20260719-route-operation-feedback-plan.md
+++ b/docs/20260719-route-operation-feedback-plan.md
@@ -280,6 +280,8 @@ git commit -m "Add missing entity recovery"
 **Files:**
 - Create: `src/features/settings/hooks/useAccountOperations.ts`
 - Create: `src/features/settings/hooks/useAccountOperations.spec.tsx`
+- Modify: `src/action/event.ts`
+- Modify: `src/auth/AuthLogout.integration.spec.tsx`
 - Modify: `src/features/settings/hooks/useConfigFormState.ts`
 - Modify: `src/features/settings/hooks/useConfigFormState.spec.tsx`
 - Modify: `src/features/settings/containers/ConfigContainer.tsx`
@@ -289,21 +291,28 @@ git commit -m "Add missing entity recovery"
 
 **Interfaces:**
 - Consumes: Task 1 label-aware `RemoteMutationNotice`.
-- Produces: `useAccountOperations({ login, logout })` with `kind`, `pending`, `error`, `login`, `logout`, and `retry`.
+- Produces: `useAccountOperations({ generation, login, logout })` with `kind`, `pending`, `error`, `login`, `logout`, and `retry`.
+- Produces: explicit failed-operation metadata distinguishing a full Logout that may sign out from a cleanup continuation that cannot.
+- Produces: phase-aware Logout cleanup errors whose Retry skips sign-out and completed cleanup phases.
 
-- [ ] **Step 1: Add failing hook tests**
+- [ ] **Step 1: Add failing account lifecycle tests**
 
-Use `renderHook` with deferred Promises. Require:
+Use `renderHook` with deferred Promises and the real Settings/Auth integration where an auth transition matters. Require:
 
 - two Login calls before the first settles return the same in-flight Promise and invoke the action once;
 - Logout follows the same duplicate suppression;
 - failure sets `error`, preserves `kind`, and Retry invokes the failed operation again;
-- a new attempt clears the previous error and pending settles to false after success.
+- a new attempt clears the previous error and pending settles to false after success;
+- StrictMode keeps exact Promise reuse and does not erase feedback during its immediate resubscribe;
+- settled feedback resets when Settings is left or an unrelated auth generation arrives;
+- a post-sign-out cleanup failure survives exactly one auth-generation handoff, while a cleanup-only retry cannot gain another handoff;
+- if the original full Logout first fails during sign-out, its full Retry may still hand a later cleanup failure to the anonymous Settings remount.
 
 Use this signature:
 
 ```ts
 interface AccountOperationDependencies {
+  generation?: string;
   login: () => Promise<void>;
   logout?: () => Promise<void>;
 }
@@ -323,7 +332,7 @@ Expected: FAIL because the hook does not exist.
 
 - [ ] **Step 3: Implement the account operation hook**
 
-Store the latest dependencies, one in-flight Promise, and the last failed `AccountOperationKind` in refs, plus render state `{ kind, pending, error }`. `run(kind)` is not declared `async`; it returns the existing Promise object while pending so duplicate callers share the same result. It chooses the latest `login` or `logout` dependency, clears errors before starting, records failure, rethrows it, and clears the in-flight ref in `finally`. `retry()` replays the last failed kind and returns `Promise<void>`; it resolves immediately when there is no failed operation.
+Use a module-scope controller with the latest dependencies, one in-flight Promise, the current auth generation, rendered state `{ kind, pending, error }`, and explicit failed-operation metadata. `run(kind)` is not declared `async`; it returns the existing Promise object while pending so duplicate callers share the same result. A full Logout failure retains `maySignOut` only while Retry still points to the full operation; a custom cleanup continuation clears it. Keep settled post-sign-out cleanup feedback for one auth-generation handoff, then reset it when unused. Use subscription-generation dedupe so StrictMode's immediate resubscribe does not reset state.
 
 - [ ] **Step 4: Run the hook test and confirm GREEN**
 
@@ -358,14 +367,16 @@ Expected: FAIL because Settings does not expose account operation state.
 
 - [ ] **Step 7: Wire account operation state into Settings**
 
-Call the hook unconditionally with the existing `actions.login` and an optional authenticated logout closure. Pass `() => void account.login().catch(() => undefined)` and the Logout equivalent into `useConfigFormState`. Pass `accountPending` and a `RemoteMutationNotice` feedback slot through `useConfigFormState`/`ConfigFormProps`; use the kind-specific labels above. Render the slot below the Account action row and set the active Button's `loading={accountPending}`.
+Call the hook unconditionally with the existing `actions.login`, the current auth generation, and an optional authenticated logout closure. Pass `() => void account.login().catch(() => undefined)` and the Logout equivalent into `useConfigFormState`. Pass `accountPending` and a `RemoteMutationNotice` feedback slot through `useConfigFormState`/`ConfigFormProps`; use the kind-specific labels above. Render the slot below the Account action row and set the active Button's `loading={accountPending}`.
+
+Make `src/action/event.ts` run sign-out before query and study cleanup. Track query/study progress so the custom error Retry resumes only unfinished cleanup without another sign-out. Record the study state created by clearing and skip a later study clear if the state identity has changed. Cover ordering, repeated cleanup failure, the one-generation handoff, and the study identity guard in `src/auth/AuthLogout.integration.spec.tsx`.
 
 - [ ] **Step 8: Run all Task 3 tests and commit**
 
 Run:
 
 ```bash
-COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/settings/hooks/useAccountOperations.spec.tsx src/features/settings/components/ConfigForm.spec.tsx src/features/settings/containers/ConfigContainer.spec.tsx --no-file-parallelism
+COMPOSE_FILE=.devcontainer/compose.yaml docker compose run --rm --remove-orphans --entrypoint npm dev exec -- vitest run src/features/settings/hooks/useAccountOperations.spec.tsx src/features/settings/components/ConfigForm.spec.tsx src/features/settings/containers/ConfigContainer.spec.tsx src/auth/AuthLogout.integration.spec.tsx --no-file-parallelism
 ```
 
 Expected: PASS.
@@ -373,7 +384,7 @@ Expected: PASS.
 Commit:
 
 ```bash
-git add src/features/settings
+git add src/action/event.ts src/auth/AuthLogout.integration.spec.tsx src/features/settings
 git commit -m "Add account operation feedback"
 ```
 
@@ -395,15 +406,18 @@ git commit -m "Add account operation feedback"
 **Interfaces:**
 - Consumes: Task 1 label-aware `RemoteMutationNotice` and Task 2 route recovery copy.
 - Produces: `useDeckMutations().isPending(id: DeckId): boolean` and same-Deck in-flight Promise reuse.
+- Produces: optional latest-ref `useDeckMutations({ onRemoveSuccess(deck) })` cleanup for every successful remove attempt.
 
-- [ ] **Step 1: Add failing Deck mutation duplicate tests**
+- [ ] **Step 1: Add failing Deck mutation lifecycle tests**
 
 Model `useDeckMutations.spec.tsx` after the existing Card mutation hook spec. Use a deferred Firestore update/remove Promise and a real test QueryClient. Require:
 
 - two same-Deck remove calls return the same Promise and call Firestore remove once;
 - `pending` and `isPending(deck.id)` are true while active and false after settlement;
 - a different Deck ID is not reported pending;
-- failure remains available through `error` and Retry repeats the failed operation once.
+- failure remains available through `error` and Retry repeats the failed operation once;
+- failed removal does not run `onRemoveSuccess`;
+- a successful Retry runs `onRemoveSuccess(deck)` exactly once even after the hook/container unmounts while Retry is pending.
 
 - [ ] **Step 2: Run the hook test and confirm RED**
 
@@ -417,7 +431,7 @@ Expected: FAIL because entity pending state and duplicate suppression do not exi
 
 - [ ] **Step 3: Implement entity-scoped in-flight tracking**
 
-Keep `useMutation` and the existing service. Add a `Map<DeckId, Promise<void>>` ref and a rendered `Set<DeckId>` state. Before starting a mutation, return the Map's Promise for that Deck ID when present. Add the ID before awaiting `mutateAsync`; remove it in `finally`. Preserve `lastFailed` and existing Retry semantics. Return `pending: pendingDeckIds.size > 0` and `isPending: (id) => pendingDeckIds.has(id)`.
+Keep `useMutation` and the existing service. Add a `Map<DeckId, Promise<void>>` ref and a rendered `Set<DeckId>` state. Before starting a mutation, return the Map's Promise for that Deck ID when present. Add the ID before awaiting `mutateAsync`; remove it in `finally`. Preserve the independent latest failure record and existing Retry semantics. Store `onRemoveSuccess` in a latest ref and invoke it inside each newly created successful remove operation, so Promise reuse cannot duplicate cleanup and unmount cannot drop it. Return `pending: pendingDeckIds.size > 0` and `isPending: (id) => pendingDeckIds.has(id)`.
 
 - [ ] **Step 4: Run the hook test and confirm GREEN**
 
@@ -447,7 +461,7 @@ Expected: FAIL because pending state is not wired.
 
 Compute pending from `props.isPending?.(deck.id) ?? false` in `DeckCard`; disable its three interactive entry points and set `aria-busy`. Add `disabled?: boolean` to `DeckActionsMenu` and forward it to `ActionsMenu`.
 
-In `DeckListContainer`, pass `isPending: mutations.isPending` through `deckCard` and render:
+In `DeckListContainer`, pass `onRemoveSuccess: (deck) => studyStore.getState().removeStudy(deck.id)` into `useDeckMutations`, remove the click handler's `.then(removeStudy)`, pass `isPending: mutations.isPending` through `deckCard`, and render:
 
 ```tsx
 <RemoteMutationNotice

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -1,14 +1,20 @@
+import { createHash } from "node:crypto";
 import { expect, test } from "@playwright/test";
 import { routeAnonymousAuth, seedConfig } from "./fixtures";
 
-test.beforeEach(async ({ page }) => {
+const smokeAuthUid = (testId: string) => {
+  const digest = createHash("sha256").update(testId).digest("hex").slice(0, 16);
+  return `smoke-e2e-${digest}`;
+};
+
+test.beforeEach(async ({ page }, testInfo) => {
   const errors: string[] = [];
   page.on("console", (message) => {
     if (message.type() === "error") errors.push(message.text());
   });
   page.on("pageerror", (error) => errors.push(error.message));
 
-  await routeAnonymousAuth(page, "smoke-e2e-user");
+  await routeAnonymousAuth(page, smokeAuthUid(testInfo.testId));
   await seedConfig(page);
   await page.exposeFunction("assertNoBrowserErrors", () => expect(errors).toEqual([]));
 });

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -47,3 +47,30 @@ test("shows the import screen", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Add sample deck" })).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });
+
+test("read: recovers from an unknown route", async ({ page }) => {
+  await page.goto("/unknown-route");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Page not found" })).toBeVisible();
+  await page.getByRole("button", { name: "Go home" }).click();
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});
+
+test("read: recovers from a missing Deck", async ({ page }) => {
+  await page.goto("/deck/missing-deck");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Deck not found" })).toBeVisible();
+  await page.getByRole("button", { name: "Go home" }).click();
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});
+
+test("read: recovers from a missing Card", async ({ page }) => {
+  await page.goto("/card/missing-card");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Card not found" })).toBeVisible();
+  await page.getByRole("button", { name: "Go home" }).click();
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,9 +1,14 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { User } from "firebase/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthState } from "@/auth/AuthContext";
 
 const mocks = vi.hoisted(() => ({
   darkMode: false,
   init: vi.fn(),
+  authState: { status: "initializing" } as AuthState,
 }));
 
 vi.mock("zustand", () => ({
@@ -14,6 +19,7 @@ vi.mock("zustand", () => ({
 }));
 vi.mock("@/store/configStore", () => ({ configStore: {} }));
 vi.mock("@/action", () => ({ event: { init: mocks.init } }));
+vi.mock("@/auth/AuthContext", () => ({ useAuth: () => mocks.authState }));
 vi.mock("@/page", () => ({
   DeckListPage: () => <div>Deck list</div>,
   CardListPage: () => null,
@@ -32,7 +38,9 @@ describe("App", () => {
   beforeEach(() => {
     mocks.darkMode = false;
     mocks.init.mockReset();
+    mocks.authState = { status: "authenticated", user: {} as User, uid: "test-user" };
     document.documentElement.classList.remove("dark");
+    window.history.replaceState({}, "", "/");
   });
 
   it("updates only the theme when the setting changes", () => {
@@ -44,5 +52,45 @@ describe("App", () => {
 
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     expect(mocks.init).not.toHaveBeenCalled();
+  });
+
+  it("shows startup feedback for initializing and signed-out authentication", () => {
+    mocks.authState = { status: "initializing" };
+    const view = render(<App />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.queryByText("Deck list")).toBeNull();
+
+    mocks.authState = { status: "signedOut" };
+    view.rerender(<App />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.queryByText("Deck list")).toBeNull();
+  });
+
+  it("shows startup errors and reloads on request", () => {
+    const reload = vi.fn();
+    mocks.authState = { status: "error", error: new Error("auth failed") };
+    render(<App reload={reload} />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Unable to start Tango" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("renders normal routes after authentication", () => {
+    render(<App />);
+
+    expect(screen.getByText("Deck list")).toBeInTheDocument();
+  });
+
+  it("recovers from authenticated unknown routes", () => {
+    window.history.replaceState({}, "", "/unknown");
+    render(<App />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Page not found" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+    expect(window.location.pathname).toBe("/");
+    expect(screen.getByText("Deck list")).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,49 @@
 import React from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { useStore } from "zustand";
+import { RouteFeedback } from "@/components";
+import { useAuth } from "@/auth/AuthContext";
 import * as Page from "@/page";
 import { configStore } from "@/store/configStore";
 
-const App = () => {
+const UnknownRoute = () => {
+  const navigate = useNavigate();
+
+  return (
+    <RouteFeedback
+      title="Page not found"
+      tone="not-found"
+      primaryAction={{ label: "Go home", onClick: () => navigate("/") }}
+      secondaryAction={{ label: "Go back", onClick: () => navigate(-1) }}
+    />
+  );
+};
+
+const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location.reload() }) => {
   const darkMode = useStore(configStore, (state) => state.config.darkMode);
+  const authState = useAuth();
+
   React.useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
+
+  if (authState.status === "initializing" || authState.status === "signedOut") {
+    return (
+      <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
+    );
+  }
+
+  if (authState.status === "error") {
+    return (
+      <RouteFeedback
+        title="Unable to start Tango"
+        description="Authentication could not be initialized."
+        tone="error"
+        primaryAction={{ label: "Reload", onClick: reload }}
+      />
+    );
+  }
+
   return (
     <BrowserRouter>
       <Routes>
@@ -21,6 +56,7 @@ const App = () => {
         <Route path="/card/:id/edit" element={<Page.CardFormPage />} />
         <Route path="/settings" element={<Page.ConfigPage />} />
         <Route path="/import" element={<Page.DeckImportPage />} />
+        <Route path="*" element={<UnknownRoute />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -2,7 +2,7 @@ import { signOut, linkWithPopup, signInWithCredential, GoogleAuthProvider } from
 import type { UserCredential } from "firebase/auth";
 import { FirebaseError } from "firebase/app";
 
-import { clearStudyStore } from "@/features/study/state/studyStore";
+import { clearStudyStore, studyStore, type StudyState } from "@/features/study/state/studyStore";
 import { publishAuthenticatedUser, suspendAnonymousBootstrap } from "@/auth/AuthContext";
 import { auth } from "@/firebase";
 import { cleanupFirestoreUid } from "@/query/cleanup";
@@ -10,7 +10,10 @@ import { cleanupFirestoreUid } from "@/query/cleanup";
 interface LogoutCleanupProgress {
   query: boolean;
   study: boolean;
+  studyStateAfterClear?: StudyState;
 }
+
+type LogoutCleanupStep = "query" | "study";
 
 class LogoutCleanupError extends Error {
   constructor(
@@ -32,7 +35,7 @@ const runLogout = async (
     if (signOutRequired) await signOut(auth);
 
     const errors: unknown[] = [];
-    const run = async (step: keyof LogoutCleanupProgress, cleanup: () => unknown | Promise<unknown>) => {
+    const run = async (step: LogoutCleanupStep, cleanup: () => unknown | Promise<unknown>) => {
       if (progress[step]) return;
       try {
         await cleanup();
@@ -43,7 +46,12 @@ const runLogout = async (
     };
 
     await run("query", () => cleanupFirestoreUid(confirmedUid));
-    await run("study", clearStudyStore);
+    await run("study", async () => {
+      if (progress.studyStateAfterClear && studyStore.getState() !== progress.studyStateAfterClear) return;
+      const cleanup = clearStudyStore();
+      progress.studyStateAfterClear = studyStore.getState();
+      await cleanup;
+    });
     if (errors.length > 0) {
       throw new LogoutCleanupError(errors[0], () => runLogout(confirmedUid, progress, false));
     }

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -7,28 +7,53 @@ import { publishAuthenticatedUser, suspendAnonymousBootstrap } from "@/auth/Auth
 import { auth } from "@/firebase";
 import { cleanupFirestoreUid } from "@/query/cleanup";
 
-export const logout = async (confirmedUid: string): Promise<void> => {
+interface LogoutCleanupProgress {
+  query: boolean;
+  study: boolean;
+}
+
+class LogoutCleanupError extends Error {
+  constructor(
+    readonly originalError: unknown,
+    readonly retry: () => Promise<void>
+  ) {
+    super(originalError instanceof Error ? originalError.message : "Logout cleanup failed");
+    this.name = "LogoutCleanupError";
+  }
+}
+
+const runLogout = async (
+  confirmedUid: string,
+  progress: LogoutCleanupProgress,
+  signOutRequired: boolean
+): Promise<void> => {
   const resumeAnonymousBootstrap = suspendAnonymousBootstrap();
   try {
-    await signOut(auth);
+    if (signOutRequired) await signOut(auth);
+
     const errors: unknown[] = [];
-    const run = async (step: () => unknown | Promise<unknown>) => {
+    const run = async (step: keyof LogoutCleanupProgress, cleanup: () => unknown | Promise<unknown>) => {
+      if (progress[step]) return;
       try {
-        await step();
+        await cleanup();
+        progress[step] = true;
       } catch (error) {
         errors.push(error);
       }
     };
 
-    await run(() => cleanupFirestoreUid(confirmedUid));
-    await run(clearStudyStore);
+    await run("query", () => cleanupFirestoreUid(confirmedUid));
+    await run("study", clearStudyStore);
     if (errors.length > 0) {
-      throw errors[0];
+      throw new LogoutCleanupError(errors[0], () => runLogout(confirmedUid, progress, false));
     }
   } finally {
     resumeAnonymousBootstrap();
   }
 };
+
+export const logout = (confirmedUid: string): Promise<void> =>
+  runLogout(confirmedUid, { query: false, study: false }, true);
 
 export const loginGoogle = async (): Promise<void> => {
   const currentUser = auth.currentUser;

--- a/src/auth/AuthLogout.integration.spec.tsx
+++ b/src/auth/AuthLogout.integration.spec.tsx
@@ -226,6 +226,54 @@ it("keeps post-sign-out cleanup failures visible and retries only unfinished cle
   expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
 });
 
+it("hands cleanup feedback across auth after retrying a failed sign-out", async () => {
+  const userA = { uid: "retry-uid-a", isAnonymous: false, providerData: [] } as unknown as User;
+  const userB = { uid: "retry-uid-b", isAnonymous: true, providerData: [] } as unknown as User;
+  const signOutError = new Error("sign out failed");
+  const cleanupError = new Error("cleanup failed after retry");
+  const anonymousBootstrap = new Promise<UserCredential>(() => undefined);
+
+  mocks.onAuthStateChanged.mockImplementation((_auth, onUser) => {
+    mocks.publishUser = onUser;
+    return vi.fn();
+  });
+  mocks.signOut.mockRejectedValueOnce(signOutError).mockImplementationOnce(async () => mocks.publishUser?.(null));
+  mocks.signInAnonymously.mockReturnValue(anonymousBootstrap);
+  mocks.cleanupUid.mockRejectedValueOnce(cleanupError).mockResolvedValueOnce(undefined);
+  mocks.clearStudyStore.mockResolvedValue(undefined);
+
+  const store = createAuthStore({
+    auth: mocks.auth as unknown as Auth,
+    onAuthStateChanged: mocks.onAuthStateChanged,
+    signInAnonymously: mocks.signInAnonymously,
+  });
+  render(
+    <AuthProvider store={store}>
+      <AuthenticatedSettings />
+    </AuthProvider>
+  );
+  act(() => mocks.publishUser?.(userA));
+
+  fireEvent.click(await screen.findByRole("button", { name: "Logout" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+  expect(mocks.signOut).toHaveBeenCalledOnce();
+  expect(mocks.cleanupUid).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(screen.queryByRole("button", { name: "Logout" })).not.toBeInTheDocument());
+  await waitFor(() => expect(mocks.cleanupUid).toHaveBeenCalledOnce());
+  await act(async () => Promise.resolve());
+  act(() => mocks.publishUser?.(userB));
+
+  expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+  await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  expect(mocks.signOut).toHaveBeenCalledTimes(2);
+  expect(mocks.cleanupUid).toHaveBeenCalledTimes(2);
+  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+});
+
 it("does not erase a new anonymous study when obsolete logout cleanup is retried", async () => {
   const userA = { uid: "study-uid-a", isAnonymous: false, providerData: [] } as unknown as User;
   const userB = { uid: "study-uid-b", isAnonymous: true, providerData: [] } as unknown as User;

--- a/src/auth/AuthLogout.integration.spec.tsx
+++ b/src/auth/AuthLogout.integration.spec.tsx
@@ -1,7 +1,8 @@
-import { act, cleanup, render, waitFor } from "@testing-library/react";
-import type { User, UserCredential } from "firebase/auth";
-import { StrictMode } from "react";
-import { afterEach, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { Auth, User, UserCredential } from "firebase/auth";
+import { StrictMode, type ReactNode } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   auth: { currentUser: null },
@@ -14,6 +15,14 @@ const mocks = vi.hoisted(() => ({
   cleanupUid: vi.fn(),
   clearStudyStore: vi.fn(),
   operations: [] as string[],
+  accountActions: {
+    login: vi.fn(),
+    logout: vi.fn(),
+    configUpdate: vi.fn(),
+    goToTop: vi.fn(),
+    setDarkMode: vi.fn(),
+    goByMenu: vi.fn(),
+  },
 }));
 
 vi.mock("@/firebase", () => ({ auth: mocks.auth }));
@@ -32,12 +41,42 @@ vi.mock("@/action/firestore", () => ({}));
 vi.mock("@/query/cleanup", () => ({ cleanupFirestoreUid: mocks.cleanupUid }));
 vi.mock("@/query/remoteReadSession", () => ({ startRemoteReads: mocks.startRemoteReads }));
 vi.mock("@/features/study/state/studyStore", () => ({ clearStudyStore: mocks.clearStudyStore }));
+vi.mock("@/hooks/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
+vi.mock("@/hooks/useActions", () => ({ useActions: () => mocks.accountActions }));
+vi.mock("@/features/settings/hooks/useConfigFormState", () => ({
+  useConfigFormState: (options: Record<string, unknown>) => options,
+}));
+vi.mock("@/features/settings/components/templates/ConfigFormTemplate", () => ({
+  ConfigFormTemplate: ({ configForm }: { configForm: Record<string, unknown> }) => (
+    <>
+      {configForm.accountFeedback as ReactNode}
+      {typeof configForm.onLogout === "function" && (
+        <button type="button" onClick={configForm.onLogout as () => void}>
+          Logout
+        </button>
+      )}
+    </>
+  ),
+}));
+vi.mock("react-use", () => ({ useKey: vi.fn() }));
 
 import { logout } from "@/action/event";
 import { AuthBootstrap } from "@/auth/AuthBootstrap";
-import { AuthProvider } from "@/auth/AuthContext";
+import { AuthProvider, createAuthStore, useAuth } from "@/auth/AuthContext";
+import { ConfigContainer } from "@/features/settings/containers/ConfigContainer";
 
 afterEach(() => cleanup());
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.auth.currentUser = null;
+  mocks.publishUser = undefined;
+  mocks.operations.length = 0;
+  mocks.accountActions.login.mockResolvedValue(undefined);
+  mocks.accountActions.logout.mockImplementation(logout);
+});
+
+const AuthenticatedSettings = () => (useAuth().status === "authenticated" ? <ConfigContainer /> : null);
 
 it("waits for logout cleanup before bootstrapping the next anonymous UID", async () => {
   let resolveCleanup: () => void = () => undefined;
@@ -107,4 +146,67 @@ it("waits for logout cleanup before bootstrapping the next anonymous UID", async
   expect(clearStudyIndex).toBeGreaterThanOrEqual(0);
   expect(anonymousStartIndex).toBeGreaterThan(clearStudyIndex);
   expect(subscribeBIndex).toBeGreaterThan(anonymousStartIndex);
+});
+
+it("keeps post-sign-out cleanup failures visible and retries only unfinished cleanup", async () => {
+  const userA = { uid: "feedback-uid-a", isAnonymous: false, providerData: [] } as unknown as User;
+  const userB = { uid: "feedback-uid-b", isAnonymous: true, providerData: [] } as unknown as User;
+  const firstCleanupError = new Error("cleanup failed");
+  const retryCleanupError = new Error("retry cleanup failed");
+  let rejectFirstCleanup!: (error: unknown) => void;
+  const firstCleanup = new Promise<void>((_resolve, reject) => {
+    rejectFirstCleanup = reject;
+  });
+  const anonymousBootstrap = new Promise<UserCredential>(() => undefined);
+
+  mocks.onAuthStateChanged.mockImplementation((_auth, onUser) => {
+    mocks.publishUser = onUser;
+    return vi.fn();
+  });
+  let publishedSignedOut = false;
+  mocks.signOut.mockImplementation(async () => {
+    if (!publishedSignedOut) {
+      publishedSignedOut = true;
+      mocks.publishUser?.(null);
+    }
+  });
+  mocks.signInAnonymously.mockReturnValue(anonymousBootstrap);
+  mocks.cleanupUid
+    .mockReturnValueOnce(firstCleanup)
+    .mockRejectedValueOnce(retryCleanupError)
+    .mockResolvedValueOnce(undefined);
+  mocks.clearStudyStore.mockResolvedValue(undefined);
+
+  const store = createAuthStore({
+    auth: mocks.auth as unknown as Auth,
+    onAuthStateChanged: mocks.onAuthStateChanged,
+    signInAnonymously: mocks.signInAnonymously,
+  });
+  render(
+    <AuthProvider store={store}>
+      <AuthenticatedSettings />
+    </AuthProvider>
+  );
+  act(() => mocks.publishUser?.(userA));
+  fireEvent.click(await screen.findByRole("button", { name: "Logout" }));
+  await waitFor(() => expect(screen.queryByRole("button", { name: "Logout" })).not.toBeInTheDocument());
+  await act(async () => rejectFirstCleanup(firstCleanupError));
+  act(() => mocks.publishUser?.(userB));
+
+  expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+  expect(mocks.signOut).toHaveBeenCalledOnce();
+  expect(mocks.cleanupUid).toHaveBeenCalledOnce();
+  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(mocks.cleanupUid).toHaveBeenCalledTimes(2));
+  expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+  expect(mocks.signOut).toHaveBeenCalledOnce();
+  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  expect(mocks.cleanupUid).toHaveBeenCalledTimes(3);
+  expect(mocks.signOut).toHaveBeenCalledOnce();
+  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
 });

--- a/src/auth/AuthLogout.integration.spec.tsx
+++ b/src/auth/AuthLogout.integration.spec.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   startRemoteReads: vi.fn(),
   cleanupUid: vi.fn(),
   clearStudyStore: vi.fn(),
+  actualClearStudyStore: undefined as undefined | (() => Promise<void>),
   operations: [] as string[],
   accountActions: {
     login: vi.fn(),
@@ -40,7 +41,11 @@ vi.mock("firebase/app", () => ({
 vi.mock("@/action/firestore", () => ({}));
 vi.mock("@/query/cleanup", () => ({ cleanupFirestoreUid: mocks.cleanupUid }));
 vi.mock("@/query/remoteReadSession", () => ({ startRemoteReads: mocks.startRemoteReads }));
-vi.mock("@/features/study/state/studyStore", () => ({ clearStudyStore: mocks.clearStudyStore }));
+vi.mock("@/features/study/state/studyStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/study/state/studyStore")>();
+  mocks.actualClearStudyStore = actual.clearStudyStore;
+  return { ...actual, clearStudyStore: mocks.clearStudyStore };
+});
 vi.mock("@/hooks/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
 vi.mock("@/hooks/useActions", () => ({ useActions: () => mocks.accountActions }));
 vi.mock("@/features/settings/hooks/useConfigFormState", () => ({
@@ -64,8 +69,12 @@ import { logout } from "@/action/event";
 import { AuthBootstrap } from "@/auth/AuthBootstrap";
 import { AuthProvider, createAuthStore, useAuth } from "@/auth/AuthContext";
 import { ConfigContainer } from "@/features/settings/containers/ConfigContainer";
+import { studyStore } from "@/features/study/state/studyStore";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -74,6 +83,12 @@ beforeEach(() => {
   mocks.operations.length = 0;
   mocks.accountActions.login.mockResolvedValue(undefined);
   mocks.accountActions.logout.mockImplementation(logout);
+  mocks.clearStudyStore.mockImplementation(() => {
+    if (!mocks.actualClearStudyStore) throw new Error("Actual study cleanup was not initialized");
+    return mocks.actualClearStudyStore();
+  });
+  studyStore.setState({ sessionsByDeckId: {}, showBackText: false, autoPlay: false, lastSwipe: undefined });
+  localStorage.clear();
 });
 
 const AuthenticatedSettings = () => (useAuth().status === "authenticated" ? <ConfigContainer /> : null);
@@ -208,5 +223,57 @@ it("keeps post-sign-out cleanup failures visible and retries only unfinished cle
   await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   expect(mocks.cleanupUid).toHaveBeenCalledTimes(3);
   expect(mocks.signOut).toHaveBeenCalledOnce();
+  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+});
+
+it("does not erase a new anonymous study when obsolete logout cleanup is retried", async () => {
+  const userA = { uid: "study-uid-a", isAnonymous: false, providerData: [] } as unknown as User;
+  const userB = { uid: "study-uid-b", isAnonymous: true, providerData: [] } as unknown as User;
+  const cleanupError = new Error("study storage cleanup failed");
+
+  mocks.onAuthStateChanged.mockImplementation((_auth, onUser) => {
+    mocks.publishUser = onUser;
+    return vi.fn();
+  });
+  mocks.signOut.mockImplementation(async () => mocks.publishUser?.(null));
+  mocks.signInAnonymously.mockImplementation(() =>
+    Promise.resolve().then(() => {
+      mocks.publishUser?.(userB);
+      return { user: userB } as UserCredential;
+    })
+  );
+  mocks.cleanupUid.mockResolvedValue(undefined);
+  vi.spyOn(Storage.prototype, "removeItem").mockImplementationOnce(() => {
+    throw cleanupError;
+  });
+
+  const store = createAuthStore({
+    auth: mocks.auth as unknown as Auth,
+    onAuthStateChanged: mocks.onAuthStateChanged,
+    signInAnonymously: mocks.signInAnonymously,
+  });
+  render(
+    <StrictMode>
+      <AuthProvider store={store}>
+        <AuthenticatedSettings />
+      </AuthProvider>
+    </StrictMode>
+  );
+  act(() => mocks.publishUser?.(userA));
+  studyStore.getState().startStudy("old-deck", ["old-card"]);
+
+  fireEvent.click(await screen.findByRole("button", { name: "Logout" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+  expect(studyStore.getState().sessionsByDeckId).toEqual({});
+
+  act(() => studyStore.getState().startStudy("new-deck", ["new-card"]));
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+  await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  expect(studyStore.getState().sessionsByDeckId).toEqual({
+    "new-deck": expect.objectContaining({ deckId: "new-deck", cardOrderIds: ["new-card"] }),
+  });
+  expect(mocks.signOut).toHaveBeenCalledOnce();
+  expect(mocks.cleanupUid).toHaveBeenCalledOnce();
   expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
 });

--- a/src/components/feedback/RemoteMutationNotice.spec.tsx
+++ b/src/components/feedback/RemoteMutationNotice.spec.tsx
@@ -28,4 +28,23 @@ describe("RemoteMutationNotice", () => {
     fireEvent.click(view.getByRole("button", { name: "Retry" }));
     expect(onRetry).toHaveBeenCalledOnce();
   });
+
+  it("uses a custom pending label", () => {
+    const view = render(<RemoteMutationNotice pending error={null} onRetry={vi.fn()} pendingLabel="Deleting deck…" />);
+
+    expect(view.getByRole("status")).toHaveTextContent("Deleting deck…");
+  });
+
+  it("uses a custom error label", () => {
+    const view = render(
+      <RemoteMutationNotice
+        pending={false}
+        error={new Error("delete failed")}
+        onRetry={vi.fn()}
+        errorLabel="Unable to delete deck."
+      />
+    );
+
+    expect(view.getByRole("alert")).toHaveTextContent("Unable to delete deck.");
+  });
 });

--- a/src/components/feedback/RemoteMutationNotice.stories.tsx
+++ b/src/components/feedback/RemoteMutationNotice.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { RemoteMutationNotice as Template } from "@/components/feedback/RemoteMutationNotice";
+
+const meta = {
+  title: "Shared/Feedback/RemoteMutationNotice",
+  component: Template,
+  tags: ["autodocs"],
+  args: { pending: true, error: null, onRetry: () => {} },
+} satisfies Meta<typeof Template>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pending: Story = {};
+
+export const Deleting: Story = {
+  args: { pendingLabel: "Deleting deck…" },
+};
+
+export const DefaultError: Story = {
+  args: { pending: false, error: new Error("save failed") },
+};
+
+export const AccountError: Story = {
+  args: {
+    pending: false,
+    error: new Error("account deletion failed"),
+    errorLabel: "Unable to delete account.",
+  },
+};

--- a/src/components/feedback/RemoteMutationNotice.tsx
+++ b/src/components/feedback/RemoteMutationNotice.tsx
@@ -1,17 +1,22 @@
 import { Button } from "@/components/forms/Button";
 
-interface RemoteMutationNoticeProps {
+export interface RemoteMutationNoticeProps {
   pending: boolean;
   error: unknown;
   onRetry: () => void;
   showPending?: boolean;
+  pendingLabel?: string;
+  errorLabel?: string;
 }
 
 export const RemoteMutationNotice = (props: RemoteMutationNoticeProps) => {
+  const pendingLabel = props.pendingLabel ?? "Saving…";
+  const errorLabel = props.errorLabel ?? "Unable to save changes.";
+
   if (props.error != null) {
     return (
       <div role="alert" className="my-2 flex items-center justify-between rounded border border-red-300 p-2 text-sm">
-        <span>Unable to save changes.</span>
+        <span>{errorLabel}</span>
         <Button small onClick={props.onRetry}>
           Retry
         </Button>
@@ -21,7 +26,7 @@ export const RemoteMutationNotice = (props: RemoteMutationNoticeProps) => {
   if (!props.pending || props.showPending === false) return null;
   return (
     <div role="status" className="my-2 text-sm text-gray-500">
-      Saving…
+      {pendingLabel}
     </div>
   );
 };

--- a/src/components/feedback/RemoteReadBoundary.spec.tsx
+++ b/src/components/feedback/RemoteReadBoundary.spec.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
 import { RemoteReadBoundary } from "@/components/feedback/RemoteReadBoundary";
+import { RouteFeedback } from "@/components/feedback/RouteFeedback";
 
 describe("RemoteReadBoundary", () => {
   it("shows loading instead of children before initial data", () => {
@@ -59,5 +61,21 @@ describe("RemoteReadBoundary", () => {
     );
 
     expect(screen.getByRole("status").textContent).toContain("No decks yet.");
+  });
+
+  it("shows custom empty content after a successful empty read", () => {
+    render(
+      <RemoteReadBoundary
+        status="ready"
+        hasData={false}
+        emptyContent={<RouteFeedback title="Deck not found" tone="not-found" />}
+        onRetry={vi.fn()}
+      >
+        content
+      </RemoteReadBoundary>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Deck not found" })).toBeInTheDocument();
+    expect(screen.queryByText("No data yet.")).toBeNull();
   });
 });

--- a/src/components/feedback/RemoteReadBoundary.stories.tsx
+++ b/src/components/feedback/RemoteReadBoundary.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { RemoteReadBoundary as Template } from "@/components/feedback/RemoteReadBoundary";
+import { RouteFeedback } from "@/components/feedback/RouteFeedback";
+
+const meta = {
+  title: "Shared/Feedback/RemoteReadBoundary",
+  component: Template,
+  tags: ["autodocs"],
+  args: { status: "loading", hasData: false, onRetry: () => {}, children: "Deck content" },
+} satisfies Meta<typeof Template>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InitialLoading: Story = {};
+
+export const InitialError: Story = {
+  args: { status: "error", hasData: false },
+};
+
+export const CachedSyncError: Story = {
+  args: { status: "error", hasData: true, children: "Cached deck content" },
+};
+
+export const BlockedStorage: Story = {
+  args: { status: "blocked", hasData: false },
+};
+
+export const EmptyRead: Story = {
+  args: {
+    status: "ready",
+    hasData: false,
+    emptyContent: <RouteFeedback title="No decks yet." tone="not-found" />,
+  },
+};

--- a/src/components/feedback/RemoteReadBoundary.tsx
+++ b/src/components/feedback/RemoteReadBoundary.tsx
@@ -1,20 +1,16 @@
 import type { ReactNode } from "react";
 
 import { Button } from "@/components/forms/Button";
+import { RouteFeedback } from "@/components/feedback/RouteFeedback";
 
-type RemoteReadBoundaryProps = {
+export type RemoteReadBoundaryProps = {
   status: "idle" | "loading" | "ready" | "error" | "blocked";
   hasData: boolean;
   emptyLabel?: string;
+  emptyContent?: ReactNode;
   onRetry: () => void;
   children: ReactNode;
 };
-
-const Status = ({ children }: { children: ReactNode }) => (
-  <div role="status" className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
-    {children}
-  </div>
-);
 
 const ErrorNotice = ({ hasData, onRetry }: Pick<RemoteReadBoundaryProps, "hasData" | "onRetry">) => (
   <div
@@ -31,19 +27,26 @@ const ErrorNotice = ({ hasData, onRetry }: Pick<RemoteReadBoundaryProps, "hasDat
 export const RemoteReadBoundary = (props: RemoteReadBoundaryProps) => {
   if (props.status === "blocked") {
     return (
-      <div
-        role="alert"
-        className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
-      >
-        Offline storage is unavailable. Close other tabs or use a supported browser, then reload this page.
-      </div>
+      <RouteFeedback
+        title="Offline storage is unavailable."
+        description="Close other tabs or use a supported browser, then reload this page."
+        tone="error"
+      />
     );
   }
-  if (props.status === "loading" && !props.hasData) return <Status>Loading…</Status>;
+  if (props.status === "loading" && !props.hasData) return <RouteFeedback title="Loading…" tone="loading" />;
   if (props.status === "error" && !props.hasData) {
-    return <ErrorNotice hasData={false} onRetry={props.onRetry} />;
+    return (
+      <RouteFeedback
+        title="Unable to load data."
+        tone="error"
+        primaryAction={{ label: "Retry", onClick: props.onRetry }}
+      />
+    );
   }
-  if (props.status === "ready" && !props.hasData) return <Status>{props.emptyLabel ?? "No data yet."}</Status>;
+  if (props.status === "ready" && !props.hasData) {
+    return props.emptyContent ?? <RouteFeedback title={props.emptyLabel ?? "No data yet."} tone="not-found" />;
+  }
 
   return (
     <>

--- a/src/components/feedback/RouteFeedback.spec.tsx
+++ b/src/components/feedback/RouteFeedback.spec.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import { RouteFeedback } from "@/components";
+
+describe("RouteFeedback", () => {
+  it("renders loading feedback with a heading and description", () => {
+    render(
+      <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
+    );
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.getByText("Preparing your decks and study progress.")).toBeInTheDocument();
+  });
+
+  it("renders error feedback as an alert and invokes its primary action", () => {
+    const onReload = vi.fn();
+    render(
+      <RouteFeedback
+        title="Unable to start Tango"
+        tone="error"
+        primaryAction={{ label: "Reload", onClick: onReload }}
+      />
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it("renders secondary action before primary action for not-found feedback", () => {
+    const onGoBack = vi.fn();
+    const onGoHome = vi.fn();
+    render(
+      <RouteFeedback
+        title="Page not found"
+        tone="not-found"
+        primaryAction={{ label: "Go home", onClick: onGoHome }}
+        secondaryAction={{ label: "Go back", onClick: onGoBack }}
+      />
+    );
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual(["Go back", "Go home"]);
+    fireEvent.click(screen.getByRole("button", { name: "Go back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+    expect(onGoBack).toHaveBeenCalledOnce();
+    expect(onGoHome).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/feedback/RouteFeedback.stories.tsx
+++ b/src/components/feedback/RouteFeedback.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { RouteFeedback as Template } from "@/components/feedback/RouteFeedback";
+
+const meta = {
+  title: "Shared/Feedback/RouteFeedback",
+  component: Template,
+  tags: ["autodocs"],
+  args: { title: "Starting Tango…", tone: "loading" },
+} satisfies Meta<typeof Template>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {};
+
+export const ErrorState: Story = {
+  args: {
+    title: "Unable to start Tango",
+    description: "Authentication could not be initialized.",
+    tone: "error",
+    primaryAction: { label: "Reload", onClick: () => {} },
+  },
+};
+
+export const NotFound: Story = {
+  args: {
+    title: "Page not found",
+    tone: "not-found",
+    primaryAction: { label: "Go home", onClick: () => {} },
+    secondaryAction: { label: "Go back", onClick: () => {} },
+  },
+};
+
+export const Dark: Story = {
+  args: { title: "Starting Tango…", tone: "loading" },
+  globals: { theme: "dark" },
+};

--- a/src/components/feedback/RouteFeedback.tsx
+++ b/src/components/feedback/RouteFeedback.tsx
@@ -1,0 +1,50 @@
+import type * as React from "react";
+
+import { Button, type ButtonVariant } from "@/components/forms/Button";
+import { Layout } from "@/components/layout/Layout";
+
+export type RouteFeedbackTone = "loading" | "error" | "not-found";
+
+export interface RouteFeedbackAction {
+  label: string;
+  onClick: () => void;
+  variant?: ButtonVariant;
+}
+
+export interface RouteFeedbackProps {
+  title: string;
+  description?: string;
+  tone?: RouteFeedbackTone;
+  primaryAction?: RouteFeedbackAction;
+  secondaryAction?: RouteFeedbackAction;
+}
+
+const ActionButton = ({ action, defaultVariant }: { action: RouteFeedbackAction; defaultVariant: ButtonVariant }) => (
+  <Button variant={action.variant ?? defaultVariant} onClick={action.onClick}>
+    {action.label}
+  </Button>
+);
+
+export const RouteFeedback: React.FC<RouteFeedbackProps> = (props) => {
+  const tone = props.tone ?? "loading";
+  const role = tone === "error" ? "alert" : "status";
+
+  return (
+    <Layout>
+      <section
+        role={role}
+        aria-live={tone === "error" ? "assertive" : "polite"}
+        className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 text-center text-ink shadow-surface md:p-6"
+      >
+        <h1 className="text-title font-bold">{props.title}</h1>
+        {props.description ? <p className="mt-2 text-body text-ink-muted">{props.description}</p> : null}
+        {props.primaryAction || props.secondaryAction ? (
+          <div className="mt-6 flex flex-wrap justify-center gap-2">
+            {props.secondaryAction ? <ActionButton action={props.secondaryAction} defaultVariant="quiet" /> : null}
+            {props.primaryAction ? <ActionButton action={props.primaryAction} defaultVariant="primary" /> : null}
+          </div>
+        ) : null}
+      </section>
+    </Layout>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export * from "@/components/content/Card";
 export * from "@/components/content/Code";
 export * from "@/components/content/Description";
 export * from "@/components/feedback/Feedback";
+export * from "@/components/feedback/RouteFeedback";
 export * from "@/components/feedback/RemoteReadBoundary";
 export * from "@/components/feedback/RemoteMutationNotice";
 export * from "@/components/feedback/buttonInteraction";

--- a/src/features/card/containers/CardFormContainer.spec.tsx
+++ b/src/features/card/containers/CardFormContainer.spec.tsx
@@ -149,6 +149,33 @@ describe("CardFormContainer", () => {
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
+  it("shows recovery actions when the card is unavailable", () => {
+    mocks.card = null;
+    const view = render(<CardFormContainer />);
+
+    expect(view.getByRole("heading", { level: 1, name: "Card not found" })).toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Go home" })).toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Go back" })).toBeInTheDocument();
+  });
+
+  it("goes home when card recovery is requested", async () => {
+    mocks.card = null;
+    const view = render(<CardFormContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Go home" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("goes back when card recovery is requested", async () => {
+    mocks.card = null;
+    const view = render(<CardFormContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Go back" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith(-1);
+  });
+
   it("preserves the invalid route error", () => {
     mocks.params.id = undefined;
 

--- a/src/features/card/containers/CardFormContainer.tsx
+++ b/src/features/card/containers/CardFormContainer.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import * as C from "@/constant";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteMutationNotice, RemoteReadBoundary } from "@/components";
+import { RemoteMutationNotice, RemoteReadBoundary, RouteFeedback } from "@/components";
 import { useActions } from "@/hooks/useActions";
 import { CardFormTemplate } from "@/features/card/components/templates/CardFormTemplate";
 import { useCardFormState } from "@/features/card/hooks/useCardFormState";
@@ -50,6 +50,7 @@ const CardFormContent = ({ card }: { card: Card }) => {
 
 export const CardFormContainer: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const cardId = params.id;
   if (cardId == null) throw Error("invalid card id");
   const remote = useRemoteCollections();
@@ -59,7 +60,15 @@ export const CardFormContainer: React.FC = () => {
     <RemoteReadBoundary
       status={remote.status}
       hasData={card != null}
-      emptyLabel="Card not found."
+      emptyContent={
+        <RouteFeedback
+          title="Card not found"
+          description="The requested card is unavailable or has been removed."
+          tone="not-found"
+          primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+          secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+        />
+      }
       onRetry={remote.retry}
     >
       {card != null ? <CardFormContent card={card} /> : null}

--- a/src/features/card/containers/CardListContainer.spec.tsx
+++ b/src/features/card/containers/CardListContainer.spec.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   cardUpdateBy: vi.fn(),
   cardRemove: vi.fn(),
   onClickTag: vi.fn(),
+  navigate: vi.fn(),
 }));
 
 vi.mock("@/features/card/hooks/useCardMutations", () => ({
@@ -49,6 +50,7 @@ vi.mock("@/query/useRemoteCollections", () => ({
 
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
+  useNavigate: () => mocks.navigate,
 }));
 
 vi.mock("react-use", () => ({
@@ -138,6 +140,7 @@ describe("CardListContainer", () => {
     mocks.cardUpdateBy.mockReset().mockResolvedValue(undefined);
     mocks.cardRemove.mockReset().mockResolvedValue(undefined);
     mocks.onClickTag.mockReset();
+    mocks.navigate.mockReset();
   });
 
   afterEach(() => {

--- a/src/features/card/containers/CardListContainer.tsx
+++ b/src/features/card/containers/CardListContainer.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
 import * as C from "@/constant";
 import * as util from "@/util";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteMutationNotice, RemoteReadBoundary } from "@/components";
+import { RemoteMutationNotice, RemoteReadBoundary, RouteFeedback } from "@/components";
 import { useActions } from "@/hooks/useActions";
 import { CardListTemplate } from "@/features/card/components/templates/CardListTemplate";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
@@ -82,6 +82,7 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
 
 export const CardListContainer: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
   const config = useConfig();
@@ -94,7 +95,15 @@ export const CardListContainer: React.FC = () => {
     <RemoteReadBoundary
       status={remote.status}
       hasData={deck != null}
-      emptyLabel="Deck not found."
+      emptyContent={
+        <RouteFeedback
+          title="Deck not found"
+          description="The requested deck is unavailable or has been removed."
+          tone="not-found"
+          primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+          secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+        />
+      }
       onRetry={remote.retry}
     >
       {deck != null ? <CardListContent deck={deck} cards={cards} tags={tags} config={config} /> : null}

--- a/src/features/card/containers/CardViewContainer.tsx
+++ b/src/features/card/containers/CardViewContainer.tsx
@@ -1,10 +1,10 @@
 import type * as React from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import * as C from "@/constant";
 import * as util from "@/util";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/components";
+import { RemoteReadBoundary, RouteFeedback } from "@/components";
 import { useActions } from "@/hooks/useActions";
 import { CardViewTemplate } from "@/features/card/components/templates/CardViewTemplate";
 import { useConfig } from "@/hooks/useConfig";
@@ -36,6 +36,7 @@ const CardViewContent = ({ card, deck }: { card: Card; deck: Deck }) => {
 
 export const CardViewContainer: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const cardId = params.id;
   if (cardId == null) throw Error("invalid card id");
   const remote = useRemoteCollections();
@@ -44,7 +45,20 @@ export const CardViewContainer: React.FC = () => {
   const available = card != null && deck != null;
 
   return (
-    <RemoteReadBoundary status={remote.status} hasData={available} emptyLabel="Card not found." onRetry={remote.retry}>
+    <RemoteReadBoundary
+      status={remote.status}
+      hasData={available}
+      emptyContent={
+        <RouteFeedback
+          title="Card not found"
+          description="The requested card is unavailable or has been removed."
+          tone="not-found"
+          primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+          secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+        />
+      }
+      onRetry={remote.retry}
+    >
       {available ? <CardViewContent card={card} deck={deck} /> : null}
     </RemoteReadBoundary>
   );

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -19,6 +19,25 @@ const ControlledMenu: React.FC<ControlledMenuProps> = (props) => {
   );
 };
 
+const DisableableMenu: React.FC = () => {
+  const [open, setOpen] = React.useState(false);
+  const [disabled, setDisabled] = React.useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setDisabled((value) => !value)}>
+        Toggle disabled
+      </button>
+      <DeckActionsMenu
+        deckName="Physics"
+        open={open}
+        disabled={disabled}
+        onToggle={() => setOpen((value) => !value)}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+};
+
 describe("DeckActionsMenu", () => {
   afterEach(cleanup);
 
@@ -137,6 +156,23 @@ describe("DeckActionsMenu", () => {
     const view = render(<DeckActionsMenu deckName="Physics" open disabled onToggle={vi.fn()} onClose={vi.fn()} />);
 
     expect(view.getByRole("button", { name: "Open actions for Physics" })).toBeDisabled();
+    expect(view.queryByRole("menu", { name: "Actions for Physics" })).not.toBeInTheDocument();
+  });
+
+  it("closes controlled state when disabled so the menu stays closed when re-enabled", () => {
+    const view = render(<DisableableMenu />);
+    const trigger = view.getByRole("button", { name: "Open actions for Physics" });
+    const toggleDisabled = view.getByRole("button", { name: "Toggle disabled" });
+
+    fireEvent.click(trigger);
+    expect(view.getByRole("menu", { name: "Actions for Physics" })).toBeInTheDocument();
+    fireEvent.click(toggleDisabled);
+    expect(trigger).toBeDisabled();
+    expect(view.queryByRole("menu", { name: "Actions for Physics" })).not.toBeInTheDocument();
+
+    fireEvent.click(toggleDisabled);
+
+    expect(trigger).not.toBeDisabled();
     expect(view.queryByRole("menu", { name: "Actions for Physics" })).not.toBeInTheDocument();
   });
 });

--- a/src/features/deck/components/DeckActionsMenu.spec.tsx
+++ b/src/features/deck/components/DeckActionsMenu.spec.tsx
@@ -132,4 +132,11 @@ describe("DeckActionsMenu", () => {
     await waitFor(() => expect(view.queryByRole("menu")).not.toBeInTheDocument());
     expect(externalTarget).toHaveFocus();
   });
+
+  it("disables its trigger and hides a controlled open menu", () => {
+    const view = render(<DeckActionsMenu deckName="Physics" open disabled onToggle={vi.fn()} onClose={vi.fn()} />);
+
+    expect(view.getByRole("button", { name: "Open actions for Physics" })).toBeDisabled();
+    expect(view.queryByRole("menu", { name: "Actions for Physics" })).not.toBeInTheDocument();
+  });
 });

--- a/src/features/deck/components/DeckActionsMenu.tsx
+++ b/src/features/deck/components/DeckActionsMenu.tsx
@@ -5,6 +5,7 @@ import { ActionsMenu, type ActionsMenuItem } from "@/components/forms/ActionsMen
 export interface DeckActionsMenuProps {
   deckName: string;
   open: boolean;
+  disabled?: boolean;
   onToggle: () => void;
   onClose: () => void;
   onRestart?: () => void;
@@ -45,6 +46,7 @@ export const DeckActionsMenu: React.FC<DeckActionsMenuProps> = (props) => {
       triggerLabel={`Open actions for ${props.deckName}`}
       menuLabel={`Actions for ${props.deckName}`}
       open={props.open}
+      {...(props.disabled !== undefined ? { disabled: props.disabled } : {})}
       onToggle={props.onToggle}
       onClose={props.onClose}
       items={items}

--- a/src/features/deck/components/DeckActionsMenu.tsx
+++ b/src/features/deck/components/DeckActionsMenu.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 import { AiOutlineCloudDownload, AiOutlineDelete, AiOutlineEdit, AiOutlineReload } from "react-icons/ai";
 import { ActionsMenu, type ActionsMenuItem } from "@/components/forms/ActionsMenu";
 
@@ -15,6 +15,11 @@ export interface DeckActionsMenuProps {
 }
 
 export const DeckActionsMenu: React.FC<DeckActionsMenuProps> = (props) => {
+  const { disabled, onClose, open } = props;
+  React.useEffect(() => {
+    if (disabled && open) onClose();
+  }, [disabled, onClose, open]);
+
   const items: ActionsMenuItem[] = [
     ...(props.onRestart != null
       ? [{ key: "restart", label: "Restart", icon: <AiOutlineReload aria-hidden="true" />, onSelect: props.onRestart }]

--- a/src/features/deck/components/DeckCard.spec.tsx
+++ b/src/features/deck/components/DeckCard.spec.tsx
@@ -123,4 +123,25 @@ describe("DeckCard", () => {
     expect(onClickStudy).toHaveBeenCalledExactlyOnceWith(deck.id);
     expect(onClickName).not.toHaveBeenCalled();
   });
+
+  it("makes only the pending Deck row unavailable", () => {
+    const otherDeck = createDeck({ id: "other-deck", name: "Other deck" });
+    const view = render(
+      <>
+        <ControlledDeckCard deck={deck} cardCount={8} isPending={(id) => id === deck.id} />
+        <ControlledDeckCard deck={otherDeck} cardCount={2} isPending={(id) => id === deck.id} />
+      </>
+    );
+
+    expect(view.getByRole("button", { name: "View Deck name" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "Study Deck name" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "Open actions for Deck name" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "View Deck name" }).closest("article")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+    expect(view.getByRole("button", { name: "View Other deck" })).not.toBeDisabled();
+    expect(view.getByRole("button", { name: "Study Other deck" })).not.toBeDisabled();
+    expect(view.getByRole("button", { name: "Open actions for Other deck" })).not.toBeDisabled();
+  });
 });

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -17,6 +17,7 @@ export interface DeckCardActions {
   onClickDownload?: (id: DeckId) => void;
   onClickEdit?: (id: DeckId) => void;
   onClickDelete?: (id: DeckId) => void;
+  isPending?: (id: DeckId) => boolean;
   openMenuDeckId?: DeckId | undefined;
   onToggleMenu?: (id: DeckId) => void;
   onCloseMenu?: () => void;
@@ -50,11 +51,15 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
   const active = studyProgress != null;
   const progressValue = active ? studyProgress.currentIndex + 1 : 0;
   const progressPercent = active ? Math.min(100, (progressValue / studyProgress.cardCount) * 100) : 0;
+  const pending = props.isPending?.(deck.id) ?? false;
   const withId = (action?: (id: DeckId) => void) => () => action?.(deck.id);
   const statusId = React.useId();
 
   return (
-    <article className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0">
+    <article
+      aria-busy={pending}
+      className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0"
+    >
       <div className="min-w-0 flex-1 px-1 py-1">
         <button
           type="button"
@@ -62,6 +67,7 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
           aria-describedby={statusId}
           className="flex w-full min-w-0 items-center gap-1.5 rounded-control text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
           onClick={withId(props.onClickName)}
+          disabled={pending}
         >
           <span className="truncate text-body font-semibold text-ink">{deck.name}</span>
           {deck.isPublic && (
@@ -107,6 +113,7 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
             : "border border-border bg-transparent text-ink hover:bg-surface-muted"
         }`}
         onClick={withId(active ? props.onClickContinue : props.onClickStudy)}
+        disabled={pending}
       >
         {active && <AiFillCaretRight aria-hidden="true" />}
         <span>{active ? "Continue" : "Study"}</span>
@@ -115,6 +122,7 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
       <DeckActionsMenu
         deckName={deck.name}
         open={props.openMenuDeckId === deck.id}
+        disabled={pending}
         onToggle={withId(props.onToggleMenu)}
         onClose={() => props.onCloseMenu?.()}
         {...(active ? { onRestart: withId(props.onClickRestart) } : {})}

--- a/src/features/deck/containers/DeckFormContainer.spec.tsx
+++ b/src/features/deck/containers/DeckFormContainer.spec.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   deck: null as Deck | null,
   updateAndGoToList: vi.fn(),
   goToList: vi.fn(),
+  navigate: vi.fn(),
 }));
 
 vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
@@ -23,6 +24,7 @@ vi.mock("@/query/useRemoteCollections", () => ({
 
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
+  useNavigate: () => mocks.navigate,
 }));
 
 vi.mock("@/hooks/useActions", () => ({
@@ -69,6 +71,7 @@ describe("DeckFormContainer", () => {
     mocks.config = { darkMode: false } as ConfigState;
     mocks.updateAndGoToList.mockReset();
     mocks.goToList.mockReset();
+    mocks.navigate.mockReset();
   });
 
   afterEach(() => {
@@ -154,6 +157,33 @@ describe("DeckFormContainer", () => {
     const view = render(<DeckFormContainer />);
 
     expect(view.container.querySelector("input[name='isPublic']")).not.toBeInTheDocument();
+  });
+
+  it("shows recovery actions when the deck is unavailable", () => {
+    mocks.deck = null;
+    const view = render(<DeckFormContainer />);
+
+    expect(view.getByRole("heading", { level: 1, name: "Deck not found" })).toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Go home" })).toBeInTheDocument();
+    expect(view.getByRole("button", { name: "Go back" })).toBeInTheDocument();
+  });
+
+  it("goes home when deck recovery is requested", async () => {
+    mocks.deck = null;
+    const view = render(<DeckFormContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Go home" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("goes back when deck recovery is requested", async () => {
+    mocks.deck = null;
+    const view = render(<DeckFormContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Go back" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith(-1);
   });
 
   it("preserves the invalid route error", () => {

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 
 import * as C from "@/constant";
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteMutationNotice, RemoteReadBoundary } from "@/components";
+import { RemoteMutationNotice, RemoteReadBoundary, RouteFeedback } from "@/components";
 import { useActions } from "@/hooks/useActions";
 import { DeckFormTemplate } from "@/features/deck/components/templates/DeckFormTemplate";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
@@ -67,6 +67,7 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
 
 export const DeckFormContainer: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
   const remote = useRemoteCollections();
@@ -76,7 +77,15 @@ export const DeckFormContainer: React.FC = () => {
     <RemoteReadBoundary
       status={remote.status}
       hasData={deck != null}
-      emptyLabel="Deck not found."
+      emptyContent={
+        <RouteFeedback
+          title="Deck not found"
+          description="The requested deck is unavailable or has been removed."
+          tone="not-found"
+          primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+          secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+        />
+      }
       onRetry={remote.retry}
     >
       {deck != null ? <DeckFormContent deck={deck} /> : null}

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -11,7 +11,10 @@ const mocks = vi.hoisted(() => ({
   cardsById: {} as Record<CardId, Card>,
   hydrated: true,
   pending: false,
+  pendingDeckIds: new Set<DeckId>(),
+  error: null as unknown,
   remove: vi.fn(async (_deck: Deck) => undefined),
+  retry: vi.fn(),
   downloadData: vi.fn(),
   actions: {
     goToSettings: vi.fn(),
@@ -46,7 +49,13 @@ vi.mock("@/query/useRemoteCollections", () => ({
 vi.mock("react-use", () => ({ useKey: vi.fn() }));
 vi.mock("@/hooks/useActions", () => ({ useActions: () => mocks.actions }));
 vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
-  useDeckMutations: () => ({ remove: mocks.remove, pending: mocks.pending, error: null, retry: vi.fn() }),
+  useDeckMutations: () => ({
+    remove: mocks.remove,
+    pending: mocks.pending,
+    isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
+    error: mocks.error,
+    retry: mocks.retry,
+  }),
 }));
 vi.mock("@/features/import/hooks/useSampleDeckBootstrap", () => ({ useSampleDeckBootstrap: vi.fn() }));
 
@@ -62,6 +71,8 @@ describe("DeckListContainer", () => {
     vi.clearAllMocks();
     mocks.hydrated = true;
     mocks.pending = false;
+    mocks.pendingDeckIds = new Set();
+    mocks.error = null;
     mocks.config = createConfig({ darkMode: false });
     mocks.decksById = { [otherDeck.id]: otherDeck, [oldDeck.id]: oldDeck, [recentDeck.id]: recentDeck };
     mocks.cardsById = {
@@ -183,5 +194,20 @@ describe("DeckListContainer", () => {
     mocks.decksById[recentDeck.id] = recentDeck;
     view.rerender(<DeckListContainer />);
     expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeDefined();
+  });
+
+  it("shows Deck deletion feedback and disables only the pending row", () => {
+    mocks.pending = true;
+    mocks.pendingDeckIds = new Set([recentDeck.id]);
+    mocks.error = new Error("delete failed");
+    const view = render(<DeckListContainer />);
+
+    expect(view.getByRole("alert")).toHaveTextContent("Unable to delete deck.");
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(mocks.retry).toHaveBeenCalledOnce();
+    expect(view.getByRole("button", { name: "View Recent deck" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "Continue Recent deck" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "Open actions for Recent deck" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "View Alpha deck" })).not.toBeDisabled();
   });
 });

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   pending: false,
   pendingDeckIds: new Set<DeckId>(),
   error: null as unknown,
+  onRemoveSuccess: undefined as ((deck: Deck) => void) | undefined,
   remove: vi.fn(async (_deck: Deck) => undefined),
   retry: vi.fn(),
   downloadData: vi.fn(),
@@ -49,13 +50,16 @@ vi.mock("@/query/useRemoteCollections", () => ({
 vi.mock("react-use", () => ({ useKey: vi.fn() }));
 vi.mock("@/hooks/useActions", () => ({ useActions: () => mocks.actions }));
 vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
-  useDeckMutations: () => ({
-    remove: mocks.remove,
-    pending: mocks.pending,
-    isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
-    error: mocks.error,
-    retry: mocks.retry,
-  }),
+  useDeckMutations: (options?: { onRemoveSuccess?: (deck: Deck) => void }) => {
+    mocks.onRemoveSuccess = options?.onRemoveSuccess;
+    return {
+      remove: (deck: Deck) => mocks.remove(deck).then(() => mocks.onRemoveSuccess?.(deck)),
+      pending: mocks.pending,
+      isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
+      error: mocks.error,
+      retry: mocks.retry,
+    };
+  },
 }));
 vi.mock("@/features/import/hooks/useSampleDeckBootstrap", () => ({ useSampleDeckBootstrap: vi.fn() }));
 
@@ -73,6 +77,7 @@ describe("DeckListContainer", () => {
     mocks.pending = false;
     mocks.pendingDeckIds = new Set();
     mocks.error = null;
+    mocks.onRemoveSuccess = undefined;
     mocks.config = createConfig({ darkMode: false });
     mocks.decksById = { [otherDeck.id]: otherDeck, [oldDeck.id]: oldDeck, [recentDeck.id]: recentDeck };
     mocks.cardsById = {
@@ -153,6 +158,16 @@ describe("DeckListContainer", () => {
 
     await waitFor(() => expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(recentDeck));
     await waitFor(() => expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeUndefined());
+    expect(studyStore.getState().sessionsByDeckId[oldDeck.id]).toBeDefined();
+  });
+
+  it("owns successful removal cleanup through the Deck mutation lifecycle", () => {
+    render(<DeckListContainer />);
+
+    expect(mocks.onRemoveSuccess).toBeTypeOf("function");
+    act(() => mocks.onRemoveSuccess?.(recentDeck));
+
+    expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeUndefined();
     expect(studyStore.getState().sessionsByDeckId[oldDeck.id]).toBeDefined();
   });
 

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -49,7 +49,13 @@ export const DeckListContainer: React.FC = () => {
         <DeckListTemplate
           sections={sections}
           feedbackSlot={
-            <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+            <RemoteMutationNotice
+              pending={mutations.pending}
+              error={mutations.error}
+              onRetry={mutations.retry}
+              pendingLabel="Deleting deck…"
+              errorLabel="Unable to delete deck."
+            />
           }
           layout={{
             headerProps: {
@@ -60,6 +66,7 @@ export const DeckListContainer: React.FC = () => {
             },
           }}
           deckCard={{
+            isPending: mutations.isPending,
             openMenuDeckId,
             onToggleMenu: (id) => setOpenMenuDeckId((value) => (value === id ? undefined : id)),
             onCloseMenu: () => setOpenMenuDeckId(undefined),

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -18,7 +18,9 @@ export const DeckListContainer: React.FC = () => {
   const actions = useActions();
   const config = useConfig();
   const remote = useRemoteCollections();
-  const mutations = useDeckMutations();
+  const mutations = useDeckMutations({
+    onRemoveSuccess: (deck) => studyStore.getState().removeStudy(deck.id),
+  });
   const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
   const sessionsByDeckId = useStudyStore((state) => state.sessionsByDeckId);
   const hydrated = useStudyHydrated();
@@ -85,10 +87,7 @@ export const DeckListContainer: React.FC = () => {
             onClickDelete: (id) => {
               const deck = remote.deckById(id);
               if (deck != null && window.confirm("Are you sure of removing this deck?")) {
-                void mutations
-                  .remove(deck)
-                  .then(() => studyStore.getState().removeStudy(id))
-                  .catch(() => undefined);
+                void mutations.remove(deck).catch(() => undefined);
               }
             },
           }}

--- a/src/features/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/features/deck/hooks/useDeckMutations.spec.tsx
@@ -89,6 +89,27 @@ describe("useDeckMutations", () => {
     await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
   });
 
+  it("clears a failed removal after the same Deck is removed manually", async () => {
+    const deck = createDeck({ id: "deck-a" });
+    const error = new Error("delete failed");
+    mocks.remove.mockRejectedValueOnce(error).mockResolvedValue(undefined);
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { [deck.id]: deck });
+    const { result } = renderHook(useDeckMutations, { wrapper: createQueryWrapper(client) });
+
+    await act(async () => {
+      await expect(result.current.remove(deck)).rejects.toThrow(error);
+    });
+    await waitFor(() => expect(result.current.error).toBe(error));
+
+    await act(async () => result.current.remove(deck));
+
+    expect(result.current.error).toBeNull();
+    act(() => result.current.retry());
+    expect(result.current.pending).toBe(false);
+    expect(mocks.remove).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps a Deck failure after an unrelated Deck succeeds until its retry succeeds", async () => {
     const failedDeck = createDeck({ id: "deck-a" });
     const successfulDeck = createDeck({ id: "deck-b" });

--- a/src/features/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/features/deck/hooks/useDeckMutations.spec.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { firestoreKeys } from "@/query/firestoreKeys";
+import { createQueryWrapper, createTestQueryClient } from "@/query/testUtils";
+import { createDeck } from "@/test/factories";
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/auth/AuthContext", () => ({
+  useAuth: () => ({ status: "authenticated", uid: "uid-a", user: { uid: "uid-a" } }),
+}));
+vi.mock("@/action/firestore", () => ({
+  deck: {
+    create: mocks.create,
+    update: mocks.update,
+    remove: mocks.remove,
+  },
+}));
+
+import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
+
+describe("useDeckMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.create.mockResolvedValue("deck-id");
+    mocks.update.mockResolvedValue(undefined);
+    mocks.remove.mockResolvedValue(undefined);
+  });
+
+  it("shares one in-flight removal for the same Deck", async () => {
+    let finishRemove: () => void = () => undefined;
+    mocks.remove.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRemove = resolve;
+        })
+    );
+    const deck = createDeck({ id: "deck-a" });
+    const otherDeck = createDeck({ id: "deck-b" });
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { [deck.id]: deck, [otherDeck.id]: otherDeck });
+    const { result } = renderHook(useDeckMutations, { wrapper: createQueryWrapper(client) });
+    let firstRemove: Promise<void> | undefined;
+    let secondRemove: Promise<void> | undefined;
+
+    act(() => {
+      firstRemove = result.current.remove(deck);
+      secondRemove = result.current.remove(deck);
+    });
+
+    try {
+      await waitFor(() => {
+        expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(deck.id, "uid-a");
+        expect(result.current.pending).toBe(true);
+        expect(result.current.isPending(deck.id)).toBe(true);
+        expect(result.current.isPending(otherDeck.id)).toBe(false);
+      });
+      expect(secondRemove).toBe(firstRemove);
+    } finally {
+      await act(async () => {
+        finishRemove();
+        await firstRemove;
+      });
+    }
+
+    expect(result.current.pending).toBe(false);
+    expect(result.current.isPending(deck.id)).toBe(false);
+  });
+
+  it("keeps a failed removal available for a safe retry", async () => {
+    const deck = createDeck({ id: "deck-a" });
+    const error = new Error("delete failed");
+    mocks.remove.mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { [deck.id]: deck });
+    const { result } = renderHook(useDeckMutations, { wrapper: createQueryWrapper(client) });
+
+    await act(async () => {
+      await expect(result.current.remove(deck)).rejects.toThrow(error);
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(error));
+    act(() => result.current.retry());
+    await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/features/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/features/deck/hooks/useDeckMutations.spec.tsx
@@ -88,4 +88,112 @@ describe("useDeckMutations", () => {
     act(() => result.current.retry());
     await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
   });
+
+  it("keeps a Deck failure after an unrelated Deck succeeds until its retry succeeds", async () => {
+    const failedDeck = createDeck({ id: "deck-a" });
+    const successfulDeck = createDeck({ id: "deck-b" });
+    const error = new Error("deck-a failed");
+    let rejectFailedDeck: (error: Error) => void = () => undefined;
+    let finishSuccessfulDeck: () => void = () => undefined;
+    let failedDeckAttempts = 0;
+    mocks.remove.mockImplementation((id: DeckId) => {
+      if (id === failedDeck.id && ++failedDeckAttempts === 1) {
+        return new Promise<void>((_resolve, reject) => {
+          rejectFailedDeck = reject;
+        });
+      }
+      if (id === successfulDeck.id) {
+        return new Promise<void>((resolve) => {
+          finishSuccessfulDeck = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), {
+      [failedDeck.id]: failedDeck,
+      [successfulDeck.id]: successfulDeck,
+    });
+    const { result } = renderHook(useDeckMutations, { wrapper: createQueryWrapper(client) });
+    let failedRemoval: Promise<void> | undefined;
+    let successfulRemoval: Promise<void> | undefined;
+
+    act(() => {
+      failedRemoval = result.current.remove(failedDeck);
+      successfulRemoval = result.current.remove(successfulDeck);
+    });
+    await waitFor(() => {
+      expect(mocks.remove).toHaveBeenCalledTimes(2);
+      expect(result.current.pending).toBe(true);
+      expect(result.current.isPending(failedDeck.id)).toBe(true);
+      expect(result.current.isPending(successfulDeck.id)).toBe(true);
+    });
+    await act(async () => {
+      rejectFailedDeck(error);
+      await expect(failedRemoval).rejects.toThrow(error);
+    });
+    await waitFor(() => {
+      expect(result.current.error).toBe(error);
+      expect(result.current.pending).toBe(true);
+      expect(result.current.isPending(failedDeck.id)).toBe(false);
+      expect(result.current.isPending(successfulDeck.id)).toBe(true);
+    });
+    await act(async () => {
+      finishSuccessfulDeck();
+      await successfulRemoval;
+    });
+
+    expect(result.current.error).toBe(error);
+    expect(result.current.pending).toBe(false);
+    expect(result.current.isPending(failedDeck.id)).toBe(false);
+    expect(result.current.isPending(successfulDeck.id)).toBe(false);
+    act(() => result.current.retry());
+    await waitFor(() => {
+      expect(mocks.remove).toHaveBeenCalledTimes(3);
+      expect(mocks.remove.mock.calls.filter(([id]) => id === failedDeck.id)).toHaveLength(2);
+      expect(mocks.remove.mock.calls.filter(([id]) => id === successfulDeck.id)).toHaveLength(1);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  it("retries the most recently settled Deck failure", async () => {
+    const firstDeck = createDeck({ id: "deck-c" });
+    const laterDeck = createDeck({ id: "deck-d" });
+    const firstError = new Error("deck-c failed");
+    const laterError = new Error("deck-d failed");
+    const rejectById = new Map<DeckId, (error: Error) => void>();
+    mocks.remove.mockImplementation((id: DeckId) => {
+      if (rejectById.has(id)) return Promise.resolve();
+      return new Promise<void>((_resolve, reject) => rejectById.set(id, reject));
+    });
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { [firstDeck.id]: firstDeck, [laterDeck.id]: laterDeck });
+    const { result } = renderHook(useDeckMutations, { wrapper: createQueryWrapper(client) });
+    let firstRemoval: Promise<void> | undefined;
+    let laterRemoval: Promise<void> | undefined;
+
+    act(() => {
+      firstRemoval = result.current.remove(firstDeck);
+      laterRemoval = result.current.remove(laterDeck);
+    });
+    await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      rejectById.get(firstDeck.id)?.(firstError);
+      await expect(firstRemoval).rejects.toThrow(firstError);
+    });
+    await waitFor(() => expect(result.current.error).toBe(firstError));
+    await act(async () => {
+      rejectById.get(laterDeck.id)?.(laterError);
+      await expect(laterRemoval).rejects.toThrow(laterError);
+    });
+    await waitFor(() => expect(result.current.error).toBe(laterError));
+
+    act(() => result.current.retry());
+
+    await waitFor(() => {
+      expect(mocks.remove).toHaveBeenCalledTimes(3);
+      expect(mocks.remove).toHaveBeenLastCalledWith(laterDeck.id, "uid-a");
+      expect(result.current.error).toBeNull();
+    });
+  });
 });

--- a/src/features/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/features/deck/hooks/useDeckMutations.spec.tsx
@@ -89,6 +89,34 @@ describe("useDeckMutations", () => {
     await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
   });
 
+  it("runs remove success cleanup after a retry finishes beyond the hook lifetime", async () => {
+    const deck = createDeck({ id: "deck-a" });
+    const error = new Error("delete failed");
+    let finishRetry: () => void = () => undefined;
+    const retryRequest = new Promise<void>((resolve) => {
+      finishRetry = resolve;
+    });
+    mocks.remove.mockRejectedValueOnce(error).mockReturnValueOnce(retryRequest);
+    const onRemoveSuccess = vi.fn();
+    const client = createTestQueryClient();
+    client.setQueryData(firestoreKeys.decks("uid-a"), { [deck.id]: deck });
+    const { result, unmount } = renderHook(() => useDeckMutations({ onRemoveSuccess }), {
+      wrapper: createQueryWrapper(client),
+    });
+
+    await act(async () => {
+      await expect(result.current.remove(deck)).rejects.toBe(error);
+    });
+    expect(onRemoveSuccess).not.toHaveBeenCalled();
+
+    act(() => result.current.retry());
+    await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
+    unmount();
+    finishRetry();
+
+    await waitFor(() => expect(onRemoveSuccess).toHaveBeenCalledExactlyOnceWith(deck));
+  });
+
   it("clears a failed removal after the same Deck is removed manually", async () => {
     const deck = createDeck({ id: "deck-a" });
     const error = new Error("delete failed");

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import * as firestore from "@/action/firestore";
 import { useAuth } from "@/auth/AuthContext";
@@ -11,6 +11,8 @@ export const useDeckMutations = () => {
   const auth = useAuth();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const client = useQueryClient();
+  const inFlight = useRef(new Map<DeckId, Promise<void>>());
+  const [pendingDeckIds, setPendingDeckIds] = useState<Set<DeckId>>(() => new Set());
   const lastFailed = useRef<Variables>(undefined);
   const service = useMemo(
     () =>
@@ -33,14 +35,31 @@ export const useDeckMutations = () => {
     },
   });
   const run = useCallback(
-    async (variables: Variables) => {
-      try {
-        await mutation.mutateAsync(variables);
-        lastFailed.current = undefined;
-      } catch (error) {
-        lastFailed.current = variables;
-        throw error;
-      }
+    (variables: Variables) => {
+      const deckId = variables.deck.id;
+      const current = inFlight.current.get(deckId);
+      if (current != null) return current;
+
+      setPendingDeckIds((pending) => new Set(pending).add(deckId));
+      const operation = mutation.mutateAsync(variables).then(
+        () => {
+          lastFailed.current = undefined;
+        },
+        (error: unknown) => {
+          lastFailed.current = variables;
+          throw error;
+        }
+      );
+      const settled = operation.finally(() => {
+        inFlight.current.delete(deckId);
+        setPendingDeckIds((pending) => {
+          const next = new Set(pending);
+          next.delete(deckId);
+          return next;
+        });
+      });
+      inFlight.current.set(deckId, settled);
+      return settled;
     },
     [mutation]
   );
@@ -49,7 +68,8 @@ export const useDeckMutations = () => {
     create: (deck: Deck) => run({ kind: "create", deck }),
     update: (deck: DeckEdit) => run({ kind: "update", deck }),
     remove: (deck: Deck) => run({ kind: "remove", deck }),
-    pending: mutation.isPending,
+    pending: pendingDeckIds.size > 0,
+    isPending: (id: DeckId) => pendingDeckIds.has(id),
     error: mutation.error,
     retry: () => {
       const variables = lastFailed.current;

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import * as firestore from "@/action/firestore";
 import { useAuth } from "@/auth/AuthContext";
@@ -8,13 +8,21 @@ import { createDeckMutationService } from "@/query/deckMutationService";
 type Variables = { kind: "create"; deck: Deck } | { kind: "update"; deck: DeckEdit } | { kind: "remove"; deck: Deck };
 type Failure = { variables: Variables; error: unknown };
 
+interface UseDeckMutationsOptions {
+  onRemoveSuccess?: (deck: Deck) => void;
+}
+
 const isSameOperation = (left: Variables, right: Variables) =>
   left.kind === right.kind && left.deck.id === right.deck.id;
 
-export const useDeckMutations = () => {
+export const useDeckMutations = ({ onRemoveSuccess }: UseDeckMutationsOptions = {}) => {
   const auth = useAuth();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const client = useQueryClient();
+  const onRemoveSuccessRef = useRef(onRemoveSuccess);
+  useEffect(() => {
+    onRemoveSuccessRef.current = onRemoveSuccess;
+  }, [onRemoveSuccess]);
   const inFlight = useRef(new Map<DeckId, Promise<void>>());
   const [pendingDeckIds, setPendingDeckIds] = useState<Set<DeckId>>(() => new Set());
   const failureRef = useRef<Failure>(undefined);
@@ -62,6 +70,7 @@ export const useDeckMutations = () => {
       setPendingDeckIds((pending) => new Set(pending).add(deckId));
       const operation = mutation.mutateAsync(variables).then(
         () => {
+          if (variables.kind === "remove") onRemoveSuccessRef.current?.(variables.deck);
           if (retryOf == null || failureRef.current !== retryOf) return;
           failureRef.current = undefined;
           setFailure(undefined);

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -6,6 +6,7 @@ import { useAuth } from "@/auth/AuthContext";
 import { createDeckMutationService } from "@/query/deckMutationService";
 
 type Variables = { kind: "create"; deck: Deck } | { kind: "update"; deck: DeckEdit } | { kind: "remove"; deck: Deck };
+type Failure = { variables: Variables; error: unknown };
 
 export const useDeckMutations = () => {
   const auth = useAuth();
@@ -13,7 +14,8 @@ export const useDeckMutations = () => {
   const client = useQueryClient();
   const inFlight = useRef(new Map<DeckId, Promise<void>>());
   const [pendingDeckIds, setPendingDeckIds] = useState<Set<DeckId>>(() => new Set());
-  const lastFailed = useRef<Variables>(undefined);
+  const failureRef = useRef<Failure>(undefined);
+  const [failure, setFailure] = useState<Failure>();
   const service = useMemo(
     () =>
       createDeckMutationService({
@@ -35,18 +37,34 @@ export const useDeckMutations = () => {
     },
   });
   const run = useCallback(
-    (variables: Variables) => {
+    (variables: Variables, retryOf?: Failure) => {
       const deckId = variables.deck.id;
       const current = inFlight.current.get(deckId);
-      if (current != null) return current;
+      if (current != null) {
+        if (retryOf != null) {
+          void current.then(
+            () => {
+              if (failureRef.current !== retryOf) return;
+              failureRef.current = undefined;
+              setFailure(undefined);
+            },
+            () => undefined
+          );
+        }
+        return current;
+      }
 
       setPendingDeckIds((pending) => new Set(pending).add(deckId));
       const operation = mutation.mutateAsync(variables).then(
         () => {
-          lastFailed.current = undefined;
+          if (retryOf == null || failureRef.current !== retryOf) return;
+          failureRef.current = undefined;
+          setFailure(undefined);
         },
         (error: unknown) => {
-          lastFailed.current = variables;
+          const nextFailure = { variables, error };
+          failureRef.current = nextFailure;
+          setFailure(nextFailure);
           throw error;
         }
       );
@@ -70,10 +88,10 @@ export const useDeckMutations = () => {
     remove: (deck: Deck) => run({ kind: "remove", deck }),
     pending: pendingDeckIds.size > 0,
     isPending: (id: DeckId) => pendingDeckIds.has(id),
-    error: mutation.error,
+    error: failure?.error ?? null,
     retry: () => {
-      const variables = lastFailed.current;
-      if (variables != null) void run(variables).catch(() => undefined);
+      const failed = failureRef.current;
+      if (failed != null) void run(failed.variables, failed).catch(() => undefined);
     },
   };
 };

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -8,6 +8,9 @@ import { createDeckMutationService } from "@/query/deckMutationService";
 type Variables = { kind: "create"; deck: Deck } | { kind: "update"; deck: DeckEdit } | { kind: "remove"; deck: Deck };
 type Failure = { variables: Variables; error: unknown };
 
+const isSameOperation = (left: Variables, right: Variables) =>
+  left.kind === right.kind && left.deck.id === right.deck.id;
+
 export const useDeckMutations = () => {
   const auth = useAuth();
   const uid = auth.status === "authenticated" ? auth.uid : "";
@@ -37,7 +40,9 @@ export const useDeckMutations = () => {
     },
   });
   const run = useCallback(
-    (variables: Variables, retryOf?: Failure) => {
+    (variables: Variables) => {
+      const failed = failureRef.current;
+      const retryOf = failed != null && isSameOperation(failed.variables, variables) ? failed : undefined;
       const deckId = variables.deck.id;
       const current = inFlight.current.get(deckId);
       if (current != null) {
@@ -91,7 +96,7 @@ export const useDeckMutations = () => {
     error: failure?.error ?? null,
     retry: () => {
       const failed = failureRef.current;
-      if (failed != null) void run(failed.variables, failed).catch(() => undefined);
+      if (failed != null) void run(failed.variables).catch(() => undefined);
     },
   };
 };

--- a/src/features/settings/components/ConfigForm.spec.tsx
+++ b/src/features/settings/components/ConfigForm.spec.tsx
@@ -157,4 +157,30 @@ describe("ConfigForm", () => {
     await userEvent.click(view.getByRole("button", { name: "Logout" }));
     expect(onLogout).toHaveBeenCalledOnce();
   });
+
+  it("shows account feedback and disables the active account action while pending", () => {
+    const feedback = <p>Signing in…</p>;
+    const view = render(<ConfigForm {...createProps({ accountPending: true, accountFeedback: feedback })} />);
+
+    const login = view.getByRole("button", { name: "Login" });
+    expect(login).toBeDisabled();
+    expect(login).toHaveAttribute("aria-busy", "true");
+    expect(view.getByText("Signing in…").closest("section")).toBe(
+      view.getByRole("heading", { level: 2, name: "Account" }).closest("section")
+    );
+
+    view.rerender(
+      <ConfigForm
+        {...createProps({
+          isLoggedIn: true,
+          identity: { uid: "user-123", displayName: "Settings User" },
+          accountPending: true,
+        })}
+      />
+    );
+
+    const logout = view.getByRole("button", { name: "Logout" });
+    expect(logout).toBeDisabled();
+    expect(logout).toHaveAttribute("aria-busy", "true");
+  });
 });

--- a/src/features/settings/components/ConfigForm.tsx
+++ b/src/features/settings/components/ConfigForm.tsx
@@ -27,6 +27,8 @@ export interface ConfigFormProps {
   cardInterval: number;
   onLogin?: () => void;
   onLogout?: () => void;
+  accountPending?: boolean;
+  accountFeedback?: React.ReactNode;
   version?: string;
 }
 
@@ -68,15 +70,26 @@ export const ConfigForm: React.FC<ConfigFormProps> = (props) => {
             </div>
           </div>
           {props.isLoggedIn ? (
-            <Button variant="quiet" size="sm" {...(props.onLogout !== undefined ? { onClick: props.onLogout } : {})}>
+            <Button
+              variant="quiet"
+              size="sm"
+              {...(props.accountPending !== undefined ? { loading: props.accountPending } : {})}
+              {...(props.onLogout !== undefined ? { onClick: props.onLogout } : {})}
+            >
               Logout
             </Button>
           ) : (
-            <Button variant="primary" size="sm" {...(props.onLogin !== undefined ? { onClick: props.onLogin } : {})}>
+            <Button
+              variant="primary"
+              size="sm"
+              {...(props.accountPending !== undefined ? { loading: props.accountPending } : {})}
+              {...(props.onLogin !== undefined ? { onClick: props.onLogin } : {})}
+            >
               Login
             </Button>
           )}
         </div>
+        {props.accountFeedback}
       </SettingsSection>
 
       <SettingsSection title="Appearance" description="Navigation and visual feedback" icon={<AiOutlineEye />}>

--- a/src/features/settings/containers/ConfigContainer.spec.tsx
+++ b/src/features/settings/containers/ConfigContainer.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import type React from "react";
 import type { User } from "firebase/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,6 +17,15 @@ const mocks = vi.hoisted(() => ({
     goByMenu: vi.fn(),
   },
   useConfigFormState: vi.fn((options: Record<string, unknown>) => options),
+  accountOperations: {
+    kind: "login" as "login" | "logout" | null,
+    pending: true,
+    error: null as unknown,
+    login: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn().mockResolvedValue(undefined),
+    retry: vi.fn().mockResolvedValue(undefined),
+  },
+  useAccountOperations: vi.fn(),
 }));
 
 vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
@@ -23,6 +33,9 @@ vi.mock("@/auth/AuthContext", () => ({ useAuth: () => mocks.authState }));
 vi.mock("@/hooks/useActions", () => ({ useActions: () => mocks.actions }));
 vi.mock("@/features/settings/hooks/useConfigFormState", () => ({
   useConfigFormState: mocks.useConfigFormState,
+}));
+vi.mock("@/features/settings/hooks/useAccountOperations", () => ({
+  useAccountOperations: mocks.useAccountOperations,
 }));
 vi.mock("@/features/settings/components/templates/ConfigFormTemplate", () => ({
   ConfigFormTemplate: () => null,
@@ -36,6 +49,15 @@ describe("ConfigContainer auth identity", () => {
     vi.clearAllMocks();
     mocks.config = createConfig();
     mocks.authState = { status: "initializing" };
+    mocks.accountOperations = {
+      kind: "login",
+      pending: true,
+      error: null,
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      retry: vi.fn().mockResolvedValue(undefined),
+    };
+    mocks.useAccountOperations.mockImplementation(() => mocks.accountOperations);
   });
 
   it("uses the confirmed AuthContext UID for display and logout", () => {
@@ -59,7 +81,7 @@ describe("ConfigContainer auth identity", () => {
     });
     expect(options.isLoggedIn).toBe(true);
     options.onLogout();
-    expect(mocks.actions.logout).toHaveBeenCalledWith("confirmed-uid");
+    expect(mocks.accountOperations.logout).toHaveBeenCalledOnce();
   });
 
   it("does not expose persisted identity while auth is unconfirmed", () => {
@@ -73,5 +95,58 @@ describe("ConfigContainer auth identity", () => {
     expect(options.identity).toEqual({ uid: "", displayName: null });
     expect(options.isLoggedIn).toBe(false);
     expect(options.onLogout).toBeUndefined();
+  });
+
+  it("passes local account feedback and wrapped account actions to settings", () => {
+    const user = {
+      uid: "confirmed-uid",
+      isAnonymous: false,
+      providerData: [{ displayName: "Confirmed User" }],
+    } as User;
+    mocks.authState = { status: "authenticated", uid: user.uid, user };
+
+    render(<ConfigContainer />);
+
+    const dependencies = mocks.useAccountOperations.mock.calls[0]?.[0] as {
+      login: () => Promise<void>;
+      logout: () => Promise<void>;
+    };
+    expect(dependencies.login).toBe(mocks.actions.login);
+    dependencies.logout();
+    expect(mocks.actions.logout).toHaveBeenCalledWith("confirmed-uid");
+
+    const options = mocks.useConfigFormState.mock.calls[0]?.[0] as {
+      accountPending: boolean;
+      accountFeedback: React.ReactElement<{
+        pending: boolean;
+        error: unknown;
+        onRetry: () => Promise<void>;
+        pendingLabel: string;
+        errorLabel: string;
+      }>;
+      onLogin: () => void;
+      onLogout: () => void;
+    };
+    expect(options.accountPending).toBe(true);
+    expect(options.accountFeedback.props).toMatchObject({
+      pending: true,
+      error: null,
+      pendingLabel: "Signing in…",
+      errorLabel: "Unable to sign in.",
+    });
+    options.onLogin();
+    expect(mocks.accountOperations.login).toHaveBeenCalledOnce();
+    options.onLogout();
+    expect(mocks.accountOperations.logout).toHaveBeenCalledOnce();
+    options.accountFeedback.props.onRetry();
+    expect(mocks.accountOperations.retry).toHaveBeenCalledOnce();
+
+    mocks.accountOperations.kind = "logout";
+    render(<ConfigContainer />);
+    const logoutOptions = mocks.useConfigFormState.mock.calls[1]?.[0] as typeof options;
+    expect(logoutOptions.accountFeedback.props).toMatchObject({
+      pendingLabel: "Signing out…",
+      errorLabel: "Unable to sign out.",
+    });
   });
 });

--- a/src/features/settings/containers/ConfigContainer.spec.tsx
+++ b/src/features/settings/containers/ConfigContainer.spec.tsx
@@ -108,9 +108,11 @@ describe("ConfigContainer auth identity", () => {
     render(<ConfigContainer />);
 
     const dependencies = mocks.useAccountOperations.mock.calls[0]?.[0] as {
+      generation: string;
       login: () => Promise<void>;
       logout: () => Promise<void>;
     };
+    expect(dependencies.generation).toBe("authenticated:confirmed-uid:linked");
     expect(dependencies.login).toBe(mocks.actions.login);
     dependencies.logout();
     expect(mocks.actions.logout).toHaveBeenCalledWith("confirmed-uid");

--- a/src/features/settings/containers/ConfigContainer.spec.tsx
+++ b/src/features/settings/containers/ConfigContainer.spec.tsx
@@ -97,7 +97,7 @@ describe("ConfigContainer auth identity", () => {
     expect(options.onLogout).toBeUndefined();
   });
 
-  it("passes local account feedback and wrapped account actions to settings", () => {
+  it("passes local account feedback and wrapped account actions to settings", async () => {
     const user = {
       uid: "confirmed-uid",
       isAnonymous: false,
@@ -120,7 +120,7 @@ describe("ConfigContainer auth identity", () => {
       accountFeedback: React.ReactElement<{
         pending: boolean;
         error: unknown;
-        onRetry: () => Promise<void>;
+        onRetry: () => void;
         pendingLabel: string;
         errorLabel: string;
       }>;
@@ -138,7 +138,9 @@ describe("ConfigContainer auth identity", () => {
     expect(mocks.accountOperations.login).toHaveBeenCalledOnce();
     options.onLogout();
     expect(mocks.accountOperations.logout).toHaveBeenCalledOnce();
-    options.accountFeedback.props.onRetry();
+    mocks.accountOperations.retry.mockRejectedValueOnce(new Error("retry failed"));
+    expect(options.accountFeedback.props.onRetry()).toBeUndefined();
+    await Promise.resolve();
     expect(mocks.accountOperations.retry).toHaveBeenCalledOnce();
 
     mocks.accountOperations.kind = "logout";

--- a/src/features/settings/containers/ConfigContainer.tsx
+++ b/src/features/settings/containers/ConfigContainer.tsx
@@ -2,6 +2,8 @@ import type * as React from "react";
 import { useKey } from "react-use";
 
 import { ConfigFormTemplate } from "@/features/settings/components/templates/ConfigFormTemplate";
+import { RemoteMutationNotice } from "@/components/feedback/RemoteMutationNotice";
+import { useAccountOperations } from "@/features/settings/hooks/useAccountOperations";
 import { useConfigFormState } from "@/features/settings/hooks/useConfigFormState";
 import { useActions } from "@/hooks/useActions";
 import { useAuth } from "@/auth/AuthContext";
@@ -16,13 +18,27 @@ export const ConfigContainer: React.FC = () => {
     uid: authenticated?.uid ?? "",
     displayName: authenticated?.user.providerData[0]?.displayName ?? null,
   };
+  const account = useAccountOperations({
+    login: actions.login,
+    ...(authenticated ? { logout: () => actions.logout(authenticated.uid) } : {}),
+  });
   const configForm = useConfigFormState({
     config,
     identity,
     version: __APP_VERSION__,
     isLoggedIn: authenticated != null && !authenticated.user.isAnonymous,
-    onLogin: actions.login,
-    ...(authenticated ? { onLogout: () => actions.logout(authenticated.uid) } : {}),
+    onLogin: () => void account.login().catch(() => undefined),
+    ...(authenticated ? { onLogout: () => void account.logout().catch(() => undefined) } : {}),
+    accountPending: account.pending,
+    accountFeedback: (
+      <RemoteMutationNotice
+        pending={account.pending}
+        error={account.error}
+        onRetry={account.retry}
+        pendingLabel={account.kind === "logout" ? "Signing out…" : "Signing in…"}
+        errorLabel={account.kind === "logout" ? "Unable to sign out." : "Unable to sign in."}
+      />
+    ),
     onSubmit: actions.configUpdate,
   });
   useKey("t", actions.goToTop);

--- a/src/features/settings/containers/ConfigContainer.tsx
+++ b/src/features/settings/containers/ConfigContainer.tsx
@@ -19,6 +19,9 @@ export const ConfigContainer: React.FC = () => {
     displayName: authenticated?.user.providerData[0]?.displayName ?? null,
   };
   const account = useAccountOperations({
+    generation: authenticated
+      ? `authenticated:${authenticated.uid}:${authenticated.user.isAnonymous ? "anonymous" : "linked"}`
+      : authState.status,
     login: actions.login,
     ...(authenticated ? { logout: () => actions.logout(authenticated.uid) } : {}),
   });

--- a/src/features/settings/containers/ConfigContainer.tsx
+++ b/src/features/settings/containers/ConfigContainer.tsx
@@ -34,7 +34,7 @@ export const ConfigContainer: React.FC = () => {
       <RemoteMutationNotice
         pending={account.pending}
         error={account.error}
-        onRetry={account.retry}
+        onRetry={() => void account.retry().catch(() => undefined)}
         pendingLabel={account.kind === "logout" ? "Signing out…" : "Signing in…"}
         errorLabel={account.kind === "logout" ? "Unable to sign out." : "Unable to sign in."}
       />

--- a/src/features/settings/hooks/useAccountOperations.spec.tsx
+++ b/src/features/settings/hooks/useAccountOperations.spec.tsx
@@ -183,4 +183,68 @@ describe("useAccountOperations", () => {
     expect(later.result.current).toMatchObject({ kind: null, pending: false, error: null });
     expect(retry).not.toHaveBeenCalled();
   });
+
+  it("resets an in-flight cleanup retry when a later auth generation takes over", async () => {
+    const cleanupRequest = deferred<void>();
+    const cleanupFailure = new Error("cleanup retry failed");
+    const retryCleanup = vi.fn(() => cleanupRequest.promise);
+    const initialFailure = Object.assign(new Error("logout cleanup failed"), { retry: retryCleanup });
+    const first = renderHook(
+      () =>
+        useAccountOperations({
+          generation: "authenticated-user",
+          login: vi.fn(),
+          logout: vi.fn().mockRejectedValue(initialFailure),
+        }),
+      { wrapper: StrictModeWrapper }
+    );
+
+    await act(async () => {
+      await expect(first.result.current.logout()).rejects.toBe(initialFailure);
+    });
+    first.unmount();
+    await act(async () => Promise.resolve());
+
+    const nextLoginRequest = deferred<void>();
+    const nextLogin = vi.fn(() => nextLoginRequest.promise);
+    const anonymous = renderHook(
+      ({ generation }) => useAccountOperations({ generation, login: nextLogin, logout: vi.fn() }),
+      { initialProps: { generation: "anonymous-user" }, wrapper: StrictModeWrapper }
+    );
+    expect(anonymous.result.current).toMatchObject({ kind: "logout", pending: false, error: initialFailure });
+
+    let staleRetry!: Promise<void>;
+    act(() => {
+      staleRetry = anonymous.result.current.retry();
+    });
+    expect(retryCleanup).toHaveBeenCalledOnce();
+    expect(anonymous.result.current).toMatchObject({ kind: "logout", pending: true, error: null });
+
+    anonymous.rerender({ generation: "later-user" });
+    await waitFor(() => expect(anonymous.result.current).toMatchObject({ kind: null, pending: false, error: null }));
+    const retryAfterReset = anonymous.result.current.retry();
+    expect(retryAfterReset).not.toBe(staleRetry);
+    await expect(retryAfterReset).resolves.toBeUndefined();
+    expect(retryCleanup).toHaveBeenCalledOnce();
+
+    let nextOperation!: Promise<void>;
+    act(() => {
+      nextOperation = anonymous.result.current.login();
+    });
+    expect(nextOperation).not.toBe(staleRetry);
+    expect(nextLogin).toHaveBeenCalledOnce();
+    expect(anonymous.result.current).toMatchObject({ kind: "login", pending: true, error: null });
+
+    await act(async () => {
+      cleanupRequest.reject(cleanupFailure);
+      await expect(staleRetry).rejects.toBe(cleanupFailure);
+    });
+    expect(anonymous.result.current).toMatchObject({ kind: "login", pending: true, error: null });
+
+    await act(async () => {
+      nextLoginRequest.resolve();
+      await nextOperation;
+    });
+    expect(anonymous.result.current).toMatchObject({ kind: "login", pending: false, error: null });
+  });
 });

--- a/src/features/settings/hooks/useAccountOperations.spec.tsx
+++ b/src/features/settings/hooks/useAccountOperations.spec.tsx
@@ -1,5 +1,6 @@
-import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { StrictMode, type PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useAccountOperations } from "@/features/settings/hooks/useAccountOperations";
 
@@ -14,11 +15,15 @@ const deferred = <T,>() => {
   return { promise, resolve, reject };
 };
 
+const StrictModeWrapper = ({ children }: PropsWithChildren) => <StrictMode>{children}</StrictMode>;
+
+afterEach(() => cleanup());
+
 describe("useAccountOperations", () => {
   it("shares the login promise while login is pending", async () => {
     const request = deferred<void>();
     const login = vi.fn(() => request.promise);
-    const { result } = renderHook(() => useAccountOperations({ login }));
+    const { result } = renderHook(() => useAccountOperations({ login }), { wrapper: StrictModeWrapper });
 
     let first!: Promise<void>;
     let second!: Promise<void>;
@@ -42,7 +47,9 @@ describe("useAccountOperations", () => {
   it("shares the logout promise while logout is pending", async () => {
     const request = deferred<void>();
     const logout = vi.fn(() => request.promise);
-    const { result } = renderHook(() => useAccountOperations({ login: vi.fn(), logout }));
+    const { result } = renderHook(() => useAccountOperations({ login: vi.fn(), logout }), {
+      wrapper: StrictModeWrapper,
+    });
 
     let first!: Promise<void>;
     let second!: Promise<void>;
@@ -106,5 +113,74 @@ describe("useAccountOperations", () => {
     });
 
     expect(result.current).toMatchObject({ kind: "login", pending: false, error: null });
+  });
+
+  it("discards a settled failure after Settings is left", async () => {
+    const error = new Error("sign in failed");
+    const login = vi.fn().mockRejectedValue(error);
+    const first = renderHook(() => useAccountOperations({ login, generation: "user-a" }), {
+      wrapper: StrictModeWrapper,
+    });
+
+    await act(async () => {
+      await expect(first.result.current.login()).rejects.toBe(error);
+    });
+    first.unmount();
+    await act(async () => Promise.resolve());
+
+    const next = renderHook(() => useAccountOperations({ login, generation: "user-a" }), {
+      wrapper: StrictModeWrapper,
+    });
+    expect(next.result.current).toMatchObject({ kind: null, pending: false, error: null });
+    await expect(next.result.current.retry()).resolves.toBeUndefined();
+    expect(login).toHaveBeenCalledOnce();
+  });
+
+  it("discards settled feedback after an unrelated auth generation", async () => {
+    const error = new Error("sign in failed");
+    const login = vi.fn().mockRejectedValue(error);
+    const { result, rerender } = renderHook(({ generation }) => useAccountOperations({ login, generation }), {
+      initialProps: { generation: "user-a" },
+      wrapper: StrictModeWrapper,
+    });
+
+    await act(async () => {
+      await expect(result.current.login()).rejects.toBe(error);
+    });
+    rerender({ generation: "user-b" });
+
+    await waitFor(() => expect(result.current).toMatchObject({ kind: null, pending: false, error: null }));
+    await expect(result.current.retry()).resolves.toBeUndefined();
+    expect(login).toHaveBeenCalledOnce();
+  });
+
+  it("hands retryable logout cleanup to one auth-driven remount", async () => {
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const error = Object.assign(new Error("logout cleanup failed"), { retry });
+    const logout = vi.fn().mockRejectedValue(error);
+    const first = renderHook(() => useAccountOperations({ login: vi.fn(), logout, generation: "authenticated-user" }), {
+      wrapper: StrictModeWrapper,
+    });
+
+    await act(async () => {
+      await expect(first.result.current.logout()).rejects.toBe(error);
+    });
+    first.unmount();
+    await act(async () => Promise.resolve());
+
+    const anonymous = renderHook(
+      () => useAccountOperations({ login: vi.fn(), logout: vi.fn(), generation: "anonymous-user" }),
+      { wrapper: StrictModeWrapper }
+    );
+    expect(anonymous.result.current).toMatchObject({ kind: "logout", pending: false, error });
+
+    anonymous.unmount();
+    await act(async () => Promise.resolve());
+    const later = renderHook(
+      () => useAccountOperations({ login: vi.fn(), logout: vi.fn(), generation: "anonymous-user" }),
+      { wrapper: StrictModeWrapper }
+    );
+    expect(later.result.current).toMatchObject({ kind: null, pending: false, error: null });
+    expect(retry).not.toHaveBeenCalled();
   });
 });

--- a/src/features/settings/hooks/useAccountOperations.spec.tsx
+++ b/src/features/settings/hooks/useAccountOperations.spec.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useAccountOperations } from "@/features/settings/hooks/useAccountOperations";
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
+describe("useAccountOperations", () => {
+  it("shares the login promise while login is pending", async () => {
+    const request = deferred<void>();
+    const login = vi.fn(() => request.promise);
+    const { result } = renderHook(() => useAccountOperations({ login }));
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.login();
+      second = result.current.login();
+    });
+
+    expect(first).toBe(second);
+    expect(login).toHaveBeenCalledOnce();
+    expect(result.current).toMatchObject({ kind: "login", pending: true, error: null });
+
+    await act(async () => {
+      request.resolve();
+      await first;
+    });
+
+    expect(result.current.pending).toBe(false);
+  });
+
+  it("shares the logout promise while logout is pending", async () => {
+    const request = deferred<void>();
+    const logout = vi.fn(() => request.promise);
+    const { result } = renderHook(() => useAccountOperations({ login: vi.fn(), logout }));
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.logout();
+      second = result.current.logout();
+    });
+
+    expect(first).toBe(second);
+    expect(logout).toHaveBeenCalledOnce();
+    expect(result.current).toMatchObject({ kind: "logout", pending: true, error: null });
+
+    await act(async () => {
+      request.resolve();
+      await first;
+    });
+
+    expect(result.current.pending).toBe(false);
+  });
+
+  it("retries the failed operation", async () => {
+    const error = new Error("sign in failed");
+    const login = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useAccountOperations({ login }));
+
+    await act(async () => {
+      await expect(result.current.login()).rejects.toBe(error);
+    });
+
+    expect(result.current).toMatchObject({ kind: "login", pending: false, error });
+
+    await act(async () => {
+      await expect(result.current.retry()).resolves.toBeUndefined();
+    });
+
+    expect(login).toHaveBeenCalledTimes(2);
+    expect(result.current).toMatchObject({ kind: "login", pending: false, error: null });
+  });
+
+  it("clears an earlier failure when a new attempt starts", async () => {
+    const error = new Error("sign in failed");
+    const request = deferred<void>();
+    const login = vi.fn().mockRejectedValueOnce(error).mockReturnValueOnce(request.promise);
+    const { result } = renderHook(() => useAccountOperations({ login }));
+
+    await act(async () => {
+      await expect(result.current.login()).rejects.toBe(error);
+    });
+    expect(result.current.error).toBe(error);
+
+    let retry!: Promise<void>;
+    act(() => {
+      retry = result.current.login();
+    });
+
+    expect(result.current).toMatchObject({ kind: "login", pending: true, error: null });
+
+    await act(async () => {
+      request.resolve();
+      await retry;
+    });
+
+    expect(result.current).toMatchObject({ kind: "login", pending: false, error: null });
+  });
+});

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -14,10 +14,15 @@ interface AccountOperationState {
   error: unknown;
 }
 
+interface FailedOperation {
+  operation: () => Promise<void>;
+  maySignOut: boolean;
+}
+
 const createAccountOperationController = () => {
   let dependencies: AccountOperationDependencies = { login: () => Promise.resolve() };
   let inFlight: Promise<void> | null = null;
-  let failedOperation: (() => Promise<void>) | null = null;
+  let failedOperation: FailedOperation | null = null;
   let generation: string | undefined;
   let logoutHandoffAvailable = false;
   let subscriptionGeneration = 0;
@@ -64,23 +69,23 @@ const createAccountOperationController = () => {
     generation = nextGeneration;
   };
 
-  const run = (kind: AccountOperationKind, retryOperation?: () => Promise<void>): Promise<void> => {
+  const run = (kind: AccountOperationKind, retryOperation?: FailedOperation): Promise<void> => {
     if (inFlight != null) return inFlight;
 
-    const operation = retryOperation ?? (kind === "login" ? dependencies.login : dependencies.logout);
+    const operation = retryOperation?.operation ?? (kind === "login" ? dependencies.login : dependencies.logout);
     if (operation == null) return Promise.resolve();
 
     failedOperation = null;
     logoutHandoffAvailable = false;
     const operationGeneration = generation;
-    const mayHandoffLogout = kind === "logout" && retryOperation == null;
+    const maySignOut = retryOperation?.maySignOut ?? kind === "logout";
     setState({ kind, pending: true, error: null });
     const promise = operation().then(
       () => setState({ kind, pending: false, error: null }),
       (error: unknown) => {
         const retry = getRetryOperation(error, operation);
-        failedOperation = retry;
-        logoutHandoffAvailable = mayHandoffLogout && retry !== operation && operationGeneration === generation;
+        failedOperation = { operation: retry, maySignOut: maySignOut && retry === operation };
+        logoutHandoffAvailable = maySignOut && retry !== operation && operationGeneration === generation;
         setState({ kind, pending: false, error });
         throw error;
       }

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -17,14 +17,21 @@ interface AccountOperationState {
 interface FailedOperation {
   operation: () => Promise<void>;
   maySignOut: boolean;
+  handoffAvailable: boolean;
+}
+
+interface InFlightOperation {
+  promise: Promise<void>;
+  handoffAvailable: boolean;
 }
 
 const createAccountOperationController = () => {
   let dependencies: AccountOperationDependencies = { login: () => Promise.resolve() };
-  let inFlight: Promise<void> | null = null;
+  let inFlight: InFlightOperation | null = null;
   let failedOperation: FailedOperation | null = null;
   let generation: string | undefined;
   let logoutHandoffAvailable = false;
+  let scopeEpoch = 0;
   let subscriptionGeneration = 0;
   let state: AccountOperationState = { kind: null, pending: false, error: null };
   const listeners = new Set<() => void>();
@@ -42,6 +49,8 @@ const createAccountOperationController = () => {
   };
 
   const reset = () => {
+    scopeEpoch += 1;
+    inFlight = null;
     failedOperation = null;
     logoutHandoffAvailable = false;
     generation = undefined;
@@ -59,7 +68,13 @@ const createAccountOperationController = () => {
     }
     if (generation === nextGeneration) return;
 
-    if (inFlight != null || logoutHandoffAvailable) {
+    if (inFlight?.handoffAvailable) {
+      inFlight.handoffAvailable = false;
+      generation = nextGeneration;
+      logoutHandoffAvailable = false;
+      return;
+    }
+    if (logoutHandoffAvailable) {
       generation = nextGeneration;
       logoutHandoffAvailable = false;
       return;
@@ -70,7 +85,7 @@ const createAccountOperationController = () => {
   };
 
   const run = (kind: AccountOperationKind, retryOperation?: FailedOperation): Promise<void> => {
-    if (inFlight != null) return inFlight;
+    if (inFlight != null) return inFlight.promise;
 
     const operation = retryOperation?.operation ?? (kind === "login" ? dependencies.login : dependencies.logout);
     if (operation == null) return Promise.resolve();
@@ -79,27 +94,46 @@ const createAccountOperationController = () => {
     logoutHandoffAvailable = false;
     const operationGeneration = generation;
     const maySignOut = retryOperation?.maySignOut ?? kind === "logout";
+    const operationEpoch = scopeEpoch;
+    let currentOperation!: InFlightOperation;
     setState({ kind, pending: true, error: null });
     const promise = operation().then(
-      () => setState({ kind, pending: false, error: null }),
+      () => {
+        if (operationEpoch === scopeEpoch) setState({ kind, pending: false, error: null });
+      },
       (error: unknown) => {
-        const retry = getRetryOperation(error, operation);
-        failedOperation = { operation: retry, maySignOut: maySignOut && retry === operation };
-        logoutHandoffAvailable = maySignOut && retry !== operation && operationGeneration === generation;
-        setState({ kind, pending: false, error });
+        if (operationEpoch === scopeEpoch) {
+          const retry = getRetryOperation(error, operation);
+          const retriesFullOperation = maySignOut && retry === operation;
+          failedOperation = {
+            operation: retry,
+            maySignOut: retriesFullOperation,
+            handoffAvailable: retriesFullOperation && currentOperation.handoffAvailable,
+          };
+          logoutHandoffAvailable =
+            maySignOut &&
+            retry !== operation &&
+            currentOperation.handoffAvailable &&
+            operationGeneration === generation;
+          setState({ kind, pending: false, error });
+        }
         throw error;
       }
     );
-    inFlight = promise;
+    currentOperation = {
+      promise,
+      handoffAvailable: retryOperation?.handoffAvailable ?? maySignOut,
+    };
+    inFlight = currentOperation;
     void promise.then(
       () => {
-        if (inFlight === promise) {
+        if (inFlight?.promise === promise) {
           inFlight = null;
           resetWhenUnused();
         }
       },
       () => {
-        if (inFlight === promise) {
+        if (inFlight?.promise === promise) {
           inFlight = null;
           resetWhenUnused();
         }

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -1,0 +1,63 @@
+import * as React from "react";
+
+interface AccountOperationDependencies {
+  login: () => Promise<void>;
+  logout?: () => Promise<void>;
+}
+
+type AccountOperationKind = "login" | "logout";
+
+interface AccountOperationState {
+  kind: AccountOperationKind | null;
+  pending: boolean;
+  error: unknown;
+}
+
+export const useAccountOperations = ({ login, logout }: AccountOperationDependencies) => {
+  const dependenciesRef = React.useRef({ login, logout });
+  const inFlightRef = React.useRef<Promise<void> | null>(null);
+  const lastFailedKindRef = React.useRef<AccountOperationKind | null>(null);
+  const [state, setState] = React.useState<AccountOperationState>({ kind: null, pending: false, error: null });
+
+  dependenciesRef.current = { login, logout };
+
+  const run = React.useCallback((kind: AccountOperationKind): Promise<void> => {
+    if (inFlightRef.current != null) return inFlightRef.current;
+
+    const operation = kind === "login" ? dependenciesRef.current.login : dependenciesRef.current.logout;
+    if (operation == null) return Promise.resolve();
+
+    lastFailedKindRef.current = null;
+    setState({ kind, pending: true, error: null });
+    const promise = operation().then(
+      () => setState({ kind, pending: false, error: null }),
+      (error: unknown) => {
+        lastFailedKindRef.current = kind;
+        setState({ kind, pending: false, error });
+        throw error;
+      }
+    );
+    inFlightRef.current = promise;
+    void promise.then(
+      () => {
+        if (inFlightRef.current === promise) inFlightRef.current = null;
+      },
+      () => {
+        if (inFlightRef.current === promise) inFlightRef.current = null;
+      }
+    );
+
+    return promise;
+  }, []);
+
+  const retry = React.useCallback(() => {
+    return lastFailedKindRef.current == null ? Promise.resolve() : run(lastFailedKindRef.current);
+  }, [run]);
+
+  return {
+    ...state,
+    login: () => run("login"),
+    logout: () => run("logout"),
+    retry,
+  };
+};

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -13,51 +13,83 @@ interface AccountOperationState {
   error: unknown;
 }
 
-export const useAccountOperations = ({ login, logout }: AccountOperationDependencies) => {
-  const dependenciesRef = React.useRef({ login, logout });
-  const inFlightRef = React.useRef<Promise<void> | null>(null);
-  const lastFailedKindRef = React.useRef<AccountOperationKind | null>(null);
-  const [state, setState] = React.useState<AccountOperationState>({ kind: null, pending: false, error: null });
+const createAccountOperationController = () => {
+  let dependencies: AccountOperationDependencies = { login: () => Promise.resolve() };
+  let inFlight: Promise<void> | null = null;
+  let failedOperation: (() => Promise<void>) | null = null;
+  let state: AccountOperationState = { kind: null, pending: false, error: null };
+  const listeners = new Set<() => void>();
 
-  dependenciesRef.current = { login, logout };
+  const setState = (nextState: AccountOperationState) => {
+    state = nextState;
+    for (const listener of listeners) listener();
+  };
 
-  const run = React.useCallback((kind: AccountOperationKind): Promise<void> => {
-    if (inFlightRef.current != null) return inFlightRef.current;
+  const getRetryOperation = (error: unknown, operation: () => Promise<void>) => {
+    if (typeof error !== "object" || error == null || !("retry" in error) || typeof error.retry !== "function") {
+      return operation;
+    }
+    return error.retry as () => Promise<void>;
+  };
 
-    const operation = kind === "login" ? dependenciesRef.current.login : dependenciesRef.current.logout;
+  const run = (kind: AccountOperationKind, retryOperation?: () => Promise<void>): Promise<void> => {
+    if (inFlight != null) return inFlight;
+
+    const operation = retryOperation ?? (kind === "login" ? dependencies.login : dependencies.logout);
     if (operation == null) return Promise.resolve();
 
-    lastFailedKindRef.current = null;
+    failedOperation = null;
     setState({ kind, pending: true, error: null });
     const promise = operation().then(
       () => setState({ kind, pending: false, error: null }),
       (error: unknown) => {
-        lastFailedKindRef.current = kind;
+        failedOperation = getRetryOperation(error, operation);
         setState({ kind, pending: false, error });
         throw error;
       }
     );
-    inFlightRef.current = promise;
+    inFlight = promise;
     void promise.then(
       () => {
-        if (inFlightRef.current === promise) inFlightRef.current = null;
+        if (inFlight === promise) inFlight = null;
       },
       () => {
-        if (inFlightRef.current === promise) inFlightRef.current = null;
+        if (inFlight === promise) inFlight = null;
       }
     );
 
     return promise;
-  }, []);
+  };
 
-  const retry = React.useCallback(() => {
-    return lastFailedKindRef.current == null ? Promise.resolve() : run(lastFailedKindRef.current);
-  }, [run]);
+  return {
+    getSnapshot: () => state,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    setDependencies: (nextDependencies: AccountOperationDependencies) => {
+      dependencies = nextDependencies;
+    },
+    login: () => run("login"),
+    logout: () => run("logout"),
+    retry: () => (failedOperation == null || state.kind == null ? Promise.resolve() : run(state.kind, failedOperation)),
+  };
+};
+
+const accountOperationController = createAccountOperationController();
+
+export const useAccountOperations = ({ login, logout }: AccountOperationDependencies) => {
+  accountOperationController.setDependencies({ login, ...(logout ? { logout } : {}) });
+  const state = React.useSyncExternalStore(
+    accountOperationController.subscribe,
+    accountOperationController.getSnapshot,
+    accountOperationController.getSnapshot
+  );
 
   return {
     ...state,
-    login: () => run("login"),
-    logout: () => run("logout"),
-    retry,
+    login: accountOperationController.login,
+    logout: accountOperationController.logout,
+    retry: accountOperationController.retry,
   };
 };

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 interface AccountOperationDependencies {
+  generation?: string;
   login: () => Promise<void>;
   logout?: () => Promise<void>;
 }
@@ -17,6 +18,9 @@ const createAccountOperationController = () => {
   let dependencies: AccountOperationDependencies = { login: () => Promise.resolve() };
   let inFlight: Promise<void> | null = null;
   let failedOperation: (() => Promise<void>) | null = null;
+  let generation: string | undefined;
+  let logoutHandoffAvailable = false;
+  let subscriptionGeneration = 0;
   let state: AccountOperationState = { kind: null, pending: false, error: null };
   const listeners = new Set<() => void>();
 
@@ -32,6 +36,34 @@ const createAccountOperationController = () => {
     return error.retry as () => Promise<void>;
   };
 
+  const reset = () => {
+    failedOperation = null;
+    logoutHandoffAvailable = false;
+    generation = undefined;
+    setState({ kind: null, pending: false, error: null });
+  };
+
+  const resetWhenUnused = () => {
+    if (listeners.size === 0 && inFlight == null && !logoutHandoffAvailable) reset();
+  };
+
+  const connectGeneration = (nextGeneration: string) => {
+    if (generation == null) {
+      generation = nextGeneration;
+      return;
+    }
+    if (generation === nextGeneration) return;
+
+    if (inFlight != null || logoutHandoffAvailable) {
+      generation = nextGeneration;
+      logoutHandoffAvailable = false;
+      return;
+    }
+
+    reset();
+    generation = nextGeneration;
+  };
+
   const run = (kind: AccountOperationKind, retryOperation?: () => Promise<void>): Promise<void> => {
     if (inFlight != null) return inFlight;
 
@@ -39,11 +71,16 @@ const createAccountOperationController = () => {
     if (operation == null) return Promise.resolve();
 
     failedOperation = null;
+    logoutHandoffAvailable = false;
+    const operationGeneration = generation;
+    const mayHandoffLogout = kind === "logout" && retryOperation == null;
     setState({ kind, pending: true, error: null });
     const promise = operation().then(
       () => setState({ kind, pending: false, error: null }),
       (error: unknown) => {
-        failedOperation = getRetryOperation(error, operation);
+        const retry = getRetryOperation(error, operation);
+        failedOperation = retry;
+        logoutHandoffAvailable = mayHandoffLogout && retry !== operation && operationGeneration === generation;
         setState({ kind, pending: false, error });
         throw error;
       }
@@ -51,10 +88,16 @@ const createAccountOperationController = () => {
     inFlight = promise;
     void promise.then(
       () => {
-        if (inFlight === promise) inFlight = null;
+        if (inFlight === promise) {
+          inFlight = null;
+          resetWhenUnused();
+        }
       },
       () => {
-        if (inFlight === promise) inFlight = null;
+        if (inFlight === promise) {
+          inFlight = null;
+          resetWhenUnused();
+        }
       }
     );
 
@@ -63,9 +106,18 @@ const createAccountOperationController = () => {
 
   return {
     getSnapshot: () => state,
-    subscribe: (listener: () => void) => {
+    subscribe: (nextGeneration: string, listener: () => void) => {
+      subscriptionGeneration += 1;
+      connectGeneration(nextGeneration);
       listeners.add(listener);
-      return () => listeners.delete(listener);
+      return () => {
+        listeners.delete(listener);
+        const cleanupGeneration = ++subscriptionGeneration;
+        // StrictMode immediately resubscribes, while leaving Settings does not.
+        queueMicrotask(() => {
+          if (cleanupGeneration === subscriptionGeneration) resetWhenUnused();
+        });
+      };
     },
     setDependencies: (nextDependencies: AccountOperationDependencies) => {
       dependencies = nextDependencies;
@@ -78,10 +130,14 @@ const createAccountOperationController = () => {
 
 const accountOperationController = createAccountOperationController();
 
-export const useAccountOperations = ({ login, logout }: AccountOperationDependencies) => {
+export const useAccountOperations = ({ generation = "settings", login, logout }: AccountOperationDependencies) => {
   accountOperationController.setDependencies({ login, ...(logout ? { logout } : {}) });
+  const subscribe = React.useCallback(
+    (listener: () => void) => accountOperationController.subscribe(generation, listener),
+    [generation]
+  );
   const state = React.useSyncExternalStore(
-    accountOperationController.subscribe,
+    subscribe,
     accountOperationController.getSnapshot,
     accountOperationController.getSnapshot
   );

--- a/src/features/settings/hooks/useConfigFormState.ts
+++ b/src/features/settings/hooks/useConfigFormState.ts
@@ -10,6 +10,8 @@ export interface UseConfigFormStateOptions {
   identity?: ConfigFormProps["identity"];
   onLogin?: () => void;
   onLogout?: () => void;
+  accountPending?: boolean;
+  accountFeedback?: React.ReactNode;
   version?: string;
 }
 
@@ -20,6 +22,8 @@ export const useConfigFormState = ({
   identity,
   onLogin,
   onLogout,
+  accountPending,
+  accountFeedback,
   version,
 }: UseConfigFormStateOptions): ConfigFormProps => {
   const { control, handleSubmit, register, setValue, subscribe } = useForm<ConfigState>({
@@ -45,6 +49,8 @@ export const useConfigFormState = ({
     ...(identity !== undefined ? { identity } : {}),
     ...(onLogin !== undefined ? { onLogin } : {}),
     ...(onLogout !== undefined ? { onLogout } : {}),
+    ...(accountPending !== undefined ? { accountPending } : {}),
+    ...(accountFeedback !== undefined ? { accountFeedback } : {}),
     ...(version !== undefined ? { version } : {}),
     maxNumberOfCardsToLearn,
     cardInterval,

--- a/src/features/study/containers/DeckStartContainer.tsx
+++ b/src/features/study/containers/DeckStartContainer.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { useRemoteCollections } from "@/query/useRemoteCollections";
-import { RemoteReadBoundary } from "@/components";
+import { RemoteReadBoundary, RouteFeedback } from "@/components";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
@@ -53,6 +53,7 @@ export const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: Con
 
 export const DeckStartContainer: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deckId");
   const config = useConfig();
@@ -65,7 +66,15 @@ export const DeckStartContainer: React.FC = () => {
     <RemoteReadBoundary
       status={remote.status}
       hasData={deck != null}
-      emptyLabel="Deck not found."
+      emptyContent={
+        <RouteFeedback
+          title="Deck not found"
+          description="The requested deck is unavailable or has been removed."
+          tone="not-found"
+          primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+          secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+        />
+      }
       onRetry={remote.retry}
     >
       {deck != null ? <DeckStartContent deck={deck} cards={cards} config={config} tags={tags} /> : null}

--- a/src/lib/componentArchitecture.spec.ts
+++ b/src/lib/componentArchitecture.spec.ts
@@ -255,7 +255,13 @@ describe("component architecture", () => {
   });
 
   it("groups shared feedback components", () => {
-    expectSharedComponentGroup("feedback", ["Feedback", "Overlay"]);
+    expectSharedComponentGroup("feedback", [
+      "Feedback",
+      "Overlay",
+      "RemoteMutationNotice",
+      "RemoteReadBoundary",
+      "RouteFeedback",
+    ]);
   });
 
   it("keeps the exact shared component groups", () => {

--- a/src/lib/sharedComponentPublicApi.spec.ts
+++ b/src/lib/sharedComponentPublicApi.spec.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 import * as Shared from "@/components";
-import type { ActionsMenuItem, ActionsMenuProps, HeaderProps, LayoutProps, Option } from "@/components";
+import type {
+  ActionsMenuItem,
+  ActionsMenuProps,
+  HeaderProps,
+  LayoutProps,
+  Option,
+  RemoteMutationNoticeProps,
+  RemoteReadBoundaryProps,
+  RouteFeedbackAction,
+  RouteFeedbackProps,
+} from "@/components";
 
 const components = {
   ActionsMenu: Shared.ActionsMenu,
@@ -21,6 +31,9 @@ const components = {
   MathContent: Shared.MathContent,
   Outer: Shared.Outer,
   Overlay: Shared.Overlay,
+  RemoteMutationNotice: Shared.RemoteMutationNotice,
+  RemoteReadBoundary: Shared.RemoteReadBoundary,
+  RouteFeedback: Shared.RouteFeedback,
   Score: Shared.Score,
   Section: Shared.Section,
   Select: Shared.Select,
@@ -41,13 +54,21 @@ describe("component public API", () => {
       _actionsMenuItem: ActionsMenuItem,
       _header: HeaderProps,
       _layout: LayoutProps,
-      _option: Option
+      _option: Option,
+      _remoteMutationNotice: RemoteMutationNoticeProps,
+      _remoteReadBoundary: RemoteReadBoundaryProps,
+      _routeFeedback: RouteFeedbackProps,
+      _routeFeedbackAction: RouteFeedbackAction
     ) => {
       void _actionsMenu;
       void _actionsMenuItem;
       void _header;
       void _layout;
       void _option;
+      void _remoteMutationNotice;
+      void _remoteReadBoundary;
+      void _routeFeedback;
+      void _routeFeedbackAction;
     };
     acceptsTypes(
       {
@@ -62,7 +83,11 @@ describe("component public API", () => {
       { key: "edit", label: "Edit", icon: null },
       {},
       {},
-      { label: "label", value: "value" }
+      { label: "label", value: "value" },
+      { pending: false, error: null, onRetry: () => {} },
+      { status: "idle", hasData: false, onRetry: () => {}, children: null },
+      { title: "Title" },
+      { label: "Continue", onClick: () => {} }
     );
     expect(Object.values(components).every((component) => typeof component === "function")).toBe(true);
   });


### PR DESCRIPTION
## Summary

- add shared route feedback for startup, unknown URLs, remote reads, and missing Deck/Card recovery
- keep cached route content and read-error precedence intact while providing accurate Retry actions
- add lifecycle-safe Login/Logout feedback and Deck deletion feedback with duplicate suppression
- add Storybook states plus unit, Firestore, sample, and browser recovery coverage

## Why

Issue #205 spans several feedback paths that previously used inconsistent copy and recovery behavior. This centralizes the stateless presentation layer while keeping Query, auth, and mutation state with their existing owners. It also preserves logout cleanup failures across the one required auth remount and prevents duplicate or stale Deck deletion work.

## Testing

- make check (97 test files, 556 tests)
- make ci (production/PWA build, Storybook build, 66 Firestore tests, 82 sample tests, and 19 Playwright tests)

Closes #205
Refs #203