### PR TITLE
fix: deduplicate Storybook Vite plugins

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,4 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import { mergeConfig } from "vite";
-import { createReactCompilerPlugin } from "../reactCompiler";
 import { withoutPwaPlugins } from "./vitePlugins";
 
 const config: StorybookConfig = {
@@ -15,14 +13,9 @@ const config: StorybookConfig = {
     options: {},
   },
   viteFinal: async (viteConfig) =>
-    mergeConfig(
-      {
-        ...viteConfig,
-        plugins: withoutPwaPlugins(viteConfig.plugins),
-      },
-      {
-        plugins: [createReactCompilerPlugin()],
-      },
-    ),
+    ({
+      ...viteConfig,
+      plugins: withoutPwaPlugins(viteConfig.plugins),
+    }),
 };
 export default config;

--- a/reactCompiler.spec.ts
+++ b/reactCompiler.spec.ts
@@ -44,15 +44,20 @@ const compilerPlugins = async (values: readonly unknown[] | undefined) =>
     (plugin) => "name" in plugin && plugin.name === compilerPluginName,
   );
 
-const storybookInput = { plugins: [] };
+const pluginNames = async (values: readonly unknown[] | undefined) =>
+  (await collectPlugins(values)).flatMap((plugin) =>
+    "name" in plugin && typeof plugin.name === "string" ? [plugin.name] : [],
+  );
+
+const storybookInput = { plugins: viteConfig.plugins ?? [] };
 const storybookViteConfig = await storybookConfig.viteFinal?.(
   storybookInput,
   { configType: "PRODUCTION" } as never,
 );
 
 describe("React Compiler Vite integration", () => {
-  it("calls the shared factory once for every environment", () => {
-    expect(createReactCompilerPlugin).toHaveBeenCalledTimes(3);
+  it("calls the shared factory for the application and Vitest", () => {
+    expect(createReactCompilerPlugin).toHaveBeenCalledTimes(2);
   });
 
   it("adds one compiler plugin to the application", async () => {
@@ -63,20 +68,28 @@ describe("React Compiler Vite integration", () => {
     expect(await compilerPlugins(vitestConfig.plugins)).toHaveLength(1);
   });
 
-  it("adds one compiler plugin to Storybook", async () => {
+  it("keeps one compiler plugin from the root Vite configuration in Storybook", async () => {
     expect(storybookConfig.viteFinal).toBeTypeOf("function");
     expect(storybookViteConfig).not.toBe(storybookInput);
     expect(await compilerPlugins(storybookViteConfig?.plugins)).toHaveLength(1);
   });
 
-  it("creates independent plugin instances for every environment", async () => {
+  it("removes PWA plugins from the Storybook configuration", async () => {
+    expect(await pluginNames(storybookViteConfig?.plugins)).not.toContain(
+      "vite-plugin-pwa",
+    );
+    expect(await pluginNames(storybookViteConfig?.plugins)).not.toContain(
+      "vite-plugin-pwa:build",
+    );
+  });
+
+  it("creates independent plugin instances for the application and Vitest", async () => {
     const instances = [
       ...(await compilerPlugins(viteConfig.plugins)),
       ...(await compilerPlugins(vitestConfig.plugins)),
-      ...(await compilerPlugins(storybookViteConfig?.plugins)),
     ];
 
-    expect(instances).toHaveLength(3);
-    expect(new Set(instances).size).toBe(3);
+    expect(instances).toHaveLength(2);
+    expect(new Set(instances).size).toBe(2);
   });
 });

--- a/storybookPwaBoundary.spec.ts
+++ b/storybookPwaBoundary.spec.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import { withoutPwaPlugins } from "./.storybook/vitePlugins";
 
 describe("Storybook Vite plugins", () => {
+  it("returns an empty plugin list when Vite has no plugins", () => {
+    expect(withoutPwaPlugins(undefined)).toEqual([]);
+  });
+
   it("excludes PWA plugins from Storybook builds", () => {
     const plugins = [
       { name: "vite:react-babel" },


### PR DESCRIPTION
## Summary
- rely on Storybook's root Vite config merge for the React Compiler plugin
- keep Storybook-specific Vite processing limited to removing PWA plugins
- cover the merged root plugin list and empty plugin edge case

## Testing
- npm run build:storybook
- make check