### PR TITLE
fix: make ci independent of COMPOSE_FILE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,7 @@ jobs:
           path: coverage/
           if-no-files-found: warn
 
-      # mise sets COMPOSE_FILE for local development; make ci needs the Makefile defaults.
-      - run: env -u COMPOSE_FILE make ci
+      - run: make ci
 
       - name: Upload Playwright report
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-COMPOSE_FILE ?= .devcontainer/compose.yaml
-COMPOSE = COMPOSE_FILE=$(COMPOSE_FILE) docker compose
+export COMPOSE_FILE := .devcontainer/compose.yaml
+COMPOSE = docker compose
 RUN = $(COMPOSE) run --rm --remove-orphans
 SERVICE = dev
 NPM = $(RUN) --entrypoint npm $(SERVICE)
@@ -56,7 +56,7 @@ ci: build fmt-check lint-check test e2e ## Run the same checks as the pull reque
 check: sample-build fmt-check lint-check test-unit ## Run lightweight checks
 
 .PHONY: e2e
-e2e: COMPOSE_FILE := .devcontainer/compose.yaml:.devcontainer/compose.e2e.yaml
+e2e: export COMPOSE_FILE := .devcontainer/compose.yaml:.devcontainer/compose.e2e.yaml
 e2e: ## Run end-to-end tests
 	$(COMPOSE) up --wait --wait-timeout 120 --remove-orphans
 	$(RUN) --env CI --entrypoint npm $(SERVICE) run e2e

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Run every TypeScript and React spec, including the Firestore emulator specs, in 
 ```bash
 mise run coverage
 # Or run the same coverage command in Docker
-env -u COMPOSE_FILE make coverage
+make coverage
 ```
 
 Coverage includes `src/**/*.{ts,tsx}`, including files that no test imports. Specs, stories, declaration files,

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,3 +1,6 @@
+# Use this directory's docker-compose.yml instead of the root project's configuration.
+unexport COMPOSE_FILE
+
 COMPOSE = docker compose
 RUN = $(COMPOSE) run --rm --remove-orphans
 SERVICE = base


### PR DESCRIPTION
## Summary
- export the root Compose configuration from the Makefile so external COMPOSE_FILE values cannot alter CI targets
- keep the sample Makefile scoped to its own Compose file
- remove env -u COMPOSE_FILE workarounds from CI and documentation

## Testing
- COMPOSE_FILE=.devcontainer/compose.yaml:.devcontainer/compose.local.yaml make check
- COMPOSE_FILE=.devcontainer/compose.yaml:.devcontainer/compose.local.yaml make ci (blocked locally by pre-existing Firestore emulator data; isolated rerun was blocked by Docker network-pool exhaustion)