### PR TITLE
Expose local npm binaries through mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ watchexec = "2.5.1"
 
 [env]
 _.file = ".env"
+_.path = ["{{config_root}}/node_modules/.bin"]
 COMPOSE_FILE = ".devcontainer/compose.yaml:.devcontainer/compose.local.yaml"
 
 [hooks]


### PR DESCRIPTION
## Summary

- add the project-local `node_modules/.bin` directory to the mise-managed PATH
- allow commands such as `vitest` to run directly after `npm ci`, including from subdirectories

## Testing

- `mise exec -- command -v vitest`
- `mise exec -- vitest --version`
- `direnv exec . make check`