### PR TITLE
Use native Vite tsconfig path resolution

### DIFF
--- a/docs/react-compiler-plan.md
+++ b/docs/react-compiler-plan.md
@@ -192,11 +192,13 @@ Do not pass compiler options or mutate the preset filter.
 Import the factory into both root configurations. Use these plugin orders:
 
 ```ts
-plugins: [react(), createReactCompilerPlugin(), tsconfigPaths()]
+plugins: [react(), createReactCompilerPlugin()]
+resolve: { tsconfigPaths: true }
 ```
 
 ```ts
-plugins: [createReactCompilerPlugin(), tsconfigPaths()]
+plugins: [createReactCompilerPlugin()]
+resolve: { tsconfigPaths: true }
 ```
 
 The Babel compiler runs before non-Babel application transforms, and each configuration receives its own plugin instance.

--- a/docs/summary/testing.md
+++ b/docs/summary/testing.md
@@ -50,7 +50,7 @@ annotation mode、filter、suppression、custom panic threshold、runtime gating
 
 ## Vitest Configuration
 
-`vitest.config.ts` は `globals: true`、`environment: "jsdom"`、`vite-tsconfig-paths` plugin を設定しています。Firestore integration tests は `src/action/firestore/init.ts` で emulator に接続し、mock user token を使います。
+`vitest.config.ts` は `globals: true`、`environment: "jsdom"`、Vite の native tsconfig paths resolution を設定しています。Firestore integration tests は `src/action/firestore/init.ts` で emulator に接続し、mock user token を使います。
 
 ## Test Suites
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "typescript": "^5.9.3",
         "vite": "^8.1.3",
         "vite-plugin-pwa": "^1.3.0",
-        "vite-tsconfig-paths": "^4.3.2",
         "vitest": "4.1.10"
       },
       "engines": {
@@ -12968,12 +12967,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
-    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -21258,26 +21251,6 @@
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
-    "node_modules/tsconfck": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.3.tgz",
-      "integrity": "sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==",
-      "dev": true,
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -22063,25 +22036,6 @@
       },
       "peerDependenciesMeta": {
         "@vite-pwa/assets-generator": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
-      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "typescript": "^5.9.3",
     "vite": "^8.1.3",
     "vite-plugin-pwa": "^1.3.0",
-    "vite-tsconfig-paths": "^4.3.2",
     "vitest": "4.1.10"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
-import tsconfigPaths from "vite-tsconfig-paths";
 import { pwaOptions } from "./pwaConfig";
 import { createReactCompilerPlugin } from "./reactCompiler";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), createReactCompilerPlugin(), tsconfigPaths(), VitePWA(pwaOptions)],
+  plugins: [react(), createReactCompilerPlugin(), VitePWA(pwaOptions)],
+  resolve: {
+    tsconfigPaths: true,
+  },
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,14 +3,16 @@ import { fileURLToPath } from 'node:url'
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
 import { playwright } from '@vitest/browser-playwright'
 import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { createReactCompilerPlugin } from './reactCompiler'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [createReactCompilerPlugin(), tsconfigPaths()],
+  plugins: [createReactCompilerPlugin()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   define: {
     '__APP_VERSION__': JSON.stringify(process.env.npm_package_version),
   },


### PR DESCRIPTION
## Summary

- replace `vite-tsconfig-paths` with Vite native `resolve.tsconfigPaths` in app and test configs
- remove the unused plugin dependency and transitive lockfile entries
- update documentation examples to match the native configuration

## Testing

- `make check`
- `npm run build` (via the development container)