### PR TITLE
Constrain Vitest unit test discovery

### DIFF
--- a/storybookVitest.spec.ts
+++ b/storybookVitest.spec.ts
@@ -17,6 +17,7 @@ interface TestProject {
   };
   test?: {
     name?: string;
+    include?: string[];
     environment?: string;
     attachmentsDir?: string;
     browser?: {
@@ -45,6 +46,10 @@ describe("Storybook Vitest integration", () => {
   });
 
   it("keeps unit and Chromium Storybook tests isolated", () => {
+    expect(projectNamed("unit")?.test?.include).toEqual([
+      "src/**/*.spec.{ts,tsx}",
+      "*.spec.{ts,tsx}",
+    ]);
     expect(projectNamed("unit")?.test?.environment).toBe("jsdom");
     expect(projectNamed("storybook")?.test?.browser).toMatchObject({
       enabled: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         test: {
           name: 'unit',
           globals: true,
+          include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}'],
           environment: 'jsdom',
         },
       },


### PR DESCRIPTION
## Summary

- explicitly include unit specs under `src` and the repository root
- prevent repository-local worktrees from matching Vitest filename filters
- cover the unit project include patterns with a configuration test

## Testing

- `npx vitest run storybookVitest.spec.ts --project=unit --no-file-parallelism`
- `npx vitest list src/store --project=unit`
- `make check`