### PR TITLE
Fix Storybook extensionless import warning

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,5 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import { withoutPwaPlugins } from "./vitePlugins";
+import { withoutPwaPlugins } from "./vitePlugins.ts";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.tsx"],

--- a/storybookMainConfig.spec.ts
+++ b/storybookMainConfig.spec.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const storybookMain = readFileSync(
+  path.resolve(".storybook/main.ts"),
+  "utf8",
+);
+const nodeTsconfig = JSON.parse(
+  readFileSync(path.resolve("tsconfig.node.json"), "utf8"),
+) as {
+  compilerOptions?: {
+    allowImportingTsExtensions?: boolean;
+  };
+};
+
+describe("Storybook main configuration", () => {
+  it("uses an explicit TypeScript extension for local imports", () => {
+    expect(storybookMain).toContain('from "./vitePlugins.ts"');
+  });
+
+  it("allows TypeScript extensions in Node configuration imports", () => {
+    expect(nodeTsconfig.compilerOptions?.allowImportingTsExtensions).toBe(true);
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx"


### PR DESCRIPTION
## Summary

- use an explicit TypeScript extension for the local Storybook config import
- allow TypeScript extensions in the Node TypeScript configuration
- add regression coverage for both configuration requirements

## Testing

- `make check`
- `vitest src/store/`