### PR TITLE
Remove unnecessary manual memoization

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "vite dev",
     "start:all": "firebase emulators:start & storybook dev & vite dev --open & wait",
     "build": "vite build && node scripts/verify-pwa-build.mjs",
-    "verify:react-compiler": "vite build --minify=false --sourcemap && node scripts/verify-react-compiler.mjs",
+    "verify:react-compiler": "vite build --config vite.react-compiler.config.ts --minify=false --sourcemap && node scripts/verify-react-compiler.mjs",
     "build:storybook": "storybook build",
     "db": "firebase emulators:start",
     "e2e": "playwright test",

--- a/reactCompiler.spec.ts
+++ b/reactCompiler.spec.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import storybookConfig from "./.storybook/main";
 import viteConfig from "./vite.config";
+import compilerVerificationConfig from "./vite.react-compiler.config";
 import vitestConfig from "./vitest.config";
 
 const reactCompilerMock = vi.hoisted(() => {
@@ -58,8 +59,8 @@ const storybookViteConfig = await storybookConfig.viteFinal?.(
 );
 
 describe("React Compiler Vite integration", () => {
-  it("calls the shared factory for the application and Vitest", () => {
-    expect(createReactCompilerPlugin).toHaveBeenCalledTimes(2);
+  it("calls the shared factory for the application, compiler verification, and Vitest", () => {
+    expect(createReactCompilerPlugin).toHaveBeenCalledTimes(3);
   });
 
   it("adds one compiler plugin to the application", async () => {
@@ -68,6 +69,12 @@ describe("React Compiler Vite integration", () => {
 
   it("adds one compiler plugin to Vitest", async () => {
     expect(await compilerPlugins(vitestConfig.plugins)).toHaveLength(1);
+  });
+
+  it("adds one compiler plugin without PWA generation to compiler verification", async () => {
+    expect(await compilerPlugins(compilerVerificationConfig.plugins)).toHaveLength(1);
+    expect(await pluginNames(compilerVerificationConfig.plugins)).not.toContain("vite-plugin-pwa");
+    expect(await pluginNames(compilerVerificationConfig.plugins)).not.toContain("vite-plugin-pwa:build");
   });
 
   it("keeps one compiler plugin from the root Vite configuration in Storybook", async () => {
@@ -88,10 +95,11 @@ describe("React Compiler Vite integration", () => {
   it("creates independent plugin instances for the application and Vitest", async () => {
     const instances = [
       ...(await compilerPlugins(viteConfig.plugins)),
+      ...(await compilerPlugins(compilerVerificationConfig.plugins)),
       ...(await compilerPlugins(vitestConfig.plugins)),
     ];
 
-    expect(instances).toHaveLength(2);
-    expect(new Set(instances).size).toBe(2);
+    expect(instances).toHaveLength(3);
+    expect(new Set(instances).size).toBe(3);
   });
 });

--- a/src/features/card/containers/CardFormContainer.tsx
+++ b/src/features/card/containers/CardFormContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import * as C from "@/constant";
@@ -15,7 +15,7 @@ const CardFormContent = ({ card }: { card: Card }) => {
   const actions = useActions();
   const navigate = useNavigate();
   const mutations = useCardMutations();
-  const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
+  const categoryOptions = C.CATEGORY.map((category) => ({ label: category, value: category }));
   const goBack = () => void navigate(-1);
   const cardForm = useCardFormState({
     card,

--- a/src/features/card/containers/CardListContainer.tsx
+++ b/src/features/card/containers/CardListContainer.tsx
@@ -22,7 +22,7 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
   const mutations = useCardMutations();
   const deckActions = useDeckActions(deckId);
   const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
-  const closeCard = React.useCallback(() => setShowCard(undefined), []);
+  const closeCard = () => setShowCard(undefined);
   const category = showCard == null ? undefined : util.getCategory(deck.category, showCard.tags);
 
   useKey("t", actions.goToTop);

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -41,6 +41,15 @@ describe("useCardMutations", () => {
     mocks.readAll.mockResolvedValue([]);
   });
 
+  it("keeps the update runner stable across an unchanged render", () => {
+    const { result, rerender } = renderHook(useCardMutations, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const update = result.current.update;
+
+    rerender();
+
+    expect(result.current.update).toBe(update);
+  });
+
   it("routes Card updates through the Firestore mutation service", async () => {
     const deck = createDeck();
     mocks.card = createCard({ deckId: deck.id, score: 0 });

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import * as firestore from "@/adapters/firestore";
 import { useAuth } from "@/auth/AuthContext";
@@ -19,6 +19,43 @@ const variableIds = (variables: CardMutationVariables): CardId[] => {
   return [variables.card.id];
 };
 
+interface CardMutationRunDependencies {
+  mutateAsync: (variables: CardMutationVariables) => Promise<unknown>;
+  lastFailed: { current: CardMutationVariables | undefined };
+  setPendingCounts: (update: (current: Map<CardId, number>) => Map<CardId, number>) => void;
+}
+
+const runCardMutation = async (
+  variables: CardMutationVariables,
+  { mutateAsync, lastFailed, setPendingCounts }: CardMutationRunDependencies
+) => {
+  const ids = variableIds(variables);
+  setPendingCounts((current) => {
+    const next = new Map(current);
+    ids.forEach((id) => {
+      next.set(id, (next.get(id) ?? 0) + 1);
+    });
+    return next;
+  });
+  try {
+    await mutateAsync(variables);
+    lastFailed.current = undefined;
+  } catch (error) {
+    lastFailed.current = variables;
+    throw error;
+  } finally {
+    setPendingCounts((current) => {
+      const next = new Map(current);
+      ids.forEach((id) => {
+        const count = (next.get(id) ?? 1) - 1;
+        if (count === 0) next.delete(id);
+        else next.set(id, count);
+      });
+      return next;
+    });
+  }
+};
+
 export const useCardMutations = () => {
   const auth = useAuth();
   const uid = auth.status === "authenticated" ? auth.uid : "";
@@ -26,18 +63,14 @@ export const useCardMutations = () => {
   const remote = useRemoteCollections();
   const [pendingCounts, setPendingCounts] = useState(() => new Map<CardId, number>());
   const lastFailed = useRef<CardMutationVariables>(undefined);
-  const service = useMemo(
-    () =>
-      createCardMutationService({
-        cache: createRemoteCache(client),
-        createCard: firestore.card.create,
-        updateCard: firestore.card.update,
-        removeCard: firestore.card.logicalRemove,
-        upsertCard: firestore.card.upsert,
-        readCards: firestore.card.readAll,
-      }),
-    [client]
-  );
+  const service = createCardMutationService({
+    cache: createRemoteCache(client),
+    createCard: firestore.card.create,
+    updateCard: firestore.card.update,
+    removeCard: firestore.card.logicalRemove,
+    upsertCard: firestore.card.upsert,
+    readCards: firestore.card.readAll,
+  });
 
   const mutation = useMutation({
     retry: false,
@@ -55,38 +88,14 @@ export const useCardMutations = () => {
     },
   });
 
-  const run = useCallback(
-    async (variables: CardMutationVariables) => {
-      const ids = variableIds(variables);
-      setPendingCounts((current) => {
-        const next = new Map(current);
-        ids.forEach((id) => {
-          next.set(id, (next.get(id) ?? 0) + 1);
-        });
-        return next;
-      });
-      try {
-        await mutation.mutateAsync(variables);
-        lastFailed.current = undefined;
-      } catch (error) {
-        lastFailed.current = variables;
-        throw error;
-      } finally {
-        setPendingCounts((current) => {
-          const next = new Map(current);
-          ids.forEach((id) => {
-            const count = (next.get(id) ?? 1) - 1;
-            if (count === 0) next.delete(id);
-            else next.set(id, count);
-          });
-          return next;
-        });
-      }
-    },
-    [mutation]
-  );
+  const run = (variables: CardMutationVariables) =>
+    runCardMutation(variables, {
+      mutateAsync: mutation.mutateAsync,
+      lastFailed,
+      setPendingCounts,
+    });
 
-  const update = useCallback((card: CardEdit) => run({ kind: "update", card }), [run]);
+  const update = (card: CardEdit) => run({ kind: "update", card });
 
   return {
     create: (card: Card) => run({ kind: "create", card }),

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
@@ -16,7 +16,7 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
   const config = useConfig();
   const actions = useActions();
   const deckActions = useDeckActions(deck.id);
-  const categoryOptions = React.useMemo(() => C.CATEGORY.map((category) => ({ label: category, value: category })), []);
+  const categoryOptions = C.CATEGORY.map((category) => ({ label: category, value: category }));
   const { formState, handleSubmit, register } = useForm<DeckFormValues>({
     defaultValues: {
       name: deck.name,

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -24,10 +24,7 @@ export const DeckListContainer: React.FC = () => {
   const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
   const sessionsByDeckId = useStudyStore((state) => state.sessionsByDeckId);
   const hydrated = useStudyHydrated();
-  const sections = React.useMemo(
-    () => buildDeckListSections(remote.decks, remote.cards, sessionsByDeckId),
-    [remote.cards, remote.decks, sessionsByDeckId]
-  );
+  const sections = buildDeckListSections(remote.decks, remote.cards, sessionsByDeckId);
   useSampleDeckBootstrap();
   useKey("s", actions.goToSettings);
   useKey("i", actions.goToImport);

--- a/src/features/deck/hooks/useDeckActions.ts
+++ b/src/features/deck/hooks/useDeckActions.ts
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
@@ -8,26 +7,23 @@ export const useDeckActions = (id: DeckId) => {
   const navigate = useNavigate();
   const remote = useRemoteCollections();
   const mutations = useDeckMutations();
-  return React.useMemo(
-    () => ({
-      update: mutations.update,
-      updateAndGoToList: async (deck: Deck) => {
-        try {
-          await mutations.update(deck);
-          void navigate("/", { replace: true });
-        } catch {
-          // The mutation notice owns error feedback and retry.
-        }
-      },
-      goToList: () => void navigate("/", { replace: true }),
-      remove: () => {
-        const deck = remote.deckById(id);
-        return deck == null ? Promise.reject(new Error(`Deck ${id} is not available`)) : mutations.remove(deck);
-      },
-      pending: mutations.pending,
-      error: mutations.error,
-      retry: mutations.retry,
-    }),
-    [id, mutations, navigate, remote]
-  );
+  return {
+    update: mutations.update,
+    updateAndGoToList: async (deck: Deck) => {
+      try {
+        await mutations.update(deck);
+        void navigate("/", { replace: true });
+      } catch {
+        // The mutation notice owns error feedback and retry.
+      }
+    },
+    goToList: () => void navigate("/", { replace: true }),
+    remove: () => {
+      const deck = remote.deckById(id);
+      return deck == null ? Promise.reject(new Error(`Deck ${id} is not available`)) : mutations.remove(deck);
+    },
+    pending: mutations.pending,
+    error: mutations.error,
+    retry: mutations.retry,
+  };
 };

--- a/src/features/deck/hooks/useDeckFilterState.ts
+++ b/src/features/deck/hooks/useDeckFilterState.ts
@@ -25,24 +25,18 @@ export const useDeckFilterState = ({ deck, tags, onSubmit }: UseDeckFilterStateO
     });
   }, [handleSubmit, onSubmit, subscribe]);
 
-  const onClickFilter = React.useCallback(
-    (value: boolean) => {
-      setValue("tagAndFilter", value);
-    },
-    [setValue]
-  );
-  const onClickAll = React.useCallback(() => {
+  const onClickFilter = (value: boolean) => {
+    setValue("tagAndFilter", value);
+  };
+  const onClickAll = () => {
     setValue("selectedTags", tags);
-  }, [setValue, tags]);
-  const onClickClear = React.useCallback(() => {
+  };
+  const onClickClear = () => {
     setValue("selectedTags", []);
-  }, [setValue]);
-  const onClickTag = React.useCallback(
-    (value: string[]) => {
-      setValue("selectedTags", value);
-    },
-    [setValue]
-  );
+  };
+  const onClickTag = (value: string[]) => {
+    setValue("selectedTags", value);
+  };
 
   return {
     scoreMax,

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import * as firestore from "@/adapters/firestore";
 import { useAuth } from "@/auth/AuthContext";
@@ -28,16 +28,12 @@ export const useDeckMutations = ({ onRemoveSuccess }: UseDeckMutationsOptions = 
   const [pendingDeckIds, setPendingDeckIds] = useState<Set<DeckId>>(() => new Set());
   const failureRef = useRef<Failure>(undefined);
   const [failure, setFailure] = useState<Failure>();
-  const service = useMemo(
-    () =>
-      createDeckMutationService({
-        cache: createRemoteCache(client),
-        createDeck: firestore.deck.create,
-        updateDeck: firestore.deck.update,
-        removeDeck: firestore.deck.remove,
-      }),
-    [client]
-  );
+  const service = createDeckMutationService({
+    cache: createRemoteCache(client),
+    createDeck: firestore.deck.create,
+    updateDeck: firestore.deck.update,
+    removeDeck: firestore.deck.remove,
+  });
   const mutation = useMutation({
     retry: false,
     mutationFn: async (variables: Variables) => {
@@ -48,54 +44,51 @@ export const useDeckMutations = ({ onRemoveSuccess }: UseDeckMutationsOptions = 
       else await service.remove(uid, deck.id);
     },
   });
-  const run = useCallback(
-    (variables: Variables) => {
-      const failed = failureRef.current;
-      const retryOf = failed != null && isSameOperation(failed.variables, variables) ? failed : undefined;
-      const deckId = variables.deck.id;
-      const current = inFlight.current.get(deckId);
-      if (current != null) {
-        if (retryOf != null) {
-          void current.then(
-            () => {
-              if (failureRef.current !== retryOf) return;
-              failureRef.current = undefined;
-              setFailure(undefined);
-            },
-            () => undefined
-          );
-        }
-        return current;
+  const run = (variables: Variables) => {
+    const failed = failureRef.current;
+    const retryOf = failed != null && isSameOperation(failed.variables, variables) ? failed : undefined;
+    const deckId = variables.deck.id;
+    const current = inFlight.current.get(deckId);
+    if (current != null) {
+      if (retryOf != null) {
+        void current.then(
+          () => {
+            if (failureRef.current !== retryOf) return;
+            failureRef.current = undefined;
+            setFailure(undefined);
+          },
+          () => undefined
+        );
       }
+      return current;
+    }
 
-      setPendingDeckIds((pending) => new Set(pending).add(deckId));
-      const operation = mutation.mutateAsync(variables).then(
-        () => {
-          if (variables.kind === "remove") onRemoveSuccessRef.current?.(variables.deck);
-          if (retryOf == null || failureRef.current !== retryOf) return;
-          failureRef.current = undefined;
-          setFailure(undefined);
-        },
-        (error: unknown) => {
-          const nextFailure = { variables, error };
-          failureRef.current = nextFailure;
-          setFailure(nextFailure);
-          throw error;
-        }
-      );
-      const settled = operation.finally(() => {
-        inFlight.current.delete(deckId);
-        setPendingDeckIds((pending) => {
-          const next = new Set(pending);
-          next.delete(deckId);
-          return next;
-        });
+    setPendingDeckIds((pending) => new Set(pending).add(deckId));
+    const operation = mutation.mutateAsync(variables).then(
+      () => {
+        if (variables.kind === "remove") onRemoveSuccessRef.current?.(variables.deck);
+        if (retryOf == null || failureRef.current !== retryOf) return;
+        failureRef.current = undefined;
+        setFailure(undefined);
+      },
+      (error: unknown) => {
+        const nextFailure = { variables, error };
+        failureRef.current = nextFailure;
+        setFailure(nextFailure);
+        throw error;
+      }
+    );
+    const settled = operation.finally(() => {
+      inFlight.current.delete(deckId);
+      setPendingDeckIds((pending) => {
+        const next = new Set(pending);
+        next.delete(deckId);
+        return next;
       });
-      inFlight.current.set(deckId, settled);
-      return settled;
-    },
-    [mutation]
-  );
+    });
+    inFlight.current.set(deckId, settled);
+    return settled;
+  };
 
   return {
     create: (deck: Deck) => run({ kind: "create", deck }),

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -58,6 +58,15 @@ describe("useDeckImport", () => {
     mocks.bulkUpsert.mockResolvedValue(undefined);
   });
 
+  it("keeps retry orchestration stable across an unchanged render", () => {
+    const { result, rerender } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
+    const retry = result.current.retry;
+
+    rerender();
+
+    expect(result.current.retry).toBe(retry);
+  });
+
   it("previews a file without writing until import is confirmed", async () => {
     const { result } = renderHook(useDeckImport, { wrapper: createQueryWrapper(createTestQueryClient()) });
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import * as action from "@/action";
 import { documentMetadata as firestoreMetadata } from "@/adapters/firestore";
@@ -39,6 +39,129 @@ const partialResultFrom = (error: unknown): DeckImportResult | undefined => {
   return result as DeckImportResult;
 };
 
+interface DeckImportDependencies {
+  uid: string;
+  decks: Deck[];
+  cardsByDeckId: (id: DeckId) => Card[];
+  createDeck: (deck: Deck) => Promise<unknown>;
+  bulkUpsert: (cards: Card[]) => Promise<unknown>;
+}
+
+const executeDeckImport = async (
+  request: ImportRequest,
+  { uid, decks, cardsByDeckId, createDeck, bulkUpsert }: DeckImportDependencies
+): Promise<DeckImportResult> => {
+  if (uid === "") throw new Error("A confirmed user is required for imports");
+  const name = request.kind === "sample" ? SAMPLE_DECK_NAME : request.name;
+  const preferredDeckId = request.kind === "sample" ? sampleDeckId(uid) : undefined;
+  const rows = request.kind === "sample" ? rowsFromCards(sampleCards as CardRaw[]) : request.rows;
+  let deck = decks.find((candidate) =>
+    preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId
+  );
+  if (deck == null) {
+    deck = action.deck.prepare({ name }, uid, firestoreMetadata.generateDeckId);
+    if (preferredDeckId !== undefined) deck = { ...deck, id: preferredDeckId };
+    await createDeck(deck);
+  }
+
+  const existing = cardsByDeckId(deck.id);
+  const byUniqueKey = new Map(existing.map((card) => [card.uniqueKey, card]));
+  const plan = buildDeckImportPlan(rows, existing);
+  const upserts: Card[] = [];
+  const createdIds = new Set<CardId>();
+  const updatedIds = new Set<CardId>();
+  plan.rows.forEach((row) => {
+    const current = byUniqueKey.get(row.card.uniqueKey);
+    if (row.action === "create") {
+      const card = action.card.prepare(row.card, deck, firestoreMetadata.generateCardId);
+      upserts.push(card);
+      createdIds.add(card.id);
+    } else if (row.action === "update" && current != null) {
+      upserts.push({ ...current, ...row.card });
+      updatedIds.add(current.id);
+    }
+  });
+  try {
+    if (upserts.length > 0) await bulkUpsert(upserts);
+  } catch (error) {
+    const failedIds = error instanceof CardBulkMutationError ? error.failedIds : upserts.map((card) => card.id);
+    const failed = new Set(failedIds);
+    throw Object.assign(new Error(`Deck import did not complete: ${String(error)}`), {
+      result: {
+        created: [...createdIds].filter((id) => !failed.has(id)).length,
+        updated: [...updatedIds].filter((id) => !failed.has(id)).length,
+        skipped: plan.unchanged,
+        failed: failed.size,
+        deckId: deck.id,
+      },
+    });
+  }
+  return {
+    created: plan.created,
+    updated: plan.updated,
+    skipped: plan.unchanged,
+    failed: 0,
+    deckId: deck.id,
+  };
+};
+
+interface ImportRunDependencies {
+  runningRef: { current: boolean };
+  setRunning: (running: boolean) => void;
+  lastRequest: { current: ImportRequest | undefined };
+  mutateAsync: (request: ImportRequest) => Promise<DeckImportResult>;
+}
+
+const runDeckImport = async (
+  request: ImportRequest,
+  { runningRef, setRunning, lastRequest, mutateAsync }: ImportRunDependencies
+) => {
+  if (runningRef.current) throw new Error("A Deck import is already running");
+  runningRef.current = true;
+  setRunning(true);
+  lastRequest.current = request;
+  try {
+    return await mutateAsync(request);
+  } finally {
+    runningRef.current = false;
+    setRunning(false);
+  }
+};
+
+interface FilePreviewDependencies {
+  runningRef: { current: boolean };
+  setValidating: (validating: boolean) => void;
+  setPreview: (preview: DeckImportPreview | undefined) => void;
+  reset: () => void;
+  decks: Deck[];
+  cardsByDeckId: (id: DeckId) => Card[];
+}
+
+const previewDeckImportFile = async (
+  file: File,
+  { runningRef, setValidating, setPreview, reset, decks, cardsByDeckId }: FilePreviewDependencies
+) => {
+  if (runningRef.current) throw new Error("A Deck import is already running");
+  setValidating(true);
+  setPreview(undefined);
+  reset();
+  try {
+    const analysis = await parseDeckImportCsv(file);
+    const deck = decks.find((candidate) => candidate.name === file.name);
+    const existing = deck == null ? [] : cardsByDeckId(deck.id);
+    const next = {
+      fileName: file.name,
+      deckName: file.name,
+      analysis,
+      plan: buildDeckImportPlan(analysis.rows, existing),
+    };
+    setPreview(next);
+    return next;
+  } finally {
+    setValidating(false);
+  }
+};
+
 export const useDeckImport = () => {
   const auth = useAuth();
   const config = useConfig();
@@ -53,105 +176,35 @@ export const useDeckImport = () => {
 
   const operation = useMutation({
     retry: false,
-    mutationFn: async (request: ImportRequest): Promise<DeckImportResult> => {
-      const uid = auth.status === "authenticated" ? auth.uid : "";
-      if (uid === "") throw new Error("A confirmed user is required for imports");
-      const name = request.kind === "sample" ? SAMPLE_DECK_NAME : request.name;
-      const preferredDeckId = request.kind === "sample" ? sampleDeckId(uid) : undefined;
-      const rows = request.kind === "sample" ? rowsFromCards(sampleCards as CardRaw[]) : request.rows;
-      let deck = remote.decks.find((candidate) =>
-        preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId
-      );
-      if (deck == null) {
-        deck = action.deck.prepare({ name }, uid, firestoreMetadata.generateDeckId);
-        if (preferredDeckId !== undefined) deck = { ...deck, id: preferredDeckId };
-        await deckMutations.create(deck);
-      }
-
-      const existing = remote.cardsByDeckId(deck.id);
-      const byUniqueKey = new Map(existing.map((card) => [card.uniqueKey, card]));
-      const plan = buildDeckImportPlan(rows, existing);
-      const upserts: Card[] = [];
-      const createdIds = new Set<CardId>();
-      const updatedIds = new Set<CardId>();
-      plan.rows.forEach((row) => {
-        const current = byUniqueKey.get(row.card.uniqueKey);
-        if (row.action === "create") {
-          const card = action.card.prepare(row.card, deck, firestoreMetadata.generateCardId);
-          upserts.push(card);
-          createdIds.add(card.id);
-        } else if (row.action === "update" && current != null) {
-          upserts.push({ ...current, ...row.card });
-          updatedIds.add(current.id);
-        }
-      });
-      try {
-        if (upserts.length > 0) await cardMutations.bulkUpsert(upserts);
-      } catch (error) {
-        const failedIds = error instanceof CardBulkMutationError ? error.failedIds : upserts.map((card) => card.id);
-        const failed = new Set(failedIds);
-        throw Object.assign(new Error(`Deck import did not complete: ${String(error)}`), {
-          result: {
-            created: [...createdIds].filter((id) => !failed.has(id)).length,
-            updated: [...updatedIds].filter((id) => !failed.has(id)).length,
-            skipped: plan.unchanged,
-            failed: failed.size,
-            deckId: deck.id,
-          },
-        });
-      }
-      return {
-        created: plan.created,
-        updated: plan.updated,
-        skipped: plan.unchanged,
-        failed: 0,
-        deckId: deck.id,
-      };
-    },
+    mutationFn: (request: ImportRequest) =>
+      executeDeckImport(request, {
+        uid: auth.status === "authenticated" ? auth.uid : "",
+        decks: remote.decks,
+        cardsByDeckId: remote.cardsByDeckId,
+        createDeck: deckMutations.create,
+        bulkUpsert: cardMutations.bulkUpsert,
+      }),
   });
 
-  const run = useCallback(
-    async (request: ImportRequest) => {
-      if (runningRef.current) throw new Error("A Deck import is already running");
-      runningRef.current = true;
-      setRunning(true);
-      lastRequest.current = request;
-      try {
-        return await operation.mutateAsync(request);
-      } finally {
-        runningRef.current = false;
-        setRunning(false);
-      }
-    },
-    [operation]
-  );
+  const run = (request: ImportRequest) =>
+    runDeckImport(request, {
+      runningRef,
+      setRunning,
+      lastRequest,
+      mutateAsync: operation.mutateAsync,
+    });
 
-  const selectFile = useCallback(
-    async (file: File) => {
-      if (runningRef.current) throw new Error("A Deck import is already running");
-      setValidating(true);
-      setPreview(undefined);
-      operation.reset();
-      try {
-        const analysis = await parseDeckImportCsv(file);
-        const deck = remote.decks.find((candidate) => candidate.name === file.name);
-        const existing = deck == null ? [] : remote.cardsByDeckId(deck.id);
-        const next = {
-          fileName: file.name,
-          deckName: file.name,
-          analysis,
-          plan: buildDeckImportPlan(analysis.rows, existing),
-        };
-        setPreview(next);
-        return next;
-      } finally {
-        setValidating(false);
-      }
-    },
-    [operation, remote]
-  );
+  const selectFile = (file: File) =>
+    previewDeckImportFile(file, {
+      runningRef,
+      setValidating,
+      setPreview,
+      reset: operation.reset,
+      decks: remote.decks,
+      cardsByDeckId: remote.cardsByDeckId,
+    });
 
-  const importPreview = useCallback(() => {
+  const importPreview = () => {
     if (runningRef.current) return Promise.reject(new Error("A Deck import is already running"));
     if (preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
     if (preview.analysis.invalidCount > 0) {
@@ -161,31 +214,28 @@ export const useDeckImport = () => {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
     return run({ kind: "content", name: preview.deckName, rows: preview.analysis.rows });
-  }, [preview, run]);
+  };
 
-  const importUrl = useCallback(
-    async (url: string, name?: string) => {
-      const headers: Record<string, string> = {};
-      if (config.githubAccessToken !== "") {
-        headers.Accept = "application/vnd.github.raw";
-        headers.Authorization = `Bearer ${config.githubAccessToken}`;
-      }
-      const response = await fetch(url, { headers });
-      if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
-      const cards = await action.deck.parseCsv(await response.text());
-      return await run({
-        kind: "content",
-        name: name ?? url.split("/").pop() ?? "no name",
-        rows: rowsFromCards(cards),
-      });
-    },
-    [config.githubAccessToken, run]
-  );
+  const importUrl = async (url: string, name?: string) => {
+    const headers: Record<string, string> = {};
+    if (config.githubAccessToken !== "") {
+      headers.Accept = "application/vnd.github.raw";
+      headers.Authorization = `Bearer ${config.githubAccessToken}`;
+    }
+    const response = await fetch(url, { headers });
+    if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
+    const cards = await action.deck.parseCsv(await response.text());
+    return await run({
+      kind: "content",
+      name: name ?? url.split("/").pop() ?? "no name",
+      rows: rowsFromCards(cards),
+    });
+  };
 
-  const retry = useCallback(() => {
+  const retry = () => {
     const request = lastRequest.current;
     if (request != null && !runningRef.current) void run(request).catch(() => undefined);
-  }, [run]);
+  };
 
   return {
     selectFile,

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -171,10 +171,7 @@ const accountOperationController = createAccountOperationController();
 
 export const useAccountOperations = ({ generation = "settings", login, logout }: AccountOperationDependencies) => {
   accountOperationController.setDependencies({ login, ...(logout ? { logout } : {}) });
-  const subscribe = React.useCallback(
-    (listener: () => void) => accountOperationController.subscribe(generation, listener),
-    [generation]
-  );
+  const subscribe = (listener: () => void) => accountOperationController.subscribe(generation, listener);
   const state = React.useSyncExternalStore(
     subscribe,
     accountOperationController.getSnapshot,

--- a/src/features/study/containers/DeckStartContainer.tsx
+++ b/src/features/study/containers/DeckStartContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
@@ -23,13 +23,10 @@ export const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: Con
   const startStudy = studyActions.start;
   const actions = useActions();
   const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
-  const startFromEnter = React.useCallback(
-    (event: KeyboardEvent) => {
-      if (cards.length === 0 || hasInteractiveShortcutTarget(event.target)) return;
-      startStudy();
-    },
-    [cards.length, startStudy]
-  );
+  const startFromEnter = (event: KeyboardEvent) => {
+    if (cards.length === 0 || hasInteractiveShortcutTarget(event.target)) return;
+    startStudy();
+  };
   useKey("Enter", startFromEnter, {}, [startFromEnter]);
 
   return (

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -4,12 +4,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useStudyActions } from "@/features/study/hooks/useStudyActions";
 import { studyStore } from "@/features/study/state/studyStore";
 
-const mocks = vi.hoisted(() => ({
-  state: null as { card: Record<CardId, Card>; config: ConfigState } | null,
-  navigate: vi.fn(),
-  cardUpdate: vi.fn(),
-  pendingIds: new Set<CardId>(),
-}));
+const mocks = vi.hoisted(() => {
+  const cardUpdate = vi.fn();
+  const pendingIds = new Set<CardId>();
+
+  return {
+    state: null as { card: Record<CardId, Card>; config: ConfigState } | null,
+    filteredCards: [] as Card[],
+    navigate: vi.fn(),
+    cardUpdate,
+    pendingIds,
+    cardMutations: {
+      update: cardUpdate,
+      isPending: (id: CardId) => pendingIds.has(id),
+      pending: false,
+      error: null,
+      retry: vi.fn(),
+    },
+  };
+});
 
 vi.mock("@/hooks/useConfig", () => ({
   useConfig: () => {
@@ -23,8 +36,7 @@ vi.mock("@/query/useRemoteCollections", () => ({
     const cardsById = mocks.state?.card ?? {};
     return {
       cardsById,
-      filteredCardsByDeckId: (deckId: string) =>
-        Object.values(cardsById).filter((card): card is Card => card?.deckId === deckId),
+      filteredCardsByDeckId: () => mocks.filteredCards,
     };
   },
 }));
@@ -34,13 +46,7 @@ vi.mock("react-router-dom", () => ({
 }));
 
 vi.mock("@/features/card/hooks/useCardMutations", () => ({
-  useCardMutations: () => ({
-    update: mocks.cardUpdate,
-    isPending: (id: CardId) => mocks.pendingIds.has(id),
-    pending: false,
-    error: null,
-    retry: vi.fn(),
-  }),
+  useCardMutations: () => mocks.cardMutations,
 }));
 
 const deck: Deck = {
@@ -104,12 +110,22 @@ describe("useStudyActions", () => {
     mocks.cardUpdate.mockResolvedValue(undefined);
     mocks.pendingIds.clear();
     mocks.state = createState();
+    mocks.filteredCards = Object.values(mocks.state.card);
     studyStore.setState({
       sessionsByDeckId: {},
       showBackText: false,
       autoPlay: false,
       lastSwipe: undefined,
     });
+  });
+
+  it("keeps the action API stable across an unchanged render", () => {
+    const { result, rerender } = renderHook(() => useStudyActions(deck.id));
+    const actions = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(actions);
   });
 
   afterEach(() => {

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -23,6 +23,75 @@ export interface StudyActions {
   retry: () => void;
 }
 
+interface StudySwipeDependencies {
+  mutationTokenRef: { current: symbol | undefined };
+  deckId: DeckId;
+  config: ConfigState;
+  cardsById: Partial<Record<CardId, Card>>;
+  isPending: (id: CardId) => boolean;
+  update: (card: CardEdit) => Promise<void>;
+}
+
+const runStudySwipe = async (
+  direction: SwipeDirection,
+  { mutationTokenRef, deckId, config, cardsById, isPending, update }: StudySwipeDependencies
+): Promise<void> => {
+  if (mutationTokenRef.current !== undefined) return;
+  const state = studyStore.getState();
+  const session = state.sessionsByDeckId[deckId];
+  if (session == null) return;
+
+  const swipeAction = resolveSwipeAction(config, direction);
+  if (swipeAction === "DoNothing") return;
+
+  if (swipeAction === "GoBack") {
+    state.setLastSwipe(direction);
+    state.removeStudy(deckId);
+    return;
+  }
+
+  const cardId = session.cardOrderIds[session.currentIndex];
+  const card = cardId == null ? undefined : cardsById[cardId];
+  if (card == null || isPending(card.id)) return;
+
+  const previous = {
+    session: { ...session },
+    showBackText: state.showBackText,
+    lastSwipe: state.lastSwipe,
+  };
+
+  state.setLastSwipe(direction);
+  if (config.hideBodyWhenCardChanged) {
+    state.hideBackText();
+  }
+
+  const patch = buildStudyPatch(card, swipeAction, Date.now());
+  const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
+  const mutationToken = Symbol();
+  mutationTokenRef.current = mutationToken;
+  if (nextIndex < 0) state.removeStudy(deckId);
+  else state.setCurrentIndex(deckId, nextIndex);
+  const optimisticSession = studyStore.getState().sessionsByDeckId[deckId];
+  try {
+    await update(patch);
+  } catch {
+    const current = studyStore.getState();
+    const currentSession = current.sessionsByDeckId[deckId];
+    const changeStillCurrent =
+      mutationTokenRef.current === mutationToken &&
+      (nextIndex < 0 ? currentSession == null : currentSession === optimisticSession);
+    if (changeStillCurrent) {
+      studyStore.setState((state) => ({
+        sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
+        showBackText: previous.showBackText,
+        lastSwipe: previous.lastSwipe,
+      }));
+    }
+  } finally {
+    if (mutationTokenRef.current === mutationToken) mutationTokenRef.current = undefined;
+  }
+};
+
 export const useStudyActions = (deckId: DeckId): StudyActions => {
   const navigate = useNavigate();
   const config = useConfig();
@@ -32,94 +101,41 @@ export const useStudyActions = (deckId: DeckId): StudyActions => {
   const cardMutations = useCardMutations();
   const mutationTokenRef = React.useRef<symbol | undefined>(undefined);
 
-  const start = React.useCallback(() => {
+  const start = () => {
     const cardOrderIds = buildStudySession(cards, config);
     const state = studyStore.getState();
     state.startStudy(deckId, cardOrderIds);
     state.initializeStudyUi(config.defaultAutoPlay);
     void navigate(`/deck/${deckId}/study`, { replace: true });
-  }, [cards, config, deckId, navigate]);
+  };
 
-  const swipe = React.useCallback(
-    async (direction: SwipeDirection): Promise<void> => {
-      if (mutationTokenRef.current !== undefined) return;
+  const swipe = (direction: SwipeDirection) =>
+    runStudySwipe(direction, {
+      mutationTokenRef,
+      deckId,
+      config,
+      cardsById,
+      isPending: cardMutations.isPending,
+      update: cardMutations.update,
+    });
+
+  return {
+    start,
+    swipeUp: () => swipe("cardSwipeUp"),
+    swipeDown: () => swipe("cardSwipeDown"),
+    swipeLeft: () => swipe("cardSwipeLeft"),
+    swipeRight: () => swipe("cardSwipeRight"),
+    updateIndex: (currentIndex: number) => {
       const state = studyStore.getState();
-      const session = state.sessionsByDeckId[deckId];
-      if (session == null) return;
-
-      const swipeAction = resolveSwipeAction(config, direction);
-      if (swipeAction === "DoNothing") return;
-
-      if (swipeAction === "GoBack") {
-        state.setLastSwipe(direction);
-        state.removeStudy(deckId);
-        return;
-      }
-
-      const cardId = session.cardOrderIds[session.currentIndex];
-      const card = cardId == null ? undefined : cardsById[cardId];
-      if (card == null || cardMutations.isPending(card.id)) return;
-
-      const previous = {
-        session: { ...session },
-        showBackText: state.showBackText,
-        lastSwipe: state.lastSwipe,
-      };
-
-      state.setLastSwipe(direction);
-      if (config.hideBodyWhenCardChanged) {
-        state.hideBackText();
-      }
-
-      const patch = buildStudyPatch(card, swipeAction, Date.now());
-      const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
-      const mutationToken = Symbol();
-      mutationTokenRef.current = mutationToken;
-      if (nextIndex < 0) state.removeStudy(deckId);
-      else state.setCurrentIndex(deckId, nextIndex);
-      const optimisticSession = studyStore.getState().sessionsByDeckId[deckId];
-      try {
-        await cardMutations.update(patch);
-      } catch {
-        const current = studyStore.getState();
-        const currentSession = current.sessionsByDeckId[deckId];
-        const changeStillCurrent =
-          mutationTokenRef.current === mutationToken &&
-          (nextIndex < 0 ? currentSession == null : currentSession === optimisticSession);
-        if (changeStillCurrent) {
-          studyStore.setState((state) => ({
-            sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
-            showBackText: previous.showBackText,
-            lastSwipe: previous.lastSwipe,
-          }));
-        }
-      } finally {
-        if (mutationTokenRef.current === mutationToken) mutationTokenRef.current = undefined;
-      }
+      if (state.sessionsByDeckId[deckId] == null) return;
+      state.hideBackText();
+      state.setCurrentIndex(deckId, currentIndex);
     },
-    [cardMutations, cardsById, config, deckId]
-  );
-
-  return React.useMemo(
-    () => ({
-      start,
-      swipeUp: () => swipe("cardSwipeUp"),
-      swipeDown: () => swipe("cardSwipeDown"),
-      swipeLeft: () => swipe("cardSwipeLeft"),
-      swipeRight: () => swipe("cardSwipeRight"),
-      updateIndex: (currentIndex: number) => {
-        const state = studyStore.getState();
-        if (state.sessionsByDeckId[deckId] == null) return;
-        state.hideBackText();
-        state.setCurrentIndex(deckId, currentIndex);
-      },
-      toggleShowBackText: () => studyStore.getState().toggleShowBackText(),
-      toggleAutoPlay: () => studyStore.getState().toggleAutoPlay(),
-      resetStudy: () => studyStore.getState().removeStudy(deckId),
-      pending: cardMutations.pending,
-      error: cardMutations.error,
-      retry: cardMutations.retry,
-    }),
-    [cardMutations.error, cardMutations.pending, cardMutations.retry, deckId, start, swipe]
-  );
+    toggleShowBackText: () => studyStore.getState().toggleShowBackText(),
+    toggleAutoPlay: () => studyStore.getState().toggleAutoPlay(),
+    resetStudy: () => studyStore.getState().removeStudy(deckId),
+    pending: cardMutations.pending,
+    error: cardMutations.error,
+    retry: cardMutations.retry,
+  };
 };

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -1,58 +1,54 @@
-import React from "react";
 import { useNavigate } from "react-router-dom";
 import * as action from "@/action";
 import { configStore } from "@/store/configStore";
 
 export const useActions = () => {
   const navigate = useNavigate();
-  return React.useMemo(
-    () => ({
-      goToView: (id: DeckId) => {
-        void navigate(`/deck/${id}`);
-      },
-      goToStart: (id: DeckId) => {
-        void navigate(`/deck/${id}/start`);
-      },
-      goToEdit: (id: DeckId) => {
-        void navigate(`/deck/${id}/edit`);
-      },
-      goToStudy: (id: DeckId) => {
-        void navigate(`/deck/${id}/study`);
-      },
-      goToCardView: (id: CardId) => {
-        void navigate(`/card/${id}`);
-      },
-      goToCardEdit: (id: CardId) => {
-        void navigate(`/card/${id}/edit`);
-      },
-      goToTop: () => {
-        void navigate("/");
-      },
-      goToSettings: () => {
+  return {
+    goToView: (id: DeckId) => {
+      void navigate(`/deck/${id}`);
+    },
+    goToStart: (id: DeckId) => {
+      void navigate(`/deck/${id}/start`);
+    },
+    goToEdit: (id: DeckId) => {
+      void navigate(`/deck/${id}/edit`);
+    },
+    goToStudy: (id: DeckId) => {
+      void navigate(`/deck/${id}/study`);
+    },
+    goToCardView: (id: CardId) => {
+      void navigate(`/card/${id}`);
+    },
+    goToCardEdit: (id: CardId) => {
+      void navigate(`/card/${id}/edit`);
+    },
+    goToTop: () => {
+      void navigate("/");
+    },
+    goToSettings: () => {
+      void navigate("/settings");
+    },
+    goToImport: () => {
+      void navigate("/import");
+    },
+    goByMenu: (key: PageKey) => {
+      if (key === "config") {
         void navigate("/settings");
-      },
-      goToImport: () => {
+      } else if (key === "upload") {
         void navigate("/import");
-      },
-      goByMenu: (key: PageKey) => {
-        if (key === "config") {
-          void navigate("/settings");
-        } else if (key === "upload") {
-          void navigate("/import");
-        } else {
-          void navigate("/");
-        }
-      },
-      deckDownloadCsvSampleText: () => {
-        action.deck.downloadCsvSampleText();
-      },
-      login: action.event.loginGoogle,
-      logout: action.event.logout,
-      configUpdate: (config: ConfigState) => configStore.getState().updateConfig(config),
-      setDarkMode: (darkMode: boolean) => configStore.getState().updateConfig({ darkMode }),
-      toggleShowHeader: () => configStore.getState().toggleConfig("showHeader"),
-      toggleShowSwipeButtonList: () => configStore.getState().toggleConfig("showSwipeButtonList"),
-    }),
-    [navigate]
-  );
+      } else {
+        void navigate("/");
+      }
+    },
+    deckDownloadCsvSampleText: () => {
+      action.deck.downloadCsvSampleText();
+    },
+    login: action.event.loginGoogle,
+    logout: action.event.logout,
+    configUpdate: (config: ConfigState) => configStore.getState().updateConfig(config),
+    setDarkMode: (darkMode: boolean) => configStore.getState().updateConfig({ darkMode }),
+    toggleShowHeader: () => configStore.getState().toggleConfig("showHeader"),
+    toggleShowSwipeButtonList: () => configStore.getState().toggleConfig("showSwipeButtonList"),
+  };
 };

--- a/src/lib/componentArchitecture.spec.ts
+++ b/src/lib/componentArchitecture.spec.ts
@@ -6,6 +6,7 @@ const sourceRoot = path.resolve(process.cwd(), "src");
 const sourceExtension = /\.tsx?$/;
 const testOrStory = /\.(?:spec|stories)\.tsx?$/;
 const mutablePresentationHook = /\b(?:React\.)?(?:useState|useReducer|useForm|useController|useWatch)\s*\(/;
+const manualMemoizationHook = /\b(?:React\.)?(?:useMemo|useCallback)\s*\(/g;
 const customHookDefinition = /\b(?:const|function)\s+(use[A-Z][A-Za-z0-9]*)\b/g;
 const firestoreCompositionModules = new Set([
   "firebase.ts",
@@ -159,6 +160,15 @@ function expectSharedComponentGroup(
 }
 
 describe("component architecture", () => {
+  it("leaves render memoization to React Compiler", () => {
+    const inventory = productionFilesUnder("").flatMap((relativePath) => {
+      const count = readSource(relativePath).match(manualMemoizationHook)?.length ?? 0;
+      return count === 0 ? [] : [{ relativePath, count }];
+    });
+
+    expect(inventory).toEqual([]);
+  });
+
   it("normalizes baseUrl source imports before checking boundaries", () => {
     expect(resolveModuleSpecifier("components/content/Card.tsx", "src/action")).toBe("@/action");
   });

--- a/vite.react-compiler.config.ts
+++ b/vite.react-compiler.config.ts
@@ -1,0 +1,17 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+import { createReactCompilerPlugin } from "./reactCompiler";
+
+export default defineConfig({
+  plugins: [react(), createReactCompilerPlugin()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
+  build: {
+    outDir: "build",
+  },
+});


### PR DESCRIPTION
## Summary

- remove all 25 manual useMemo and useCallback calls now covered by React Compiler
- extract async mutation, import, and study orchestration so affected hooks remain compiler-optimized
- add identity and inventory coverage plus a PWA-free compiler verification build

## Testing

- make check
- npm run test:storybook
- npm run verify:react-compiler
- npm run build
- verified compiler cache output for all 13 affected components and hooks

Closes #352