### PR TITLE
Enforce required issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: バグ報告
+description: 再現可能な不具合を報告します。
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: 現在の挙動
+      description: 現在発生している挙動を説明してください。
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: 再現手順
+      description: 問題を再現する手順を記載してください。
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 期待する挙動
+      description: 期待していた挙動を説明してください。
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: 実際の挙動
+      description: 実際に発生した挙動を説明してください。
+    validations:
+      required: true
+  - type: dropdown
+    id: change-areas
+    attributes:
+      label: Change areas
+      description: Select every area changed by this issue.
+      multiple: true
+      options:
+        - ci
+        - ui
+        - test
+        - dev
+        - docs
+        - dependencies
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,48 @@
+name: 改善提案
+description: 機能や開発体験の改善を提案します。
+title: "[Improvement]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目的
+      description: この改善で達成したいことを説明してください。
+    validations:
+      required: true
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景
+      description: この改善が必要な背景を説明してください。
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: 対象範囲
+      description: 変更する範囲と変更しない範囲を記載してください。
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 受け入れ条件
+      description: 完了と判断できる条件を記載してください。
+    validations:
+      required: true
+  - type: dropdown
+    id: change-areas
+    attributes:
+      label: Change areas
+      description: Select every area changed by this issue.
+      multiple: true
+      options:
+        - ci
+        - ui
+        - test
+        - dev
+        - docs
+        - dependencies
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,19 @@
+name: 質問
+description: プロジェクトに関する質問をします。
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: 質問
+      description: 知りたいことを具体的に記載してください。
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: 背景
+      description: 質問に至った背景や試したことを記載してください。
+    validations:
+      required: true

--- a/.github/workflows/issue-label-guard.yml
+++ b/.github/workflows/issue-label-guard.yml
@@ -1,0 +1,48 @@
+name: Issue label guard
+
+on:
+  workflow_dispatch:
+  issues:
+    types: [opened, edited, reopened, transferred, labeled, unlabeled]
+
+permissions: {}
+
+jobs:
+  reconcile-issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: issue-label-guard-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.15.0
+      - name: Reconcile issue labels
+        run: node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --issue "$ISSUE_NUMBER"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+  reconcile-all:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: issue-label-guard-${{ github.repository }}-all
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.15.0
+      - name: Reconcile all open issues
+        run: node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --all-open
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Do not work directly on `main`.
 - Do not commit files ignored by `.gitignore`.
 - Do not add files under `docs` unless the user explicitly requests them.
+- Follow `CONTRIBUTING.md` when creating GitHub issues.
 - Write comments, commit messages, pull request titles, and pull request descriptions in English.
 - If `gh` fails in the sandbox, rerun it outside the sandbox.
 - Before finishing non-documentation changes, run `make check`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# コントリビューションガイド
+
+## Issue のラベル
+
+すべての Issue には、種類を表すラベルを 1 つ付けます。種類ラベルは `bug`、`enhancement`、`question` のいずれかです。
+
+`bug` または `enhancement` の Issue には、変更対象の領域ラベルを少なくとも 1 つ付けます。使用できる領域ラベルは `ci`、`ui`、`test`、`dev`、`docs`、`dependencies` です。
+
+種類または領域の分類が不足している Issue には、`needs-triage` ラベルを付けます。

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,8 @@
         "typescript": "^5.9.3",
         "vite": "^8.1.3",
         "vite-plugin-pwa": "^1.3.0",
-        "vitest": "4.1.10"
+        "vitest": "4.1.10",
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=24.15.0 <25"

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.1.3",
     "vite-plugin-pwa": "^1.3.0",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yaml": "2.9.0"
   }
 }

--- a/scripts/issue-form-config.spec.mjs
+++ b/scripts/issue-form-config.spec.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const issueTemplateDirectory = path.join(process.cwd(), ".github", "ISSUE_TEMPLATE");
+
+function readIssueForm(name) {
+  return parse(readFileSync(path.join(issueTemplateDirectory, name), "utf8"));
+}
+
+function changeAreaFields(form) {
+  return form.body.filter((field) => field.type === "dropdown" && field.attributes.label === "Change areas");
+}
+
+describe("issue form configuration", () => {
+  it("applies one type label per form", () => {
+    expect(readIssueForm("bug.yml").labels).toEqual(["bug"]);
+    expect(readIssueForm("improvement.yml").labels).toEqual(["enhancement"]);
+    expect(readIssueForm("question.yml").labels).toEqual(["question"]);
+  });
+
+  it("requires an allowlisted area for implementation forms", () => {
+    const expectedOptions = ["ci", "ui", "test", "dev", "docs", "dependencies"];
+
+    for (const name of ["bug.yml", "improvement.yml"]) {
+      const fields = changeAreaFields(readIssueForm(name));
+
+      expect(fields).toHaveLength(1);
+      const [field] = fields;
+      expect(field.attributes.multiple).toBe(true);
+      expect(field.attributes.options).toEqual(expectedOptions);
+      expect(field.validations.required).toBe(true);
+    }
+
+    expect(changeAreaFields(readIssueForm("question.yml"))).toEqual([]);
+  });
+
+  it("disables blank issues for contributors", () => {
+    expect(readIssueForm("config.yml").blank_issues_enabled).toBe(false);
+  });
+});

--- a/scripts/issue-label-policy.mjs
+++ b/scripts/issue-label-policy.mjs
@@ -1,0 +1,74 @@
+export const TYPE_LABELS = ["bug", "enhancement", "question"];
+export const AREA_LABELS = ["ci", "ui", "test", "dev", "docs", "dependencies"];
+export const TRIAGE_LABEL = "needs-triage";
+
+function openingFence(line) {
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})/);
+  if (match === null) return null;
+
+  return { marker: match[1][0], length: match[1].length };
+}
+
+function closesFence(line, fence) {
+  const match = line.match(/^ {0,3}(`+|~+)[ \t]*$/);
+  return match !== null && match[1][0] === fence.marker && match[1].length >= fence.length;
+}
+
+function unfencedLines(body) {
+  const result = [];
+  let fence = null;
+
+  for (const [index, line] of body.replaceAll("\r\n", "\n").split("\n").entries()) {
+    if (fence !== null) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+
+    fence = openingFence(line);
+    if (fence === null) result.push({ index, line });
+  }
+
+  return result;
+}
+
+export function parseChangeAreas(body) {
+  if (typeof body !== "string" || body.length === 0) return [];
+
+  const lines = unfencedLines(body);
+  const headings = lines.filter(({ line }) => line === "### Change areas");
+  if (headings.length !== 1) return [];
+
+  const headingIndex = headings[0].index;
+  const nextHeading = lines.find(({ index, line }) => index > headingIndex && line.startsWith("### "));
+  const values = lines
+    .filter(({ index }) => index > headingIndex && (nextHeading === undefined || index < nextHeading.index))
+    .map(({ line }) => line)
+    .filter((line) => line !== "");
+
+  if (values.length !== 1) return [];
+
+  const tokens = values[0].split(", ");
+  if (!tokens.every((token) => AREA_LABELS.includes(token))) return [];
+
+  const selected = new Set(tokens);
+  return AREA_LABELS.filter((area) => selected.has(area));
+}
+
+export function evaluateIssuePolicy({ labels, body }) {
+  const currentLabels = new Set(labels);
+  const parsedAreas = parseChangeAreas(body);
+  const effectiveLabels = new Set([...currentLabels, ...parsedAreas]);
+  const hasType = TYPE_LABELS.some((type) => effectiveLabels.has(type));
+  const requiresArea = effectiveLabels.has("bug") || effectiveLabels.has("enhancement");
+  const hasArea = AREA_LABELS.some((area) => effectiveLabels.has(area));
+  const compliant = hasType && (!requiresArea || hasArea);
+  const add = parsedAreas.filter((area) => !currentLabels.has(area));
+
+  if (!compliant && !currentLabels.has(TRIAGE_LABEL)) add.push(TRIAGE_LABEL);
+
+  return {
+    compliant,
+    add,
+    remove: compliant && currentLabels.has(TRIAGE_LABEL) ? [TRIAGE_LABEL] : [],
+  };
+}

--- a/scripts/issue-label-policy.mjs
+++ b/scripts/issue-label-policy.mjs
@@ -3,8 +3,10 @@ export const AREA_LABELS = ["ci", "ui", "test", "dev", "docs", "dependencies"];
 export const TRIAGE_LABEL = "needs-triage";
 
 function openingFence(line) {
-  const match = line.match(/^ {0,3}(`{3,}|~{3,})/);
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
   if (match === null) return null;
+
+  if (match[1][0] === "`" && match[2].includes("`")) return null;
 
   return { marker: match[1][0], length: match[1].length };
 }
@@ -14,18 +16,19 @@ function closesFence(line, fence) {
   return match !== null && match[1][0] === fence.marker && match[1].length >= fence.length;
 }
 
-function unfencedLines(body) {
+function linesWithFenceState(body) {
   const result = [];
   let fence = null;
 
   for (const [index, line] of body.replaceAll("\r\n", "\n").split("\n").entries()) {
     if (fence !== null) {
       if (closesFence(line, fence)) fence = null;
+      result.push({ index, line, fenced: true });
       continue;
     }
 
     fence = openingFence(line);
-    if (fence === null) result.push({ index, line });
+    result.push({ index, line, fenced: fence !== null });
   }
 
   return result;
@@ -34,12 +37,14 @@ function unfencedLines(body) {
 export function parseChangeAreas(body) {
   if (typeof body !== "string" || body.length === 0) return [];
 
-  const lines = unfencedLines(body);
-  const headings = lines.filter(({ line }) => line === "### Change areas");
+  const lines = linesWithFenceState(body);
+  const headings = lines.filter(({ line, fenced }) => !fenced && line === "### Change areas");
   if (headings.length !== 1) return [];
 
   const headingIndex = headings[0].index;
-  const nextHeading = lines.find(({ index, line }) => index > headingIndex && line.startsWith("### "));
+  const nextHeading = lines.find(
+    ({ index, line, fenced }) => index > headingIndex && !fenced && line.startsWith("### ")
+  );
   const values = lines
     .filter(({ index }) => index > headingIndex && (nextHeading === undefined || index < nextHeading.index))
     .map(({ line }) => line)

--- a/scripts/issue-label-policy.spec.mjs
+++ b/scripts/issue-label-policy.spec.mjs
@@ -62,9 +62,24 @@ describe("parseChangeAreas", () => {
   });
 
   it("reads only through the next unfenced level-three heading", () => {
-    const body = `### Change areas\n\nui\n\n~~~\n### Ignored heading\n~~~\n\n### Goal\n\ndocs`;
+    const body = `### Change areas\n\nui\n\n### Goal\n\ndocs`;
 
     expect(parseChangeAreas(body)).toEqual(["ui"]);
+  });
+
+  it.each([
+    ["unknown", "```\nunknown\n```"],
+    ["shell-like", "~~~\nui; gh issue delete 1\n~~~"],
+  ])("rejects %s fenced content inside the selected section", (_name, fencedContent) => {
+    const body = `### Change areas\n\nui\n\n${fencedContent}\n\n### Goal\n\nText`;
+
+    expect(parseChangeAreas(body)).toEqual([]);
+  });
+
+  it("does not let an invalid backtick info string hide a duplicate heading", () => {
+    const body = `### Change areas\n\nui\n\n\`\`\`invalid\`info\n### Change areas\n\ndocs\n\`\`\``;
+
+    expect(parseChangeAreas(body)).toEqual([]);
   });
 
   it.each([

--- a/scripts/issue-label-policy.spec.mjs
+++ b/scripts/issue-label-policy.spec.mjs
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  AREA_LABELS,
+  TRIAGE_LABEL,
+  TYPE_LABELS,
+  evaluateIssuePolicy,
+  parseChangeAreas,
+} from "./issue-label-policy.mjs";
+
+const single = `### Change areas\n\nui\n\n### Goal\n\nImprove navigation.`;
+const multiple = `### Change areas\n\nci, test, docs\n\n### Goal\n\nImprove delivery.`;
+
+describe("issue label policy constants", () => {
+  it("defines the supported type, area, and triage labels", () => {
+    expect(TYPE_LABELS).toEqual(["bug", "enhancement", "question"]);
+    expect(AREA_LABELS).toEqual(["ci", "ui", "test", "dev", "docs", "dependencies"]);
+    expect(TRIAGE_LABEL).toBe("needs-triage");
+  });
+});
+
+describe("parseChangeAreas", () => {
+  it.each([
+    [single, ["ui"]],
+    [multiple, ["ci", "test", "docs"]],
+    [multiple.replaceAll("\n", "\r\n"), ["ci", "test", "docs"]],
+    [`### Change areas\n\ndocs, ci, docs, ui`, ["ci", "ui", "docs"]],
+  ])("parses allowlisted values in deterministic order", (body, expected) => {
+    expect(parseChangeAreas(body)).toEqual(expected);
+  });
+
+  it.each([null, undefined, "", "### Change Areas\n\nui", "## Change areas\n\nui", " ### Change areas\n\nui"])(
+    "returns no areas when the exact heading is absent",
+    (body) => {
+      expect(parseChangeAreas(body)).toEqual([]);
+    }
+  );
+
+  it("rejects duplicate exact unfenced headings", () => {
+    expect(parseChangeAreas(`### Change areas\n\nui\n\n### Goal\n\nText\n\n### Change areas\n\ndocs`)).toEqual([]);
+  });
+
+  it.each([
+    ["```", "```"],
+    ["````", "````"],
+    ["````", "`````"],
+    ["~~~", "~~~"],
+    ["~~~~", "~~~~~"],
+  ])("ignores matching headings inside %s fenced blocks closed by %s", (opening, closing) => {
+    const body = `${opening}\n### Change areas\n\ndocs\n${closing}\n\n${single}`;
+
+    expect(parseChangeAreas(body)).toEqual(["ui"]);
+  });
+
+  it("does not close a fence with a different marker or a shorter run", () => {
+    const body = `\`\`\`\`\n### Change areas\n\ndocs\n~~~\n\`\`\`\n### Change areas\n\nci`;
+
+    expect(parseChangeAreas(body)).toEqual([]);
+  });
+
+  it("ignores headings inside an unclosed fence", () => {
+    expect(parseChangeAreas(`~~~\n### Change areas\n\nui`)).toEqual([]);
+  });
+
+  it("reads only through the next unfenced level-three heading", () => {
+    const body = `### Change areas\n\nui\n\n~~~\n### Ignored heading\n~~~\n\n### Goal\n\ndocs`;
+
+    expect(parseChangeAreas(body)).toEqual(["ui"]);
+  });
+
+  it.each([
+    "ci,test",
+    "ci,  test",
+    " ci",
+    "ci ",
+    "CI",
+    "Test",
+    "area: ci",
+    "ci area",
+    "unknown",
+    "ui; gh issue delete 1",
+  ])("rejects a malformed section value: %s", (value) => {
+    expect(parseChangeAreas(`### Change areas\n\n${value}\n\n### Goal\n\nText`)).toEqual([]);
+  });
+});
+
+describe("evaluateIssuePolicy", () => {
+  const cases = [
+    ["empty", [], false],
+    ["question", ["question"], true],
+    ["question with optional area", ["question", "docs"], true],
+    ["bug missing area", ["bug"], false],
+    ["enhancement missing area", ["enhancement"], false],
+    ["bug with area", ["bug", "ui"], true],
+    ["enhancement with area", ["enhancement", "ci"], true],
+    ["question plus bug missing area", ["question", "bug"], false],
+    ["question plus bug with area", ["question", "bug", "dev"], true],
+    ["question plus enhancement missing area", ["question", "enhancement"], false],
+    ["question plus enhancement with area", ["question", "enhancement", "test"], true],
+    ["bug plus enhancement missing area", ["bug", "enhancement"], false],
+    ["bug plus enhancement with area", ["bug", "enhancement", "dependencies"], true],
+    ["area only", ["docs"], false],
+  ];
+
+  it.each(cases)("evaluates %s without an existing triage label", (_name, labels, compliant) => {
+    expect(evaluateIssuePolicy({ labels, body: "" })).toEqual({
+      compliant,
+      add: compliant ? [] : [TRIAGE_LABEL],
+      remove: [],
+    });
+  });
+
+  it.each(cases)("evaluates %s with an existing triage label", (_name, labels, compliant) => {
+    expect(evaluateIssuePolicy({ labels: [...labels, TRIAGE_LABEL], body: "" })).toEqual({
+      compliant,
+      add: [],
+      remove: compliant ? [TRIAGE_LABEL] : [],
+    });
+  });
+
+  it.each(AREA_LABELS)("accepts bug issues in the %s area", (area) => {
+    expect(evaluateIssuePolicy({ labels: ["bug", area], body: "" }).compliant).toBe(true);
+  });
+
+  it("adds parsed body areas that are missing and uses them for compliance", () => {
+    expect(evaluateIssuePolicy({ labels: ["bug"], body: multiple })).toEqual({
+      compliant: true,
+      add: ["ci", "test", "docs"],
+      remove: [],
+    });
+  });
+
+  it("adds parsed areas before triage when the issue still has no type", () => {
+    expect(evaluateIssuePolicy({ labels: [], body: multiple })).toEqual({
+      compliant: false,
+      add: ["ci", "test", "docs", TRIAGE_LABEL],
+      remove: [],
+    });
+  });
+
+  it("does not duplicate current area labels or parsed values", () => {
+    const body = `### Change areas\n\ndocs, ci, docs, ui`;
+
+    expect(evaluateIssuePolicy({ labels: ["question", "ui", "ci", "ci"], body })).toEqual({
+      compliant: true,
+      add: ["docs"],
+      remove: [],
+    });
+  });
+
+  it("adds missing areas and removes only triage for a compliant issue", () => {
+    expect(evaluateIssuePolicy({ labels: ["enhancement", TRIAGE_LABEL, "custom"], body: single })).toEqual({
+      compliant: true,
+      add: ["ui"],
+      remove: [TRIAGE_LABEL],
+    });
+  });
+
+  it("returns duplicate-free actions for duplicate current labels", () => {
+    expect(evaluateIssuePolicy({ labels: ["bug", "bug", TRIAGE_LABEL, TRIAGE_LABEL], body: "" })).toEqual({
+      compliant: false,
+      add: [],
+      remove: [],
+    });
+  });
+});

--- a/scripts/issue-label-workflow.spec.mjs
+++ b/scripts/issue-label-workflow.spec.mjs
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const workflowPath = path.join(process.cwd(), ".github", "workflows", "issue-label-guard.yml");
+const checkoutAction = "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683";
+const setupNodeAction = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020";
+
+function readWorkflow() {
+  return parse(readFileSync(workflowPath, "utf8"));
+}
+
+function triggersFor(workflow) {
+  if (Object.hasOwn(workflow, "on")) {
+    return workflow.on;
+  }
+
+  expect(Object.hasOwn(workflow, "true")).toBe(true);
+  return workflow.true;
+}
+
+function expectJobBase(job, group) {
+  expect(job).toMatchObject({
+    "runs-on": "ubuntu-latest",
+    permissions: {
+      contents: "read",
+      issues: "write",
+    },
+    concurrency: {
+      group,
+      "cancel-in-progress": false,
+    },
+  });
+  expect(Object.keys(job.permissions).sort()).toEqual(["contents", "issues"]);
+  expect(job.concurrency.group).not.toBe("");
+}
+
+function expectSteps(job, name, run, env) {
+  expect(job.steps).toEqual([
+    { uses: checkoutAction },
+    {
+      uses: setupNodeAction,
+      with: { "node-version": "24.15.0" },
+    },
+    { name, run, env },
+  ]);
+}
+
+describe("issue label guard workflow", () => {
+  it("reconciles issue events and manual runs with the required least-privilege contract", () => {
+    const workflow = readWorkflow();
+    const triggers = triggersFor(workflow);
+
+    expect(workflow.name).toBe("Issue label guard");
+    expect(Object.keys(triggers).sort()).toEqual(["issues", "workflow_dispatch"]);
+    expect(triggers.workflow_dispatch).toBeNull();
+    expect(triggers.issues).toEqual({
+      types: ["opened", "edited", "reopened", "transferred", "labeled", "unlabeled"],
+    });
+    expect(workflow.permissions).toEqual({});
+    expect(Object.keys(workflow.jobs).sort()).toEqual(["reconcile-all", "reconcile-issue"]);
+
+    const issueJob = workflow.jobs["reconcile-issue"];
+    const allJob = workflow.jobs["reconcile-all"];
+
+    expect(issueJob.if).toBe("github.event_name == 'issues'");
+    expect(allJob.if).toBe("github.event_name == 'workflow_dispatch'");
+    expectJobBase(issueJob, "issue-label-guard-${{ github.repository }}-${{ github.event.issue.number }}");
+    expectJobBase(allJob, "issue-label-guard-${{ github.repository }}-all");
+    expect(issueJob.concurrency.group).not.toBe(allJob.concurrency.group);
+
+    expectSteps(
+      issueJob,
+      "Reconcile issue labels",
+      'node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --issue "$ISSUE_NUMBER"',
+      {
+        GH_TOKEN: "${{ github.token }}",
+        ISSUE_NUMBER: "${{ github.event.issue.number }}",
+      }
+    );
+    expectSteps(
+      allJob,
+      "Reconcile all open issues",
+      'node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --all-open',
+      { GH_TOKEN: "${{ github.token }}" }
+    );
+  });
+});

--- a/scripts/issue-label-workflow.spec.mjs
+++ b/scripts/issue-label-workflow.spec.mjs
@@ -6,21 +6,29 @@ import { parse } from "yaml";
 const workflowPath = path.join(process.cwd(), ".github", "workflows", "issue-label-guard.yml");
 const checkoutAction = "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683";
 const setupNodeAction = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020";
+const workflowKeys = ["jobs", "name", "on", "permissions"];
+const jobKeys = ["concurrency", "if", "permissions", "runs-on", "steps"];
 
 function readWorkflow() {
   return parse(readFileSync(workflowPath, "utf8"));
 }
 
-function triggersFor(workflow) {
-  if (Object.hasOwn(workflow, "on")) {
-    return workflow.on;
-  }
+function workflowWithTrueTrigger() {
+  return parse(readFileSync(workflowPath, "utf8").replace(/^on:/m, "true:"));
+}
 
-  expect(Object.hasOwn(workflow, "true")).toBe(true);
-  return workflow.true;
+function alteredWorkflow(mutate) {
+  const workflow = readWorkflow();
+  mutate(workflow);
+  return workflow;
+}
+
+function expectExactKeys(value, keys) {
+  expect(Object.keys(value).sort()).toEqual(keys);
 }
 
 function expectJobBase(job, group) {
+  expectExactKeys(job, jobKeys);
   expect(job).toMatchObject({
     "runs-on": "ubuntu-latest",
     permissions: {
@@ -47,43 +55,69 @@ function expectSteps(job, name, run, env) {
   ]);
 }
 
+function expectWorkflowContract(workflow) {
+  expectExactKeys(workflow, workflowKeys);
+  expect(Object.hasOwn(workflow, "on")).toBe(true);
+  expect(Object.hasOwn(workflow, "true")).toBe(false);
+
+  const triggers = workflow.on;
+
+  expect(workflow.name).toBe("Issue label guard");
+  expect(Object.keys(triggers).sort()).toEqual(["issues", "workflow_dispatch"]);
+  expect(triggers.workflow_dispatch).toBeNull();
+  expect(triggers.issues).toEqual({
+    types: ["opened", "edited", "reopened", "transferred", "labeled", "unlabeled"],
+  });
+  expect(workflow.permissions).toEqual({});
+  expect(Object.keys(workflow.jobs).sort()).toEqual(["reconcile-all", "reconcile-issue"]);
+
+  const issueJob = workflow.jobs["reconcile-issue"];
+  const allJob = workflow.jobs["reconcile-all"];
+
+  expect(Object.hasOwn(workflow, "env")).toBe(false);
+  expect(Object.hasOwn(issueJob, "env")).toBe(false);
+  expect(Object.hasOwn(allJob, "env")).toBe(false);
+  expect(issueJob.if).toBe("github.event_name == 'issues'");
+  expect(allJob.if).toBe("github.event_name == 'workflow_dispatch'");
+  expectJobBase(issueJob, "issue-label-guard-${{ github.repository }}-${{ github.event.issue.number }}");
+  expectJobBase(allJob, "issue-label-guard-${{ github.repository }}-all");
+  expect(issueJob.concurrency.group).not.toBe(allJob.concurrency.group);
+
+  expectSteps(
+    issueJob,
+    "Reconcile issue labels",
+    'node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --issue "$ISSUE_NUMBER"',
+    {
+      GH_TOKEN: "${{ github.token }}",
+      ISSUE_NUMBER: "${{ github.event.issue.number }}",
+    }
+  );
+  expectSteps(
+    allJob,
+    "Reconcile all open issues",
+    'node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --all-open',
+    { GH_TOKEN: "${{ github.token }}" }
+  );
+  expect(issueJob.steps[2].env.ISSUE_NUMBER).toBe("${{ github.event.issue.number }}");
+  expect(allJob.steps.flatMap((step) => Object.keys(step.env ?? {}))).not.toContain("ISSUE_NUMBER");
+}
+
 describe("issue label guard workflow", () => {
   it("reconciles issue events and manual runs with the required least-privilege contract", () => {
-    const workflow = readWorkflow();
-    const triggers = triggersFor(workflow);
+    expectWorkflowContract(readWorkflow());
+  });
 
-    expect(workflow.name).toBe("Issue label guard");
-    expect(Object.keys(triggers).sort()).toEqual(["issues", "workflow_dispatch"]);
-    expect(triggers.workflow_dispatch).toBeNull();
-    expect(triggers.issues).toEqual({
-      types: ["opened", "edited", "reopened", "transferred", "labeled", "unlabeled"],
-    });
-    expect(workflow.permissions).toEqual({});
-    expect(Object.keys(workflow.jobs).sort()).toEqual(["reconcile-all", "reconcile-issue"]);
-
-    const issueJob = workflow.jobs["reconcile-issue"];
-    const allJob = workflow.jobs["reconcile-all"];
-
-    expect(issueJob.if).toBe("github.event_name == 'issues'");
-    expect(allJob.if).toBe("github.event_name == 'workflow_dispatch'");
-    expectJobBase(issueJob, "issue-label-guard-${{ github.repository }}-${{ github.event.issue.number }}");
-    expectJobBase(allJob, "issue-label-guard-${{ github.repository }}-all");
-    expect(issueJob.concurrency.group).not.toBe(allJob.concurrency.group);
-
-    expectSteps(
-      issueJob,
-      "Reconcile issue labels",
-      'node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --issue "$ISSUE_NUMBER"',
-      {
-        GH_TOKEN: "${{ github.token }}",
-        ISSUE_NUMBER: "${{ github.event.issue.number }}",
-      }
-    );
-    expectSteps(
-      allJob,
-      "Reconcile all open issues",
-      'node scripts/reconcile-issue-labels.mjs --repo "$GITHUB_REPOSITORY" --all-open',
-      { GH_TOKEN: "${{ github.token }}" }
-    );
+  it.each([
+    ["a true trigger key", workflowWithTrueTrigger],
+    ["a top-level ISSUE_NUMBER environment", () => alteredWorkflow((workflow) => (workflow.env = { ISSUE_NUMBER: "1" }))],
+    ["a job-level ISSUE_NUMBER environment", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].env = { ISSUE_NUMBER: "1" }))],
+    ["job defaults", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].defaults = { run: { shell: "bash" } }))],
+    ["a job container", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].container = "node:24"))],
+    ["job services", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].services = { redis: { image: "redis" } }))],
+    ["a reusable job", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].uses = "owner/repo/.github/workflows/reusable.yml@main"))],
+    ["a job strategy", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].strategy = { matrix: { node: [24] } }))],
+    ["a step execution control", () => alteredWorkflow((workflow) => (workflow.jobs["reconcile-issue"].steps[2]["continue-on-error"] = true))],
+  ])("rejects %s", (_name, createWorkflow) => {
+    expect(() => expectWorkflowContract(createWorkflow())).toThrow();
   });
 });

--- a/scripts/reconcile-issue-labels.mjs
+++ b/scripts/reconcile-issue-labels.mjs
@@ -1,0 +1,320 @@
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import {
+  AREA_LABELS,
+  TRIAGE_LABEL,
+  TYPE_LABELS,
+  evaluateIssuePolicy,
+} from "./issue-label-policy.mjs";
+
+export function createGhRunner({ spawnImpl }) {
+  return function runGh({ args, input }) {
+    return new Promise((resolve, reject) => {
+      let child;
+
+      try {
+        child = spawnImpl("gh", args, { stdio: ["pipe", "pipe", "pipe"] });
+      } catch (error) {
+        reject(error);
+        return;
+      }
+
+      const stdoutChunks = [];
+      const stderrChunks = [];
+
+      child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+      child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+      child.once("error", reject);
+      child.once("close", (code) => {
+        const stdout = Buffer.concat(stdoutChunks).toString();
+        const stderr = Buffer.concat(stderrChunks).toString();
+
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+
+        const error = new Error(`gh exited with code ${code}: ${stderr}`);
+        error.code = code;
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+      });
+
+      if (input !== undefined) child.stdin.write(JSON.stringify(input));
+      child.stdin.end();
+    });
+  };
+}
+
+export function createGhClient({ runGh }) {
+  return {
+    async getIssue(repo, issueNumber) {
+      const stdout = await runGh({
+        args: ["api", "--method", "GET", `repos/${repo}/issues/${issueNumber}`],
+      });
+      return JSON.parse(stdout);
+    },
+
+    async listOpenIssues(repo) {
+      const stdout = await runGh({
+        args: [
+          "api",
+          "--method",
+          "GET",
+          `repos/${repo}/issues?state=open&per_page=100`,
+          "--paginate",
+          "--slurp",
+        ],
+      });
+      return JSON.parse(stdout).flat();
+    },
+
+    async addLabels(repo, issueNumber, labels) {
+      await runGh({
+        args: ["api", "--method", "POST", `repos/${repo}/issues/${issueNumber}/labels`, "--input", "-"],
+        input: { labels },
+      });
+    },
+
+    async removeTriage(repo, issueNumber) {
+      await runGh({
+        args: [
+          "api",
+          "--method",
+          "DELETE",
+          `repos/${repo}/issues/${issueNumber}/labels/${TRIAGE_LABEL}`,
+          "--silent",
+        ],
+      });
+    },
+  };
+}
+
+function labelNames(issue) {
+  return issue.labels.map(({ name }) => name);
+}
+
+function isPullRequest(issue) {
+  return issue.pull_request !== undefined;
+}
+
+export async function reconcileIssue({ repo, issueNumber, client }) {
+  const issue = await client.getIssue(repo, issueNumber);
+
+  if (issue.state !== "open") throw new Error(`Issue #${issueNumber} is closed`);
+  if (isPullRequest(issue)) throw new Error(`#${issueNumber} is a pull request`);
+
+  const { add, remove } = evaluateIssuePolicy({
+    labels: labelNames(issue),
+    body: issue.body,
+  });
+
+  if (add.length > 0) await client.addLabels(repo, issueNumber, add);
+
+  if (remove.includes(TRIAGE_LABEL)) {
+    try {
+      await client.removeTriage(repo, issueNumber);
+    } catch (deleteError) {
+      let current;
+
+      try {
+        current = await client.getIssue(repo, issueNumber);
+      } catch {
+        throw deleteError;
+      }
+
+      if (labelNames(current).includes(TRIAGE_LABEL)) throw deleteError;
+    }
+  }
+
+  return { number: issue.number, add, remove };
+}
+
+export async function reconcileAllOpen({ repo, client }) {
+  const issues = await client.listOpenIssues(repo);
+  const failures = [];
+  let processed = 0;
+  let skippedPullRequests = 0;
+
+  for (const issue of issues) {
+    if (isPullRequest(issue)) {
+      skippedPullRequests += 1;
+      continue;
+    }
+
+    processed += 1;
+    try {
+      await reconcileIssue({ repo, issueNumber: issue.number, client });
+    } catch (error) {
+      failures.push({ number: issue.number, error });
+    }
+  }
+
+  const result = { processed, skippedPullRequests, failures };
+  if (failures.length > 0) {
+    const error = new AggregateError(
+      failures.map((failure) => failure.error),
+      `Failed to reconcile ${failures.length} issue(s)`
+    );
+    error.result = result;
+    throw error;
+  }
+
+  return result;
+}
+
+function auditReasons(issue) {
+  const labels = new Set(labelNames(issue));
+  const reasons = [];
+  const hasType = TYPE_LABELS.some((label) => labels.has(label));
+  const hasArea = AREA_LABELS.some((label) => labels.has(label));
+
+  if (!hasType && !labels.has(TRIAGE_LABEL)) reasons.push("missing a type label or needs-triage");
+  if (labels.has("bug") && !hasArea) reasons.push("bug requires an area label");
+  if (labels.has("enhancement") && !hasArea) reasons.push("enhancement requires an area label");
+
+  return reasons;
+}
+
+export async function auditAllOpen({ repo, client }) {
+  const issues = await client.listOpenIssues(repo);
+  const violations = [];
+  let processed = 0;
+  let skippedPullRequests = 0;
+
+  for (const issue of issues) {
+    if (isPullRequest(issue)) {
+      skippedPullRequests += 1;
+      continue;
+    }
+
+    processed += 1;
+    const reasons = auditReasons(issue);
+    if (reasons.length > 0) violations.push({ number: issue.number, reasons });
+  }
+
+  violations.sort((left, right) => left.number - right.number);
+  return { processed, skippedPullRequests, violations };
+}
+
+function flagValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) throw new Error(`Missing value for ${flag}`);
+  return value;
+}
+
+export function parseArgs(argv) {
+  let repo;
+  const modes = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--repo") {
+      if (repo !== undefined) throw new Error("Duplicate --repo");
+      repo = flagValue(argv, index, argument);
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--issue") {
+      const rawIssueNumber = flagValue(argv, index, argument);
+      if (!/^\d+$/.test(rawIssueNumber)) throw new Error("Invalid issue number");
+      const issueNumber = Number(rawIssueNumber);
+      if (!Number.isSafeInteger(issueNumber) || issueNumber < 1) throw new Error("Invalid issue number");
+      modes.push({ mode: "issue", issueNumber });
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--all-open") {
+      modes.push({ mode: "all-open" });
+      continue;
+    }
+
+    if (argument === "--audit") {
+      modes.push({ mode: "audit" });
+      continue;
+    }
+
+    if (argument.startsWith("--")) throw new Error(`Unknown flag: ${argument}`);
+    throw new Error(`Unexpected positional argument: ${argument}`);
+  }
+
+  if (repo === undefined) throw new Error("Missing --repo");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) throw new Error(`Invalid repository: ${repo}`);
+  if (modes.length !== 1) throw new Error("Choose exactly one mode");
+
+  return { repo, ...modes[0] };
+}
+
+function write(stream, text) {
+  stream.write(text);
+}
+
+function printAggregateError(error, stderr) {
+  if (error.result === undefined) return false;
+
+  write(
+    stderr,
+    `Processed ${error.result.processed} issues; skipped ${error.result.skippedPullRequests} pull requests; ` +
+      `${error.result.failures.length} failures.\n`
+  );
+  for (const failure of error.result.failures) {
+    write(stderr, `Issue #${failure.number}: ${failure.error.message}\n`);
+  }
+  return true;
+}
+
+export async function main(argv, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout;
+  const stderr = dependencies.stderr ?? process.stderr;
+
+  try {
+    const options = parseArgs(argv);
+    const runGh = dependencies.runGh ?? createGhRunner({ spawnImpl: dependencies.spawnImpl ?? spawn });
+    const client = dependencies.client ?? createGhClient({ runGh });
+
+    if (options.mode === "issue") {
+      const result = await reconcileIssue({
+        repo: options.repo,
+        issueNumber: options.issueNumber,
+        client,
+      });
+      write(
+        stdout,
+        `Issue #${result.number}: add ${result.add.join(", ") || "none"}; ` +
+          `remove ${result.remove.join(", ") || "none"}.\n`
+      );
+      return 0;
+    }
+
+    if (options.mode === "all-open") {
+      const result = await reconcileAllOpen({ repo: options.repo, client });
+      write(
+        stdout,
+        `Processed ${result.processed} issues; skipped ${result.skippedPullRequests} pull requests; ` +
+          `${result.failures.length} failures.\n`
+      );
+      return 0;
+    }
+
+    const result = await auditAllOpen({ repo: options.repo, client });
+    write(
+      stdout,
+      `Audited ${result.processed} issues; skipped ${result.skippedPullRequests} pull requests; ` +
+        `found ${result.violations.length} violations.\n`
+    );
+    for (const violation of result.violations) {
+      write(stdout, `Issue #${violation.number}: ${violation.reasons.join("; ")}\n`);
+    }
+    return result.violations.length > 0 ? 1 : 0;
+  } catch (error) {
+    if (!printAggregateError(error, stderr)) write(stderr, `${error.message}\n`);
+    return 1;
+  }
+}
+
+const isEntrypoint = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isEntrypoint) process.exitCode = await main(process.argv.slice(2));

--- a/scripts/reconcile-issue-labels.mjs
+++ b/scripts/reconcile-issue-labels.mjs
@@ -10,27 +10,39 @@ import {
 export function createGhRunner({ spawnImpl }) {
   return function runGh({ args, input }) {
     return new Promise((resolve, reject) => {
+      let settled = false;
+      const settle = (error, stdout) => {
+        if (settled) return;
+        settled = true;
+
+        if (error !== undefined) reject(error);
+        else resolve(stdout);
+      };
       let child;
 
       try {
         child = spawnImpl("gh", args, { stdio: ["pipe", "pipe", "pipe"] });
       } catch (error) {
-        reject(error);
+        settle(error);
         return;
       }
 
       const stdoutChunks = [];
       const stderrChunks = [];
+      const settleError = (error) => settle(error);
 
+      child.once("error", settleError);
+      child.stdin.once("error", settleError);
+      child.stdout.once("error", settleError);
+      child.stderr.once("error", settleError);
       child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
       child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
-      child.once("error", reject);
       child.once("close", (code) => {
         const stdout = Buffer.concat(stdoutChunks).toString();
         const stderr = Buffer.concat(stderrChunks).toString();
 
         if (code === 0) {
-          resolve(stdout);
+          settle(undefined, stdout);
           return;
         }
 
@@ -38,11 +50,15 @@ export function createGhRunner({ spawnImpl }) {
         error.code = code;
         error.stdout = stdout;
         error.stderr = stderr;
-        reject(error);
+        settle(error);
       });
 
-      if (input !== undefined) child.stdin.write(JSON.stringify(input));
-      child.stdin.end();
+      try {
+        if (input !== undefined) child.stdin.write(JSON.stringify(input));
+        child.stdin.end();
+      } catch (error) {
+        settle(error);
+      }
     });
   };
 }

--- a/scripts/reconcile-issue-labels.spec.mjs
+++ b/scripts/reconcile-issue-labels.spec.mjs
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { spawnSync } from "node:child_process";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
@@ -16,13 +17,23 @@ function issue({ number = 1, state = "open", body = "", labels = [], pullRequest
 
 function createFakeChild() {
   const child = new EventEmitter();
-  child.stdin = {
-    write: vi.fn(),
-    end: vi.fn(),
-  };
+  child.stdin = new EventEmitter();
+  child.stdin.write = vi.fn();
+  child.stdin.end = vi.fn();
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
   return child;
+}
+
+async function emitErrorAsynchronously(emitter, error) {
+  await Promise.resolve();
+
+  try {
+    emitter.emit("error", error);
+    return undefined;
+  } catch (thrown) {
+    return thrown;
+  }
 }
 
 async function loadModule() {
@@ -30,10 +41,57 @@ async function loadModule() {
 }
 
 describe("module loading", () => {
-  it("is import-safe and exports main without executing it", async () => {
-    const imported = await import(`${modulePath}?import-safe=${crypto.randomUUID()}`);
+  it("has no process, gh, mutation, or output effects when freshly imported", () => {
+    const targetUrl = `${new URL(modulePath, import.meta.url).href}?isolated=${crypto.randomUUID()}`;
+    const harness = `
+      import childProcess from "node:child_process";
+      import { syncBuiltinESMExports } from "node:module";
 
-    expect(imported.main).toBeTypeOf("function");
+      const spawnCalls = [];
+      childProcess.spawn = (...args) => {
+        spawnCalls.push(args);
+        throw new Error("gh spawn during import");
+      };
+      syncBuiltinESMExports();
+
+      const output = [];
+      const stdoutWrite = process.stdout.write.bind(process.stdout);
+      const stderrWrite = process.stderr.write.bind(process.stderr);
+      const initialExitCode = process.exitCode;
+      process.stdout.write = (chunk) => {
+        output.push({ stream: "stdout", text: String(chunk) });
+        return true;
+      };
+      process.stderr.write = (chunk) => {
+        output.push({ stream: "stderr", text: String(chunk) });
+        return true;
+      };
+
+      const imported = await import(${JSON.stringify(targetUrl)});
+      const result = {
+        exportsMain: typeof imported.main === "function",
+        spawnCalls,
+        output,
+        exitCodeChanged: process.exitCode !== initialExitCode,
+      };
+
+      process.stdout.write = stdoutWrite;
+      process.stderr.write = stderrWrite;
+      process.exitCode = 0;
+      stdoutWrite(JSON.stringify(result));
+    `;
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", harness], {
+      encoding: "utf8",
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toEqual({
+      exportsMain: true,
+      spawnCalls: [],
+      output: [],
+      exitCodeChanged: false,
+    });
   });
 });
 
@@ -92,6 +150,61 @@ describe("createGhRunner", () => {
       stderr: "permission denied",
     });
   });
+
+  it("attaches one-shot stream error handlers before writing or ending stdin", async () => {
+    const { createGhRunner } = await loadModule();
+    const child = createFakeChild();
+    const expectErrorHandlers = () => {
+      expect(child.stdin.listenerCount("error")).toBe(1);
+      expect(child.stdout.listenerCount("error")).toBe(1);
+      expect(child.stderr.listenerCount("error")).toBe(1);
+    };
+    child.stdin.write.mockImplementation(expectErrorHandlers);
+    child.stdin.end.mockImplementation(expectErrorHandlers);
+    const runGh = createGhRunner({ spawnImpl: () => child });
+
+    const pending = runGh({ args: ["api", "input"], input: { key: "value" } });
+    child.stdout.end();
+    child.stderr.end();
+    child.emit("close", 0);
+
+    await expect(pending).resolves.toBe("");
+    expect(child.stdin.write).toHaveBeenCalledExactlyOnceWith('{"key":"value"}');
+    expect(child.stdin.end).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("rejects an asynchronous stdin EPIPE even when the child later closes successfully", async () => {
+    const { createGhRunner } = await loadModule();
+    const child = createFakeChild();
+    const runGh = createGhRunner({ spawnImpl: () => child });
+    const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+
+    const pending = runGh({ args: ["api", "input"], input: { key: "value" } });
+    const unhandled = await emitErrorAsynchronously(child.stdin, error);
+    child.emit("close", 0);
+
+    expect(unhandled).toBeUndefined();
+    await expect(pending).rejects.toBe(error);
+    expect(child.stdin.listenerCount("error")).toBe(0);
+  });
+
+  it.each(["stdout", "stderr"])(
+    "rejects an asynchronous %s stream error even when the child later closes successfully",
+    async (streamName) => {
+      const { createGhRunner } = await loadModule();
+      const child = createFakeChild();
+      const runGh = createGhRunner({ spawnImpl: () => child });
+      const error = new Error(`${streamName} read failed`);
+
+      const pending = runGh({ args: ["api", "output"] });
+      const unhandled = await emitErrorAsynchronously(child[streamName], error);
+      child.emit("close", 0);
+
+      expect(unhandled).toBeUndefined();
+      await expect(pending).rejects.toBe(error);
+      expect(child[streamName].listenerCount("error")).toBe(0);
+    }
+  );
 });
 
 describe("createGhClient", () => {

--- a/scripts/reconcile-issue-labels.spec.mjs
+++ b/scripts/reconcile-issue-labels.spec.mjs
@@ -1,0 +1,486 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+const modulePath = "./reconcile-issue-labels.mjs";
+
+function issue({ number = 1, state = "open", body = "", labels = [], pullRequest = false } = {}) {
+  return {
+    number,
+    state,
+    body,
+    labels: labels.map((name) => ({ name })),
+    ...(pullRequest ? { pull_request: {} } : {}),
+  };
+}
+
+function createFakeChild() {
+  const child = new EventEmitter();
+  child.stdin = {
+    write: vi.fn(),
+    end: vi.fn(),
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  return child;
+}
+
+async function loadModule() {
+  return import(modulePath);
+}
+
+describe("module loading", () => {
+  it("is import-safe and exports main without executing it", async () => {
+    const imported = await import(`${modulePath}?import-safe=${crypto.randomUUID()}`);
+
+    expect(imported.main).toBeTypeOf("function");
+  });
+});
+
+describe("createGhRunner", () => {
+  it("spawns gh without a shell, writes exact JSON bytes, and collects stdout", async () => {
+    const { createGhRunner } = await loadModule();
+    const child = createFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const runGh = createGhRunner({ spawnImpl });
+    const args = ["api", "--method", "POST", "repos/owner/repo/issues/7/labels", "--input", "-"];
+    const input = { labels: ["ci", "ui"] };
+
+    const pending = runGh({ args, input });
+    child.stdout.write("first");
+    child.stdout.write(Buffer.from(" second"));
+    child.stderr.end();
+    child.stdout.end();
+    child.emit("close", 0);
+
+    await expect(pending).resolves.toBe("first second");
+    expect(spawnImpl).toHaveBeenCalledExactlyOnceWith("gh", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    expect(child.stdin.write).toHaveBeenCalledExactlyOnceWith('{"labels":["ci","ui"]}');
+    expect(child.stdin.end).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("ends stdin without writing when input is absent", async () => {
+    const { createGhRunner } = await loadModule();
+    const child = createFakeChild();
+    const runGh = createGhRunner({ spawnImpl: () => child });
+
+    const pending = runGh({ args: ["api", "--method", "GET", "repos/owner/repo/issues/8"] });
+    child.stdout.end();
+    child.stderr.end();
+    child.emit("close", 0);
+
+    await pending;
+    expect(child.stdin.write).not.toHaveBeenCalled();
+    expect(child.stdin.end).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("rejects a nonzero exit with collected stdout and stderr", async () => {
+    const { createGhRunner } = await loadModule();
+    const child = createFakeChild();
+    const runGh = createGhRunner({ spawnImpl: () => child });
+
+    const pending = runGh({ args: ["api", "failure"] });
+    child.stdout.end("partial output");
+    child.stderr.end("permission denied");
+    child.emit("close", 4);
+
+    await expect(pending).rejects.toMatchObject({
+      code: 4,
+      stdout: "partial output",
+      stderr: "permission denied",
+    });
+  });
+});
+
+describe("createGhClient", () => {
+  it("uses the exact GET issue call and parses its JSON", async () => {
+    const { createGhClient } = await loadModule();
+    const expected = issue({ number: 9, labels: ["bug"] });
+    const runGh = vi.fn().mockResolvedValue(JSON.stringify(expected));
+    const client = createGhClient({ runGh });
+
+    await expect(client.getIssue("owner/repo", 9)).resolves.toEqual(expected);
+    expect(runGh).toHaveBeenCalledExactlyOnceWith({
+      args: ["api", "--method", "GET", "repos/owner/repo/issues/9"],
+    });
+  });
+
+  it("lists all pages with exact arguments and flattens beyond 100 issues", async () => {
+    const { createGhClient } = await loadModule();
+    const firstPage = Array.from({ length: 100 }, (_, index) => issue({ number: index + 1 }));
+    const secondPage = [issue({ number: 101 }), issue({ number: 102 })];
+    const runGh = vi.fn().mockResolvedValue(JSON.stringify([firstPage, secondPage]));
+    const client = createGhClient({ runGh });
+
+    const result = await client.listOpenIssues("owner/repo");
+
+    expect(result).toHaveLength(102);
+    expect(result.at(-1).number).toBe(102);
+    expect(runGh).toHaveBeenCalledExactlyOnceWith({
+      args: [
+        "api",
+        "--method",
+        "GET",
+        "repos/owner/repo/issues?state=open&per_page=100",
+        "--paginate",
+        "--slurp",
+      ],
+    });
+  });
+});
+
+describe("reconcileIssue", () => {
+  it("refetches, adds deterministic parsed areas, and removes only triage in exact order", async () => {
+    const { createGhClient, reconcileIssue } = await loadModule();
+    const current = issue({
+      number: 12,
+      labels: ["enhancement", "needs-triage", "custom"],
+      body: "### Change areas\n\ndocs, ci, ui\n\n### Goal\n\nShip it.",
+    });
+    const runGh = vi
+      .fn()
+      .mockResolvedValueOnce(JSON.stringify(current))
+      .mockResolvedValueOnce(JSON.stringify([{ name: "ci" }, { name: "ui" }, { name: "docs" }]))
+      .mockResolvedValueOnce("");
+    const client = createGhClient({ runGh });
+
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 12, client })).resolves.toEqual({
+      number: 12,
+      add: ["ci", "ui", "docs"],
+      remove: ["needs-triage"],
+    });
+    expect(runGh.mock.calls).toEqual([
+      [
+        {
+          args: ["api", "--method", "GET", "repos/owner/repo/issues/12"],
+        },
+      ],
+      [
+        {
+          args: ["api", "--method", "POST", "repos/owner/repo/issues/12/labels", "--input", "-"],
+          input: { labels: ["ci", "ui", "docs"] },
+        },
+      ],
+      [
+        {
+          args: [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/owner/repo/issues/12/labels/needs-triage",
+            "--silent",
+          ],
+        },
+      ],
+    ]);
+    expect(runGh.mock.calls.flatMap(([call]) => call.args)).not.toContain("PATCH");
+  });
+
+  it("rejects a closed issue after refetch and before mutation", async () => {
+    const { reconcileIssue } = await loadModule();
+    const client = {
+      getIssue: vi.fn().mockResolvedValue(issue({ number: 13, state: "closed" })),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn(),
+    };
+
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 13, client })).rejects.toThrow(
+      "Issue #13 is closed"
+    );
+    expect(client.addLabels).not.toHaveBeenCalled();
+    expect(client.removeTriage).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pull request after refetch and before mutation", async () => {
+    const { reconcileIssue } = await loadModule();
+    const client = {
+      getIssue: vi.fn().mockResolvedValue(issue({ number: 14, pullRequest: true })),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn(),
+    };
+
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 14, client })).rejects.toThrow(
+      "#14 is a pull request"
+    );
+    expect(client.addLabels).not.toHaveBeenCalled();
+    expect(client.removeTriage).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when rerun after applying parsed Issue Form areas", async () => {
+    const { reconcileIssue } = await loadModule();
+    const labels = new Set(["bug"]);
+    const body = "### Change areas\n\ntest, dev\n\n### Goal\n\nImprove coverage.";
+    const client = {
+      getIssue: vi.fn(async () => issue({ number: 15, labels: [...labels], body })),
+      addLabels: vi.fn(async (_repo, _number, additions) => {
+        for (const label of additions) labels.add(label);
+      }),
+      removeTriage: vi.fn(),
+    };
+
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 15, client })).resolves.toEqual({
+      number: 15,
+      add: ["test", "dev"],
+      remove: [],
+    });
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 15, client })).resolves.toEqual({
+      number: 15,
+      add: [],
+      remove: [],
+    });
+    expect(client.addLabels).toHaveBeenCalledExactlyOnceWith("owner/repo", 15, ["test", "dev"]);
+  });
+
+  it("treats a failed triage DELETE as converged only after a refetch shows it absent", async () => {
+    const { reconcileIssue } = await loadModule();
+    const deleteError = new Error("gh returned an opaque failure");
+    const client = {
+      getIssue: vi
+        .fn()
+        .mockResolvedValueOnce(issue({ number: 16, labels: ["question", "needs-triage"] }))
+        .mockResolvedValueOnce(issue({ number: 16, labels: ["question"] })),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn().mockRejectedValue(deleteError),
+    };
+
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 16, client })).resolves.toEqual({
+      number: 16,
+      add: [],
+      remove: ["needs-triage"],
+    });
+    expect(client.getIssue.mock.invocationCallOrder[0]).toBeLessThan(client.removeTriage.mock.invocationCallOrder[0]);
+    expect(client.removeTriage.mock.invocationCallOrder[0]).toBeLessThan(client.getIssue.mock.invocationCallOrder[1]);
+  });
+
+  it("rethrows the original failed DELETE when triage remains after refetch", async () => {
+    const { reconcileIssue } = await loadModule();
+    const deleteError = new Error("original delete failure");
+    const current = issue({ number: 17, labels: ["question", "needs-triage"] });
+    const client = {
+      getIssue: vi.fn().mockResolvedValue(current),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn().mockRejectedValue(deleteError),
+    };
+
+    await expect(reconcileIssue({ repo: "owner/repo", issueNumber: 17, client })).rejects.toBe(deleteError);
+    expect(client.getIssue).toHaveBeenCalledTimes(2);
+    expect(client.getIssue.mock.invocationCallOrder[1]).toBeGreaterThan(
+      client.removeTriage.mock.invocationCallOrder[0]
+    );
+  });
+});
+
+describe("reconcileAllOpen", () => {
+  it("skips pull requests and reconciles every issue", async () => {
+    const { reconcileAllOpen } = await loadModule();
+    const client = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issue({ number: 20 }),
+        issue({ number: 21, pullRequest: true }),
+        issue({ number: 22, labels: ["question"] }),
+      ]),
+      getIssue: vi
+        .fn()
+        .mockResolvedValueOnce(issue({ number: 20 }))
+        .mockResolvedValueOnce(issue({ number: 22, labels: ["question"] })),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn(),
+    };
+
+    await expect(reconcileAllOpen({ repo: "owner/repo", client })).resolves.toEqual({
+      processed: 2,
+      skippedPullRequests: 1,
+      failures: [],
+    });
+    expect(client.getIssue.mock.calls).toEqual([
+      ["owner/repo", 20],
+      ["owner/repo", 22],
+    ]);
+  });
+
+  it("continues after item failures and throws an aggregate with structured context", async () => {
+    const { reconcileAllOpen } = await loadModule();
+    const firstError = new Error("first failed");
+    const client = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issue({ number: 30 }),
+        issue({ number: 31 }),
+        issue({ number: 32, pullRequest: true }),
+        issue({ number: 33, labels: ["question"] }),
+      ]),
+      getIssue: vi
+        .fn()
+        .mockRejectedValueOnce(firstError)
+        .mockResolvedValueOnce(issue({ number: 31 }))
+        .mockResolvedValueOnce(issue({ number: 33, labels: ["question"] })),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn(),
+    };
+
+    const caught = await reconcileAllOpen({ repo: "owner/repo", client }).catch((error) => error);
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect(caught.errors).toEqual([firstError]);
+    expect(caught.result).toEqual({
+      processed: 3,
+      skippedPullRequests: 1,
+      failures: [{ number: 30, error: firstError }],
+    });
+    expect(client.getIssue.mock.calls).toEqual([
+      ["owner/repo", 30],
+      ["owner/repo", 31],
+      ["owner/repo", 33],
+    ]);
+  });
+});
+
+describe("auditAllOpen", () => {
+  it("reports strict deterministic violations without mutations or free-text inference", async () => {
+    const { auditAllOpen } = await loadModule();
+    const client = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issue({ number: 44, labels: ["bug", "needs-triage"] }),
+        issue({ number: 41, labels: [], body: "This is probably a UI bug." }),
+        issue({ number: 43, labels: ["question"] }),
+        issue({ number: 42, labels: ["enhancement", "docs"] }),
+        issue({ number: 45, pullRequest: true }),
+        issue({ number: 46, labels: ["needs-triage"] }),
+        issue({ number: 40, labels: ["docs"] }),
+      ]),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn(),
+    };
+
+    await expect(auditAllOpen({ repo: "owner/repo", client })).resolves.toEqual({
+      processed: 6,
+      skippedPullRequests: 1,
+      violations: [
+        { number: 40, reasons: ["missing a type label or needs-triage"] },
+        { number: 41, reasons: ["missing a type label or needs-triage"] },
+        { number: 44, reasons: ["bug requires an area label"] },
+      ],
+    });
+    expect(client.addLabels).not.toHaveBeenCalled();
+    expect(client.removeTriage).not.toHaveBeenCalled();
+  });
+
+  it("reports both strict area reasons for an issue with both required types", async () => {
+    const { auditAllOpen } = await loadModule();
+    const client = {
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValue([issue({ number: 47, labels: ["bug", "enhancement", "needs-triage"] })]),
+    };
+
+    await expect(auditAllOpen({ repo: "owner/repo", client })).resolves.toEqual({
+      processed: 1,
+      skippedPullRequests: 0,
+      violations: [
+        {
+          number: 47,
+          reasons: ["bug requires an area label", "enhancement requires an area label"],
+        },
+      ],
+    });
+  });
+});
+
+describe("parseArgs", () => {
+  it.each([
+    [
+      ["--repo", "owner/name", "--issue", "123"],
+      { repo: "owner/name", mode: "issue", issueNumber: 123 },
+    ],
+    [["--repo", "owner/name", "--all-open"], { repo: "owner/name", mode: "all-open" }],
+    [["--repo", "owner/name", "--audit"], { repo: "owner/name", mode: "audit" }],
+  ])("parses a supported mode", async (argv, expected) => {
+    const { parseArgs } = await loadModule();
+
+    expect(parseArgs(argv)).toEqual(expected);
+  });
+
+  it.each([
+    [[], "Missing --repo"],
+    [["--repo"], "Missing value for --repo"],
+    [["--repo", "owner"], "Invalid repository"],
+    [["--repo", "owner/name/extra", "--audit"], "Invalid repository"],
+    [["--repo", "owner/name"], "Choose exactly one mode"],
+    [["--repo", "owner/name", "--issue"], "Missing value for --issue"],
+    [["--repo", "owner/name", "--issue", "0"], "Invalid issue number"],
+    [["--repo", "owner/name", "--issue", "1.5"], "Invalid issue number"],
+    [["--repo", "owner/name", "--issue", "abc"], "Invalid issue number"],
+    [["--repo", "owner/name", "--all-open", "--audit"], "Choose exactly one mode"],
+    [["--repo", "owner/name", "--issue", "1", "--all-open"], "Choose exactly one mode"],
+    [["--repo", "owner/name", "--audit", "extra"], "Unexpected positional argument"],
+    [["--repo", "owner/name", "--unknown"], "Unknown flag"],
+    [["--repo", "owner/name", "--audit", "--audit"], "Choose exactly one mode"],
+    [["--repo", "owner/name", "--repo", "other/name", "--audit"], "Duplicate --repo"],
+  ])("rejects invalid arguments: %j", async (argv, message) => {
+    const { parseArgs } = await loadModule();
+
+    expect(() => parseArgs(argv)).toThrow(message);
+  });
+});
+
+describe("main", () => {
+  function outputCapture() {
+    return { write: vi.fn() };
+  }
+
+  it("prints a deterministic single-issue summary", async () => {
+    const { main } = await loadModule();
+    const stdout = outputCapture();
+    const stderr = outputCapture();
+    const client = {
+      getIssue: vi.fn().mockResolvedValue(issue({ number: 50 })),
+      addLabels: vi.fn(),
+      removeTriage: vi.fn(),
+    };
+
+    await expect(
+      main(["--repo", "owner/name", "--issue", "50"], { client, stdout, stderr })
+    ).resolves.toBe(0);
+    expect(stdout.write).toHaveBeenCalledExactlyOnceWith(
+      "Issue #50: add needs-triage; remove none.\n"
+    );
+    expect(stderr.write).not.toHaveBeenCalled();
+  });
+
+  it("returns nonzero and lists every audit violation", async () => {
+    const { main } = await loadModule();
+    const stdout = outputCapture();
+    const stderr = outputCapture();
+    const client = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issue({ number: 51 }),
+        issue({ number: 52, labels: ["bug", "needs-triage"] }),
+      ]),
+    };
+
+    await expect(main(["--repo", "owner/name", "--audit"], { client, stdout, stderr })).resolves.toBe(1);
+    expect(stdout.write.mock.calls.map(([text]) => text).join("")).toBe(
+      "Audited 2 issues; skipped 0 pull requests; found 2 violations.\n" +
+        "Issue #51: missing a type label or needs-triage\n" +
+        "Issue #52: bug requires an area label\n"
+    );
+    expect(stderr.write).not.toHaveBeenCalled();
+  });
+
+  it("returns nonzero and prints operational failures", async () => {
+    const { main } = await loadModule();
+    const stdout = outputCapture();
+    const stderr = outputCapture();
+    const failure = new Error("GitHub unavailable");
+    const client = {
+      getIssue: vi.fn().mockRejectedValue(failure),
+    };
+
+    await expect(
+      main(["--repo", "owner/name", "--issue", "53"], { client, stdout, stderr })
+    ).resolves.toBe(1);
+    expect(stdout.write).not.toHaveBeenCalled();
+    expect(stderr.write).toHaveBeenCalledExactlyOnceWith("GitHub unavailable\n");
+  });
+});

--- a/storybookVitest.spec.ts
+++ b/storybookVitest.spec.ts
@@ -49,6 +49,7 @@ describe("Storybook Vitest integration", () => {
     expect(projectNamed("unit")?.test?.include).toEqual([
       "src/**/*.spec.{ts,tsx}",
       "*.spec.{ts,tsx}",
+      "scripts/**/*.spec.mjs",
     ]);
     expect(projectNamed("unit")?.test?.environment).toBe("jsdom");
     expect(projectNamed("storybook")?.test?.browser).toMatchObject({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         test: {
           name: 'unit',
           globals: true,
-          include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}'],
+          include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}', 'scripts/**/*.spec.mjs'],
           environment: 'jsdom',
         },
       },


### PR DESCRIPTION
## Summary

- add classified GitHub Issue Forms and document the canonical type/area label policy
- parse selected change areas and reconcile labels through additive GitHub API operations
- add a least-privilege issue label guard workflow for issue events and manual bulk reconciliation
- add strict audits, pagination, convergence handling, and contract tests for forms, policy, CLI, and workflow

## Testing

- `make check` — 105 test files, 715 tests passed
- focused Issue #255 suites — 4 test files, 126 tests passed
- `git diff --check origin/main...HEAD`

## Rollout

The required GitHub label catalog has already been normalized. After merge, run the manual reconciliation workflow, strict audit, and live Issue Form/edit/label integration checks described in #255. Transfer and stale-failed-run cases remain dependent on suitable external state.

Implements #255.