### PR TITLE
Prevent offline CSV imports from hanging

### DIFF
--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -15,6 +15,8 @@ import { CardBulkMutationError } from "@/query/mutations/cardMutationService";
 const mocks = vi.hoisted(() => ({
   uid: "uid-a",
   config: {} as ConfigState,
+  remoteStatus: "ready" as "idle" | "loading" | "ready" | "error" | "blocked",
+  syncStatus: "synced" as "cached" | "pending" | "synced" | undefined,
   decks: [] as Deck[],
   cards: [] as Card[],
   parseDeckImportCsv: vi.fn(),
@@ -34,6 +36,8 @@ vi.mock("@/auth/AuthContext", () => ({
 }));
 vi.mock("@/query/useRemoteCollections", () => ({
   useRemoteCollections: () => ({
+    status: mocks.remoteStatus,
+    syncStatus: mocks.syncStatus,
     decks: mocks.decks,
     cardsByDeckId: (id: DeckId) => mocks.cards.filter((card) => card.deckId === id),
   }),
@@ -66,6 +70,8 @@ describe("useDeckImport", () => {
     vi.clearAllMocks();
     mocks.uid = "uid-a";
     mocks.config = createConfig({ githubAccessToken: "" });
+    mocks.remoteStatus = "ready";
+    mocks.syncStatus = "synced";
     mocks.decks = [];
     mocks.cards = [];
     mocks.parseDeckImportCsv.mockImplementation(async (content: string | File) => {
@@ -116,6 +122,45 @@ describe("useDeckImport", () => {
     expect(mocks.prepareCard).toHaveBeenCalledWith(expect.anything(), expect.anything(), mocks.generateCardId);
     expect(mocks.bulkUpsert).toHaveBeenCalledWith([expect.objectContaining({ id: "card" })]);
     expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" });
+  });
+
+  it("rejects an import before writing when Firestore is not synchronized", async () => {
+    mocks.syncStatus = "cached";
+    const { result } = renderHook(useDeckImport);
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await act(async () => result.current.selectFile(file));
+    await act(async () => {
+      await expect(result.current.importPreview()).rejects.toThrow("synchronized connection");
+    });
+
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toEqual(
+      new Error("Deck import requires a synchronized connection. Check your connection and retry.")
+    );
+    expect(mocks.prepareDeck).not.toHaveBeenCalled();
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("retries the rejected import after Firestore synchronizes", async () => {
+    mocks.syncStatus = "cached";
+    const { result, rerender } = renderHook(useDeckImport);
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await act(async () => result.current.selectFile(file));
+    await act(async () => {
+      await expect(result.current.importPreview()).rejects.toThrow("synchronized connection");
+    });
+    mocks.syncStatus = "synced";
+    rerender();
+    act(() => result.current.retry());
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual({ created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" })
+    );
+    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
   });
 
   it("keeps invalid files in preview without mutating state", async () => {

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -71,15 +71,18 @@ const partialResultFrom = (error: unknown): DeckImportResult | undefined => {
 
 interface DeckImportDependencies {
   uid: string;
+  synchronized: boolean;
   decks: Deck[];
   cardsByDeckId: (id: DeckId) => Card[];
   createDeck: (deck: Deck) => Promise<unknown>;
   bulkUpsert: (cards: Card[]) => Promise<unknown>;
 }
 
+type DeckImportPreparationDependencies = Pick<DeckImportDependencies, "uid" | "decks" | "cardsByDeckId">;
+
 const prepareDeckImportAttempt = (
   request: ImportRequest,
-  { uid, decks, cardsByDeckId }: DeckImportDependencies
+  { uid, decks, cardsByDeckId }: DeckImportPreparationDependencies
 ): DeckImportAttempt => {
   const name = request.kind === "sample" ? SAMPLE_DECK_NAME : request.name;
   const preferredDeckId = request.kind === "sample" ? sampleDeckId(uid) : undefined;
@@ -128,12 +131,15 @@ const prepareDeckImportAttempt = (
  */
 const executeDeckImport = async (
   request: ImportRequest,
-  { uid, decks, cardsByDeckId, createDeck, bulkUpsert }: DeckImportDependencies
+  { uid, synchronized, decks, cardsByDeckId, createDeck, bulkUpsert }: DeckImportDependencies
 ): Promise<DeckImportResult> => {
   if (uid === "") throw new Error("A confirmed user is required for imports");
+  if (!synchronized) {
+    throw new Error("Deck import requires a synchronized connection. Check your connection and retry.");
+  }
   let attempt = request.attempt;
   if (attempt == null || attempt.uid !== uid) {
-    attempt = prepareDeckImportAttempt(request, { uid, decks, cardsByDeckId, createDeck, bulkUpsert });
+    attempt = prepareDeckImportAttempt(request, { uid, decks, cardsByDeckId });
     request.attempt = attempt;
   }
   if (attempt.createDeckPending) {
@@ -308,12 +314,21 @@ export const useDeckImport = () => {
   useEffect(() => {
     dependenciesRef.current = {
       uid,
+      synchronized: remote.status === "ready" && remote.syncStatus === "synced",
       decks: remote.decks,
       cardsByDeckId: remote.cardsByDeckId,
       createDeck: deckMutations.create,
       bulkUpsert: cardMutations.bulkUpsert,
     };
-  }, [cardMutations.bulkUpsert, deckMutations.create, remote.cardsByDeckId, remote.decks, uid]);
+  }, [
+    cardMutations.bulkUpsert,
+    deckMutations.create,
+    remote.cardsByDeckId,
+    remote.decks,
+    remote.status,
+    remote.syncStatus,
+    uid,
+  ]);
   const setRunning = (value: boolean) => setRunningState({ uid, value });
   const setValidating = (value: boolean) => setValidatingState({ uid, value });
   const setPreview = (value: DeckImportPreview | undefined) => setPreviewState({ uid, value });


### PR DESCRIPTION
## Summary

- Require a server-synchronized Firestore state before starting deck imports.
- Show an actionable import failure instead of leaving the Import button pending indefinitely.
- Keep the selected preview retryable after Firestore reconnects.

## Root cause

Firestore write promises remain pending while the client is offline. The import awaited Deck creation before Card writes, so an import started from cached data could remain on `Importing…` indefinitely and never reach Card writes.

## Validation

- Added regression coverage for cached/offline import rejection before any writes.
- Added coverage for Retry after Firestore returns to `synced`.
- `make check` (101 test files, 760 tests passed).