### PR TITLE
Add MSW-backed Storybook page stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,22 +1,44 @@
+import { fileURLToPath } from "node:url";
 import type { StorybookConfig } from "@storybook/react-vite";
+import { mergeConfig } from "vite";
 import { withoutPwaPlugins } from "./vitePlugins.ts";
+
+const storybookFirebase = fileURLToPath(new URL("../src/storybook/firebase.ts", import.meta.url));
+const storybookFirestoreRuntime = fileURLToPath(
+  new URL("../src/storybook/firestoreRuntime.ts", import.meta.url),
+);
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.tsx"],
+  staticDirs: ["../public"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-docs",
     "@storybook/addon-themes",
     "@storybook/addon-vitest",
+    "msw-storybook-addon",
   ],
   framework: {
     name: "@storybook/react-vite",
     options: {},
   },
   viteFinal: async (viteConfig) =>
-    ({
-      ...viteConfig,
-      plugins: withoutPwaPlugins(viteConfig.plugins),
-    }),
+    mergeConfig(
+      {
+        ...viteConfig,
+        plugins: withoutPwaPlugins(viteConfig.plugins),
+      },
+      {
+        resolve: {
+          alias: [
+            { find: /^@\/firebase$/, replacement: storybookFirebase },
+            {
+              find: /^@\/adapters\/firestore\/runtime$/,
+              replacement: storybookFirestoreRuntime,
+            },
+          ],
+        },
+      },
+    ),
 };
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,6 +2,9 @@
 
 import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react";
+import { setupWorker } from "msw/browser";
+import { mswLoader } from "msw-storybook-addon/csf3";
+import { storybookHandlers } from "../src/storybook/handlers";
 import { INITIAL_VIEWPORTS } from "../src/storybook/storybookViewports";
 import "../src/index.css";
 
@@ -15,6 +18,18 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  loaders: [
+    mswLoader(async () => {
+      const worker = setupWorker();
+      await worker.start({
+        onUnhandledRequest: "bypass",
+        serviceWorker: {
+          url: "./mockServiceWorker.js",
+        },
+      });
+      return worker;
+    }),
+  ],
   parameters: {
     controls: {
       matchers: {
@@ -22,6 +37,7 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    msw: storybookHandlers,
     viewport: {
       options: INITIAL_VIEWPORTS,
     },

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Demo data is stored in Firestore and may be **deleted** without notice.
 
 Browse the latest Storybook at https://her0e1c1.github.io/tango/. Updates are published automatically from `main`.
 
+Run Storybook locally with:
+
+```bash
+npm run storybook
+```
+
+The `Page` stories render every application route with deterministic authentication, remote collections, configuration,
+and study progress. They do not require a Firebase project or emulator. Storybook initializes Mock Service Worker (MSW)
+globally, serves `public/mockServiceWorker.js`, and provides a mocked CSV response for the fixture deck's reimport URL.
+Additional network states can be defined per story with `beforeEach(({ msw }) => msw.use(...handlers))`.
+
 ## Development
 
 ### Setup for development
@@ -78,7 +89,7 @@ make coverage
 ```
 
 Coverage includes `src/**/*.{ts,tsx}`, including files that no test imports. Specs, stories, declaration files,
-and `src/shared/storybook/**` are excluded. The committed global thresholds are 86% statements, 78% branches,
+and `src/storybook/**` are excluded. The committed global thresholds are 86% statements, 78% branches,
 85% functions, and 92% lines. When the full-suite result improves, raise the relevant integer threshold manually
 in `vitest.config.ts`; do not auto-update thresholds.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,8 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "firebase-tools": "^15.22.4",
         "jsdom": "^29.1.1",
+        "msw": "^2.15.0",
+        "msw-storybook-addon": "^3.0.0",
         "postcss": "^8.5.16",
         "storybook": "^10.4.6",
         "tailwindcss": "^4.3.2",
@@ -5069,6 +5071,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -5087,6 +5114,31 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
@@ -7985,6 +8037,23 @@
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11980,6 +12049,23 @@
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
@@ -11996,6 +12082,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",
@@ -13352,6 +13448,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gtoken": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
@@ -13635,6 +13741,24 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/heap-js": {
       "version": "2.7.1",
@@ -14316,6 +14440,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-npm": {
       "version": "5.0.0",
@@ -16989,6 +17120,209 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/msw": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
+      "integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-3.0.0.tgz",
+      "integrity": "sha512-tyYmYAwSGcfFSHhrE5yzun/OXuVIkBGOt4YTsH5IR94N38F+hzZhvGqe5scu1ENJh/hOApI/8ZRQkWdFNFsKcw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "msw-storybook-migrate": "build/migrate.mjs"
+      },
+      "peerDependencies": {
+        "msw": ">=2",
+        "storybook": ">=9"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/msw/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -17507,6 +17841,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -19167,6 +19508,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
@@ -20295,6 +20643,13 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -20704,6 +21059,19 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.3.2",
@@ -21685,6 +22053,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/upath": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "firebase-tools": "^15.22.4",
     "jsdom": "^29.1.1",
+    "msw": "^2.15.0",
+    "msw-storybook-addon": "^3.0.0",
     "postcss": "^8.5.16",
     "storybook": "^10.4.6",
     "tailwindcss": "^4.3.2",
@@ -97,5 +99,10 @@
     "vite-plugin-pwa": "^1.3.0",
     "vitest": "4.1.10",
     "yaml": "2.9.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,361 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = isEventStreamResponse ? null : response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
+          },
+        },
+      },
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,25 @@ const UnknownRoute = () => {
 };
 
 /**
+ * Renders Tango's route tree inside the router supplied by the caller.
+ * Production uses BrowserRouter while Storybook can provide MemoryRouter for isolated page stories.
+ */
+export const AppRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<Page.DeckListPage />} />
+    <Route path="/deck/:id" element={<Page.CardListPage />} />
+    <Route path="/deck/:id/edit" element={<Page.DeckFormPage />} />
+    <Route path="/deck/:id/start" element={<Page.DeckStartPage />} />
+    <Route path="/deck/:id/study" element={<Page.DeckSwiperPage />} />
+    <Route path="/card/:id" element={<Page.CardViewPage />} />
+    <Route path="/card/:id/edit" element={<Page.CardFormPage />} />
+    <Route path="/settings" element={<Page.ConfigPage />} />
+    <Route path="/import" element={<Page.DeckImportPage />} />
+    <Route path="*" element={<UnknownRoute />} />
+  </Routes>
+);
+
+/**
  * Renders the App user interface.
  * Reads authentication and display settings, installs the application routes, and offers reload
  * when startup fails.
@@ -61,18 +80,7 @@ const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location
 
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Page.DeckListPage />} />
-        <Route path="/deck/:id" element={<Page.CardListPage />} />
-        <Route path="/deck/:id/edit" element={<Page.DeckFormPage />} />
-        <Route path="/deck/:id/start" element={<Page.DeckStartPage />} />
-        <Route path="/deck/:id/study" element={<Page.DeckSwiperPage />} />
-        <Route path="/card/:id" element={<Page.CardViewPage />} />
-        <Route path="/card/:id/edit" element={<Page.CardFormPage />} />
-        <Route path="/settings" element={<Page.ConfigPage />} />
-        <Route path="/import" element={<Page.DeckImportPage />} />
-        <Route path="*" element={<UnknownRoute />} />
-      </Routes>
+      <AppRoutes />
     </BrowserRouter>
   );
 };

--- a/src/page/Page.stories.tsx
+++ b/src/page/Page.stories.tsx
@@ -1,0 +1,82 @@
+/**
+ * @file Defines Storybook examples for every route-level page.
+ * The stories render the production route tree with deterministic authentication, stores, routing,
+ * and MSW-backed network behavior.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "storybook/test";
+
+import { AppRoutes } from "@/App";
+import { type PageStoryParameters, preparePageStory, withPageStory } from "@/storybook/PageDecorator";
+import { PAGE_STORY_CARD_ID, PAGE_STORY_DECK_ID, pageStoryState } from "@/storybook/pageFixture";
+import { STORYBOOK_DECK_IMPORT_URL } from "@/storybook/handlers";
+
+const page = (path: string, overrides: Partial<Omit<PageStoryParameters, "path">> = {}): PageStoryParameters => ({
+  ...pageStoryState,
+  ...overrides,
+  path,
+});
+
+const meta = {
+  title: "Page",
+  component: AppRoutes,
+  decorators: [withPageStory],
+  loaders: [
+    async ({ parameters }) => {
+      await preparePageStory(parameters.page as PageStoryParameters);
+      return {};
+    },
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof AppRoutes>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DeckList: Story = {
+  parameters: { page: page("/") },
+};
+
+export const CardList: Story = {
+  parameters: { page: page(`/deck/${PAGE_STORY_DECK_ID}`) },
+};
+
+export const DeckForm: Story = {
+  parameters: { page: page(`/deck/${PAGE_STORY_DECK_ID}/edit`) },
+};
+
+export const DeckStart: Story = {
+  parameters: { page: page(`/deck/${PAGE_STORY_DECK_ID}/start`) },
+};
+
+export const DeckStudy: Story = {
+  parameters: { page: page(`/deck/${PAGE_STORY_DECK_ID}/study`) },
+};
+
+export const CardView: Story = {
+  parameters: { page: page(`/card/${PAGE_STORY_CARD_ID}`) },
+};
+
+export const CardForm: Story = {
+  parameters: { page: page(`/card/${PAGE_STORY_CARD_ID}/edit`) },
+};
+
+export const Settings: Story = {
+  parameters: { page: page("/settings") },
+};
+
+export const Import: Story = {
+  parameters: { page: page("/import") },
+  play: async () => {
+    const response = await fetch(STORYBOOK_DECK_IMPORT_URL);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("hello word in python");
+  },
+};
+
+export const NotFound: Story = {
+  parameters: { page: page("/not-found") },
+};

--- a/src/storybook/PageDecorator.tsx
+++ b/src/storybook/PageDecorator.tsx
@@ -1,0 +1,124 @@
+/**
+ * @file Provides the authenticated router and deterministic application state used by page stories.
+ * The helper keeps Storybook composition outside production page components while preserving their
+ * normal containers, hooks, and route parameters.
+ */
+
+import type { Decorator } from "@storybook/react";
+import type { User } from "firebase/auth";
+import { MemoryRouter } from "react-router-dom";
+
+import { AuthProvider, type AuthState, type AuthStore } from "@/auth/AuthContext";
+import { studyStore, type StudySession } from "@/features/study/state/studyStore";
+import { configStore, defaultConfig } from "@/store/configStore";
+import { remoteStore, toRemoteById } from "@/store/remoteStore";
+
+export const PAGE_STORY_UID = "storybook-user";
+
+export interface PageStoryParameters {
+  path: string;
+  decks?: Deck[];
+  cards?: Card[];
+  config?: Partial<ConfigState>;
+  sessionsByDeckId?: Partial<Record<DeckId, StudySession>>;
+  showBackText?: boolean;
+  autoPlay?: boolean;
+}
+
+const storybookUser = {
+  uid: PAGE_STORY_UID,
+  isAnonymous: true,
+  providerData: [],
+} as unknown as User;
+
+const storybookAuthState: AuthState = {
+  status: "authenticated",
+  user: storybookUser,
+  uid: PAGE_STORY_UID,
+};
+
+const storybookAuthStore: AuthStore = {
+  getSnapshot: () => storybookAuthState,
+  subscribe: () => () => false,
+  publishAuthenticatedUser: () => undefined,
+  suspendAnonymousBootstrap: () => () => undefined,
+  dispose: () => undefined,
+};
+
+const cloneDeck = (deck: Deck): Deck => ({
+  ...deck,
+  selectedTags: [...deck.selectedTags],
+});
+
+const cloneCard = (card: Card): Card => ({
+  ...card,
+  tags: [...card.tags],
+  ...(card.nextSeeingAt === undefined ? {} : { nextSeeingAt: new Date(card.nextSeeingAt.getTime()) }),
+});
+
+const cloneSessions = (
+  sessionsByDeckId: Partial<Record<DeckId, StudySession>>
+): Partial<Record<DeckId, StudySession>> => {
+  const sessions: Partial<Record<DeckId, StudySession>> = {};
+  Object.entries(sessionsByDeckId).forEach(([deckId, session]) => {
+    if (session != null) sessions[deckId] = { ...session, cardOrderIds: [...session.cardOrderIds] };
+  });
+  return sessions;
+};
+
+/**
+ * Rehydrates persisted stores and replaces their values with one story's deterministic fixture.
+ * Running this in a Storybook loader guarantees study hydration is complete before the route renders.
+ */
+export const preparePageStory = async (parameters: PageStoryParameters): Promise<void> => {
+  await Promise.all([configStore.persist.rehydrate(), studyStore.persist.rehydrate()]);
+
+  const decks = (parameters.decks ?? []).map(cloneDeck);
+  const cards = (parameters.cards ?? []).map(cloneCard);
+  const config = { ...defaultConfig, ...parameters.config };
+  configStore.setState({
+    config: {
+      ...config,
+      selectedTags: [...config.selectedTags],
+    },
+  });
+  studyStore.setState({
+    sessionsByDeckId: cloneSessions(parameters.sessionsByDeckId ?? {}),
+    showBackText: parameters.showBackText ?? false,
+    autoPlay: parameters.autoPlay ?? false,
+    lastSwipe: undefined,
+  });
+  remoteStore.setState({
+    read: {
+      uid: PAGE_STORY_UID,
+      status: "ready",
+      decksById: toRemoteById(decks),
+      cardsById: toRemoteById(cards),
+      syncStatus: "synced",
+    },
+    cardMutation: {
+      uid: PAGE_STORY_UID,
+      pendingCounts: new Map<CardId, number>(),
+      error: null,
+    },
+    deckMutation: {
+      uid: PAGE_STORY_UID,
+      pendingCounts: new Map<DeckId, number>(),
+      error: null,
+    },
+  });
+};
+
+/** Wraps a page story with the providers normally supplied by the application entry point. */
+export const withPageStory: Decorator = (Story, context) => {
+  const parameters = context.parameters.page as PageStoryParameters | undefined;
+  if (parameters == null) throw new Error("Page stories require parameters.page");
+
+  return (
+    <AuthProvider store={storybookAuthStore}>
+      <MemoryRouter key={context.id} initialEntries={[parameters.path]}>
+        <Story />
+      </MemoryRouter>
+    </AuthProvider>
+  );
+};

--- a/src/storybook/firebase.ts
+++ b/src/storybook/firebase.ts
@@ -1,0 +1,9 @@
+/**
+ * @file Provides Storybook-safe Firebase authentication composition values.
+ * Page stories supply a fixture-backed AuthStore, so the real Firebase app must not initialize or
+ * open emulator and persistence connections inside the preview iframe.
+ */
+
+import type { Auth } from "firebase/auth";
+
+export const auth = { currentUser: null } as Auth;

--- a/src/storybook/firestoreRuntime.ts
+++ b/src/storybook/firestoreRuntime.ts
@@ -1,0 +1,24 @@
+/**
+ * @file Provides a ready, connection-free Firestore runtime for Storybook.
+ * Route stories seed the application remote store directly; attempted mutations fail immediately
+ * instead of opening a real Firestore connection or waiting for production initialization.
+ */
+
+export type FirestoreInitializationState =
+  | { status: "initializing" }
+  | { status: "ready" }
+  | { status: "blocked"; error: Error };
+
+const ready = { status: "ready" } as const satisfies FirestoreInitializationState;
+
+export const initializeFirestoreRuntime = (_db: unknown): void => undefined;
+export const blockFirestoreRuntime = (_error: Error): void => undefined;
+export const getDb = (): never => {
+  throw new Error("Firestore is unavailable in Storybook page stories");
+};
+export const getFirestoreInitializationState = (): FirestoreInitializationState => ready;
+export const waitForFirestoreInitialization = async (): Promise<FirestoreInitializationState> => ready;
+export const subscribeFirestoreInitialization =
+  (_listener: Callback): Callback =>
+  () =>
+    undefined;

--- a/src/storybook/handlers.ts
+++ b/src/storybook/handlers.ts
@@ -1,0 +1,18 @@
+/** @file Defines reusable network behavior for Storybook stories. */
+
+import { HttpResponse, http } from "msw";
+
+export const STORYBOOK_DECK_IMPORT_URL = "https://storybook.tango.invalid/decks/starter.csv";
+
+const storybookDeckImportCsv = `\
+"Write a question in front text","Write the answer for it in back text","","question-answer-example"
+"hello word in python","print('hello world')","python","hello-world-python"
+"What is the area of a circle with a radius of r?","$\\pi r^2$","math","circle-area"`;
+
+export const storybookHandlers = [
+  http.get(STORYBOOK_DECK_IMPORT_URL, () =>
+    HttpResponse.text(storybookDeckImportCsv, {
+      headers: { "Content-Type": "text/csv; charset=utf-8" },
+    })
+  ),
+];

--- a/src/storybook/pageFixture.ts
+++ b/src/storybook/pageFixture.ts
@@ -1,0 +1,102 @@
+/** @file Defines deterministic application data shared by route-level Storybook stories. */
+
+import { createCard, createConfig, createDeck } from "@/test/factories";
+import { STORYBOOK_DECK_IMPORT_URL } from "@/storybook/handlers";
+import { PAGE_STORY_UID, type PageStoryParameters } from "@/storybook/PageDecorator";
+
+export const PAGE_STORY_DECK_ID: DeckId = "storybook-japanese";
+export const PAGE_STORY_SECONDARY_DECK_ID: DeckId = "storybook-math";
+export const PAGE_STORY_CARD_ID: CardId = "storybook-hello";
+
+const timestamp = Date.UTC(2026, 6, 1, 9, 0, 0);
+
+export const pageStoryDecks: Deck[] = [
+  createDeck({
+    id: PAGE_STORY_DECK_ID,
+    uid: PAGE_STORY_UID,
+    name: "Japanese starter",
+    category: "markdown",
+    selectedTags: ["greeting"],
+    url: STORYBOOK_DECK_IMPORT_URL,
+    createdAt: timestamp - 14 * 24 * 60 * 60 * 1000,
+    updatedAt: timestamp,
+  }),
+  createDeck({
+    id: PAGE_STORY_SECONDARY_DECK_ID,
+    uid: PAGE_STORY_UID,
+    name: "Everyday mathematics",
+    category: "math",
+    createdAt: timestamp - 30 * 24 * 60 * 60 * 1000,
+    updatedAt: timestamp - 24 * 60 * 60 * 1000,
+  }),
+];
+
+export const pageStoryCards: Card[] = [
+  createCard({
+    id: PAGE_STORY_CARD_ID,
+    deckId: PAGE_STORY_DECK_ID,
+    uid: PAGE_STORY_UID,
+    frontText: "Hello",
+    backText: "こんにちは",
+    tags: ["greeting"],
+    uniqueKey: "storybook-hello",
+    score: 3,
+    numberOfSeen: 8,
+    createdAt: timestamp - 10 * 24 * 60 * 60 * 1000,
+    updatedAt: timestamp,
+  }),
+  createCard({
+    id: "storybook-good-morning",
+    deckId: PAGE_STORY_DECK_ID,
+    uid: PAGE_STORY_UID,
+    frontText: "Good morning",
+    backText: "おはようございます",
+    tags: ["greeting", "polite"],
+    uniqueKey: "storybook-good-morning",
+    score: 1,
+    numberOfSeen: 4,
+    createdAt: timestamp - 9 * 24 * 60 * 60 * 1000,
+    updatedAt: timestamp - 60 * 60 * 1000,
+  }),
+  createCard({
+    id: "storybook-thank-you",
+    deckId: PAGE_STORY_DECK_ID,
+    uid: PAGE_STORY_UID,
+    frontText: "Thank you",
+    backText: "ありがとうございます",
+    tags: ["polite"],
+    uniqueKey: "storybook-thank-you",
+    score: 0,
+    numberOfSeen: 2,
+    createdAt: timestamp - 8 * 24 * 60 * 60 * 1000,
+    updatedAt: timestamp - 2 * 60 * 60 * 1000,
+  }),
+  createCard({
+    id: "storybook-circle-area",
+    deckId: PAGE_STORY_SECONDARY_DECK_ID,
+    uid: PAGE_STORY_UID,
+    frontText: "What is the area of a circle with radius r?",
+    backText: "$\\pi r^2$",
+    tags: ["geometry"],
+    uniqueKey: "storybook-circle-area",
+    createdAt: timestamp - 20 * 24 * 60 * 60 * 1000,
+    updatedAt: timestamp - 3 * 24 * 60 * 60 * 1000,
+  }),
+];
+
+export const pageStoryState = {
+  decks: pageStoryDecks,
+  cards: pageStoryCards,
+  config: createConfig({
+    maxNumberOfCardsToLearn: 20,
+    showScoreSlider: true,
+  }),
+  sessionsByDeckId: {
+    [PAGE_STORY_DECK_ID]: {
+      deckId: PAGE_STORY_DECK_ID,
+      cardOrderIds: pageStoryCards.filter((card) => card.deckId === PAGE_STORY_DECK_ID).map((card) => card.id),
+      currentIndex: 1,
+      lastStudiedAt: timestamp - 30 * 60 * 1000,
+    },
+  },
+} satisfies Omit<PageStoryParameters, "path">;

--- a/storybookMsw.spec.ts
+++ b/storybookMsw.spec.ts
@@ -1,0 +1,57 @@
+/** @file Verifies the committed Storybook MSW and route-story integration contract. */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (relativePath: string) => readFileSync(path.join(root, relativePath), "utf8");
+
+describe("Storybook MSW integration", () => {
+  it("commits the worker and exposes it through Storybook static assets", () => {
+    expect(existsSync(path.join(root, "public/mockServiceWorker.js"))).toBe(true);
+    expect(read("public/mockServiceWorker.js")).toContain("Mock Service Worker");
+    expect(read(".storybook/main.ts")).toContain('staticDirs: ["../public"]');
+  });
+
+  it("registers the addon and initializes its CSF3 loader with the shared handlers", () => {
+    const main = read(".storybook/main.ts");
+    const preview = read(".storybook/preview.ts");
+
+    expect(main).toContain('"msw-storybook-addon"');
+    expect(preview).toContain('from "msw-storybook-addon/csf3"');
+    expect(preview).toContain("mswLoader(async () =>");
+    expect(preview).toContain("setupWorker()");
+    expect(preview).toContain("storybookHandlers");
+  });
+
+  it("declares the MSW packages and generated worker directory", () => {
+    const packageJson = JSON.parse(read("package.json")) as {
+      devDependencies?: Record<string, string>;
+      msw?: { workerDirectory?: string[] };
+    };
+
+    expect(packageJson.devDependencies?.msw).toBeDefined();
+    expect(packageJson.devDependencies?.["msw-storybook-addon"]).toBeDefined();
+    expect(packageJson.msw?.workerDirectory).toEqual(["public"]);
+  });
+
+  it("covers the application route tree with page stories", () => {
+    const stories = read("src/page/Page.stories.tsx");
+
+    for (const story of [
+      "DeckList",
+      "CardList",
+      "DeckForm",
+      "DeckStart",
+      "DeckStudy",
+      "CardView",
+      "CardForm",
+      "Settings",
+      "Import",
+      "NotFound",
+    ]) {
+      expect(stories).toContain(`export const ${story}`);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
         'src/**/*.d.ts',
         'src/**/*.spec.{ts,tsx}',
         'src/**/*.stories.{ts,tsx}',
-        'src/shared/storybook/**',
+        'src/storybook/**',
       ],
       reporter: ['text', 'html', 'lcov', 'json-summary'],
       reportOnFailure: true,


### PR DESCRIPTION
## Summary
- add MSW 2.15 and `msw-storybook-addon` 3.0, commit the generated worker under `public/`, and expose it through Storybook static assets
- initialize MSW with the Storybook CSF3 loader and a relative worker URL that works locally and under the GitHub Pages subpath
- export the production `AppRoutes` tree and add `Page` stories for every application route, including the not-found route
- provide deterministic authenticated-user, remote collection, configuration, and study-session fixtures without starting Firebase or Firestore
- mock the fixture deck CSV endpoint and verify interception from the Import page story
- document local usage and add an integration contract test for the worker, addon, and route-story coverage

## Validation
- `mise run ci`
- `npm run test:storybook`
- `make ci`

All checks pass on the latest squashed commit.