### PR TITLE
Harden remote store writes and GitHub imports

### DIFF
--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -12,14 +12,16 @@ import { clearStudyStore, studyStore, type StudyState } from "@/features/study/s
 import { publishAuthenticatedUser, suspendAnonymousBootstrap } from "@/auth/AuthContext";
 import { auth } from "@/firebase";
 import { remoteStore } from "@/store/remoteStore";
+import { configStore } from "@/store/configStore";
 
 interface LogoutCleanupProgress {
   remote: boolean;
   study: boolean;
+  credentials: boolean;
   studyStateAfterClear?: StudyState;
 }
 
-type LogoutCleanupStep = "remote" | "study";
+type LogoutCleanupStep = "remote" | "study" | "credentials";
 
 /**
  * Represents the logout cleanup error condition used by the application.
@@ -66,6 +68,7 @@ const runLogout = async (
     };
 
     await run("remote", () => remoteStore.getState().stop(confirmedUid));
+    await run("credentials", () => configStore.getState().updateConfig({ githubAccessToken: "" }));
     await run("study", async () => {
       if (progress.studyStateAfterClear && studyStore.getState() !== progress.studyStateAfterClear) return;
       const cleanup = clearStudyStore();
@@ -85,7 +88,7 @@ const runLogout = async (
  * If local cleanup fails, the returned error carries a retry that resumes the unfinished steps.
  */
 export const logout = (confirmedUid: string): Promise<void> =>
-  runLogout(confirmedUid, { remote: false, study: false }, true);
+  runLogout(confirmedUid, { remote: false, study: false, credentials: false }, true);
 
 /**
  * Upgrades the current anonymous Firebase user to a Google-authenticated account.

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -2,7 +2,9 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { remoteStore } from "@/store/remoteStore";
-import { createCard } from "@/test/factories";
+import { createCard as createCardFixture } from "@/test/factories";
+
+const createCard = (overrides: Partial<Card> = {}) => createCardFixture({ uid: "uid-a", ...overrides });
 
 const mocks = vi.hoisted(() => ({
   uid: "uid-a",
@@ -81,7 +83,7 @@ describe("useCardMutations", () => {
     await act(async () => result.current.updateBy(card.id, () => ({ score: 2 })));
     await act(async () => result.current.remove(card.id));
 
-    expect(mocks.update).toHaveBeenCalledWith({ ...card, score: 2 });
+    expect(mocks.update).toHaveBeenCalledWith({ id: card.id, deckId: card.deckId, score: 2 });
     expect(mocks.logicalRemove).toHaveBeenCalledWith(card.id);
   });
 

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -87,6 +87,17 @@ describe("useCardMutations", () => {
     expect(mocks.logicalRemove).toHaveBeenCalledWith(card.id);
   });
 
+  it("does not allow updateBy patches to redirect the target Card", async () => {
+    const card = createCard({ id: "card", deckId: "deck" });
+    mocks.card = card;
+    const { result } = renderHook(useCardMutations);
+    const redirectingPatch = () => ({ id: "other-card", deckId: "other-deck", score: 2 });
+
+    await act(async () => result.current.updateBy(card.id, redirectingPatch));
+
+    expect(mocks.update).toHaveBeenCalledWith({ id: card.id, deckId: card.deckId, score: 2 });
+  });
+
   it("rejects updateBy and remove when the Card is unavailable", async () => {
     const { result } = renderHook(useCardMutations);
 

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -7,6 +7,7 @@ import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { remoteStore } from "@/store/remoteStore";
 
 const noPendingCards = new Map<CardId, number>();
+type CardPatch = Partial<Omit<Card, "id" | "deckId" | "uid">>;
 
 export const useCardMutations = () => {
   const auth = useAuth();
@@ -22,10 +23,10 @@ export const useCardMutations = () => {
 
   const create = (card: Card) => createCard(uid, card);
   const update = (card: CardEdit) => updateCard(uid, card);
-  const updateBy = (id: CardId, callback: (card: Card) => Partial<Card>) => {
+  const updateBy = (id: CardId, callback: (card: Card) => CardPatch) => {
     const card = cardById(id);
     if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
-    return updateCard(uid, { id: card.id, deckId: card.deckId, ...callback(card) });
+    return updateCard(uid, { ...callback(card), id: card.id, deckId: card.deckId });
   };
   const remove = (id: CardId) => {
     const card = cardById(id);

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -25,7 +25,7 @@ export const useCardMutations = () => {
   const updateBy = (id: CardId, callback: (card: Card) => Partial<Card>) => {
     const card = cardById(id);
     if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
-    return updateCard(uid, { ...card, ...callback(card) });
+    return updateCard(uid, { id: card.id, deckId: card.deckId, ...callback(card) });
   };
   const remove = (id: CardId) => {
     const card = cardById(id);

--- a/src/features/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/features/deck/hooks/useDeckMutations.spec.tsx
@@ -2,7 +2,9 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { remoteStore } from "@/store/remoteStore";
-import { createDeck } from "@/test/factories";
+import { createDeck as createDeckFixture } from "@/test/factories";
+
+const createDeck = (overrides: Partial<Deck> = {}) => createDeckFixture({ uid: "uid-a", ...overrides });
 
 const mocks = vi.hoisted(() => ({
   uid: "uid-a",

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -244,6 +244,32 @@ describe("useDeckImport", () => {
     expect(mocks.createDeck).not.toHaveBeenCalled();
   });
 
+  it("does not send a GitHub token to an unapproved URL", async () => {
+    mocks.config = createConfig({ githubAccessToken: "secret" });
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"front","back","","key"'));
+    const { result } = renderHook(useDeckImport);
+
+    await act(async () => result.current.importUrl("https://example.test/deck.csv"));
+
+    expect(fetch).toHaveBeenCalledWith(new URL("https://example.test/deck.csv"), { headers: {} });
+  });
+
+  it("sends a GitHub token only to the repository contents API", async () => {
+    mocks.config = createConfig({ githubAccessToken: "secret" });
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"front","back","","key"'));
+    const { result } = renderHook(useDeckImport);
+    const url = "https://api.github.com/repos/owner/repository/contents/deck.csv";
+
+    await act(async () => result.current.importUrl(url));
+
+    expect(fetch).toHaveBeenCalledWith(new URL(url), {
+      headers: {
+        Accept: "application/vnd.github.raw",
+        Authorization: "Bearer secret",
+      },
+    });
+  });
+
   it("rejects a second import while the first is pending", async () => {
     let finish!: () => void;
     mocks.bulkUpsert.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -34,6 +34,11 @@ type ImportRequest =
 
 const SAMPLE_DECK_NAME = "Sample Deck";
 const SAMPLE_VERSION = 1;
+
+const isGitHubContentsApiUrl = (url: URL): boolean =>
+  url.protocol === "https:" &&
+  url.hostname === "api.github.com" &&
+  /^\/repos\/[^/]+\/[^/]+\/contents\/.+/.test(url.pathname);
 /**
  * Builds the stable sample deck id used by the import feature.
  * Centralizing the format prevents different callers from producing incompatible identifiers.
@@ -425,11 +430,12 @@ export const useDeckImport = () => {
     const operationGeneration = generation.current;
     const operationUid = uid;
     const headers: Record<string, string> = {};
-    if (config.githubAccessToken !== "") {
+    const parsedUrl = new URL(url);
+    if (config.githubAccessToken !== "" && isGitHubContentsApiUrl(parsedUrl)) {
       headers.Accept = "application/vnd.github.raw";
       headers.Authorization = `Bearer ${config.githubAccessToken}`;
     }
-    const response = await fetch(url, { headers });
+    const response = await fetch(parsedUrl, { headers });
     if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
     const cards = await action.deck.parseCsv(await response.text());
     if (generation.current !== operationGeneration || dependenciesRef.current?.uid !== operationUid) {

--- a/src/features/settings/components/ConfigForm.tsx
+++ b/src/features/settings/components/ConfigForm.tsx
@@ -245,7 +245,12 @@ export const ConfigForm: React.FC<ConfigFormProps> = (props) => {
               Github Access Token
             </label>
             <span className="block text-caption text-ink-muted">Used when importing private GitHub content</span>
-            <Input className="mt-2" {...props.fields.githubAccessToken} id={inputIds.githubAccessToken} />
+            <Input
+              className="mt-2"
+              {...props.fields.githubAccessToken}
+              id={inputIds.githubAccessToken}
+              type="password"
+            />
           </div>
           <div className="flex min-h-touch items-start justify-between gap-4 px-4 py-3">
             <span className="shrink-0 text-body font-medium text-ink">User ID</span>

--- a/src/lib/realtimeChange.spec.ts
+++ b/src/lib/realtimeChange.spec.ts
@@ -7,6 +7,12 @@
 import { expect, it, describe } from "vitest";
 import { applyRealtimeChange } from "@/lib/realtimeChange";
 
+it("keeps the collection reference for metadata-only changes", () => {
+  const previous = { card: { id: "card" } };
+
+  expect(applyRealtimeChange(previous, { added: [], modified: [], removed: [] })).toBe(previous);
+});
+
 describe("applyRealtimeChange", () => {
   type Item = { id: string; name: string };
 

--- a/src/lib/realtimeChange.ts
+++ b/src/lib/realtimeChange.ts
@@ -15,6 +15,9 @@ export const applyRealtimeChange = <T extends { id: string }>(
   prevById: Readonly<Record<string, T | undefined>>,
   event: { added?: T[]; modified?: T[]; removed?: string[] }
 ): Record<string, T | undefined> => {
+  if ((event.added?.length ?? 0) === 0 && (event.modified?.length ?? 0) === 0 && (event.removed?.length ?? 0) === 0) {
+    return prevById as Record<string, T | undefined>;
+  }
   const next = { ...prevById };
   (event.added ?? []).forEach((item) => {
     next[item.id] = item;

--- a/src/store/configSchema.ts
+++ b/src/store/configSchema.ts
@@ -6,7 +6,7 @@
 
 import * as z from "zod";
 
-export const defaultConfig: ConfigState = {
+export const defaultConfig: ConfigState = Object.freeze({
   useCardInterval: false,
   showSwipeButtonList: true,
   showScoreSlider: false,
@@ -25,9 +25,9 @@ export const defaultConfig: ConfigState = {
   cardSwipeLeft: "GoToPrevCard",
   cardSwipeRight: "GoToNextCard",
   darkMode: false,
-  selectedTags: [],
+  selectedTags: Object.freeze([]) as unknown as string[],
   githubAccessToken: "",
-};
+});
 
 const cardSwipeSchema = z.enum([
   "DoNothing",
@@ -39,19 +39,19 @@ const cardSwipeSchema = z.enum([
   "GoToNextCardToggleMastered",
 ]);
 
-const configSchema: z.ZodType<ConfigState> = z
+export const configSchema: z.ZodType<ConfigState> = z
   .object({
     useCardInterval: z.boolean().catch(defaultConfig.useCardInterval),
     showSwipeButtonList: z.boolean().catch(defaultConfig.showSwipeButtonList),
     showScoreSlider: z.boolean().catch(defaultConfig.showScoreSlider),
     showHeader: z.boolean().catch(defaultConfig.showHeader),
     fullscreen: z.boolean().catch(defaultConfig.fullscreen),
-    maxNumberOfCardsToLearn: z.number().catch(defaultConfig.maxNumberOfCardsToLearn),
+    maxNumberOfCardsToLearn: z.number().int().min(0).max(100).catch(defaultConfig.maxNumberOfCardsToLearn),
     hideBodyWhenCardChanged: z.boolean().catch(defaultConfig.hideBodyWhenCardChanged),
-    sizeBackText: z.number().catch(defaultConfig.sizeBackText),
+    sizeBackText: z.number().min(0).catch(defaultConfig.sizeBackText),
     shuffled: z.boolean().catch(defaultConfig.shuffled),
     defaultAutoPlay: z.boolean().catch(defaultConfig.defaultAutoPlay),
-    cardInterval: z.number().catch(defaultConfig.cardInterval),
+    cardInterval: z.number().min(0).max(60).catch(defaultConfig.cardInterval),
     keepBackTextViewed: z.boolean().catch(defaultConfig.keepBackTextViewed),
     showSwipeFeedback: z.boolean().catch(defaultConfig.showSwipeFeedback),
     cardSwipeUp: cardSwipeSchema.catch(defaultConfig.cardSwipeUp),
@@ -59,7 +59,7 @@ const configSchema: z.ZodType<ConfigState> = z
     cardSwipeLeft: cardSwipeSchema.catch(defaultConfig.cardSwipeLeft),
     cardSwipeRight: cardSwipeSchema.catch(defaultConfig.cardSwipeRight),
     darkMode: z.boolean().catch(defaultConfig.darkMode),
-    selectedTags: z.array(z.string()).catch(defaultConfig.selectedTags),
+    selectedTags: z.array(z.string()).catch([...defaultConfig.selectedTags]),
     githubAccessToken: z.string().catch(defaultConfig.githubAccessToken),
   })
   .catch(defaultConfig);
@@ -71,4 +71,7 @@ const persistedConfigStateSchema = z.object({ config: configSchema }).catch({ co
  * Malformed input is reported before downstream code relies on the result.
  */
 export const parsePersistedConfig = (persistedState: unknown): ConfigState =>
-  persistedConfigStateSchema.parse(persistedState).config;
+  configSchema.parse({
+    ...persistedConfigStateSchema.parse(persistedState).config,
+    githubAccessToken: "",
+  });

--- a/src/store/configStore.spec.ts
+++ b/src/store/configStore.spec.ts
@@ -42,8 +42,9 @@ describe("config store", () => {
     store.getState().updateConfig({ darkMode: true });
 
     const persisted = JSON.parse(storage.getItem(CONFIG_STORAGE_KEY) ?? "{}");
+    const { githubAccessToken: _githubAccessToken, ...persistedDefaultConfig } = defaultConfig;
     expect(persisted).toEqual({
-      state: { config: { ...defaultConfig, darkMode: true } },
+      state: { config: { ...persistedDefaultConfig, darkMode: true } },
       version: 1,
     });
     expect(persisted.state).not.toHaveProperty("deck");
@@ -56,6 +57,34 @@ describe("config store", () => {
     expect(restored.getState().config).toEqual({ ...defaultConfig, darkMode: true });
     expect(restored.getState().updateConfig).toBeTypeOf("function");
     expect(restored.getState().toggleConfig).toBeTypeOf("function");
+  });
+
+  it("never persists a GitHub access token and drops legacy persisted tokens", async () => {
+    const storage = createMemoryStorage();
+    const store = createConfigStore({ storage, skipHydration: true });
+
+    store.getState().updateConfig({ githubAccessToken: "secret" });
+    expect(storage.getItem(CONFIG_STORAGE_KEY)).not.toContain("secret");
+
+    storage.setItem(
+      CONFIG_STORAGE_KEY,
+      JSON.stringify({ state: { config: { ...defaultConfig, githubAccessToken: "legacy-secret" } }, version: 1 })
+    );
+    await store.persist.rehydrate();
+
+    expect(store.getState().config.githubAccessToken).toBe("");
+  });
+
+  it("validates numeric ranges during updates", () => {
+    const store = createConfigStore({ storage: createMemoryStorage(), skipHydration: true });
+
+    store.getState().updateConfig({ maxNumberOfCardsToLearn: 101, cardInterval: -1, sizeBackText: -1 });
+
+    expect(store.getState().config).toMatchObject({
+      maxNumberOfCardsToLearn: defaultConfig.maxNumberOfCardsToLearn,
+      cardInterval: defaultConfig.cardInterval,
+      sizeBackText: defaultConfig.sizeBackText,
+    });
   });
 
   it("keeps valid persisted settings and replaces invalid values with current defaults", async () => {

--- a/src/store/configStore.spec.ts
+++ b/src/store/configStore.spec.ts
@@ -45,7 +45,7 @@ describe("config store", () => {
     const { githubAccessToken: _githubAccessToken, ...persistedDefaultConfig } = defaultConfig;
     expect(persisted).toEqual({
       state: { config: { ...persistedDefaultConfig, darkMode: true } },
-      version: 1,
+      version: 2,
     });
     expect(persisted.state).not.toHaveProperty("deck");
     expect(persisted.state).not.toHaveProperty("card");
@@ -73,6 +73,8 @@ describe("config store", () => {
     await store.persist.rehydrate();
 
     expect(store.getState().config.githubAccessToken).toBe("");
+    expect(storage.getItem(CONFIG_STORAGE_KEY)).not.toContain("legacy-secret");
+    expect(JSON.parse(storage.getItem(CONFIG_STORAGE_KEY) ?? "{}")).toMatchObject({ version: 2 });
   });
 
   it("validates numeric ranges during updates", () => {

--- a/src/store/configStore.ts
+++ b/src/store/configStore.ts
@@ -6,7 +6,7 @@
 
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
-import { defaultConfig, parsePersistedConfig } from "@/store/configSchema";
+import { configSchema, defaultConfig, parsePersistedConfig } from "@/store/configSchema";
 
 export { defaultConfig } from "@/store/configSchema";
 
@@ -22,7 +22,10 @@ export interface ConfigStoreState {
   toggleConfig: (key: BooleanConfigKey) => void;
 }
 
-type PersistedConfigState = Pick<ConfigStoreState, "config">;
+type PersistedConfig = Omit<ConfigState, "githubAccessToken">;
+interface PersistedConfigState {
+  config: PersistedConfig;
+}
 
 interface CreateConfigStoreOptions {
   storage?: StateStorage;
@@ -38,8 +41,15 @@ export const createConfigStore = ({ storage, skipHydration }: CreateConfigStoreO
   return createStore<ConfigStoreState>()(
     persist<ConfigStoreState, [], [], PersistedConfigState>(
       (set) => ({
-        config: defaultConfig,
-        updateConfig: (config) => set((state) => ({ config: { ...state.config, ...config } })),
+        config: { ...defaultConfig, selectedTags: [...defaultConfig.selectedTags] },
+        updateConfig: (config) =>
+          set((state) => ({
+            config: configSchema.parse({
+              ...state.config,
+              ...config,
+              selectedTags: config.selectedTags == null ? state.config.selectedTags : [...config.selectedTags],
+            }),
+          })),
         toggleConfig: (key) =>
           set((state) => ({ config: { ...state.config, [key]: !state.config[key] } as ConfigState })),
       }),
@@ -48,7 +58,10 @@ export const createConfigStore = ({ storage, skipHydration }: CreateConfigStoreO
         version: 1,
         storage: persistStorage,
         ...(skipHydration !== undefined ? { skipHydration } : {}),
-        partialize: ({ config }) => ({ config }),
+        partialize: ({ config }) => {
+          const { githubAccessToken: _githubAccessToken, ...persistedConfig } = config;
+          return { config: persistedConfig };
+        },
         merge: (persistedState, currentState) => ({
           ...currentState,
           config: parsePersistedConfig(persistedState),

--- a/src/store/configStore.ts
+++ b/src/store/configStore.ts
@@ -11,6 +11,7 @@ import { configSchema, defaultConfig, parsePersistedConfig } from "@/store/confi
 export { defaultConfig } from "@/store/configSchema";
 
 export const CONFIG_STORAGE_KEY = "tango-config";
+const CONFIG_STORAGE_VERSION = 2;
 
 type BooleanConfigKey = {
   [Key in keyof ConfigState]: ConfigState[Key] extends boolean ? Key : never;
@@ -55,9 +56,13 @@ export const createConfigStore = ({ storage, skipHydration }: CreateConfigStoreO
       }),
       {
         name: CONFIG_STORAGE_KEY,
-        version: 1,
+        version: CONFIG_STORAGE_VERSION,
         storage: persistStorage,
         ...(skipHydration !== undefined ? { skipHydration } : {}),
+        migrate: (persistedState) => {
+          const { githubAccessToken: _githubAccessToken, ...config } = parsePersistedConfig(persistedState);
+          return { config };
+        },
         partialize: ({ config }) => {
           const { githubAccessToken: _githubAccessToken, ...persistedConfig } = config;
           return { config: persistedConfig };

--- a/src/store/remoteStore.mutations.spec.ts
+++ b/src/store/remoteStore.mutations.spec.ts
@@ -7,7 +7,10 @@ import {
   type RemoteReadDependencies,
   type RemoteSubscriptionProps,
 } from "@/store/remoteStore";
-import { createCard, createDeck } from "@/test/factories";
+import { createCard as createCardFixture, createDeck as createDeckFixture } from "@/test/factories";
+
+const createCard = (overrides: Partial<Card> = {}) => createCardFixture({ uid: "uid-a", ...overrides });
+const createDeck = (overrides: Partial<Deck> = {}) => createDeckFixture({ uid: "uid-a", ...overrides });
 
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -54,6 +57,20 @@ const createHarness = () => {
 describe("remote store mutations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("rejects writes whose owner differs from the authenticated user", async () => {
+    const { store, dependencies } = createHarness();
+
+    await expect(store.getState().createCard("uid-a", createCard({ uid: "uid-b" }))).rejects.toThrow(
+      "Card owner does not match"
+    );
+    await expect(store.getState().createDeck("uid-a", createDeck({ uid: "uid-b" }))).rejects.toThrow(
+      "Deck owner does not match"
+    );
+
+    expect(dependencies.createCard).not.toHaveBeenCalled();
+    expect(dependencies.createDeck).not.toHaveBeenCalled();
   });
 
   it("tracks a pending Card create without publishing the entity before its snapshot", async () => {

--- a/src/store/remoteStore.reads.spec.ts
+++ b/src/store/remoteStore.reads.spec.ts
@@ -169,6 +169,7 @@ describe("remote store reads", () => {
 
     expect(harness.store.getState().read.cardsById.second).toBe(unchanged);
     const changed = harness.store.getState().read.cardsById;
+    expect(Object.isFrozen(changed)).toBe(true);
     harness.cardSubscriptions[0]?.onSnapshot({
       type: "change",
       event: { added: [], modified: [], removed: [] },

--- a/src/store/remoteStore.reads.spec.ts
+++ b/src/store/remoteStore.reads.spec.ts
@@ -143,6 +143,40 @@ describe("remote store reads", () => {
     expect(listener).toHaveBeenCalledTimes(6);
   });
 
+  it("preserves unchanged entity and collection references", async () => {
+    const harness = createHarness();
+    const first = createCard({ id: "first" });
+    const second = createCard({ id: "second" });
+    await harness.store.getState().start("uid-a");
+    harness.deckSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [],
+      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
+    });
+    harness.cardSubscriptions[0]?.onSnapshot({
+      type: "replace",
+      items: [first, second],
+      metadata: { size: 2, fromCache: false, hasPendingWrites: false },
+    });
+    const initial = harness.store.getState().read.cardsById;
+    const unchanged = initial.second;
+
+    harness.cardSubscriptions[0]?.onSnapshot({
+      type: "change",
+      event: { added: [], modified: [{ ...first, frontText: "updated" }], removed: [] },
+      metadata: { size: 2, fromCache: false, hasPendingWrites: false },
+    });
+
+    expect(harness.store.getState().read.cardsById.second).toBe(unchanged);
+    const changed = harness.store.getState().read.cardsById;
+    harness.cardSubscriptions[0]?.onSnapshot({
+      type: "change",
+      event: { added: [], modified: [], removed: [] },
+      metadata: { size: 2, fromCache: true, hasPendingWrites: false },
+    });
+    expect(harness.store.getState().read.cardsById).toBe(changed);
+  });
+
   it("recovers once, then retains data on a terminal listener error and ignores stale callbacks", async () => {
     const harness = createHarness();
     const deck = createDeck({ id: "deck-a" });

--- a/src/store/remoteStore.ts
+++ b/src/store/remoteStore.ts
@@ -165,6 +165,15 @@ const freezeCollection = <T>(collection: RemoteById<T>, freezeEntity: (entity: T
   return Object.freeze(copy);
 };
 
+const freezeChange = <T extends { id: string }>(
+  event: RemoteChange<T>,
+  freezeEntity: (entity: T) => T
+): RemoteChange<T> => ({
+  added: event.added.map(freezeEntity),
+  modified: event.modified.map(freezeEntity),
+  removed: event.removed,
+});
+
 const emptyData = (): RemoteData => ({
   decksById: freezeCollection({}, freezeDeck),
   cardsById: freezeCollection({}, freezeCard),
@@ -275,6 +284,12 @@ export const createRemoteStore = (
   const store = createStore<RemoteStoreState>()((set, get) => {
     const publish = (read: RemoteReadState) => set({ read: Object.freeze(read) });
 
+    const applyFrozenChange = <T extends { id: string }>(
+      previous: RemoteById<T>,
+      event: RemoteChange<T>,
+      freezeEntity: (entity: T) => T
+    ) => dependencies.applyChange(previous, freezeChange(event, freezeEntity));
+
     const publishCardMutation = (state: RemoteMutationState<CardId>) => set({ cardMutation: Object.freeze(state) });
 
     const resetCardMutation = (uid: string | null) => {
@@ -330,6 +345,7 @@ export const createRemoteStore = (
       runCardMutation(uid, { kind: "create", card }, () =>
         withMutationLocks([cardMutationLock(uid, card.id)], () =>
           withDeckMembershipLocks([deckMembershipMutationLock(uid, card.deckId)], "shared", async () => {
+            if (card.uid !== uid) throw new Error("Card owner does not match the authenticated user");
             const create = dependencies.createCard;
             if (create == null) throw new Error("Remote Card create dependency is unavailable");
             await create(card);
@@ -341,6 +357,9 @@ export const createRemoteStore = (
       runCardMutation(uid, { kind: "update", card }, () =>
         withMutationLocks([cardMutationLock(uid, card.id)], () =>
           withDeckMembershipLocks([deckMembershipMutationLock(uid, card.deckId)], "shared", async () => {
+            if (card.uid != null && card.uid !== uid) {
+              throw new Error("Card owner does not match the authenticated user");
+            }
             const update = dependencies.updateCard;
             if (update == null) throw new Error("Remote Card update dependency is unavailable");
             await update(card);
@@ -368,6 +387,9 @@ export const createRemoteStore = (
               cards.map((card) => deckMembershipMutationLock(uid, card.deckId)),
               "shared",
               async () => {
+                if (cards.some((card) => card.uid !== uid)) {
+                  throw new Error("Card owner does not match the authenticated user");
+                }
                 const upsert = dependencies.upsertCard;
                 if (upsert == null) throw new Error("Remote Card upsert dependency is unavailable");
                 const results = await Promise.allSettled(cards.map((card) => upsert(card)));
@@ -445,6 +467,7 @@ export const createRemoteStore = (
     const createDeck = (uid: string, deck: Deck) =>
       runDeckMutation(uid, { kind: "create", deck }, () =>
         withMutationLocks([deckMutationLock(uid, deck.id)], async () => {
+          if (deck.uid !== uid) throw new Error("Deck owner does not match the authenticated user");
           const create = dependencies.createDeck;
           if (create == null) throw new Error("Remote Deck create dependency is unavailable");
           await create(deck);
@@ -454,6 +477,9 @@ export const createRemoteStore = (
     const updateDeck = (uid: string, deck: DeckEdit) =>
       runDeckMutation(uid, { kind: "update", deck }, () =>
         withMutationLocks([deckMutationLock(uid, deck.id)], async () => {
+          if (deck.uid != null && deck.uid !== uid) {
+            throw new Error("Deck owner does not match the authenticated user");
+          }
           const update = dependencies.updateDeck;
           if (update == null) throw new Error("Remote Deck update dependency is unavailable");
           await update(deck);
@@ -548,15 +574,21 @@ export const createRemoteStore = (
       const read = get().read;
       const previous = readCollection(read, collection);
       const next =
-        snapshot.type === "replace" ? toRemoteById(snapshot.items) : dependencies.applyChange(previous, snapshot.event);
+        snapshot.type === "replace"
+          ? collection === "decks"
+            ? freezeCollection(toRemoteById(snapshot.items as Deck[]), freezeDeck)
+            : freezeCollection(toRemoteById(snapshot.items as Card[]), freezeCard)
+          : collection === "decks"
+            ? applyFrozenChange(previous as RemoteById<Deck>, snapshot.event as RemoteChange<Deck>, freezeDeck)
+            : applyFrozenChange(previous as RemoteById<Card>, snapshot.event as RemoteChange<Card>, freezeCard);
       const nextMetadata = new Map(metadata);
       nextMetadata.set(collection, Object.freeze({ ...snapshot.metadata }));
       metadata = nextMetadata;
 
       const data: RemoteData =
         collection === "decks"
-          ? { decksById: freezeCollection(next as RemoteById<Deck>, freezeDeck), cardsById: read.cardsById }
-          : { decksById: read.decksById, cardsById: freezeCollection(next as RemoteById<Card>, freezeCard) };
+          ? { decksById: next as RemoteById<Deck>, cardsById: read.cardsById }
+          : { decksById: read.decksById, cardsById: next as RemoteById<Card> };
       const deckMetadata = metadata.get("decks");
       const cardMetadata = metadata.get("cards");
       if (!deckMetadata || !cardMetadata) {

--- a/src/store/remoteStore.ts
+++ b/src/store/remoteStore.ts
@@ -288,7 +288,10 @@ export const createRemoteStore = (
       previous: RemoteById<T>,
       event: RemoteChange<T>,
       freezeEntity: (entity: T) => T
-    ) => dependencies.applyChange(previous, freezeChange(event, freezeEntity));
+    ) => {
+      const next = dependencies.applyChange(previous, freezeChange(event, freezeEntity));
+      return next === previous ? previous : Object.freeze(next);
+    };
 
     const publishCardMutation = (state: RemoteMutationState<CardId>) => set({ cardMutation: Object.freeze(state) });
 


### PR DESCRIPTION
## Summary

- prevent GitHub access tokens from being persisted to local storage, discard legacy persisted tokens, clear credentials on logout, and mask the settings input
- attach GitHub authorization headers only to HTTPS `api.github.com/repos/{owner}/{repo}/contents/...` requests
- validate configuration ranges on hydration and normal updates, and isolate mutable default arrays
- preserve collection and unchanged entity references for metadata-only and single-entity snapshot changes
- send only the callback patch from `updateBy` and reject Card/Deck writes whose owner differs from the authenticated UID

## Root cause

Sensitive credentials shared the same persistence lifecycle as ordinary settings, URL imports added authorization headers without validating the destination, and remote snapshots rebuilt/froze entire collections for every callback. Mutation boundaries also accepted independent UID and entity-owner values, while `updateBy` merged patches into stale full entities.

## Impact

GitHub credentials are no longer left in local storage or sent to arbitrary hosts. Remote reads retain structural sharing, and write commands avoid stale full-entity updates and cross-owner mutations.

## Validation

- `make check`
- 99 unit test files / 767 tests passed