### PR TITLE
Preserve study sessions until Firestore syncs

### DIFF
--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   cardsById: {} as Record<CardId, Card>,
   hydrated: true,
   pending: false,
+  syncStatus: "synced" as "cached" | "pending" | "synced",
   pendingDeckIds: new Set<DeckId>(),
   error: null as unknown,
   onRemoveSuccess: undefined as ((deck: Deck) => void) | undefined,
@@ -46,6 +47,7 @@ vi.mock("@/hooks/useRemoteCollections", () => ({
     const cards = Object.values(mocks.cardsById);
     return {
       status: "ready" as const,
+      syncStatus: mocks.syncStatus,
       retry: vi.fn(),
       decks,
       cards,
@@ -82,6 +84,7 @@ describe("DeckListContainer", () => {
     vi.clearAllMocks();
     mocks.hydrated = true;
     mocks.pending = false;
+    mocks.syncStatus = "synced";
     mocks.pendingDeckIds = new Set();
     mocks.error = null;
     mocks.onRemoveSuccess = undefined;
@@ -201,6 +204,15 @@ describe("DeckListContainer", () => {
     render(<DeckListContainer />);
 
     await waitFor(() => expect(studyStore.getState().sessionsByDeckId.missing).toBeUndefined());
+    expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeDefined();
+  });
+
+  it("keeps sessions while remote decks are only available from cache", () => {
+    mocks.syncStatus = "cached";
+    delete mocks.decksById[recentDeck.id];
+
+    render(<DeckListContainer />);
+
     expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeDefined();
   });
 

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -41,12 +41,14 @@ export const DeckListContainer: React.FC = () => {
   useKey("i", actions.goToImport);
 
   React.useEffect(() => {
-    if (!hydrated || mutations.pending || remote.status !== "ready") return;
+    if (!hydrated || mutations.pending || remote.status !== "ready" || remote.syncStatus !== "synced") {
+      return;
+    }
     const deckIds = new Set(remote.decks.map((deck) => deck.id));
     for (const deckId of Object.keys(studyStore.getState().sessionsByDeckId)) {
       if (!deckIds.has(deckId)) studyStore.getState().removeStudy(deckId);
     }
-  }, [hydrated, mutations.pending, remote.decks, remote.status]);
+  }, [hydrated, mutations.pending, remote.decks, remote.status, remote.syncStatus]);
 
   return (
     <RemoteReadBoundary


### PR DESCRIPTION
## Summary

- prune orphaned study sessions only after Firestore reports a server-synced snapshot
- preserve persisted progress while deck data is cache-only
- add regression coverage for the cached snapshot case

## Testing

- `make check`