### PR TITLE
Fix Storybook Pages sample build

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -25,6 +25,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: make sample-build
       - run: npm run build:storybook
 
       - uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

- generate the sample card output before building Storybook Pages
- prevent the clean CI checkout from failing to resolve sample/build/output.json

## Testing

- make check
- make build