### PR TITLE
Fix Auth Emulator connection in Vite development mode

### DIFF
--- a/src/firebase.spec.ts
+++ b/src/firebase.spec.ts
@@ -137,8 +137,9 @@ describe("Firebase singletons", () => {
     expect(() => firebase.getDb()).toThrow("Memory fallback is disabled");
   });
 
-  it("connects auth to the configured emulator in dev mode", async () => {
-    vi.stubEnv("MODE", "dev");
+  it("connects auth to the configured emulator in development", async () => {
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("DEV", true);
     vi.stubEnv("VITE_AUTH_HOST", "127.0.0.1");
     vi.stubEnv("VITE_AUTH_PORT", "9099");
 
@@ -147,8 +148,9 @@ describe("Firebase singletons", () => {
     expect(connectAuthEmulator).toHaveBeenCalledWith(auth, "http://127.0.0.1:9099");
   });
 
-  it("does not connect auth to the emulator in test mode", async () => {
-    vi.stubEnv("MODE", "test");
+  it("does not connect auth to the emulator in production", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("DEV", false);
 
     await import("@/firebase");
 

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -28,7 +28,7 @@ initializeFirestoreAdapter(app);
 
 export { getDb, getFirestoreInitializationState, waitForFirestoreInitialization };
 
-if (import.meta.env.MODE === "dev") {
+if (import.meta.env.DEV) {
   const host = import.meta.env.VITE_AUTH_HOST;
   const port = import.meta.env.VITE_AUTH_PORT;
   connectAuthEmulator(auth, `http://${host}:${port}`);


### PR DESCRIPTION
## Summary

- use Vite's standard `import.meta.env.DEV` flag when connecting Auth Emulator
- align the Auth Emulator condition with the Firestore Emulator condition
- update regression tests to cover standard `development` mode and production non-connection

## Root cause

`npm start` runs Vite in `development` mode, but the Auth Emulator connection checked `import.meta.env.MODE === "dev"`. The condition therefore remained false during the normal development startup path.

## Impact

Normal Vite development startup now uses the configured `VITE_AUTH_HOST` and `VITE_AUTH_PORT`, while production does not connect to Auth Emulator.

## Validation

- confirmed the branch changes only `src/firebase.ts` and `src/firebase.spec.ts`
- added a regression case that would fail with the previous `MODE === "dev"` condition
- local `make check` was not run because the execution environment could not check out the repository or install dependencies; GitHub CI is expected to provide the executable validation

Closes #382