### PR TITLE
Validate Firestore documents at runtime

### DIFF
--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -47,7 +47,8 @@ const getDocument = async (collection: "deck" | "card", id: string) => {
   return (await response.json()) as { fields: Record<string, { stringValue?: string }> };
 };
 
-const deckFields = (uid: string, name: string) => ({
+const deckFields = (id: string, uid: string, name: string) => ({
+  id: field.string(id),
   uid: field.string(uid),
   name: field.string(name),
   isPublic: field.boolean(false),
@@ -62,7 +63,8 @@ const deckFields = (uid: string, name: string) => ({
   convertToBr: field.boolean(false),
 });
 
-const cardFields = (uid: string, deckId: string, frontText: string) => ({
+const cardFields = (id: string, uid: string, deckId: string, frontText: string) => ({
+  id: field.string(id),
   uid: field.string(uid),
   deckId: field.string(deckId),
   frontText: field.string(frontText),
@@ -148,9 +150,13 @@ const seedAuth = async (page: Page, uid: string, nextUid?: string) => {
 
 test("loads UID-scoped remote Decks and Cards again after reload", async ({ page }) => {
   const uid = "remote-read-user";
-  await setDocument("deck", "remote-read-deck", deckFields(uid, "Remote Query Deck"));
-  await setDocument("card", "remote-read-card", cardFields(uid, "remote-read-deck", "Remote Query Card"));
-  await setDocument("deck", "foreign-deck", deckFields("foreign-user", "Foreign Deck"));
+  await setDocument("deck", "remote-read-deck", deckFields("remote-read-deck", uid, "Remote Query Deck"));
+  await setDocument(
+    "card",
+    "remote-read-card",
+    cardFields("remote-read-card", uid, "remote-read-deck", "Remote Query Card")
+  );
+  await setDocument("deck", "foreign-deck", deckFields("foreign-deck", "foreign-user", "Foreign Deck"));
   await seedAuth(page, uid);
 
   await page.goto("/");
@@ -206,8 +212,8 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
 test("logout replaces the UID-scoped Query cache", async ({ page }) => {
   const uidA = "logout-user-a";
   const uidB = "logout-user-b";
-  await setDocument("deck", "logout-deck-a", deckFields(uidA, "Logout Deck A"));
-  await setDocument("deck", "logout-deck-b", deckFields(uidB, "Logout Deck B"));
+  await setDocument("deck", "logout-deck-a", deckFields("logout-deck-a", uidA, "Logout Deck A"));
+  await setDocument("deck", "logout-deck-b", deckFields("logout-deck-b", uidB, "Logout Deck B"));
   await seedAuth(page, uidA, uidB);
 
   await page.goto("/");

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -47,8 +47,7 @@ const getDocument = async (collection: "deck" | "card", id: string) => {
   return (await response.json()) as { fields: Record<string, { stringValue?: string }> };
 };
 
-const deckFields = (id: string, uid: string, name: string) => ({
-  id: field.string(id),
+const deckFields = (uid: string, name: string) => ({
   uid: field.string(uid),
   name: field.string(name),
   isPublic: field.boolean(false),
@@ -63,8 +62,7 @@ const deckFields = (id: string, uid: string, name: string) => ({
   convertToBr: field.boolean(false),
 });
 
-const cardFields = (id: string, uid: string, deckId: string, frontText: string) => ({
-  id: field.string(id),
+const cardFields = (uid: string, deckId: string, frontText: string) => ({
   uid: field.string(uid),
   deckId: field.string(deckId),
   frontText: field.string(frontText),
@@ -150,13 +148,13 @@ const seedAuth = async (page: Page, uid: string, nextUid?: string) => {
 
 test("loads UID-scoped remote Decks and Cards again after reload", async ({ page }) => {
   const uid = "remote-read-user";
-  await setDocument("deck", "remote-read-deck", deckFields("remote-read-deck", uid, "Remote Query Deck"));
+  await setDocument("deck", "remote-read-deck", deckFields(uid, "Remote Query Deck"));
   await setDocument(
     "card",
     "remote-read-card",
-    cardFields("remote-read-card", uid, "remote-read-deck", "Remote Query Card")
+    cardFields(uid, "remote-read-deck", "Remote Query Card")
   );
-  await setDocument("deck", "foreign-deck", deckFields("foreign-deck", "foreign-user", "Foreign Deck"));
+  await setDocument("deck", "foreign-deck", deckFields("foreign-user", "Foreign Deck"));
   await seedAuth(page, uid);
 
   await page.goto("/");
@@ -212,8 +210,8 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
 test("logout replaces the UID-scoped Query cache", async ({ page }) => {
   const uidA = "logout-user-a";
   const uidB = "logout-user-b";
-  await setDocument("deck", "logout-deck-a", deckFields("logout-deck-a", uidA, "Logout Deck A"));
-  await setDocument("deck", "logout-deck-b", deckFields("logout-deck-b", uidB, "Logout Deck B"));
+  await setDocument("deck", "logout-deck-a", deckFields(uidA, "Logout Deck A"));
+  await setDocument("deck", "logout-deck-b", deckFields(uidB, "Logout Deck B"));
   await seedAuth(page, uidA, uidB);
 
   await page.goto("/");

--- a/src/adapters/firestore/card.ts
+++ b/src/adapters/firestore/card.ts
@@ -17,7 +17,7 @@ import {
   type Firestore,
 } from "firebase/firestore";
 import { getTimestamp } from "@/adapters/firestore/documentMetadata";
-import { buildCardCreateDto, buildCardUpdateDto, mapCardDocument, type CardDocument } from "@/adapters/firestore/dto";
+import { buildCardCreateDto, buildCardUpdateDto, mapCardDocument } from "@/adapters/firestore/dto";
 import { getDb } from "@/adapters/firestore/runtime";
 
 /**
@@ -27,7 +27,7 @@ import { getDb } from "@/adapters/firestore/runtime";
 export const readAll = async (uid: string, firestore: Firestore = getDb()): Promise<Card[]> => {
   const snapshot = await getDocs(query(collection(firestore, "card"), where("uid", "==", uid)));
   return snapshot.docs
-    .map((document) => mapCardDocument(document.id, document.data() as CardDocument))
+    .map((document) => mapCardDocument(document.id, document.data()))
     .filter((card) => card.deletedAt === null);
 };
 

--- a/src/adapters/firestore/deck.ts
+++ b/src/adapters/firestore/deck.ts
@@ -17,7 +17,7 @@ import {
   type Firestore,
 } from "firebase/firestore";
 import { getTimestamp } from "@/adapters/firestore/documentMetadata";
-import { buildDeckCreateDto, buildDeckUpdateDto, mapDeckDocument, type DeckDocument } from "@/adapters/firestore/dto";
+import { buildDeckCreateDto, buildDeckUpdateDto, mapDeckDocument } from "@/adapters/firestore/dto";
 import { getDb } from "@/adapters/firestore/runtime";
 
 /**
@@ -27,7 +27,7 @@ import { getDb } from "@/adapters/firestore/runtime";
 export const readAll = async (uid: string, firestore: Firestore = getDb()): Promise<Deck[]> => {
   const snapshot = await getDocs(query(collection(firestore, "deck"), where("uid", "==", uid)));
   return snapshot.docs
-    .map((document) => mapDeckDocument(document.id, document.data() as DeckDocument))
+    .map((document) => mapDeckDocument(document.id, document.data()))
     .filter((deck) => deck.deletedAt === null);
 };
 

--- a/src/adapters/firestore/dto.spec.ts
+++ b/src/adapters/firestore/dto.spec.ts
@@ -13,6 +13,7 @@ import {
   buildCardUpdateDto,
   buildDeckCreateDto,
   buildDeckUpdateDto,
+  FirestoreDocumentValidationError,
   mapCardDocument,
   mapDeckDocument,
 } from "@/adapters/firestore/dto";
@@ -48,6 +49,22 @@ describe("Firestore DTO builders", () => {
     interval: 7,
     startLine: 8,
     endLine: 9,
+  });
+
+  const cardDocument = (overrides: Record<string, unknown> = {}) => ({
+    id: "payload-id",
+    frontText: "Remote front",
+    backText: "Remote back",
+    tags: ["science"],
+    uniqueKey: "remote-key",
+    deckId: "deck-2",
+    uid: "user-2",
+    createdAt: 10,
+    updatedAt: 20,
+    deletedAt: null,
+    score: 3,
+    numberOfSeen: 4,
+    ...overrides,
   });
 
   it("maps only remote deck fields using the snapshot id", () => {
@@ -109,19 +126,7 @@ describe("Firestore DTO builders", () => {
   });
 
   it("maps only remote card fields using the snapshot id", () => {
-    const document = {
-      id: "payload-id",
-      frontText: "Remote front",
-      backText: "Remote back",
-      tags: ["science"],
-      uniqueKey: "remote-key",
-      deckId: "deck-2",
-      uid: "user-2",
-      createdAt: 10,
-      updatedAt: 20,
-      deletedAt: null,
-      score: 3,
-      numberOfSeen: 4,
+    const document = cardDocument({
       lastSeenAt: 50,
       nextSeeingAt: Timestamp.fromMillis(60),
       interval: 7,
@@ -130,7 +135,7 @@ describe("Firestore DTO builders", () => {
       endLine: 9,
       currentIndex: 2,
       cardOrderIds: ["card-2"],
-    };
+    });
 
     expect(mapCardDocument("snapshot-id", document)).toEqual({
       id: "snapshot-id",
@@ -155,20 +160,7 @@ describe("Firestore DTO builders", () => {
   });
 
   it("omits absent optional fields when mapping a remote card", () => {
-    const document = {
-      id: "payload-id",
-      frontText: "Remote front",
-      backText: "Remote back",
-      tags: [],
-      uniqueKey: "remote-key",
-      deckId: "deck-2",
-      uid: "user-2",
-      createdAt: 10,
-      updatedAt: 20,
-      deletedAt: null,
-      score: 0,
-      numberOfSeen: 0,
-    };
+    const document = cardDocument({ tags: [], score: 0, numberOfSeen: 0 });
 
     const mapped = mapCardDocument("snapshot-id", document);
 
@@ -178,6 +170,36 @@ describe("Firestore DTO builders", () => {
     expect(mapped).not.toHaveProperty("url");
     expect(mapped).not.toHaveProperty("startLine");
     expect(mapped).not.toHaveProperty("endLine");
+  });
+
+  it("accepts a legacy Date for nextSeeingAt", () => {
+    const nextSeeingAt = new Date(60);
+
+    expect(mapCardDocument("snapshot-id", cardDocument({ nextSeeingAt }))).toEqual(
+      expect.objectContaining({ nextSeeingAt })
+    );
+  });
+
+  it.each([null, "2026-01-01", 60, {}])("rejects invalid nextSeeingAt value %j with its field path", (value) => {
+    expect(() => mapCardDocument("invalid-card", cardDocument({ nextSeeingAt: value }))).toThrowError(
+      expect.objectContaining({
+        name: "FirestoreDocumentValidationError",
+        collectionName: "card",
+        documentId: "invalid-card",
+        message: expect.stringContaining("nextSeeingAt"),
+      })
+    );
+  });
+
+  it("rejects missing required fields and field type mismatches", () => {
+    const { frontText: _frontText, ...missingFrontText } = cardDocument();
+
+    expect(() => mapCardDocument("missing-field", missingFrontText)).toThrow(FirestoreDocumentValidationError);
+    expect(() => mapDeckDocument("wrong-type", { name: 42 })).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining("name"),
+      })
+    );
   });
 
   it("allows only server deck fields when creating", () => {
@@ -256,5 +278,13 @@ describe("Firestore DTO builders", () => {
       startLine: 8,
       endLine: 9,
     });
+  });
+
+  it("validates write DTOs with the same storage contract", () => {
+    const invalidCard = { ...card, tags: ["math", 42] } as unknown as Card;
+    const invalidDeck = { ...deck, selectedTags: [42] } as unknown as Deck;
+
+    expect(() => buildCardCreateDto(invalidCard, 200)).toThrow();
+    expect(() => buildDeckUpdateDto(invalidDeck, 201)).toThrow();
   });
 });

--- a/src/adapters/firestore/dto.spec.ts
+++ b/src/adapters/firestore/dto.spec.ts
@@ -52,7 +52,6 @@ describe("Firestore DTO builders", () => {
   });
 
   const cardDocument = (overrides: Record<string, unknown> = {}) => ({
-    id: "payload-id",
     frontText: "Remote front",
     backText: "Remote back",
     tags: ["science"],
@@ -67,9 +66,8 @@ describe("Firestore DTO builders", () => {
     ...overrides,
   });
 
-  it("maps only remote deck fields using the snapshot id", () => {
+  it("maps a remote deck without a payload id using the snapshot id", () => {
     const document = {
-      id: "payload-id",
       name: "Remote Deck",
       url: "https://example.com/deck",
       isPublic: true,
@@ -125,7 +123,7 @@ describe("Firestore DTO builders", () => {
     expect(mapDeckDocument("snapshot-id", document)).not.toHaveProperty("url");
   });
 
-  it("maps only remote card fields using the snapshot id", () => {
+  it("maps a remote card without a payload id using the snapshot id", () => {
     const document = cardDocument({
       lastSeenAt: 50,
       nextSeeingAt: Timestamp.fromMillis(60),
@@ -283,8 +281,12 @@ describe("Firestore DTO builders", () => {
   it("validates write DTOs with the same storage contract", () => {
     const invalidCard = { ...card, tags: ["math", 42] } as unknown as Card;
     const invalidDeck = { ...deck, selectedTags: [42] } as unknown as Deck;
+    const cardWithoutId = { ...card, id: undefined } as unknown as Card;
+    const deckWithoutId = { ...deck, id: undefined } as unknown as Deck;
 
     expect(() => buildCardCreateDto(invalidCard, 200)).toThrow();
     expect(() => buildDeckUpdateDto(invalidDeck, 201)).toThrow();
+    expect(() => buildCardCreateDto(cardWithoutId, 200)).toThrow();
+    expect(() => buildDeckCreateDto(deckWithoutId, 200)).toThrow();
   });
 });

--- a/src/adapters/firestore/dto.ts
+++ b/src/adapters/firestore/dto.ts
@@ -32,7 +32,7 @@ const timestampOrDateSchema = z.union([validDateSchema, timestampSchema]).transf
 });
 
 export const deckDocumentSchema = z.object({
-  id: z.string(),
+  id: z.string().optional(),
   name: z.string(),
   url: z.string().optional(),
   isPublic: z.boolean(),
@@ -48,11 +48,16 @@ export const deckDocumentSchema = z.object({
   convertToBr: z.boolean(),
 });
 
+export const deckCreateDtoSchema = deckDocumentSchema.extend({
+  id: z.string(),
+});
+
 export const deckUpdateDtoSchema = deckDocumentSchema.omit({ id: true }).partial().extend({
   updatedAt: z.number(),
 });
 
 export type DeckDocument = z.infer<typeof deckDocumentSchema>;
+export type DeckCreateDto = z.infer<typeof deckCreateDtoSchema>;
 export type DeckUpdateDto = z.infer<typeof deckUpdateDtoSchema>;
 
 export class FirestoreDocumentValidationError extends Error {
@@ -106,7 +111,7 @@ export const mapDeckDocument = (id: DeckId, value: unknown): Deck => {
 };
 
 export const cardDocumentSchema = z.object({
-  id: z.string(),
+  id: z.string().optional(),
   frontText: z.string(),
   backText: z.string(),
   tags: z.array(z.string()),
@@ -126,11 +131,16 @@ export const cardDocumentSchema = z.object({
   endLine: z.number().optional(),
 });
 
+export const cardCreateDtoSchema = cardDocumentSchema.extend({
+  id: z.string(),
+});
+
 export const cardUpdateDtoSchema = cardDocumentSchema.omit({ id: true }).partial().extend({
   updatedAt: z.number(),
 });
 
 export type CardDocument = z.infer<typeof cardDocumentSchema>;
+export type CardCreateDto = z.infer<typeof cardCreateDtoSchema>;
 export type CardUpdateDto = z.infer<typeof cardUpdateDtoSchema>;
 
 export const parseCardDocument = (id: CardId, value: unknown): CardDocument =>
@@ -184,8 +194,8 @@ const omitUndefined = <T extends Record<string, unknown>>(value: T): OmitUndefin
  * The returned value is ready for the next layer, so callers do not need to repeat assembly or
  * defaulting rules.
  */
-export const buildDeckCreateDto = (deck: Deck, createdAt: number): DeckDocument =>
-  deckDocumentSchema.parse(
+export const buildDeckCreateDto = (deck: Deck, createdAt: number): DeckCreateDto =>
+  deckCreateDtoSchema.parse(
     omitUndefined({
       id: deck.id,
       name: deck.name,
@@ -233,8 +243,8 @@ export const buildDeckUpdateDto = (deck: DeckEdit, updatedAt: number): DeckUpdat
  * The returned value is ready for the next layer, so callers do not need to repeat assembly or
  * defaulting rules.
  */
-export const buildCardCreateDto = (card: Card, createdAt: number): CardDocument =>
-  cardDocumentSchema.parse(
+export const buildCardCreateDto = (card: Card, createdAt: number): CardCreateDto =>
+  cardCreateDtoSchema.parse(
     omitUndefined({
       id: card.id,
       frontText: card.frontText,

--- a/src/adapters/firestore/dto.ts
+++ b/src/adapters/firestore/dto.ts
@@ -4,30 +4,88 @@
  * not handle database details directly.
  */
 
-export interface DeckDocument {
-  id: DeckId;
-  name: string;
-  url?: string;
-  isPublic: boolean;
-  uid: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  scoreMax: number | null;
-  scoreMin: number | null;
-  selectedTags: string[];
-  tagAndFilter: boolean;
-  category: Category;
-  convertToBr: boolean;
+import type { Timestamp } from "firebase/firestore";
+import { z } from "zod";
+
+const validDateSchema = z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date");
+const timestampSchema = z.custom<Timestamp>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "toDate") === "function" &&
+    Number.isInteger(Reflect.get(value, "seconds")) &&
+    Number.isInteger(Reflect.get(value, "nanoseconds")) &&
+    Reflect.get(value, "nanoseconds") >= 0 &&
+    Reflect.get(value, "nanoseconds") < 1_000_000_000,
+  "Expected a Firestore Timestamp"
+);
+const timestampOrDateSchema = z.union([validDateSchema, timestampSchema]).transform((value, context) => {
+  if (value instanceof Date) return value;
+  try {
+    const date = value.toDate();
+    if (!Number.isNaN(date.getTime())) return date;
+  } catch {
+    // The validation issue below keeps malformed Timestamp-like values inside the DTO error boundary.
+  }
+  context.addIssue({ code: "custom", message: "Invalid Firestore Timestamp" });
+  return z.NEVER;
+});
+
+export const deckDocumentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  url: z.string().optional(),
+  isPublic: z.boolean(),
+  uid: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  deletedAt: z.number().nullable(),
+  scoreMax: z.number().nullable(),
+  scoreMin: z.number().nullable(),
+  selectedTags: z.array(z.string()),
+  tagAndFilter: z.boolean(),
+  category: z.string(),
+  convertToBr: z.boolean(),
+});
+
+export const deckUpdateDtoSchema = deckDocumentSchema.omit({ id: true }).partial().extend({
+  updatedAt: z.number(),
+});
+
+export type DeckDocument = z.infer<typeof deckDocumentSchema>;
+export type DeckUpdateDto = z.infer<typeof deckUpdateDtoSchema>;
+
+export class FirestoreDocumentValidationError extends Error {
+  constructor(
+    readonly collectionName: "deck" | "card",
+    readonly documentId: string,
+    readonly issues: z.core.$ZodIssue[]
+  ) {
+    const details = issues
+      .map((issue) => `${issue.path.length === 0 ? "<document>" : issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    super(`Invalid Firestore ${collectionName} document "${documentId}": ${details}`);
+    this.name = "FirestoreDocumentValidationError";
+  }
 }
 
-export type DeckUpdateDto = Partial<Omit<DeckDocument, "id" | "updatedAt">> & Pick<DeckDocument, "updatedAt">;
+const parseDocument = <T>(schema: z.ZodType<T>, collectionName: "deck" | "card", id: string, value: unknown): T => {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new FirestoreDocumentValidationError(collectionName, id, result.error.issues);
+  }
+  return result.data;
+};
+
+export const parseDeckDocument = (id: DeckId, value: unknown): DeckDocument =>
+  parseDocument(deckDocumentSchema, "deck", id, value);
 
 /**
  * Converts deck document into the shape used by the next application layer.
  * The mapping keeps storage-specific representations out of domain and component code.
  */
-export const mapDeckDocument = (id: DeckId, document: DeckDocument): Deck => {
+export const mapDeckDocument = (id: DeckId, value: unknown): Deck => {
+  const document = parseDeckDocument(id, value);
   const deck: Deck = {
     id,
     name: document.name,
@@ -47,34 +105,43 @@ export const mapDeckDocument = (id: DeckId, document: DeckDocument): Deck => {
   return deck;
 };
 
-export interface CardDocument {
-  id: CardId;
-  frontText: string;
-  backText: string;
-  tags: string[];
-  uniqueKey: string;
-  deckId: DeckId;
-  uid: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  score: number;
-  numberOfSeen: number;
-  lastSeenAt?: number;
-  nextSeeingAt?: Date | { toDate: () => Date };
-  interval?: number;
-  url?: string;
-  startLine?: number;
-  endLine?: number;
-}
+export const cardDocumentSchema = z.object({
+  id: z.string(),
+  frontText: z.string(),
+  backText: z.string(),
+  tags: z.array(z.string()),
+  uniqueKey: z.string(),
+  deckId: z.string(),
+  uid: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  deletedAt: z.number().nullable(),
+  score: z.number(),
+  numberOfSeen: z.number(),
+  lastSeenAt: z.number().optional(),
+  nextSeeingAt: timestampOrDateSchema.optional(),
+  interval: z.number().optional(),
+  url: z.string().optional(),
+  startLine: z.number().optional(),
+  endLine: z.number().optional(),
+});
 
-export type CardUpdateDto = Partial<Omit<CardDocument, "id" | "updatedAt">> & Pick<CardDocument, "updatedAt">;
+export const cardUpdateDtoSchema = cardDocumentSchema.omit({ id: true }).partial().extend({
+  updatedAt: z.number(),
+});
+
+export type CardDocument = z.infer<typeof cardDocumentSchema>;
+export type CardUpdateDto = z.infer<typeof cardUpdateDtoSchema>;
+
+export const parseCardDocument = (id: CardId, value: unknown): CardDocument =>
+  parseDocument(cardDocumentSchema, "card", id, value);
 
 /**
  * Converts card document into the shape used by the next application layer.
  * The mapping keeps storage-specific representations out of domain and component code.
  */
-export const mapCardDocument = (id: CardId, document: CardDocument): Card => {
+export const mapCardDocument = (id: CardId, value: unknown): Card => {
+  const document = parseCardDocument(id, value);
   const card: Card = {
     id,
     frontText: document.frontText,
@@ -90,9 +157,7 @@ export const mapCardDocument = (id: CardId, document: CardDocument): Card => {
     numberOfSeen: document.numberOfSeen,
   };
   if (document.lastSeenAt !== undefined) card.lastSeenAt = document.lastSeenAt;
-  if (document.nextSeeingAt !== undefined) {
-    card.nextSeeingAt = document.nextSeeingAt instanceof Date ? document.nextSeeingAt : document.nextSeeingAt.toDate();
-  }
+  if (document.nextSeeingAt !== undefined) card.nextSeeingAt = document.nextSeeingAt;
   if (document.interval !== undefined) card.interval = document.interval;
   if (document.url !== undefined) card.url = document.url;
   if (document.startLine !== undefined) card.startLine = document.startLine;
@@ -120,22 +185,24 @@ const omitUndefined = <T extends Record<string, unknown>>(value: T): OmitUndefin
  * defaulting rules.
  */
 export const buildDeckCreateDto = (deck: Deck, createdAt: number): DeckDocument =>
-  omitUndefined({
-    id: deck.id,
-    name: deck.name,
-    url: deck.url,
-    isPublic: deck.isPublic,
-    uid: deck.uid,
-    createdAt,
-    updatedAt: createdAt,
-    deletedAt: deck.deletedAt,
-    scoreMax: deck.scoreMax,
-    scoreMin: deck.scoreMin,
-    selectedTags: deck.selectedTags,
-    tagAndFilter: deck.tagAndFilter,
-    category: deck.category,
-    convertToBr: deck.convertToBr,
-  });
+  deckDocumentSchema.parse(
+    omitUndefined({
+      id: deck.id,
+      name: deck.name,
+      url: deck.url,
+      isPublic: deck.isPublic,
+      uid: deck.uid,
+      createdAt,
+      updatedAt: createdAt,
+      deletedAt: deck.deletedAt,
+      scoreMax: deck.scoreMax,
+      scoreMin: deck.scoreMin,
+      selectedTags: deck.selectedTags,
+      tagAndFilter: deck.tagAndFilter,
+      category: deck.category,
+      convertToBr: deck.convertToBr,
+    })
+  );
 
 /**
  * Builds deck update dto from the supplied application values.
@@ -143,21 +210,23 @@ export const buildDeckCreateDto = (deck: Deck, createdAt: number): DeckDocument 
  * defaulting rules.
  */
 export const buildDeckUpdateDto = (deck: DeckEdit, updatedAt: number): DeckUpdateDto =>
-  omitUndefined({
-    name: deck.name,
-    url: deck.url,
-    isPublic: deck.isPublic,
-    uid: deck.uid,
-    createdAt: deck.createdAt,
-    updatedAt,
-    deletedAt: deck.deletedAt,
-    scoreMax: deck.scoreMax,
-    scoreMin: deck.scoreMin,
-    selectedTags: deck.selectedTags,
-    tagAndFilter: deck.tagAndFilter,
-    category: deck.category,
-    convertToBr: deck.convertToBr,
-  });
+  deckUpdateDtoSchema.parse(
+    omitUndefined({
+      name: deck.name,
+      url: deck.url,
+      isPublic: deck.isPublic,
+      uid: deck.uid,
+      createdAt: deck.createdAt,
+      updatedAt,
+      deletedAt: deck.deletedAt,
+      scoreMax: deck.scoreMax,
+      scoreMin: deck.scoreMin,
+      selectedTags: deck.selectedTags,
+      tagAndFilter: deck.tagAndFilter,
+      category: deck.category,
+      convertToBr: deck.convertToBr,
+    })
+  );
 
 /**
  * Builds card create dto from the supplied application values.
@@ -165,26 +234,28 @@ export const buildDeckUpdateDto = (deck: DeckEdit, updatedAt: number): DeckUpdat
  * defaulting rules.
  */
 export const buildCardCreateDto = (card: Card, createdAt: number): CardDocument =>
-  omitUndefined({
-    id: card.id,
-    frontText: card.frontText,
-    backText: card.backText,
-    tags: card.tags,
-    uniqueKey: card.uniqueKey,
-    deckId: card.deckId,
-    uid: card.uid,
-    createdAt,
-    updatedAt: createdAt,
-    deletedAt: null,
-    score: card.score,
-    numberOfSeen: card.numberOfSeen,
-    lastSeenAt: card.lastSeenAt,
-    nextSeeingAt: card.nextSeeingAt,
-    interval: card.interval,
-    url: card.url,
-    startLine: card.startLine,
-    endLine: card.endLine,
-  });
+  cardDocumentSchema.parse(
+    omitUndefined({
+      id: card.id,
+      frontText: card.frontText,
+      backText: card.backText,
+      tags: card.tags,
+      uniqueKey: card.uniqueKey,
+      deckId: card.deckId,
+      uid: card.uid,
+      createdAt,
+      updatedAt: createdAt,
+      deletedAt: null,
+      score: card.score,
+      numberOfSeen: card.numberOfSeen,
+      lastSeenAt: card.lastSeenAt,
+      nextSeeingAt: card.nextSeeingAt,
+      interval: card.interval,
+      url: card.url,
+      startLine: card.startLine,
+      endLine: card.endLine,
+    })
+  );
 
 /**
  * Builds card update dto from the supplied application values.
@@ -192,22 +263,24 @@ export const buildCardCreateDto = (card: Card, createdAt: number): CardDocument 
  * defaulting rules.
  */
 export const buildCardUpdateDto = (card: CardEdit, updatedAt: number): CardUpdateDto =>
-  omitUndefined({
-    frontText: card.frontText,
-    backText: card.backText,
-    tags: card.tags,
-    uniqueKey: card.uniqueKey,
-    deckId: card.deckId,
-    uid: card.uid,
-    createdAt: card.createdAt,
-    updatedAt,
-    deletedAt: card.deletedAt,
-    score: card.score,
-    numberOfSeen: card.numberOfSeen,
-    lastSeenAt: card.lastSeenAt,
-    nextSeeingAt: card.nextSeeingAt,
-    interval: card.interval,
-    url: card.url,
-    startLine: card.startLine,
-    endLine: card.endLine,
-  });
+  cardUpdateDtoSchema.parse(
+    omitUndefined({
+      frontText: card.frontText,
+      backText: card.backText,
+      tags: card.tags,
+      uniqueKey: card.uniqueKey,
+      deckId: card.deckId,
+      uid: card.uid,
+      createdAt: card.createdAt,
+      updatedAt,
+      deletedAt: card.deletedAt,
+      score: card.score,
+      numberOfSeen: card.numberOfSeen,
+      lastSeenAt: card.lastSeenAt,
+      nextSeeingAt: card.nextSeeingAt,
+      interval: card.interval,
+      url: card.url,
+      startLine: card.startLine,
+      endLine: card.endLine,
+    })
+  );

--- a/src/adapters/firestore/event.ts
+++ b/src/adapters/firestore/event.ts
@@ -6,7 +6,7 @@
 
 import { onSnapshot, where, collection, query } from "firebase/firestore";
 
-import { mapCardDocument, mapDeckDocument, type CardDocument, type DeckDocument } from "@/adapters/firestore/dto";
+import { mapCardDocument, mapDeckDocument } from "@/adapters/firestore/dto";
 import { getDb } from "@/adapters/firestore/runtime";
 import type { RemoteChange, RemoteSubscriptionProps } from "@/domain/remoteSnapshot";
 
@@ -28,33 +28,38 @@ const subscribeReads = <T extends RemoteEntity>(
     q,
     { includeMetadataChanges: true },
     (snapshot) => {
-      const changes = snapshot.docChanges();
-      const metadata = {
-        size: initial ? snapshot.docs.length : changes.length,
-        fromCache: snapshot.metadata.fromCache,
-        hasPendingWrites: snapshot.metadata.hasPendingWrites,
-      };
-      if (initial) {
-        initial = false;
-        const items = snapshot.docs
-          .map((document) => mapDocument(document.id, document.data()))
-          .filter((item) => item.deletedAt === null);
-        props.onSnapshot({ type: "replace", items, metadata });
-        return;
-      }
-
-      const event: RemoteChange<T> = { added: [], modified: [], removed: [] };
-      for (const change of changes) {
-        const item = mapDocument(change.doc.id, change.doc.data());
-        if (item.deletedAt !== null || change.type === "removed") {
-          event.removed.push(item.id);
-        } else if (change.type === "added") {
-          event.added.push(item);
-        } else {
-          event.modified.push(item);
+      // Treat each snapshot atomically so one invalid document cannot publish a partial collection.
+      try {
+        const changes = snapshot.docChanges();
+        const metadata = {
+          size: initial ? snapshot.docs.length : changes.length,
+          fromCache: snapshot.metadata.fromCache,
+          hasPendingWrites: snapshot.metadata.hasPendingWrites,
+        };
+        if (initial) {
+          const items = snapshot.docs
+            .map((document) => mapDocument(document.id, document.data()))
+            .filter((item) => item.deletedAt === null);
+          initial = false;
+          props.onSnapshot({ type: "replace", items, metadata });
+          return;
         }
+
+        const event: RemoteChange<T> = { added: [], modified: [], removed: [] };
+        for (const change of changes) {
+          const item = mapDocument(change.doc.id, change.doc.data());
+          if (item.deletedAt !== null || change.type === "removed") {
+            event.removed.push(item.id);
+          } else if (change.type === "added") {
+            event.added.push(item);
+          } else {
+            event.modified.push(item);
+          }
+        }
+        props.onSnapshot({ type: "change", event, metadata });
+      } catch (cause) {
+        props.onError(cause instanceof Error ? cause : new Error(String(cause)));
       }
-      props.onSnapshot({ type: "change", event, metadata });
     },
     props.onError
   );
@@ -65,11 +70,11 @@ const subscribeReads = <T extends RemoteEntity>(
  * Deck-specific mapping is supplied to the shared Firestore subscription adapter.
  */
 export const subscribeDeckReads = (props: RemoteSubscriptionProps<Deck>): Callback =>
-  subscribeReads("deck", props, (id, data) => mapDeckDocument(id, data as unknown as DeckDocument));
+  subscribeReads("deck", props, mapDeckDocument);
 
 /**
  * Subscribes to active card documents for one user.
  * Card-specific mapping is supplied to the shared Firestore subscription adapter.
  */
 export const subscribeCardReads = (props: RemoteSubscriptionProps<Card>): Callback =>
-  subscribeReads("card", props, (id, data) => mapCardDocument(id, data as unknown as CardDocument));
+  subscribeReads("card", props, mapCardDocument);

--- a/src/adapters/firestore/eventAdapter.spec.ts
+++ b/src/adapters/firestore/eventAdapter.spec.ts
@@ -170,7 +170,14 @@ describe("Firestore remote-read subscriptions", () => {
     const onSnapshot = vi.fn();
     subscribeCardReads({ uid: "uid-a", onSnapshot, onError: vi.fn() });
 
-    mocks.next?.(snapshot([document("card-a", cardDocument({ nextSeeingAt: { toDate: () => new Date(50) } }))]));
+    mocks.next?.(
+      snapshot([
+        document(
+          "card-a",
+          cardDocument({ nextSeeingAt: { seconds: 0, nanoseconds: 50_000_000, toDate: () => new Date(50) } })
+        ),
+      ])
+    );
     expect(onSnapshot).toHaveBeenLastCalledWith({
       type: "replace",
       items: [expect.objectContaining({ id: "card-a", nextSeeingAt: new Date(50) })],
@@ -187,6 +194,59 @@ describe("Firestore remote-read subscriptions", () => {
       },
       metadata: { size: 1, fromCache: false, hasPendingWrites: false },
     });
+  });
+
+  it("forwards initial document validation errors without emitting a partial snapshot", () => {
+    const onSnapshot = vi.fn();
+    const onError = vi.fn();
+    subscribeCardReads({ uid: "uid-a", onSnapshot, onError });
+
+    expect(() =>
+      mocks.next?.(
+        snapshot([
+          document("card-valid", cardDocument()),
+          document("card-invalid", cardDocument({ nextSeeingAt: null })),
+        ])
+      )
+    ).not.toThrow();
+
+    expect(onSnapshot).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "FirestoreDocumentValidationError",
+        documentId: "card-invalid",
+        message: expect.stringContaining("nextSeeingAt"),
+      })
+    );
+  });
+
+  it("forwards change validation errors without emitting a partial delta", () => {
+    const onSnapshot = vi.fn();
+    const onError = vi.fn();
+    subscribeDeckReads({ uid: "uid-a", onSnapshot, onError });
+    mocks.next?.(snapshot([]));
+    onSnapshot.mockClear();
+
+    expect(() =>
+      mocks.next?.(
+        snapshot(
+          [],
+          [
+            { type: "added", doc: document("deck-valid", deckDocument()) },
+            { type: "added", doc: document("deck-invalid", deckDocument({ selectedTags: [42] })) },
+          ]
+        )
+      )
+    ).not.toThrow();
+
+    expect(onSnapshot).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "FirestoreDocumentValidationError",
+        documentId: "deck-invalid",
+        message: expect.stringContaining("selectedTags.0"),
+      })
+    );
   });
 
   it("emits metadata-only snapshots so pending writes can become synced", () => {

--- a/src/adapters/firestore/read.spec.ts
+++ b/src/adapters/firestore/read.spec.ts
@@ -79,4 +79,28 @@ describe("Firestore full reads", () => {
     await expect(deckAdapter.readAll("uid", db)).resolves.toEqual([]);
     await expect(cardAdapter.readAll("uid", db)).resolves.toEqual([]);
   });
+
+  it("rejects an invalid Deck document with its field path", async () => {
+    const deck = createDeck({ id: uuid(), uid: "uid" });
+    await seed("deck", deck.id, { ...buildDeckCreateDto(deck, deck.createdAt), selectedTags: [42] });
+
+    await expect(deckAdapter.readAll("uid", db)).rejects.toMatchObject({
+      name: "FirestoreDocumentValidationError",
+      collectionName: "deck",
+      documentId: deck.id,
+      message: expect.stringContaining("selectedTags.0"),
+    });
+  });
+
+  it("rejects an invalid Card nextSeeingAt with its field path", async () => {
+    const card = createCard({ id: uuid(), uid: "uid" });
+    await seed("card", card.id, { ...buildCardCreateDto(card, card.createdAt), nextSeeingAt: null });
+
+    await expect(cardAdapter.readAll("uid", db)).rejects.toMatchObject({
+      name: "FirestoreDocumentValidationError",
+      collectionName: "card",
+      documentId: card.id,
+      message: expect.stringContaining("nextSeeingAt"),
+    });
+  });
 });

--- a/src/firebase.spec.ts
+++ b/src/firebase.spec.ts
@@ -148,6 +148,20 @@ describe("Firebase singletons", () => {
     expect(connectAuthEmulator).toHaveBeenCalledWith(auth, "http://127.0.0.1:9099");
   });
 
+  it.each([
+    ["host", "", "9099"],
+    ["port", "127.0.0.1", ""],
+  ])("does not connect auth when the emulator %s is missing", async (_missingSetting, host, port) => {
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_AUTH_HOST", host);
+    vi.stubEnv("VITE_AUTH_PORT", port);
+
+    await import("@/firebase");
+
+    expect(connectAuthEmulator).not.toHaveBeenCalled();
+  });
+
   it("does not connect auth to the emulator in production", async () => {
     vi.stubEnv("MODE", "production");
     vi.stubEnv("DEV", false);

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -28,8 +28,8 @@ initializeFirestoreAdapter(app);
 
 export { getDb, getFirestoreInitializationState, waitForFirestoreInitialization };
 
-if (import.meta.env.DEV) {
-  const host = import.meta.env.VITE_AUTH_HOST;
-  const port = import.meta.env.VITE_AUTH_PORT;
-  connectAuthEmulator(auth, `http://${host}:${port}`);
+const authEmulatorHost = import.meta.env.VITE_AUTH_HOST;
+const authEmulatorPort = import.meta.env.VITE_AUTH_PORT;
+if (import.meta.env.DEV && authEmulatorHost && authEmulatorPort) {
+  connectAuthEmulator(auth, `http://${authEmulatorHost}:${authEmulatorPort}`);
 }


### PR DESCRIPTION
## Summary

- add shared Zod runtime schemas for Deck and Card Firestore documents and write DTOs
- validate one-shot reads and subscriptions before mapping storage data
- accept Firestore Timestamp and legacy Date values for `nextSeeingAt`, while rejecting malformed values with document IDs and field paths
- treat each snapshot atomically and forward validation or mapping failures to the Remote Store error path
- add valid, legacy-compatible, invalid, subscription, one-shot read, and write-contract regression tests

## Why

Firestore data was previously trusted through TypeScript casts, which do not validate runtime values. A malformed or partially migrated document could therefore throw inside a mapper—especially when `nextSeeingAt.toDate()` was called—and leave the Remote Store loading or crash the application.

## Impact

Invalid documents now fail predictably at the Firestore boundary. A snapshot containing an invalid document does not publish a partial collection; the whole snapshot reports an error to the existing Remote Store and UI error flow.

## Validation

- `make check` (100 test files, 750 tests)
- `make test-firestore` (11 test files, 84 tests)

Closes #390