### PR TITLE
Stop stalled deck writes from loading indefinitely

### DIFF
--- a/src/firebase.spec.ts
+++ b/src/firebase.spec.ts
@@ -151,6 +151,19 @@ describe("Firebase singletons", () => {
   it("does not connect auth to the emulator in production", async () => {
     vi.stubEnv("MODE", "production");
     vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_AUTH_HOST", "127.0.0.1");
+    vi.stubEnv("VITE_AUTH_PORT", "9099");
+
+    await import("@/firebase");
+
+    expect(connectAuthEmulator).not.toHaveBeenCalled();
+  });
+
+  it("does not connect auth to an invalid URL when the emulator is not configured", async () => {
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_AUTH_HOST", "");
+    vi.stubEnv("VITE_AUTH_PORT", "");
 
     await import("@/firebase");
 

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -28,8 +28,8 @@ initializeFirestoreAdapter(app);
 
 export { getDb, getFirestoreInitializationState, waitForFirestoreInitialization };
 
-if (import.meta.env.DEV) {
-  const host = import.meta.env.VITE_AUTH_HOST;
-  const port = import.meta.env.VITE_AUTH_PORT;
-  connectAuthEmulator(auth, `http://${host}:${port}`);
+const authHost = import.meta.env.VITE_AUTH_HOST;
+const authPort = import.meta.env.VITE_AUTH_PORT;
+if (import.meta.env.DEV && authHost && authPort) {
+  connectAuthEmulator(auth, `http://${authHost}:${authPort}`);
 }

--- a/src/services/cardCommands.spec.ts
+++ b/src/services/cardCommands.spec.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { REMOTE_WRITE_TIMEOUT_MS } from "@/services/remoteWrite";
 import { createCard as createCardFixture } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -27,6 +28,10 @@ describe("card commands", () => {
     mocks.update.mockResolvedValue(undefined);
     mocks.logicalRemove.mockResolvedValue(undefined);
     mocks.upsert.mockResolvedValue("upserted");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("rejects missing users and mismatched owners before writing", async () => {
@@ -65,6 +70,21 @@ describe("card commands", () => {
       failedIds: [second.id],
       message: "1 of 2 Card writes failed",
     });
+  });
+
+  it("reports stalled Card imports instead of leaving them pending", async () => {
+    vi.useFakeTimers();
+    const card = createCard({ id: "stalled-import" });
+    mocks.upsert.mockReturnValueOnce(new Promise(() => undefined));
+    const operation = cardCommands.bulkUpsert("uid-a", [card]);
+    const assertion = expect(operation).rejects.toMatchObject({
+      failedIds: [card.id],
+      message: "1 of 1 Card writes failed",
+    });
+
+    await vi.advanceTimersByTimeAsync(REMOTE_WRITE_TIMEOUT_MS);
+
+    await assertion;
   });
 
   it("logically removes a Card by id", async () => {

--- a/src/services/cardCommands.ts
+++ b/src/services/cardCommands.ts
@@ -10,6 +10,7 @@ import {
   withDeckMembershipLocks,
   withMutationLocks,
 } from "@/store/remoteMutationLocks";
+import { waitForRemoteWrite } from "@/services/remoteWrite";
 
 const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Card writes");
@@ -40,18 +41,22 @@ export const cardCommands = {
   create: async (uid: string, card: Card): Promise<void> => {
     requireUid(uid);
     requireOwner(uid, card.uid);
-    await withCardWriteLocks(uid, card.id, card.deckId, () => createRemoteCard(card));
+    await withCardWriteLocks(uid, card.id, card.deckId, () =>
+      waitForRemoteWrite(createRemoteCard(card), "Card creation")
+    );
   },
 
   update: async (uid: string, card: CardEdit): Promise<void> => {
     requireUid(uid);
     requireOwner(uid, card.uid);
-    await withCardWriteLocks(uid, card.id, card.deckId, () => updateRemoteCard(card));
+    await withCardWriteLocks(uid, card.id, card.deckId, () =>
+      waitForRemoteWrite(updateRemoteCard(card), "Card update")
+    );
   },
 
   remove: async (uid: string, id: CardId, deckId: DeckId): Promise<void> => {
     requireUid(uid);
-    await withCardWriteLocks(uid, id, deckId, () => removeRemoteCard(id));
+    await withCardWriteLocks(uid, id, deckId, () => waitForRemoteWrite(removeRemoteCard(id), "Card deletion"));
   },
 
   bulkUpsert: async (uid: string, cards: Card[]): Promise<void> => {
@@ -61,7 +66,9 @@ export const cardCommands = {
     }
 
     const results = await Promise.allSettled(
-      cards.map((card) => withCardWriteLocks(uid, card.id, card.deckId, () => upsertRemoteCard(card)))
+      cards.map((card) =>
+        withCardWriteLocks(uid, card.id, card.deckId, () => waitForRemoteWrite(upsertRemoteCard(card), "Card import"))
+      )
     );
     const failedIds = results.flatMap((result, index) => {
       const card = cards[index];

--- a/src/services/deckCommands.spec.ts
+++ b/src/services/deckCommands.spec.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { REMOTE_WRITE_TIMEOUT_MS } from "@/services/remoteWrite";
 import { createCard as createCardFixture, createDeck as createDeckFixture } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -46,6 +47,10 @@ describe("deck commands", () => {
     cardMocks.upsert.mockResolvedValue("upserted");
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("rejects missing users and mismatched owners before writing", async () => {
     await expect(deckCommands.create("", createDeck())).rejects.toThrow("confirmed user");
     await expect(deckCommands.remove("uid-a", createDeck({ uid: "uid-b" }))).rejects.toThrow("owner does not match");
@@ -90,6 +95,21 @@ describe("deck commands", () => {
 
     finishFirst();
     await Promise.all([firstUpdate, secondUpdate]);
+  });
+
+  it.each([
+    ["create", "Deck creation"],
+    ["update", "Deck update"],
+    ["remove", "Deck deletion"],
+  ] as const)("rejects a stalled Deck %s instead of leaving it pending", async (command, label) => {
+    vi.useFakeTimers();
+    mocks[command].mockReturnValueOnce(new Promise(() => undefined));
+    const operation = deckCommands[command]("uid-a", createDeck({ id: `stalled-${command}` }));
+    const assertion = expect(operation).rejects.toThrow(`${label} did not finish`);
+
+    await vi.advanceTimersByTimeAsync(REMOTE_WRITE_TIMEOUT_MS);
+
+    await assertion;
   });
 
   it("waits to write a Card while its Deck is being removed", async () => {

--- a/src/services/deckCommands.ts
+++ b/src/services/deckCommands.ts
@@ -9,6 +9,7 @@ import {
   withDeckMembershipLocks,
   withMutationLocks,
 } from "@/store/remoteMutationLocks";
+import { waitForRemoteWrite } from "@/services/remoteWrite";
 
 const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
@@ -24,13 +25,17 @@ export const deckCommands = {
   create: async (uid: string, deck: Deck): Promise<void> => {
     requireUid(uid);
     requireOwner(uid, deck.uid);
-    await withMutationLocks([deckMutationLock(uid, deck.id)], () => createRemoteDeck(deck));
+    await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
+      waitForRemoteWrite(createRemoteDeck(deck), "Deck creation")
+    );
   },
 
   update: async (uid: string, deck: DeckEdit): Promise<void> => {
     requireUid(uid);
     requireOwner(uid, deck.uid);
-    await withMutationLocks([deckMutationLock(uid, deck.id)], () => updateRemoteDeck(deck));
+    await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
+      waitForRemoteWrite(updateRemoteDeck(deck), "Deck update")
+    );
   },
 
   remove: async (uid: string, deck: Deck): Promise<void> => {
@@ -38,7 +43,7 @@ export const deckCommands = {
     requireOwner(uid, deck.uid);
     await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
       withDeckMembershipLocks([deckMembershipMutationLock(uid, deck.id)], "exclusive", () =>
-        removeRemoteDeck(deck.id, uid)
+        waitForRemoteWrite(removeRemoteDeck(deck.id, uid), "Deck deletion")
       )
     );
   },

--- a/src/services/remoteWrite.spec.ts
+++ b/src/services/remoteWrite.spec.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RemoteWriteTimeoutError, waitForRemoteWrite } from "@/services/remoteWrite";
+
+describe("waitForRemoteWrite", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a remote write result before the deadline", async () => {
+    await expect(waitForRemoteWrite(Promise.resolve("saved"), "Deck update")).resolves.toBe("saved");
+  });
+
+  it("preserves a remote write failure", async () => {
+    const failure = new Error("permission denied");
+
+    await expect(waitForRemoteWrite(Promise.reject(failure), "Deck update")).rejects.toBe(failure);
+  });
+
+  it("rejects a stalled remote write at the deadline", async () => {
+    vi.useFakeTimers();
+    const operation = waitForRemoteWrite(new Promise(() => undefined), "Deck update", 1_000);
+    const assertion = expect(operation).rejects.toEqual(new RemoteWriteTimeoutError("Deck update", 1_000));
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await assertion;
+  });
+});

--- a/src/services/remoteWrite.ts
+++ b/src/services/remoteWrite.ts
@@ -1,0 +1,25 @@
+export const REMOTE_WRITE_TIMEOUT_MS = 15_000;
+
+export class RemoteWriteTimeoutError extends Error {
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} did not finish within ${timeoutMs / 1000} seconds. Check your connection and retry.`);
+    this.name = "RemoteWriteTimeoutError";
+  }
+}
+
+export const waitForRemoteWrite = async <T>(
+  operation: Promise<T>,
+  name: string,
+  timeoutMs = REMOTE_WRITE_TIMEOUT_MS
+): Promise<T> => {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new RemoteWriteTimeoutError(name, timeoutMs)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operation, deadline]);
+  } finally {
+    if (timeout != null) clearTimeout(timeout);
+  }
+};


### PR DESCRIPTION
## Summary

- cap remote Deck and Card write acknowledgements at 15 seconds
- route stalled Deck edits, deletions, and imports into the existing error and retry state instead of leaving loading active forever
- cover stalled Deck create/update/delete and Card import writes with regression tests

## Testing

- `make check` (757 tests passed)