### PR TITLE
Unify Deck and Card deletion dialogs

### DIFF
--- a/e2e/card.e2e.ts
+++ b/e2e/card.e2e.ts
@@ -115,11 +115,24 @@ test("saves card edits and returns to the card list", async ({ page }) => {
 test("deletes a card from the card list", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
-  page.on("dialog", (dialog) => dialog.accept());
-  await page.getByRole("button", { name: "Open actions for apple" }).click();
+  const trigger = page.getByRole("button", { name: "Open actions for apple" });
+  await trigger.click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
+  const dialog = page.getByRole("alertdialog", { name: "Delete card?" });
+  await expect(dialog).toContainText("apple");
+  await expect(dialog).toContainText("cannot be undone");
+  await expect(page.getByRole("button", { name: "Cancel" })).toBeFocused();
+
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(trigger).toBeFocused();
+  await expect(page.getByText("apple")).toBeVisible();
+
+  await trigger.click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Delete card" }).click();
 
   await expect(page.getByText("apple")).not.toBeVisible();
+  await expect(page.getByText("Deleted card “apple”.")).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });
 

--- a/e2e/card.e2e.ts
+++ b/e2e/card.e2e.ts
@@ -129,9 +129,9 @@ test("deletes a card from the card list", async ({ page }) => {
 
   await trigger.click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
-  await page.getByRole("button", { name: "Delete card" }).click();
+  await dialog.getByRole("button", { name: "Delete card" }).click();
 
-  await expect(page.getByText("apple")).not.toBeVisible();
+  await expect(page.getByRole("button", { name: "View apple", exact: true })).toHaveCount(0);
   await expect(page.getByText("Deleted card “apple”.")).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });

--- a/e2e/deck-list.e2e.ts
+++ b/e2e/deck-list.e2e.ts
@@ -89,3 +89,28 @@ test("keeps independent progress for multiple studying decks", async ({ page }) 
   await expect(page.getByRole("button", { name: "Continue Deck B" })).not.toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });
+
+test("explains and confirms deck deletion", async ({ page }) => {
+  await page.goto("/");
+
+  const trigger = page.getByRole("button", { name: "Open actions for Deck A" });
+  await trigger.click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  const dialog = page.getByRole("alertdialog", { name: "Delete deck?" });
+  await expect(dialog).toContainText("Deck A");
+  await expect(dialog).toContainText("2 cards");
+  await expect(dialog).toContainText("in-progress study session");
+  await expect(dialog).toContainText("cannot be undone");
+
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(trigger).toBeFocused();
+  await expect(page.getByRole("button", { name: "View Deck A" })).toBeVisible();
+
+  await trigger.click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Delete deck" }).click();
+
+  await expect(page.getByRole("button", { name: "View Deck A" })).not.toBeVisible();
+  await expect(page.getByText("Deleted deck “Deck A”.")).toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});

--- a/e2e/deck.e2e.ts
+++ b/e2e/deck.e2e.ts
@@ -86,10 +86,12 @@ test("saves deck edits and returns to the deck list", async ({ page }) => {
 test("deletes a deck from the deck list", async ({ page }) => {
   await page.goto("/");
 
-  page.on("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "Open actions for E2E Deck" }).click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
+  const dialog = page.getByRole("alertdialog", { name: "Delete deck?" });
+  await dialog.getByRole("button", { name: "Delete deck" }).click();
 
-  await expect(page.getByText("E2E Deck")).not.toBeVisible();
+  await expect(page.getByRole("button", { name: "View E2E Deck", exact: true })).toHaveCount(0);
+  await expect(page.getByText("Deleted deck “E2E Deck”.")).toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -184,15 +184,18 @@ test("loads UID-scoped remote Decks and Cards again after reload", async ({ page
 
   await expect(page.getByText("Updated Remote Query Card")).toBeVisible();
 
-  page.on("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "Open actions for Updated Remote Query Card" }).click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
-  await expect(page.getByText("Updated Remote Query Card")).not.toBeVisible();
+  const cardDialog = page.getByRole("alertdialog", { name: "Delete card?" });
+  await cardDialog.getByRole("button", { name: "Delete card" }).click();
+  await expect(page.getByRole("button", { name: "View Updated Remote Query Card", exact: true })).toHaveCount(0);
 
   await page.goto("/");
   await page.getByRole("button", { name: "Open actions for Updated Remote Query Deck" }).click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
-  await expect(page.getByText("Updated Remote Query Deck")).not.toBeVisible();
+  const deckDialog = page.getByRole("alertdialog", { name: "Delete deck?" });
+  await deckDialog.getByRole("button", { name: "Delete deck" }).click();
+  await expect(page.getByRole("button", { name: "View Updated Remote Query Deck", exact: true })).toHaveCount(0);
 
   const persistedEntityState = await page.evaluate(() => {
     const root = JSON.parse(window.localStorage.getItem("tango-config") ?? "{}") as {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@biomejs/biome": "2.5.3",
-        "@firebase/rules-unit-testing": "^3.0.4",
+        "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/test": "^1.61.1",
         "@rolldown/plugin-babel": "^0.2.3",
         "@storybook/addon-docs": "^10.4.6",
@@ -3310,20 +3310,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/rules-unit-testing": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-3.0.4.tgz",
-      "integrity": "sha512-FxDc5rnTtt266PTs3dOkf4ZDq+P223TrFWXka/yG6gSFy3Es/iKwWh3bX9pROobHgbbrAd7she9+687yOC2z+A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.1.tgz",
+      "integrity": "sha512-EvbxUvgoY2cG7vgtdhKc7gjalKzeO3AWr2NiUuyEEmcXaSaOJanV3hXLj3Viigs+Y/jFYQmtVPpSoiwUs/ZlPg==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node-fetch": "2.6.4",
-        "node-fetch": "2.6.7"
-      },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "firebase": "^10.0.0"
+        "firebase": "^12.0.0"
       }
     },
     "node_modules/@firebase/storage": {
@@ -7867,16 +7863,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
       }
     },
     "node_modules/@types/papaparse": {
@@ -12482,23 +12468,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
-      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/formdata-polyfill": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@biomejs/biome": "2.5.3",
-    "@firebase/rules-unit-testing": "^3.0.4",
+    "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/test": "^1.61.1",
     "@rolldown/plugin-babel": "^0.2.3",
     "@storybook/addon-docs": "^10.4.6",

--- a/src/components/feedback/DestructiveActionDialog.spec.tsx
+++ b/src/components/feedback/DestructiveActionDialog.spec.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DestructiveActionDialog } from "@/components/feedback/DestructiveActionDialog";
+
+const defaultProps = {
+  title: "Delete deck?",
+  targetLabel: "Deck",
+  targetName: "Japanese verbs",
+  description: <p>This permanently deletes 12 cards and cannot be undone.</p>,
+  confirmLabel: "Delete deck",
+  onCancel: vi.fn(),
+  onConfirm: vi.fn(),
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("DestructiveActionDialog", () => {
+  it("labels the alert dialog with the target and explanation", () => {
+    const view = render(<DestructiveActionDialog {...defaultProps} />);
+
+    const dialog = view.getByRole("alertdialog", { name: "Delete deck?" });
+    expect(dialog).toHaveAccessibleDescription(expect.stringContaining("Japanese verbs"));
+    expect(dialog).toHaveAccessibleDescription(expect.stringContaining("cannot be undone"));
+  });
+
+  it("focuses Cancel first, traps Tab, and closes with Escape", async () => {
+    const onCancel = vi.fn();
+    const view = render(<DestructiveActionDialog {...defaultProps} onCancel={onCancel} />);
+    const cancel = view.getByRole("button", { name: "Cancel" });
+    const confirm = view.getByRole("button", { name: "Delete deck" });
+
+    expect(cancel).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(confirm).toHaveFocus();
+    await userEvent.tab();
+    expect(cancel).toHaveFocus();
+
+    fireEvent.keyDown(cancel, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("restores focus to the control that opened it", async () => {
+    const Example = () => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open delete
+          </button>
+          {open && <DestructiveActionDialog {...defaultProps} onCancel={() => setOpen(false)} />}
+        </>
+      );
+    };
+    const view = render(<Example />);
+    const trigger = view.getByRole("button", { name: "Open delete" });
+
+    await userEvent.click(trigger);
+    await userEvent.click(view.getByRole("button", { name: "Cancel" }));
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it("announces pending work and prevents duplicate confirmation", async () => {
+    const onConfirm = vi.fn();
+    const view = render(<DestructiveActionDialog {...defaultProps} pending onConfirm={onConfirm} />);
+
+    expect(view.getByRole("alertdialog")).toHaveAttribute("aria-busy", "true");
+    expect(view.getByRole("button", { name: "Delete deck" })).toBeDisabled();
+    await userEvent.click(view.getByRole("button", { name: "Delete deck" }));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("prevents duplicate confirmation before pending props update", () => {
+    const onConfirm = vi.fn(() => new Promise<void>(() => {}));
+    const view = render(<DestructiveActionDialog {...defaultProps} onConfirm={onConfirm} />);
+    const confirm = view.getByRole("button", { name: "Delete deck" });
+
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/feedback/DestructiveActionDialog.stories.tsx
+++ b/src/components/feedback/DestructiveActionDialog.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+
+import { DestructiveActionDialog as Template } from "@/components/feedback/DestructiveActionDialog";
+import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
+
+const meta = {
+  title: "Shared/Feedback/DestructiveActionDialog",
+  component: Template,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    viewport: { viewports: INITIAL_VIEWPORTS, defaultViewport: "desktop" },
+  },
+  args: {
+    title: "Delete deck?",
+    targetLabel: "Deck",
+    targetName: "Japanese verbs",
+    description: (
+      <>
+        <p>This permanently deletes 24 cards.</p>
+        <p>Any in-progress study session for this deck will also end. This action cannot be undone.</p>
+      </>
+    ),
+    confirmLabel: "Delete deck",
+    onCancel: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof Template>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Deck: Story = {};
+
+export const Card: Story = {
+  args: {
+    title: "Delete card?",
+    targetLabel: "Card front",
+    targetName:
+      "A long card front remains available to assistive technology and scrolls instead of overflowing the dialog on small screens.",
+    description: <p>This permanently deletes this card. This action cannot be undone.</p>,
+    confirmLabel: "Delete card",
+  },
+};
+
+export const Pending: Story = { args: { pending: true } };
+
+export const Failure: Story = {
+  args: { errorMessage: "Unable to delete this deck. Check your connection and try again." },
+};
+
+export const Mobile: Story = {
+  ...Card,
+  parameters: { viewport: { defaultViewport: "iphonex" } },
+};
+
+export const Dark: Story = { globals: { theme: "dark" } };

--- a/src/components/feedback/DestructiveActionDialog.tsx
+++ b/src/components/feedback/DestructiveActionDialog.tsx
@@ -1,0 +1,135 @@
+import * as React from "react";
+
+import { Button } from "@/components/forms/Button";
+
+export interface DestructiveActionDialogProps {
+  title: string;
+  targetLabel: string;
+  targetName: string;
+  description: React.ReactNode;
+  confirmLabel: string;
+  pending?: boolean;
+  errorMessage?: string;
+  onCancel: () => void;
+  onConfirm: () => unknown;
+}
+
+const focusableSelector = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (props) => {
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const cancelRef = React.useRef<HTMLButtonElement>(null);
+  const confirmingRef = React.useRef(false);
+  const titleId = React.useId();
+  const targetId = React.useId();
+  const descriptionId = React.useId();
+  const errorId = React.useId();
+
+  React.useEffect(() => {
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    cancelRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onCancel();
+      return;
+    }
+    if (event.key !== "Tab") return;
+
+    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? []);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable.at(-1);
+    if (first == null || last == null) return;
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const describedBy = [targetId, descriptionId, props.errorMessage != null ? errorId : null]
+    .filter((id) => id != null)
+    .join(" ");
+
+  const handleConfirm = () => {
+    if (props.pending || confirmingRef.current) return;
+    confirmingRef.current = true;
+    try {
+      void Promise.resolve(props.onConfirm()).finally(() => {
+        confirmingRef.current = false;
+      });
+    } catch (error) {
+      confirmingRef.current = false;
+      throw error;
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-canvas/70 px-shell-gutter py-6">
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={describedBy}
+        aria-busy={props.pending || undefined}
+        className="w-full max-w-reading rounded-surface border border-border bg-surface-elevated p-4 text-ink shadow-elevated sm:p-6"
+        onKeyDown={handleKeyDown}
+      >
+        <h2 id={titleId} className="text-title font-bold">
+          {props.title}
+        </h2>
+        <div id={targetId} className="mt-4 rounded-control bg-surface-muted p-3">
+          <span className="block text-caption font-bold uppercase tracking-wide text-ink-muted">
+            {props.targetLabel}
+          </span>
+          <span className="mt-1 block max-h-24 overflow-y-auto break-words font-semibold">{props.targetName}</span>
+        </div>
+        <div id={descriptionId} className="mt-4 space-y-2 text-body text-ink-muted">
+          {props.description}
+        </div>
+        {props.errorMessage != null && (
+          <p id={errorId} role="alert" className="mt-4 rounded-control border border-danger p-3 text-body text-danger">
+            {props.errorMessage}
+          </p>
+        )}
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-control border border-border bg-transparent px-4 py-2 font-bold text-ink hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+            onClick={props.onCancel}
+          >
+            Cancel
+          </button>
+          <Button variant="destructive" loading={Boolean(props.pending)} onClick={handleConfirm}>
+            {props.confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "@/components/content/Card";
 export * from "@/components/content/Code";
 export * from "@/components/content/Description";
 export * from "@/components/feedback/Feedback";
+export * from "@/components/feedback/DestructiveActionDialog";
 export * from "@/components/feedback/RouteFeedback";
 export * from "@/components/feedback/RemoteReadBoundary";
 export * from "@/components/feedback/RemoteMutationNotice";

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -33,6 +33,7 @@ export interface CardListTemplateProps {
   onShowCard?: (card: Card) => void;
   onRemoveTag?: (tag: string) => void;
   feedbackSlot?: React.ReactNode;
+  dialogSlot?: React.ReactNode;
   isCardPending?: (id: CardId) => boolean;
 }
 
@@ -114,6 +115,7 @@ export const CardListTemplate: React.FC<CardListTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
       {props.feedbackSlot}
+      {props.dialogSlot}
       {props.overlay != null && (
         <Overlay
           position="center"

--- a/src/features/card/containers/CardListContainer.spec.tsx
+++ b/src/features/card/containers/CardListContainer.spec.tsx
@@ -25,12 +25,19 @@ const mocks = vi.hoisted(() => ({
   cardRemove: vi.fn(),
   onClickTag: vi.fn(),
   navigate: vi.fn(),
+  onRemoveSuccess: undefined as ((card: Card) => void) | undefined,
 }));
 
 vi.mock("@/features/card/hooks/useCardMutations", () => ({
-  useCardMutations: () => ({
+  useCardMutations: (options?: { onRemoveSuccess?: (card: Card) => void }) => ({
     updateBy: mocks.cardUpdateBy,
-    remove: mocks.cardRemove,
+    remove: (id: CardId) => {
+      mocks.onRemoveSuccess = options?.onRemoveSuccess;
+      return mocks.cardRemove(id).then(() => {
+        const card = mocks.cards.find((candidate) => candidate.id === id);
+        if (card != null) mocks.onRemoveSuccess?.(card);
+      });
+    },
     isPending: (id: CardId) => id === mocks.pendingCardId,
     pending: mocks.pending,
     error: mocks.error,
@@ -148,6 +155,7 @@ describe("CardListContainer", () => {
     mocks.cardRemove.mockReset().mockResolvedValue(undefined);
     mocks.onClickTag.mockReset();
     mocks.navigate.mockReset();
+    mocks.onRemoveSuccess = undefined;
   });
 
   afterEach(() => {
@@ -175,7 +183,7 @@ describe("CardListContainer", () => {
   });
 
   it("preserves Edit, Delete, and left/right swipe connections", async () => {
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirm = vi.spyOn(window, "confirm");
     const view = render(<CardListContainer />);
     const trigger = view.getByRole("button", { name: `Open actions for ${card.frontText}` });
 
@@ -185,14 +193,19 @@ describe("CardListContainer", () => {
 
     await userEvent.click(trigger);
     await userEvent.click(view.getByRole("menuitem", { name: "Delete" }));
-    expect(confirm).toHaveBeenCalledOnce();
-    expect(mocks.cardRemove).toHaveBeenCalledExactlyOnceWith(card.id);
+    const dialog = view.getByRole("alertdialog", { name: "Delete card?" });
+    expect(dialog).toHaveTextContent(card.frontText);
+    expect(dialog).toHaveTextContent("cannot be undone");
+    await userEvent.click(view.getByRole("button", { name: "Cancel" }));
+    expect(mocks.cardRemove).not.toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
 
-    confirm.mockReturnValue(false);
     await userEvent.click(trigger);
     await userEvent.click(view.getByRole("menuitem", { name: "Delete" }));
-    expect(confirm).toHaveBeenCalledTimes(2);
+    await userEvent.click(view.getByRole("button", { name: "Delete card" }));
     expect(mocks.cardRemove).toHaveBeenCalledOnce();
+    expect(view.getByText(`Deleted card “${card.frontText}”.`).closest('[role="status"]')).toBeInTheDocument();
+    expect(confirm).not.toHaveBeenCalled();
 
     const article = view.getByRole("article");
     fireEvent.mouseDown(article, { clientX: 100, clientY: 0 });
@@ -223,6 +236,22 @@ describe("CardListContainer", () => {
     mocks.error = new Error("write failed");
     view.rerender(<CardListContainer />);
     expect(view.getByRole("alert")).toHaveTextContent("Unable to save changes.");
+    await userEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(mocks.retry).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a failed Card deletion explainable and retryable", async () => {
+    mocks.cardRemove.mockRejectedValueOnce(new Error("delete failed"));
+    const view = render(<CardListContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: `Open actions for ${card.frontText}` }));
+    await userEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+    await userEvent.click(view.getByRole("button", { name: "Delete card" }));
+
+    expect(view.getByRole("alertdialog", { name: "Delete card?" })).toBeInTheDocument();
+    expect(view.getByText("Unable to delete this card. Check your connection and try again.")).toBeInTheDocument();
+    mocks.error = new Error("delete failed");
+    view.rerender(<CardListContainer />);
     await userEvent.click(view.getByRole("button", { name: "Retry" }));
     expect(mocks.retry).toHaveBeenCalledOnce();
   });

--- a/src/features/card/containers/CardListContainer.tsx
+++ b/src/features/card/containers/CardListContainer.tsx
@@ -11,7 +11,13 @@ import { useKey } from "react-use";
 import * as C from "@/constant";
 import * as util from "@/util";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
-import { RemoteMutationNotice, RemoteReadBoundary, RouteFeedback } from "@/components";
+import {
+  DestructiveActionDialog,
+  Feedback,
+  RemoteMutationNotice,
+  RemoteReadBoundary,
+  RouteFeedback,
+} from "@/components";
 import { useActions } from "@/hooks/useActions";
 import { CardListTemplate } from "@/features/card/components/templates/CardListTemplate";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
@@ -29,8 +35,17 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
   const { deck, cards, tags, config } = props;
   const deckId = deck.id;
   const [showCard, setShowCard] = React.useState<Card>();
+  const [deletionTarget, setDeletionTarget] = React.useState<Card>();
+  const [deletionErrorCardId, setDeletionErrorCardId] = React.useState<CardId>();
+  const [successMessage, setSuccessMessage] = React.useState<string>();
   const actions = useActions();
-  const mutations = useCardMutations();
+  const mutations = useCardMutations({
+    onRemoveSuccess: (card) => {
+      setDeletionTarget((target) => (target?.id === card.id ? undefined : target));
+      setDeletionErrorCardId((id) => (id === card.id ? undefined : id));
+      setSuccessMessage(`Deleted card “${card.frontText}”.`);
+    },
+  });
   const deckActions = useDeckActions(deckId);
   const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
   /**
@@ -70,11 +85,50 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
           void mutations.updateBy(id, (card) => ({ score: card.score + 1 })).catch(() => undefined),
         goToEdit: actions.goToCardEdit,
         onDelete: (id) => {
-          if (window.confirm("Are you sure?")) void mutations.remove(id).catch(() => undefined);
+          const card = cards.find((candidate) => candidate.id === id);
+          if (card != null) {
+            setSuccessMessage(undefined);
+            setDeletionErrorCardId(undefined);
+            setDeletionTarget(card);
+          }
         },
       }}
       feedbackSlot={
-        <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
+        <>
+          <RemoteMutationNotice
+            pending={mutations.pending}
+            error={mutations.error}
+            onRetry={mutations.retry}
+            {...(deletionTarget != null ? { pendingLabel: "Deleting card…" } : {})}
+          />
+          <Feedback tone="success">{successMessage}</Feedback>
+        </>
+      }
+      dialogSlot={
+        deletionTarget != null ? (
+          <DestructiveActionDialog
+            title="Delete card?"
+            targetLabel="Card front"
+            targetName={deletionTarget.frontText}
+            description={
+              <>
+                <p>This permanently deletes this card.</p>
+                <p>This action cannot be undone.</p>
+              </>
+            }
+            confirmLabel="Delete card"
+            pending={mutations.isPending(deletionTarget.id)}
+            {...(deletionErrorCardId === deletionTarget.id
+              ? { errorMessage: "Unable to delete this card. Check your connection and try again." }
+              : {})}
+            onCancel={() => setDeletionTarget(undefined)}
+            onConfirm={() =>
+              mutations.remove(deletionTarget.id).catch(() => {
+                setDeletionErrorCardId(deletionTarget.id);
+              })
+            }
+          />
+        ) : null
       }
       isCardPending={mutations.isPending}
       {...(showCard != null && category != null

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -61,14 +61,16 @@ describe("useCardMutations", () => {
 
   it("uses the current Card for updateBy and remove", async () => {
     const card = createCard({ id: "card", score: 0 });
+    const onRemoveSuccess = vi.fn();
     mocks.card = card;
-    const { result } = renderHook(useCardMutations);
+    const { result } = renderHook(() => useCardMutations({ onRemoveSuccess }));
 
     await act(async () => result.current.updateBy(card.id, () => ({ score: 2 })));
     await act(async () => result.current.remove(card.id));
 
     expect(mocks.update).toHaveBeenCalledWith({ id: card.id, deckId: card.deckId, score: 2 });
     expect(mocks.logicalRemove).toHaveBeenCalledWith(card.id);
+    expect(onRemoveSuccess).toHaveBeenCalledExactlyOnceWith(card);
   });
 
   it("does not allow updateBy patches to redirect the target Card", async () => {
@@ -144,6 +146,22 @@ describe("useCardMutations", () => {
       expect(mocks.update).toHaveBeenCalledTimes(2);
       expect(result.current.error).toBeNull();
     });
+  });
+
+  it("reports a successful Card removal after retry", async () => {
+    const card = createCard({ id: "failed-remove" });
+    const onRemoveSuccess = vi.fn();
+    mocks.card = card;
+    mocks.logicalRemove.mockRejectedValueOnce(new Error("remove failed")).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useCardMutations({ onRemoveSuccess }));
+
+    await act(async () => {
+      await expect(result.current.remove(card.id)).rejects.toThrow("remove failed");
+    });
+    expect(onRemoveSuccess).not.toHaveBeenCalled();
+    act(() => result.current.retry());
+
+    await waitFor(() => expect(onRemoveSuccess).toHaveBeenCalledExactlyOnceWith(card));
   });
 
   it("does not expose a stale operation after the authenticated UID changes", async () => {

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -1,5 +1,7 @@
 /** @file Provides Card mutation state and actions to React features. */
 
+import { useEffect, useRef } from "react";
+
 import { useAuth } from "@/auth/AuthContext";
 import { useAsyncAction } from "@/hooks/useAsyncAction";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
@@ -7,11 +9,28 @@ import { cardCommands } from "@/services/cardCommands";
 
 type CardPatch = Partial<Omit<Card, "id" | "deckId" | "uid">>;
 
-export const useCardMutations = () => {
+interface UseCardMutationsOptions {
+  onRemoveSuccess?: (card: Card) => void;
+}
+
+export const useCardMutations = ({ onRemoveSuccess }: UseCardMutationsOptions = {}) => {
   const auth = useAuth();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const { cardById } = useRemoteCollections();
   const mutation = useAsyncAction<CardId>(uid);
+  const scope = useRef({ uid });
+  const onRemoveSuccessRef = useRef(onRemoveSuccess);
+
+  useEffect(() => {
+    onRemoveSuccessRef.current = onRemoveSuccess;
+  }, [onRemoveSuccess]);
+
+  useEffect(() => {
+    scope.current = { uid };
+    return () => {
+      scope.current = { uid };
+    };
+  }, [uid]);
 
   const create = (card: Card) => mutation.run([card.id], `create:${card.id}`, () => cardCommands.create(uid, card));
   const update = (card: CardEdit) => mutation.run([card.id], `update:${card.id}`, () => cardCommands.update(uid, card));
@@ -23,7 +42,11 @@ export const useCardMutations = () => {
   const remove = (id: CardId) => {
     const card = cardById(id);
     if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
-    return mutation.run([id], `remove:${id}`, () => cardCommands.remove(uid, id, card.deckId));
+    const operationScope = scope.current;
+    return mutation.run([id], `remove:${id}`, async () => {
+      await cardCommands.remove(uid, id, card.deckId);
+      if (scope.current === operationScope) onRemoveSuccessRef.current?.(card);
+    });
   };
   const bulkUpsert = (cards: Card[]) => {
     const ids = cards.map((card) => card.id);

--- a/src/features/deck/components/templates/DeckListTemplate.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.tsx
@@ -25,6 +25,7 @@ export interface DeckListTemplateProps {
   layout?: React.ComponentProps<typeof Layout>;
   deckCard?: DeckCardActions;
   feedbackSlot?: React.ReactNode;
+  dialogSlot?: React.ReactNode;
 }
 
 /**
@@ -83,6 +84,7 @@ export const DeckListTemplate: React.FC<DeckListTemplateProps> = (props) => {
   return (
     <Layout showHeader {...props.layout}>
       {props.feedbackSlot}
+      {props.dialogSlot}
       <div className="flex items-baseline justify-between gap-3">
         <h1 className="break-words text-title font-bold text-ink">Decks</h1>
         <span className="shrink-0 text-caption text-ink-muted">{countLabel(total)}</span>

--- a/src/features/deck/containers/DeckListContainer.spec.tsx
+++ b/src/features/deck/containers/DeckListContainer.spec.tsx
@@ -93,6 +93,8 @@ describe("DeckListContainer", () => {
     mocks.cardsById = {
       "other-1": createCard({ id: "other-1", deckId: otherDeck.id }),
       "other-2": createCard({ id: "other-2", deckId: otherDeck.id }),
+      "recent-1": createCard({ id: "recent-1", deckId: recentDeck.id }),
+      "recent-2": createCard({ id: "recent-2", deckId: recentDeck.id }),
     };
     studyStore.setState({
       sessionsByDeckId: {
@@ -160,15 +162,32 @@ describe("DeckListContainer", () => {
   });
 
   it("removes only the deleted deck session after the remote delete succeeds", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirm = vi.spyOn(window, "confirm");
     const view = render(<DeckListContainer />);
+    const trigger = view.getByRole("button", { name: "Open actions for Recent deck" });
 
-    fireEvent.click(view.getByRole("button", { name: "Open actions for Recent deck" }));
+    fireEvent.click(trigger);
     fireEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+    const dialog = view.getByRole("alertdialog", { name: "Delete deck?" });
+    expect(dialog).toHaveTextContent("Recent deck");
+    expect(dialog).toHaveTextContent("2 cards");
+    expect(dialog).toHaveTextContent("in-progress study session");
+    expect(dialog).toHaveTextContent("cannot be undone");
+    expect(view.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    fireEvent.click(view.getByRole("button", { name: "Cancel" }));
+    expect(mocks.remove).not.toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
+
+    fireEvent.click(trigger);
+    fireEvent.click(view.getByRole("menuitem", { name: "Delete" }));
+    fireEvent.click(view.getByRole("button", { name: "Delete deck" }));
 
     await waitFor(() => expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(recentDeck));
     await waitFor(() => expect(studyStore.getState().sessionsByDeckId[recentDeck.id]).toBeUndefined());
     expect(studyStore.getState().sessionsByDeckId[oldDeck.id]).toBeDefined();
+    expect(view.getByRole("status")).toHaveTextContent("Deleted deck “Recent deck”.");
+    expect(confirm).not.toHaveBeenCalled();
   });
 
   it("owns successful removal cleanup through the Deck mutation lifecycle", () => {

--- a/src/features/deck/containers/DeckListContainer.tsx
+++ b/src/features/deck/containers/DeckListContainer.tsx
@@ -17,7 +17,7 @@ import { useStudyHydrated } from "@/features/study/hooks/useStudyHydrated";
 import { useStudyStore } from "@/features/study/hooks/useStudyStore";
 import { studyStore } from "@/features/study/state/studyStore";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
-import { RemoteMutationNotice, RemoteReadBoundary } from "@/components";
+import { DestructiveActionDialog, Feedback, RemoteMutationNotice, RemoteReadBoundary } from "@/components";
 import { useActions } from "@/hooks/useActions";
 
 /**
@@ -29,8 +29,14 @@ export const DeckListContainer: React.FC = () => {
   const actions = useActions();
   const config = useConfig();
   const remote = useRemoteCollections();
+  const [deletionTarget, setDeletionTarget] = React.useState<{ deck: Deck; cardCount: number }>();
+  const [successMessage, setSuccessMessage] = React.useState<string>();
   const mutations = useDeckMutations({
-    onRemoveSuccess: (deck) => studyStore.getState().removeStudy(deck.id),
+    onRemoveSuccess: (deck) => {
+      studyStore.getState().removeStudy(deck.id);
+      setDeletionTarget((target) => (target?.deck.id === deck.id ? undefined : target));
+      setSuccessMessage(`Deleted deck “${deck.name}”.`);
+    },
   });
   const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
   const sessionsByDeckId = useStudyStore((state) => state.sessionsByDeckId);
@@ -61,13 +67,42 @@ export const DeckListContainer: React.FC = () => {
         <DeckListTemplate
           sections={sections}
           feedbackSlot={
-            <RemoteMutationNotice
-              pending={mutations.pending}
-              error={mutations.error}
-              onRetry={mutations.retry}
-              pendingLabel="Deleting deck…"
-              errorLabel="Unable to delete deck."
-            />
+            <>
+              <RemoteMutationNotice
+                pending={mutations.pending}
+                error={mutations.error}
+                onRetry={mutations.retry}
+                pendingLabel="Deleting deck…"
+                errorLabel="Unable to delete deck."
+              />
+              <Feedback tone="success">{successMessage}</Feedback>
+            </>
+          }
+          dialogSlot={
+            deletionTarget != null ? (
+              <DestructiveActionDialog
+                title="Delete deck?"
+                targetLabel="Deck"
+                targetName={deletionTarget.deck.name}
+                confirmLabel="Delete deck"
+                pending={mutations.isPending(deletionTarget.deck.id)}
+                {...(mutations.error != null
+                  ? { errorMessage: "Unable to delete this deck. Check your connection and try again." }
+                  : {})}
+                description={
+                  <>
+                    <p>
+                      This permanently deletes {deletionTarget.cardCount}{" "}
+                      {deletionTarget.cardCount === 1 ? "card" : "cards"} in this deck.
+                    </p>
+                    <p>Any in-progress study session for this deck will also end.</p>
+                    <p>This action cannot be undone.</p>
+                  </>
+                }
+                onCancel={() => setDeletionTarget(undefined)}
+                onConfirm={() => mutations.remove(deletionTarget.deck).catch(() => undefined)}
+              />
+            ) : null
           }
           layout={{
             headerProps: {
@@ -96,8 +131,9 @@ export const DeckListContainer: React.FC = () => {
             },
             onClickDelete: (id) => {
               const deck = remote.deckById(id);
-              if (deck != null && window.confirm("Are you sure of removing this deck?")) {
-                void mutations.remove(deck).catch(() => undefined);
+              if (deck != null) {
+                setSuccessMessage(undefined);
+                setDeletionTarget({ deck, cardCount: remote.cardsByDeckId(id).length });
               }
             },
           }}

--- a/src/lib/sharedComponentPublicApi.spec.ts
+++ b/src/lib/sharedComponentPublicApi.spec.ts
@@ -9,6 +9,7 @@ import * as Shared from "@/components";
 import type {
   ActionsMenuItem,
   ActionsMenuProps,
+  DestructiveActionDialogProps,
   HeaderProps,
   LayoutProps,
   Option,
@@ -24,6 +25,7 @@ const components = {
   Card: Shared.Card,
   Code: Shared.Code,
   Description: Shared.Description,
+  DestructiveActionDialog: Shared.DestructiveActionDialog,
   Feedback: Shared.Feedback,
   Form: Shared.Form,
   FormItem: Shared.FormItem,
@@ -58,6 +60,7 @@ describe("component public API", () => {
     const acceptsTypes = (
       _actionsMenu: ActionsMenuProps,
       _actionsMenuItem: ActionsMenuItem,
+      _destructiveActionDialog: DestructiveActionDialogProps,
       _header: HeaderProps,
       _layout: LayoutProps,
       _option: Option,
@@ -68,6 +71,7 @@ describe("component public API", () => {
     ) => {
       void _actionsMenu;
       void _actionsMenuItem;
+      void _destructiveActionDialog;
       void _header;
       void _layout;
       void _option;
@@ -87,6 +91,15 @@ describe("component public API", () => {
         items: [{ key: "edit", label: "Edit", icon: null }],
       },
       { key: "edit", label: "Edit", icon: null },
+      {
+        title: "Delete?",
+        targetLabel: "Item",
+        targetName: "Example",
+        description: "This cannot be undone.",
+        confirmLabel: "Delete",
+        onCancel: () => {},
+        onConfirm: () => {},
+      },
       {},
       {},
       { label: "label", value: "value" },


### PR DESCRIPTION
## Summary

- replace Deck and Card `window.confirm()` deletion prompts with a shared accessible destructive-action dialog
- explain the selected target, Deck card count, study-session impact, and irreversibility before deletion
- keep Cancel as the initial focus, trap Tab focus, support Escape, restore trigger focus, and block duplicate submissions
- report successful deletions through the shared feedback surface while preserving retry behavior
- add Deck/Card, pending, failure, mobile, and dark-mode Storybook states plus component and E2E coverage

## Why

The previous browser-native prompts did not identify Card targets or explain the broader effects of deleting a Deck. They also could not follow the application's visual, focus-management, feedback, and testing conventions.

## Validation

- `vitest run --project=unit --exclude '**/firestore/**/*.spec.ts' --no-file-parallelism` — 96 files, 754 tests passed
- targeted dialog and Deck/Card mutation/container tests — 5 files, 32 tests passed
- Docker `npm run lint:tsc` — passed
- `make check` formatting, lint, and TypeScript stages — passed twice; the parallel Vitest stage hit Docker worker-pool resource timeouts, while the same full suite passed serially
- `make e2e` attempted; the remote Playwright browser timed out before the first interaction across existing smoke, Deck, and Card tests, so E2E execution could not complete locally

Closes #405