### PR TITLE
Fix one-tap return from card back overlay

### DIFF
--- a/e2e/card.e2e.ts
+++ b/e2e/card.e2e.ts
@@ -70,6 +70,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe.configure({ mode: "serial" });
+test.use({ hasTouch: true });
 
 test("shows cards for the deck", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
@@ -83,10 +84,18 @@ test("shows cards for the deck", async ({ page }) => {
 test("opens and closes the card back text overlay", async ({ page }) => {
   await page.goto(`/deck/${e2eDeck.id}`);
 
-  await page.getByRole("button", { name: "View apple" }).click();
+  const viewCard = page.getByRole("button", { name: "View apple" });
+  const viewCardBox = await viewCard.boundingBox();
+  if (viewCardBox == null) throw new Error("Card view button bounding box is unavailable");
+  const tapPoint = {
+    x: viewCardBox.x + viewCardBox.width / 2,
+    y: viewCardBox.y + viewCardBox.height / 2,
+  };
+
+  await page.touchscreen.tap(tapPoint.x, tapPoint.y);
   await expect(page.getByText("りんご")).toBeVisible();
 
-  await page.getByText("りんご").click();
+  await page.touchscreen.tap(tapPoint.x, tapPoint.y);
   await expect(page.getByText("りんご")).not.toBeVisible();
   await page.evaluate(() => window.assertNoBrowserErrors());
 });

--- a/src/components/feedback/Overlay.spec.tsx
+++ b/src/components/feedback/Overlay.spec.tsx
@@ -23,7 +23,8 @@ describe("shared overlay surface", () => {
       "overflow-y-auto",
       "bg-surface-elevated",
       "text-ink",
-      "shadow-elevated"
+      "shadow-elevated",
+      "z-30"
     );
     expect(overlay).toHaveClass("before:bg-canvas/70");
   });

--- a/src/components/feedback/Overlay.tsx
+++ b/src/components/feedback/Overlay.tsx
@@ -26,7 +26,7 @@ export const Overlay: React.FC<{
       {...clickInteraction}
       {...(props.onClick !== undefined && props.ariaLabel !== undefined ? { "aria-label": props.ariaLabel } : {})}
       className={cx(
-        "absolute z-10 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control bg-surface-elevated text-ink shadow-elevated",
+        "absolute z-30 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control bg-surface-elevated text-ink shadow-elevated",
         props.position === "center" &&
           "before:pointer-events-none before:fixed before:inset-0 before:-z-10 before:bg-canvas/70",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2",


### PR DESCRIPTION
## Summary
- keep the back-text overlay above card row hit targets so one tap closes it instead of reselecting a card behind it
- lock the stacking contract with a unit assertion and a touch E2E that taps the same screen position twice

## Testing
- unit suite: 96 files, 754 tests passed
- ESLint passed
- Biome lint passed
- sample build, formatting, and Markdown lint passed during make check
- full make check and touch E2E did not complete locally because the shared Docker runtime stalled and the remote Playwright server refused the connection; CI should run both in a clean environment