### PR TITLE
[WIP] Add StudyAttempt Firestore foundation

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "emulators": {
     "auth": {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,19 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "studyAttempt",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "uid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "answeredAt",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -34,5 +34,77 @@ service cloud.firestore {
       allow update: if isValidOwner() && belongsToDeck();
       allow delete: if isOwner();
     }
+    match /studyAttempt/{attemptId} {
+      function cardPath() {
+        return /databases/$(database)/documents/card/$(request.resource.data.cardId);
+      }
+      function deckPath() {
+        return /databases/$(database)/documents/deck/$(request.resource.data.deckId);
+      }
+      function hasExactFields() {
+        return request.resource.data.keys().hasAll([
+                 "uid",
+                 "sessionId",
+                 "deckId",
+                 "cardId",
+                 "outcome",
+                 "answeredAt",
+                 "localDate",
+                 "timeZone",
+                 "schemaVersion"
+               ]) &&
+               request.resource.data.keys().hasOnly([
+                 "uid",
+                 "sessionId",
+                 "deckId",
+                 "cardId",
+                 "outcome",
+                 "answeredAt",
+                 "localDate",
+                 "timeZone",
+                 "schemaVersion"
+               ]);
+      }
+      function hasValidFields() {
+        return hasExactFields() &&
+               request.resource.data.uid is string &&
+               request.resource.data.uid.size() > 0 &&
+               request.resource.data.sessionId is string &&
+               request.resource.data.sessionId.size() > 0 &&
+               request.resource.data.deckId is string &&
+               request.resource.data.deckId.size() > 0 &&
+               request.resource.data.cardId is string &&
+               request.resource.data.cardId.size() > 0 &&
+               request.resource.data.outcome in ["mastered", "notMastered"] &&
+               request.resource.data.answeredAt is timestamp &&
+               request.resource.data.answeredAt >= timestamp.date(2000, 1, 1) &&
+               request.resource.data.answeredAt <= request.time + duration.value(10, "m") &&
+               request.resource.data.localDate is string &&
+               request.resource.data.localDate.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}$") &&
+               request.resource.data.timeZone is string &&
+               request.resource.data.timeZone.size() > 0 &&
+               request.resource.data.schemaVersion == 1;
+      }
+      function ownsReferencedDocuments() {
+        return existsAfter(cardPath()) &&
+               existsAfter(deckPath()) &&
+               getAfter(cardPath()).data.uid == request.auth.uid &&
+               getAfter(cardPath()).data.deckId == request.resource.data.deckId &&
+               getAfter(deckPath()).data.uid == request.auth.uid;
+      }
+      function ownsStoredAttempt() {
+        return request.auth != null && resource.data.uid == request.auth.uid;
+      }
+      allow get: if ownsStoredAttempt();
+      allow list: if ownsStoredAttempt() &&
+                     request.query.limit != null &&
+                     request.query.limit <= 6001;
+      allow create: if request.auth != null &&
+                       request.resource.data.uid == request.auth.uid &&
+                       hasValidFields() &&
+                       ownsReferencedDocuments();
+      allow update: if ownsStoredAttempt() && request.resource.data == resource.data;
+      allow delete: if false;
+    }
   }
 }

--- a/src/adapters/firestore/dto.ts
+++ b/src/adapters/firestore/dto.ts
@@ -62,7 +62,7 @@ export type DeckUpdateDto = z.infer<typeof deckUpdateDtoSchema>;
 
 export class FirestoreDocumentValidationError extends Error {
   constructor(
-    readonly collectionName: "deck" | "card",
+    readonly collectionName: "deck" | "card" | "studyAttempt",
     readonly documentId: string,
     readonly issues: z.core.$ZodIssue[]
   ) {

--- a/src/adapters/firestore/index.ts
+++ b/src/adapters/firestore/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * as documentMetadata from "@/adapters/firestore/documentMetadata";
+export type { StudyAttemptDocumentV1 } from "@/adapters/firestore/studyAttemptDto";
 export { initializeFirestoreAdapter } from "@/adapters/firestore/initialize";
 export {
   getDb,

--- a/src/adapters/firestore/rule/rule.spec.ts
+++ b/src/adapters/firestore/rule/rule.spec.ts
@@ -12,7 +12,19 @@ import {
   initializeTestEnvironment,
   type RulesTestEnvironment,
 } from "@firebase/rules-unit-testing";
-import { setDoc, doc, getDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import {
+  Timestamp,
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 import { v4 as uuid } from "uuid";
 
 describe("firestore/rule", () => {
@@ -23,6 +35,25 @@ describe("firestore/rule", () => {
       const db = context.firestore();
       await setDoc(doc(db, path, id), data);
     });
+  };
+
+  const studyAttemptData = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+    uid: "uid",
+    sessionId: "session-id",
+    deckId: "deck-id",
+    cardId: "card-id",
+    outcome: "mastered",
+    answeredAt: Timestamp.now(),
+    localDate: "2026-08-10",
+    timeZone: "Asia/Tokyo",
+    schemaVersion: 1,
+    ...overrides,
+  });
+
+  const createStudyDependencies = async (overrides: { deckUid?: string; cardUid?: string; deckId?: string } = {}) => {
+    const deckId = overrides.deckId ?? "deck-id";
+    await createData("deck", deckId, { uid: overrides.deckUid ?? "uid" });
+    await createData("card", "card-id", { uid: overrides.cardUid ?? "uid", deckId });
   };
 
   beforeAll(async () => {
@@ -102,6 +133,73 @@ describe("firestore/rule", () => {
         await assertSucceeds(deleteDoc(doc(db, "card", id)));
       });
     });
+
+    describe("studyAttempt", () => {
+      it("allows an owner to create and read a valid attempt", async () => {
+        await createStudyDependencies();
+        const data = studyAttemptData();
+
+        await assertSucceeds(setDoc(doc(db, "studyAttempt", "attempt-id"), data));
+        await assertSucceeds(getDoc(doc(db, "studyAttempt", "attempt-id")));
+      });
+
+      it("allows only an exact retry of an existing attempt", async () => {
+        await createStudyDependencies();
+        const ref = doc(db, "studyAttempt", "attempt-id");
+        const data = studyAttemptData();
+        await assertSucceeds(setDoc(ref, data));
+
+        await assertSucceeds(setDoc(ref, data));
+        await assertFails(setDoc(ref, { ...data, outcome: "notMastered" }));
+      });
+
+      it.each([
+        ["foreign owner", { uid: "other" }],
+        ["empty session ID", { sessionId: "" }],
+        ["unknown outcome", { outcome: "unknown" }],
+        ["unknown schema", { schemaVersion: 2 }],
+        ["missing field", { sessionId: null }],
+        ["extra field", { unexpected: true }],
+        ["non-timestamp answer time", { answeredAt: Date.now() }],
+        ["old timestamp", { answeredAt: Timestamp.fromMillis(Date.UTC(1999, 11, 31, 23, 59, 59)) }],
+        ["future timestamp", { answeredAt: Timestamp.fromMillis(Date.now() + 11 * 60 * 1_000) }],
+        ["invalid local date", { localDate: "2026/08/10" }],
+        ["empty time zone", { timeZone: "" }],
+      ])("rejects a %s payload", async (_name, overrides) => {
+        await createStudyDependencies();
+        const data = studyAttemptData(overrides);
+        if ("sessionId" in overrides && overrides.sessionId === null) delete data.sessionId;
+
+        await assertFails(setDoc(doc(db, "studyAttempt", uuid()), data));
+      });
+
+      it("rejects Card and Deck ownership or membership mismatches", async () => {
+        await createStudyDependencies({ cardUid: "other" });
+        await assertFails(setDoc(doc(db, "studyAttempt", "foreign-card"), studyAttemptData()));
+
+        await createData("card", "card-id", { uid: "uid", deckId: "other-deck" });
+        await createData("deck", "other-deck", { uid: "other" });
+        await assertFails(setDoc(doc(db, "studyAttempt", "foreign-deck"), studyAttemptData({ deckId: "other-deck" })));
+      });
+
+      it("denies deletion", async () => {
+        await createStudyDependencies();
+        const ref = doc(db, "studyAttempt", "attempt-id");
+        await assertSucceeds(setDoc(ref, studyAttemptData()));
+
+        await assertFails(deleteDoc(ref));
+      });
+
+      it("requires an owner UID filter and the hard query limit", async () => {
+        await createStudyDependencies();
+        await assertSucceeds(setDoc(doc(db, "studyAttempt", "attempt-id"), studyAttemptData()));
+
+        const attempts = collection(db, "studyAttempt");
+        await assertSucceeds(getDocs(query(attempts, where("uid", "==", "uid"), limit(6_001))));
+        await assertFails(getDocs(query(attempts, limit(6_001))));
+        await assertFails(getDocs(query(attempts, where("uid", "==", "uid"), limit(6_002))));
+      });
+    });
   });
 
   describe("invalid authenticated context", () => {
@@ -173,6 +271,16 @@ describe("firestore/rule", () => {
         await assertFails(deleteDoc(doc(db, "card", id)));
       });
     });
+
+    describe("studyAttempt", () => {
+      it("cannot read or create another user's attempt", async () => {
+        await createStudyDependencies();
+        await createData("studyAttempt", "attempt-id", studyAttemptData());
+
+        await assertFails(getDoc(doc(db, "studyAttempt", "attempt-id")));
+        await assertFails(setDoc(doc(db, "studyAttempt", "other-attempt"), studyAttemptData()));
+      });
+    });
   });
 
   describe("unauthenticated context", () => {
@@ -242,6 +350,16 @@ describe("firestore/rule", () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertFails(deleteDoc(doc(db, "card", id)));
+      });
+    });
+
+    describe("studyAttempt", () => {
+      it("cannot read or create an attempt", async () => {
+        await createStudyDependencies();
+        await createData("studyAttempt", "attempt-id", studyAttemptData());
+
+        await assertFails(getDoc(doc(db, "studyAttempt", "attempt-id")));
+        await assertFails(setDoc(doc(db, "studyAttempt", "other-attempt"), studyAttemptData()));
       });
     });
   });

--- a/src/adapters/firestore/studyAttempt.spec.ts
+++ b/src/adapters/firestore/studyAttempt.spec.ts
@@ -1,0 +1,150 @@
+/** @file Verifies bounded and append-only StudyAttempt Firestore access. */
+
+import { readFileSync } from "node:fs";
+import { initializeTestEnvironment, type RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, type Firestore } from "firebase/firestore";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_STUDY_ATTEMPT_QUERY_LIMIT,
+  createStudyAttempt,
+  readStudyAttempts,
+} from "@/adapters/firestore/studyAttempt";
+import { buildStudyAttemptCreateDto } from "@/adapters/firestore/studyAttemptDto";
+import type { StudyAttemptRange } from "@/domain/studyHistory";
+import { createStudyAttempt as createAttempt } from "@/test/factories";
+
+describe("StudyAttempt Firestore adapter", () => {
+  let testEnv: RulesTestEnvironment;
+  let db: Firestore;
+  const baseTime = Date.UTC(2026, 7, 10);
+
+  const range = (overrides: Partial<StudyAttemptRange> = {}): StudyAttemptRange => ({
+    fromInclusive: baseTime,
+    toExclusive: baseTime + 10_000,
+    limit: MAX_STUDY_ATTEMPT_QUERY_LIMIT,
+    ...overrides,
+  });
+
+  const seed = async (collectionName: string, id: string, data: object) => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await setDoc(doc(context.firestore(), collectionName, id), data);
+    });
+  };
+
+  const seedDependencies = async (uid = "uid", deckId = "deck-id", cardId = "card-id") => {
+    await seed("deck", deckId, { uid });
+    await seed("card", cardId, { uid, deckId });
+  };
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: "test-study-attempt",
+      firestore: {
+        rules: readFileSync("./firestore.rules", "utf8"),
+        host: import.meta.env.VITE_DB_HOST,
+        port: Number.parseInt(import.meta.env.VITE_DB_PORT, 10),
+      },
+    });
+    db = testEnv.authenticatedContext("uid").firestore() as unknown as Firestore;
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  it("creates an attempt at its ID and reads it back", async () => {
+    await seedDependencies();
+    const attempt = createAttempt({ id: "attempt-1", uid: "uid", answeredAt: baseTime, localDate: "2026-08-10" });
+
+    await createStudyAttempt(attempt, db);
+
+    expect((await getDoc(doc(db, "studyAttempt", attempt.id))).data()).toEqual(buildStudyAttemptCreateDto(attempt));
+    await expect(readStudyAttempts("uid", range(), db)).resolves.toEqual([attempt]);
+  });
+
+  it("accepts an exact retry without duplication and rejects conflicting content", async () => {
+    await seedDependencies();
+    const attempt = createAttempt({ id: "attempt-1", uid: "uid", answeredAt: baseTime, localDate: "2026-08-10" });
+    await createStudyAttempt(attempt, db);
+
+    await expect(createStudyAttempt(attempt, db)).resolves.toBeUndefined();
+    await expect(createStudyAttempt({ ...attempt, outcome: "notMastered" }, db)).rejects.toMatchObject({
+      code: "permission-denied",
+    });
+    await expect(readStudyAttempts("uid", range(), db)).resolves.toEqual([attempt]);
+  });
+
+  it("reads only the UID and half-open range in descending order with a hard limit", async () => {
+    const attempts = [
+      createAttempt({ id: "at-start", uid: "uid", answeredAt: baseTime, localDate: "2026-08-10" }),
+      createAttempt({ id: "middle", uid: "uid", answeredAt: baseTime + 5_000, localDate: "2026-08-10" }),
+      createAttempt({ id: "latest", uid: "uid", answeredAt: baseTime + 9_999, localDate: "2026-08-10" }),
+      createAttempt({ id: "at-end", uid: "uid", answeredAt: baseTime + 10_000, localDate: "2026-08-10" }),
+      createAttempt({ id: "foreign", uid: "other", answeredAt: baseTime + 7_000, localDate: "2026-08-10" }),
+    ];
+    for (const attempt of attempts) {
+      await seed("studyAttempt", attempt.id, buildStudyAttemptCreateDto(attempt));
+    }
+
+    await expect(readStudyAttempts("uid", range({ limit: 2 }), db)).resolves.toEqual([attempts[2], attempts[1]]);
+    await expect(readStudyAttempts("uid", range(), db)).resolves.toEqual([attempts[2], attempts[1], attempts[0]]);
+  });
+
+  it("orders equal timestamps by document ID descending", async () => {
+    const attempts = [
+      createAttempt({ id: "tie-a", uid: "uid", answeredAt: baseTime, localDate: "2026-08-10" }),
+      createAttempt({ id: "tie-b", uid: "uid", answeredAt: baseTime, localDate: "2026-08-10" }),
+    ];
+    for (const attempt of attempts) {
+      await seed("studyAttempt", attempt.id, buildStudyAttemptCreateDto(attempt));
+    }
+
+    await expect(readStudyAttempts("uid", range(), db)).resolves.toEqual([attempts[1], attempts[0]]);
+  });
+
+  it.each([
+    ["empty UID", "", range()],
+    ["non-finite lower bound", "uid", range({ fromInclusive: Number.NaN })],
+    ["non-finite upper bound", "uid", range({ toExclusive: Number.POSITIVE_INFINITY })],
+    ["empty range", "uid", range({ toExclusive: baseTime })],
+    ["reversed range", "uid", range({ toExclusive: baseTime - 1 })],
+    ["zero limit", "uid", range({ limit: 0 })],
+    ["fractional limit", "uid", range({ limit: 1.5 })],
+    ["excessive limit", "uid", range({ limit: MAX_STUDY_ATTEMPT_QUERY_LIMIT + 1 })],
+  ])("rejects an invalid %s before using Firestore", async (_name, uid, invalidRange) => {
+    await expect(readStudyAttempts(uid, invalidRange, {} as Firestore)).rejects.toMatchObject({
+      name: "InvalidStudyAttemptQueryError",
+    });
+  });
+
+  it("reports the document ID when a stored attempt is malformed", async () => {
+    const malformed = createAttempt({
+      id: "malformed-attempt",
+      uid: "uid",
+      answeredAt: baseTime,
+      localDate: "2026-08-10",
+    });
+    await seed("studyAttempt", malformed.id, {
+      ...buildStudyAttemptCreateDto(malformed),
+      outcome: "unknown",
+    });
+
+    await expect(readStudyAttempts("uid", range(), db)).rejects.toMatchObject({
+      name: "FirestoreDocumentValidationError",
+      collectionName: "studyAttempt",
+      documentId: malformed.id,
+      message: expect.stringContaining("outcome"),
+    });
+  });
+
+  it("cannot read another user's attempts", async () => {
+    const foreignDb = testEnv.authenticatedContext("other").firestore() as unknown as Firestore;
+
+    await expect(readStudyAttempts("uid", range(), foreignDb)).rejects.toMatchObject({ code: "permission-denied" });
+  });
+});

--- a/src/adapters/firestore/studyAttempt.ts
+++ b/src/adapters/firestore/studyAttempt.ts
@@ -1,0 +1,84 @@
+/** @file Provides bounded and append-only Firestore access for StudyAttempt documents. */
+
+import {
+  Timestamp,
+  collection,
+  doc,
+  getDocs,
+  limit as applyLimit,
+  orderBy,
+  query,
+  setDoc,
+  where,
+  type DocumentReference,
+  type Firestore,
+} from "firebase/firestore";
+
+import { getDb } from "@/adapters/firestore/runtime";
+import {
+  buildStudyAttemptCreateDto,
+  mapStudyAttemptDocument,
+  type StudyAttemptDocumentV1,
+} from "@/adapters/firestore/studyAttemptDto";
+import type { StudyAttempt, StudyAttemptRange } from "@/domain/studyHistory";
+
+export const MAX_STUDY_ATTEMPT_QUERY_LIMIT = 6_001;
+
+export class InvalidStudyAttemptQueryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidStudyAttemptQueryError";
+  }
+}
+
+export interface StudyAttemptWrite {
+  reference: DocumentReference;
+  data: StudyAttemptDocumentV1;
+}
+
+const validateQuery = (uid: string, range: StudyAttemptRange) => {
+  if (uid.trim().length === 0) {
+    throw new InvalidStudyAttemptQueryError("StudyAttempt query requires a non-empty UID");
+  }
+  if (!Number.isSafeInteger(range.fromInclusive) || !Number.isSafeInteger(range.toExclusive)) {
+    throw new InvalidStudyAttemptQueryError("StudyAttempt query bounds must be safe integer timestamps");
+  }
+  if (range.fromInclusive >= range.toExclusive) {
+    throw new InvalidStudyAttemptQueryError("StudyAttempt query requires fromInclusive before toExclusive");
+  }
+  if (!Number.isInteger(range.limit) || range.limit < 1 || range.limit > MAX_STUDY_ATTEMPT_QUERY_LIMIT) {
+    throw new InvalidStudyAttemptQueryError(
+      `StudyAttempt query limit must be an integer from 1 to ${MAX_STUDY_ATTEMPT_QUERY_LIMIT}`
+    );
+  }
+};
+
+export const buildStudyAttemptWrite = (attempt: StudyAttempt, firestore?: Firestore): StudyAttemptWrite => {
+  const data = buildStudyAttemptCreateDto(attempt);
+  return { reference: doc(firestore ?? getDb(), "studyAttempt", attempt.id), data };
+};
+
+export const createStudyAttempt = async (attempt: StudyAttempt, firestore?: Firestore): Promise<void> => {
+  const write = buildStudyAttemptWrite(attempt, firestore);
+  await setDoc(write.reference, write.data);
+};
+
+export const readStudyAttempts = async (
+  uid: string,
+  range: StudyAttemptRange,
+  firestore?: Firestore
+): Promise<StudyAttempt[]> => {
+  validateQuery(uid, range);
+  const database = firestore ?? getDb();
+  const snapshot = await getDocs(
+    query(
+      collection(database, "studyAttempt"),
+      where("uid", "==", uid),
+      where("answeredAt", ">=", Timestamp.fromMillis(range.fromInclusive)),
+      where("answeredAt", "<", Timestamp.fromMillis(range.toExclusive)),
+      orderBy("answeredAt", "desc"),
+      applyLimit(range.limit)
+    )
+  );
+  return snapshot.docs.map((document) => mapStudyAttemptDocument(document.id, document.data()));
+};

--- a/src/adapters/firestore/studyAttemptConfig.spec.ts
+++ b/src/adapters/firestore/studyAttemptConfig.spec.ts
@@ -1,0 +1,49 @@
+/** @file Verifies Firebase configuration for the bounded StudyAttempt query. */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+interface FirebaseConfig {
+  firestore?: {
+    rules?: string;
+    indexes?: string;
+  };
+}
+
+interface FirestoreIndexes {
+  indexes?: Array<{
+    collectionGroup?: string;
+    queryScope?: string;
+    fields?: Array<{ fieldPath?: string; order?: string }>;
+  }>;
+  fieldOverrides?: unknown[];
+}
+
+describe("StudyAttempt Firebase configuration", () => {
+  it("references the Rules and composite index files", () => {
+    const config = JSON.parse(readFileSync("firebase.json", "utf8")) as FirebaseConfig;
+
+    expect(config.firestore).toEqual({
+      rules: "firestore.rules",
+      indexes: "firestore.indexes.json",
+    });
+  });
+
+  it("defines only the composite index required by the version 1 query", () => {
+    const config = JSON.parse(readFileSync("firestore.indexes.json", "utf8")) as FirestoreIndexes;
+
+    expect(config).toEqual({
+      indexes: [
+        {
+          collectionGroup: "studyAttempt",
+          queryScope: "COLLECTION",
+          fields: [
+            { fieldPath: "uid", order: "ASCENDING" },
+            { fieldPath: "answeredAt", order: "DESCENDING" },
+          ],
+        },
+      ],
+      fieldOverrides: [],
+    });
+  });
+});

--- a/src/adapters/firestore/studyAttemptDto.spec.ts
+++ b/src/adapters/firestore/studyAttemptDto.spec.ts
@@ -1,0 +1,108 @@
+/** @file Verifies the version 1 StudyAttempt Firestore DTO contract. */
+
+import { Timestamp } from "firebase/firestore";
+import { describe, expect, it } from "vitest";
+
+import { buildStudyAttemptCreateDto, mapStudyAttemptDocument } from "@/adapters/firestore/studyAttemptDto";
+import type { StudyAttempt } from "@/domain/studyHistory";
+
+describe("StudyAttempt Firestore DTO", () => {
+  const answeredAt = Date.UTC(2026, 7, 9, 3, 4, 5);
+  const attempt: StudyAttempt = {
+    id: "attempt-1",
+    uid: "user-1",
+    sessionId: "session-1",
+    deckId: "deck-1",
+    cardId: "card-1",
+    outcome: "mastered",
+    answeredAt,
+    localDate: "2026-08-09",
+    timeZone: "Asia/Tokyo",
+    schemaVersion: 1,
+  };
+
+  const document = (overrides: Record<string, unknown> = {}) => ({
+    uid: attempt.uid,
+    sessionId: attempt.sessionId,
+    deckId: attempt.deckId,
+    cardId: attempt.cardId,
+    outcome: attempt.outcome,
+    answeredAt: Timestamp.fromMillis(attempt.answeredAt),
+    localDate: attempt.localDate,
+    timeZone: attempt.timeZone,
+    schemaVersion: attempt.schemaVersion,
+    ...overrides,
+  });
+
+  it("round-trips a valid version 1 attempt without duplicating its document ID", () => {
+    const dto = buildStudyAttemptCreateDto(attempt);
+
+    expect(dto).not.toHaveProperty("id");
+    expect(dto.answeredAt).toBeInstanceOf(Timestamp);
+    expect(dto.answeredAt.toMillis()).toBe(answeredAt);
+    expect(mapStudyAttemptDocument(attempt.id, dto)).toEqual(attempt);
+  });
+
+  it.each([
+    ["id", ""],
+    ["uid", ""],
+    ["sessionId", ""],
+    ["deckId", ""],
+    ["cardId", ""],
+    ["outcome", "unknown"],
+    ["answeredAt", Number.NaN],
+    ["answeredAt", Number.MAX_SAFE_INTEGER + 1],
+    ["answeredAt", Date.UTC(1999, 11, 31, 23, 59, 59)],
+    ["localDate", "2026/08/09"],
+    ["localDate", "2026-08-10"],
+    ["timeZone", "Not/AZone"],
+    ["timeZone", "+01:00"],
+    ["schemaVersion", 2],
+  ])("rejects an invalid domain %s", (field, value) => {
+    expect(() => buildStudyAttemptCreateDto({ ...attempt, [field]: value } as StudyAttempt)).toThrow();
+  });
+
+  it("rejects unknown fields when building the exact version 1 payload", () => {
+    expect(() =>
+      buildStudyAttemptCreateDto({ ...attempt, unexpected: true } as StudyAttempt & { unexpected: boolean })
+    ).toThrow();
+  });
+
+  it.each([
+    ["uid", ""],
+    ["sessionId", ""],
+    ["deckId", ""],
+    ["cardId", ""],
+    ["outcome", "unknown"],
+    ["answeredAt", answeredAt],
+    ["answeredAt", Timestamp.fromMillis(Date.UTC(1999, 11, 31, 23, 59, 59))],
+    ["localDate", "2026-02-31"],
+    ["localDate", "2026-08-10"],
+    ["timeZone", "Not/AZone"],
+    ["timeZone", "+01:00"],
+    ["schemaVersion", 2],
+  ])("rejects an invalid stored %s with document context", (field, value) => {
+    expect(() => mapStudyAttemptDocument("attempt-invalid", document({ [field]: value }))).toThrowError(
+      expect.objectContaining({
+        name: "FirestoreDocumentValidationError",
+        collectionName: "studyAttempt",
+        documentId: "attempt-invalid",
+        message: expect.stringContaining(field),
+      })
+    );
+  });
+
+  it("rejects missing, extra, and invalid document ID fields", () => {
+    const { uid: _uid, ...missingUid } = document();
+
+    expect(() => mapStudyAttemptDocument("missing-uid", missingUid)).toThrowError(
+      expect.objectContaining({ message: expect.stringContaining("uid") })
+    );
+    expect(() => mapStudyAttemptDocument("extra-field", document({ unexpected: true }))).toThrowError(
+      expect.objectContaining({ message: expect.stringContaining("unexpected") })
+    );
+    expect(() => mapStudyAttemptDocument("", document())).toThrowError(
+      expect.objectContaining({ message: expect.stringContaining("id") })
+    );
+  });
+});

--- a/src/adapters/firestore/studyAttemptDto.ts
+++ b/src/adapters/firestore/studyAttemptDto.ts
@@ -1,0 +1,146 @@
+/** @file Maps the version 1 StudyAttempt contract to and from Firestore documents. */
+
+import { Timestamp } from "firebase/firestore";
+import { z } from "zod";
+
+import { FirestoreDocumentValidationError } from "@/adapters/firestore/dto";
+import type { StudyAttempt, StudyOutcome } from "@/domain/studyHistory";
+
+const earliestStudyTime = Date.UTC(2000, 0, 1);
+const nonEmptyIdSchema = z.string().refine((value) => value.trim().length > 0, "Expected a non-empty ID");
+const localDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD");
+const studyOutcomeSchema = z.enum(["mastered", "notMastered"] satisfies StudyOutcome[]);
+const answeredAtSchema = z
+  .number()
+  .refine(Number.isSafeInteger, "Expected a safe integer timestamp")
+  .min(earliestStudyTime, "Timestamp must not be before 2000-01-01");
+const firestoreTimestampSchema = z
+  .custom<Timestamp>(
+    (value) =>
+      typeof value === "object" &&
+      value !== null &&
+      typeof Reflect.get(value, "toMillis") === "function" &&
+      Number.isInteger(Reflect.get(value, "seconds")) &&
+      Number.isInteger(Reflect.get(value, "nanoseconds")) &&
+      Reflect.get(value, "nanoseconds") >= 0 &&
+      Reflect.get(value, "nanoseconds") < 1_000_000_000,
+    "Expected a Firestore Timestamp"
+  )
+  .refine((value) => Number.isSafeInteger(value.toMillis()), "Expected a millisecond Timestamp")
+  .refine((value) => value.toMillis() >= earliestStudyTime, "Timestamp must not be before 2000-01-01");
+
+const localDateAt = (answeredAt: number, timeZone: string): string | undefined => {
+  if (!/^[A-Za-z]/.test(timeZone)) return undefined;
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      calendar: "gregory",
+      numberingSystem: "latn",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date(answeredAt));
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    if (values.year === undefined || values.month === undefined || values.day === undefined) return undefined;
+    return `${values.year}-${values.month}-${values.day}`;
+  } catch {
+    return undefined;
+  }
+};
+
+const validateTimeContext = (
+  value: { answeredAt: number; localDate: string; timeZone: string },
+  context: z.RefinementCtx
+) => {
+  const expectedLocalDate = localDateAt(value.answeredAt, value.timeZone);
+  if (expectedLocalDate === undefined) {
+    context.addIssue({ code: "custom", path: ["timeZone"], message: "Expected a valid IANA time zone" });
+  } else if (value.localDate !== expectedLocalDate) {
+    context.addIssue({
+      code: "custom",
+      path: ["localDate"],
+      message: `Expected ${expectedLocalDate} for answeredAt in ${value.timeZone}`,
+    });
+  }
+};
+
+const studyAttemptSchema: z.ZodType<StudyAttempt> = z
+  .strictObject({
+    id: nonEmptyIdSchema,
+    uid: nonEmptyIdSchema,
+    sessionId: nonEmptyIdSchema,
+    deckId: nonEmptyIdSchema,
+    cardId: nonEmptyIdSchema,
+    outcome: studyOutcomeSchema,
+    answeredAt: answeredAtSchema,
+    localDate: localDateSchema,
+    timeZone: z.string().min(1),
+    schemaVersion: z.literal(1),
+  })
+  .superRefine(validateTimeContext);
+
+export interface StudyAttemptDocumentV1 {
+  uid: string;
+  sessionId: string;
+  deckId: string;
+  cardId: string;
+  outcome: StudyOutcome;
+  answeredAt: Timestamp;
+  localDate: string;
+  timeZone: string;
+  schemaVersion: 1;
+}
+
+const studyAttemptDocumentSchema: z.ZodType<StudyAttemptDocumentV1> = z
+  .strictObject({
+    uid: nonEmptyIdSchema,
+    sessionId: nonEmptyIdSchema,
+    deckId: nonEmptyIdSchema,
+    cardId: nonEmptyIdSchema,
+    outcome: studyOutcomeSchema,
+    answeredAt: firestoreTimestampSchema,
+    localDate: localDateSchema,
+    timeZone: z.string().min(1),
+    schemaVersion: z.literal(1),
+  })
+  .superRefine((value, context) => validateTimeContext({ ...value, answeredAt: value.answeredAt.toMillis() }, context));
+
+const storedStudyAttemptSchema = z.strictObject({
+  id: nonEmptyIdSchema,
+  document: studyAttemptDocumentSchema,
+});
+
+export const buildStudyAttemptCreateDto = (attempt: StudyAttempt): StudyAttemptDocumentV1 => {
+  const parsed = studyAttemptSchema.parse(attempt);
+  return {
+    uid: parsed.uid,
+    sessionId: parsed.sessionId,
+    deckId: parsed.deckId,
+    cardId: parsed.cardId,
+    outcome: parsed.outcome,
+    answeredAt: Timestamp.fromMillis(parsed.answeredAt),
+    localDate: parsed.localDate,
+    timeZone: parsed.timeZone,
+    schemaVersion: parsed.schemaVersion,
+  };
+};
+
+export const mapStudyAttemptDocument = (id: string, value: unknown): StudyAttempt => {
+  const result = storedStudyAttemptSchema.safeParse({ id, document: value });
+  if (!result.success) {
+    throw new FirestoreDocumentValidationError("studyAttempt", id, result.error.issues);
+  }
+  const { document } = result.data;
+  return {
+    id: result.data.id,
+    uid: document.uid,
+    sessionId: document.sessionId,
+    deckId: document.deckId,
+    cardId: document.cardId,
+    outcome: document.outcome,
+    answeredAt: document.answeredAt.toMillis(),
+    localDate: document.localDate,
+    timeZone: document.timeZone,
+    schemaVersion: document.schemaVersion,
+  };
+};

--- a/src/domain/studyHistory.ts
+++ b/src/domain/studyHistory.ts
@@ -1,0 +1,22 @@
+/** @file Defines Firebase-independent study history contracts. */
+
+export type StudyOutcome = "mastered" | "notMastered";
+
+export interface StudyAttempt {
+  id: string;
+  uid: string;
+  sessionId: string;
+  deckId: DeckId;
+  cardId: CardId;
+  outcome: StudyOutcome;
+  answeredAt: number;
+  localDate: string;
+  timeZone: string;
+  schemaVersion: 1;
+}
+
+export interface StudyAttemptRange {
+  fromInclusive: number;
+  toExclusive: number;
+  limit: number;
+}

--- a/src/lib/componentArchitecture.spec.ts
+++ b/src/lib/componentArchitecture.spec.ts
@@ -31,6 +31,7 @@ const ownedFirestoreAdapterModules = new Set([
   "@/adapters/firestore/card",
   "@/adapters/firestore/deck",
   "@/adapters/firestore/event",
+  "@/adapters/firestore/studyAttempt",
 ]);
 const connectorModules = [
   "react-hook-form",

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -4,6 +4,8 @@
  * objects.
  */
 
+import type { StudyAttempt } from "@/domain/studyHistory";
+
 /**
  * Builds a complete test deck with predictable defaults and optional field overrides.
  * Tests can describe only the deck fields relevant to their scenario.
@@ -42,6 +44,24 @@ export const createCard = (overrides: Partial<Card> = {}): Card => ({
   deletedAt: null,
   score: 0,
   numberOfSeen: 0,
+  ...overrides,
+});
+
+/**
+ * Builds a complete study attempt with a stable UTC answer context.
+ * Tests can override only the identity, outcome, or time fields relevant to their scenario.
+ */
+export const createStudyAttempt = (overrides: Partial<StudyAttempt> = {}): StudyAttempt => ({
+  id: "attempt-id",
+  uid: "user-id",
+  sessionId: "session-id",
+  deckId: "deck-id",
+  cardId: "card-id",
+  outcome: "mastered",
+  answeredAt: Date.UTC(2026, 0, 1),
+  localDate: "2026-01-01",
+  timeZone: "UTC",
+  schemaVersion: 1,
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary

- add the Firebase-independent version 1 `StudyAttempt` domain and strict Firestore DTO validation
- add append-only, idempotent writes and UID/range/limit-bounded descending reads
- enforce owner, Card, Deck, schema, timestamp, and exact-retry constraints in Security Rules
- register the single composite index required by the version 1 query

## Impact

This establishes the low-level persistence boundary required by #414. It does not integrate study swipes, coordinate Card writes, aggregate metrics, or add dashboard UI.

## Testing

- `npm run test:firestore` — passed (14 files, 147 tests)
- `make check` targets with host-backed npm/sample runners — passed (96 files, 754 unit tests)
- `vitest run --project=unit src/adapters/firestore/studyAttemptDto.spec.ts` — passed (29 tests)

The host-backed `make check` path was used because Docker could not allocate another Compose network from its exhausted local address pools; the same sample build, Ruff, formatting, TypeScript, ESLint, Markdown, and unit-test targets all ran successfully.

Closes #413
Refs #411