### PR TITLE
Use ESNext TypeScript target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary

- update the TypeScript `target` from `ES2020` to `ESNext`
- update `lib` from `ES2020` to `ESNext`
- remove the now-redundant `useDefineForClassFields` option

## Why

The project targets current tooling and modern browsers, so pinning TypeScript's language and library definitions to ES2020 is unnecessarily conservative. Using `ESNext` keeps the type checker aligned with the latest ECMAScript features supported by the installed TypeScript version.

`useDefineForClassFields` defaults to `true` for modern targets, so it no longer needs to be specified explicitly.

## Impact

This changes the TypeScript language/library baseline used for type checking. It does not change the project's build command or enable TypeScript emit.

## Validation

- confirmed the branch contains only the intended `tsconfig.json` change
- full type-check/build validation is delegated to pull-request CI