### PR TITLE
Remove allowImportingTsExtensions

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import type { StorybookConfig } from "@storybook/react-vite";
 import { mergeConfig } from "vite";
-import { withoutPwaPlugins } from "./vitePlugins.ts";
+import { withoutPwaPlugins } from "./vitePlugins";
 
 const storybookFirebase = fileURLToPath(new URL("../src/storybook/firebase.ts", import.meta.url));
 const storybookFirestoreRuntime = fileURLToPath(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
## Summary
- remove `allowImportingTsExtensions` from `tsconfig.json`
- switch the Storybook helper import from `./vitePlugins.ts` to `./vitePlugins`

## Why
The option was inherited from the Vite TypeScript template. Tango only had one actual TypeScript extension import, in `.storybook/main.ts`, so keeping a project-wide opt-in was unnecessary once that import was made extensionless.

## Impact
No runtime behavior changes. This narrows the TypeScript configuration to the import style used by the project.

## Validation
- confirmed the PR diff only changes `.storybook/main.ts` and `tsconfig.json`
- confirmed the Storybook import is extensionless before removing the compiler option