### PR TITLE
Simplify Biome configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,55 +1,29 @@
 {
-	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true,
-		"defaultBranch": "main"
-	},
-	"files": {
-		"includes": ["**/*.ts", "**/*.tsx", "src/**/*.js", "src/**/*.jsx"]
-	},
-	"formatter": {
-		"enabled": true,
-		"includes": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
-		"formatWithErrors": false,
-		"indentStyle": "space",
-		"indentWidth": 2,
-		"lineEnding": "lf",
-		"lineWidth": 120,
-		"attributePosition": "auto",
-		"bracketSameLine": false,
-		"bracketSpacing": true,
-		"expand": "auto",
-		"useEditorconfig": true
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"preset": "recommended"
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"jsxQuoteStyle": "double",
-			"quoteProperties": "asNeeded",
-			"trailingCommas": "es5",
-			"semicolons": "always",
-			"arrowParentheses": "always",
-			"bracketSameLine": false,
-			"quoteStyle": "double",
-			"attributePosition": "auto",
-			"bracketSpacing": true
-		}
-	},
-	"html": {
-		"formatter": {
-			"indentScriptAndStyle": false,
-			"selfCloseVoidElements": "always"
-		}
-	},
-	"assist": {
-		"enabled": true,
-		"actions": { "source": { "organizeImports": "off" } }
-	}
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "files": {
+    "includes": ["**/*.ts", "**/*.tsx", "src/**/*.js", "src/**/*.jsx"]
+  },
+  "formatter": {
+    "includes": ["src/**"],
+    "indentStyle": "space",
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": {
+      "trailingCommas": "es5"
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "off"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- remove Biome settings that only restate defaults
- keep the existing lint target scope
- keep the formatter limited to `src`
- preserve the intentional formatting choices: space indentation, 120-column line width, ES5 trailing commas, and disabled import organization
- remove the unused HTML formatter configuration

## Why

The existing `biome.json` explicitly configured many values that already match Biome defaults. Keeping only intentional deviations makes the configuration easier to understand and maintain without changing the intended behavior.

## Impact

No application behavior changes are expected. This is configuration cleanup only.

## Validation

- confirmed the branch is one commit ahead of `main`
- confirmed the diff only modifies `biome.json` (27 additions, 53 deletions)

Local Biome checks could not be executed in this environment because the repository is not available as a local checkout; the change was applied through the GitHub connector.