### PR TITLE
refactor: remove unused *.tsx pattern from tsconfig.tools.json

### DIFF
--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["*.ts", "*.tsx", ".storybook/**/*", "e2e/**/*"]
+  "include": ["*.ts", ".storybook/**/*", "e2e/**/*"]
 }


### PR DESCRIPTION
## Description
Removes the unused `*.tsx` pattern from `tsconfig.tools.json`.
There are currently no root-level `.tsx` files in the repository. The `*.ts` pattern remains to type-check root configuration and test script files.