### PR TITLE
Make dark mode surfaces fully black

### DIFF
--- a/src/components/content/Card.tsx
+++ b/src/components/content/Card.tsx
@@ -25,7 +25,7 @@ export const Card: React.FC<{
         className={cx(
           "flex min-w-0 flex-1 flex-col justify-between overflow-hidden rounded-surface text-ink shadow-surface",
           props.disabled ? "bg-surface-muted" : "bg-surface",
-          props.border && "border border-border",
+          props.border && "border border-border dark:border-black",
           props.className
         )}
       >

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -108,7 +108,7 @@ export const Card: React.FC<{ className?: string; card: Card } & CardActionsProp
       {...handlers}
       aria-busy={disabled}
       className={cx(
-        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 sm:gap-3 sm:px-4",
+        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 sm:gap-3 sm:px-4 dark:border-black",
         disabled ? "bg-surface-muted" : "bg-surface",
         props.className
       )}

--- a/src/features/card/components/templates/CardListTemplate.tsx
+++ b/src/features/card/components/templates/CardListTemplate.tsx
@@ -81,7 +81,7 @@ const CardListRows: React.FC<Pick<CardListTemplateProps, "cards" | "card" | "onS
   const [openMenuCardId, setOpenMenuCardId] = React.useState<CardId>();
 
   return (
-    <div className="overflow-visible rounded-surface border border-border bg-surface shadow-surface">
+    <div className="overflow-visible rounded-surface border border-border bg-surface shadow-surface dark:border-black">
       {props.cards.map((card) => (
         <Card
           key={card.id}

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -78,7 +78,7 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
   return (
     <article
       aria-busy={pending}
-      className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0"
+      className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 dark:border-black"
     >
       <div className="min-w-0 flex-1 px-1 py-1">
         <button

--- a/src/features/deck/components/templates/DeckListTemplate.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.tsx
@@ -58,7 +58,7 @@ const DeckListSection: React.FC<{
           {countLabel(items.length)} · {note}
         </span>
       </div>
-      <div className="rounded-surface border border-border bg-surface shadow-surface">
+      <div className="rounded-surface border border-border bg-surface shadow-surface dark:border-black">
         {items.map((item) => (
           <DeckCard
             key={item.deck.id}

--- a/src/styles/calm-focus.css
+++ b/src/styles/calm-focus.css
@@ -49,9 +49,9 @@
 
 .dark {
   color-scheme: dark;
-  --calm-color-canvas: #111827;
-  --calm-color-surface: #182231;
-  --calm-color-surface-elevated: #202c3d;
+  --calm-color-canvas: #000000;
+  --calm-color-surface: #000000;
+  --calm-color-surface-elevated: #000000;
   --calm-color-surface-muted: #273447;
   --calm-color-ink: #edf2f7;
   --calm-color-ink-muted: #aeb9c8;
@@ -64,6 +64,7 @@
   --calm-color-warning: #e5b566;
   --calm-color-danger: #f09a9a;
   --calm-color-info: #82bde4;
+  --calm-shadow-surface: none;
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
- make dark mode canvas, surfaces, and elevated surfaces fully black
- remove surface shadows and blend card and list boundaries into the black background
- preserve light-mode colors and borders

## Testing
- make check
- verified dark and light CardListTemplate stories in Storybook