### PR TITLE
Prevent CSV formula injection

### DIFF
--- a/src/action/deck.spec.ts
+++ b/src/action/deck.spec.ts
@@ -84,6 +84,26 @@ describe("deck action", () => {
       });
       expect(fileSaver.saveAs).toHaveBeenCalledWith(blob, "Remote deck.csv");
     });
+
+    it("escapes spreadsheet formulae in exported card data", () => {
+      const blob = new Blob();
+      const blobConstructor = vi.spyOn(global, "Blob");
+      blobConstructor.mockImplementation(createBlobConstructor(blob));
+      const deck = action.deck.prepare({ name: "Formula deck" }, "uid", () => "deck-id");
+      const card = createCard({
+        frontText: "=1+1",
+        backText: "+1+1",
+        tags: ["@tag"],
+        uniqueKey: "-1+1",
+      });
+
+      action.deck.downloadData(deck, [card]);
+
+      expect(blobConstructor).toHaveBeenCalledWith(['"\'=1+1","\'+1+1","\'@tag","\'-1+1"'], {
+        type: "text/plain;charset=utf-8",
+      });
+      expect(fileSaver.saveAs).toHaveBeenCalledWith(blob, "Formula deck.csv");
+    });
   });
 
   describe("downloadCsvSampleText", () => {

--- a/src/action/deck.ts
+++ b/src/action/deck.ts
@@ -40,7 +40,7 @@ export const prepare = (deck: DeckRaw, uid: string, generateId: () => string): D
  * separately.
  */
 export const downloadData = (deck: Deck, cards: Card[]) => {
-  const csv = Papa.unparse(cards.map(action.card.toRow));
+  const csv = Papa.unparse(cards.map(action.card.toRow), { escapeFormulae: true });
   _saveAs(csv, deck.name);
 };
 


### PR DESCRIPTION
## Summary

- enable Papa Parse's `escapeFormulae` option for deck CSV exports
- add regression coverage for values beginning with `=`, `+`, `@`, and `-`

## Why

Card content is user-controlled and may also originate from imported or shared decks. Exporting formula-prefixed values unchanged allows Excel, LibreOffice, and similar spreadsheet applications to interpret those cells as formulas when the downloaded CSV is opened.

## Impact

Papa Parse now prefixes formula-like cells with an apostrophe and quotes them, so spreadsheet applications treat the content as text. Existing normal CSV output remains unchanged and continues to be covered by the existing test.

## Testing

GitHub Actions `Test` passed on the latest `main`, including:

- build, type checking, Biome, ESLint, and unit coverage (`mise run ci`)
- Storybook tests
- integration and Playwright E2E checks (`make ci`)