### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@playwright/test"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -44,3 +46,5 @@ updates:
       - "/sample"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "mcr.microsoft.com/playwright"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Update Playwright manually to keep the npm package, container image,
+    # and remote server versions aligned.
     ignore:
       - dependency-name: "@playwright/test"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/sample"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/sample"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker-compose"
+    directories:
+      - "/.devcontainer"
+      - "/sample"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,44 +7,8 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "@playwright/test"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "pip"
-    directory: "/sample"
-    schedule:
-      interval: "weekly"
-    groups:
-      python-dependencies:
-        patterns:
-          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directories:
-      - "/"
-      - "/sample"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "docker-compose"
-    directories:
-      - "/.devcontainer"
-      - "/sample"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "mcr.microsoft.com/playwright"


### PR DESCRIPTION
## Summary

- Configure weekly Dependabot updates for npm and GitHub Actions.
- Keep Playwright updates manual so the npm client, container image, and remote server remain aligned.

## Testing

- mise run check

## Notes

- The repository pins npm 12.0.1, while the current GitHub documentation lists Dependabot npm support through npm 11. Monitor the initial npm update run for compatibility.