### PR TITLE
Add test coverage to GitHub Actions job summary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,37 @@ jobs:
         run: npm run test:storybook
 
       - name: Upload Vitest coverage report
+        id: coverage
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: vitest-coverage
           path: coverage/
           if-no-files-found: warn
+
+      - name: Add coverage summary
+        if: ${{ always() }}
+        env:
+          ARTIFACT_URL: ${{ steps.coverage.outputs.artifact-url }}
+        run: |
+          if [ ! -f coverage/coverage-summary.json ]; then
+            exit 0
+          fi
+
+          {
+            echo "## Test coverage"
+            echo
+            echo "| Metric | Coverage |"
+            echo "| --- | ---: |"
+            jq -r '
+              .total |
+              "| Lines | \(.lines.pct)% |",
+              "| Statements | \(.statements.pct)% |",
+              "| Branches | \(.branches.pct)% |",
+              "| Functions | \(.functions.pct)% |"
+            ' coverage/coverage-summary.json
+            echo
+            if [ -n "$ARTIFACT_URL" ]; then
+              echo "[Download full coverage report]($ARTIFACT_URL)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- show Vitest coverage percentages in the GitHub Actions job summary
- keep the existing `vitest-coverage` artifact for the full HTML report
- link the uploaded coverage artifact from the summary when available

## Why

The current workflow already generates `coverage/coverage-summary.json` and uploads `coverage/` as an artifact, but checking the current `main` coverage requires downloading the artifact. This makes the key coverage metrics visible directly from the workflow run while preserving the detailed report.

## Validation

- confirmed the branch differs from `main` only in `.github/workflows/test.yml`
- reuses the existing Vitest `json-summary` coverage output and `upload-artifact` step