### PR TITLE
Make dark code backgrounds black

### DIFF
--- a/src/components/content/Code.tsx
+++ b/src/components/content/Code.tsx
@@ -37,7 +37,7 @@ const Highlight: React.FC<{ category: string; dark: boolean; text: string }> = (
   return (
     <pre
       className={cx(
-        "max-w-full overflow-x-auto rounded-control border border-border bg-surface-muted p-3 text-ink",
+        "max-w-full overflow-x-auto rounded-control border border-border bg-surface-muted p-3 text-ink dark:bg-black",
         category
       )}
     >

--- a/src/components/content/RichContent.spec.tsx
+++ b/src/components/content/RichContent.spec.tsx
@@ -21,7 +21,7 @@ describe("shared rich content", () => {
     const pre = view.container.querySelector("pre");
     const code = view.container.querySelector("code");
 
-    expect(pre).toHaveClass("typescript", "max-w-full", "overflow-x-auto", "bg-surface-muted");
+    expect(pre).toHaveClass("typescript", "max-w-full", "overflow-x-auto", "bg-surface-muted", "dark:bg-black");
     expect(code).toHaveTextContent(text);
     expect(code).toHaveAttribute("data-theme", "light");
     await waitFor(() => expect(code).toHaveClass("hljs"));


### PR DESCRIPTION
## Summary
- make code blocks use a black background in dark mode
- preserve the muted code background in light mode
- cover the dark background utility in the shared rich-content test
- follow up on #438

## Testing
- mise run check