### PR TITLE
refactor(vitest): remove unused scripts spec glob

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
         test: {
           name: 'unit',
           globals: true,
-          include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}', 'scripts/**/*.spec.mjs'],
+          include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}'],
           environment: 'jsdom',
         },
       },


### PR DESCRIPTION
## Summary

Remove `'scripts/**/*.spec.mjs'` from the `unit` test project `include` pattern in `vitest.config.ts`.

## Why

After simplifying the PWA build verification in #452, there are no longer any `.spec.mjs` test files under `scripts/`. Removing the unused glob pattern keeps `vitest.config.ts` clean.

## Validation

- Executed `npm run fmt:check`, `npm run lint`, and `npm run test:unit` (all 515 tests passed).