### PR TITLE
Improve shared Card spacing and Storybook examples

### DIFF
--- a/src/components/content/Card.stories.tsx
+++ b/src/components/content/Card.stories.tsx
@@ -8,24 +8,32 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Card as Template } from "@/components/content/Card";
 
+const defaultContent = (
+  <>
+    <div className="space-y-1">
+      <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Study deck</p>
+      <h2 className="text-title font-bold text-ink">TypeScript essentials</h2>
+    </div>
+    <p className="text-body text-ink-muted">Twelve focused cards for a calm, consistent review session.</p>
+  </>
+);
+
 const meta = {
   title: "Shared/Content/Card",
   component: Template,
   tags: ["autodocs"],
   args: {
-    children: "this is a text",
+    children: defaultContent,
   },
 } satisfies Meta<typeof Template>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: { children: "this is a text" },
-};
+export const Default: Story = {};
 
 export const Short: Story = {
-  args: { children: "short" },
+  args: { children: "A compact card for a short note." },
 };
 
 export const Disabled: Story = {
@@ -41,11 +49,13 @@ export const Border: Story = {
 };
 
 export const TooLong: Story = {
-  args: { children: "this is a too long text ".repeat(30) },
+  args: {
+    children: "Long content remains readable and wraps naturally without escaping the card surface. ".repeat(12),
+  },
   parameters: { viewport: { defaultViewport: "iphone5" } },
 };
 
 export const Dark: Story = {
-  args: { border: true, children: "Calm Focus surface in dark mode" },
+  args: { border: true },
   globals: { theme: "dark" },
 };

--- a/src/components/content/Card.tsx
+++ b/src/components/content/Card.tsx
@@ -23,7 +23,7 @@ export const Card: React.FC<{
     <div className={cx("flex", props.full ? "w-full" : ["w-full", "md:w-1/2", "lg:w-1/3"])}>
       <div
         className={cx(
-          "flex min-w-0 flex-1 flex-col justify-between overflow-hidden rounded-surface text-ink shadow-surface",
+          "flex min-w-0 flex-1 flex-col justify-between gap-3 overflow-hidden rounded-surface p-4 text-ink shadow-surface md:p-5",
           props.disabled ? "bg-surface-muted" : "bg-surface",
           props.border && "border border-border dark:border-black",
           props.className

--- a/src/components/content/ContentHierarchy.spec.tsx
+++ b/src/components/content/ContentHierarchy.spec.tsx
@@ -23,7 +23,16 @@ describe("shared content hierarchy", () => {
     const view = render(<Card className="custom-card">Card content</Card>);
     const surface = screen.getByText("Card content");
     expect(view.container.firstElementChild).toHaveClass("w-full", "md:w-1/2", "lg:w-1/3");
-    expect(surface).toHaveClass("rounded-surface", "bg-surface", "text-ink", "shadow-surface", "custom-card");
+    expect(surface).toHaveClass(
+      "gap-3",
+      "rounded-surface",
+      "bg-surface",
+      "p-4",
+      "md:p-5",
+      "text-ink",
+      "shadow-surface",
+      "custom-card"
+    );
 
     view.rerender(
       <Card full disabled border>


### PR DESCRIPTION
## What changed

- Add responsive internal padding and consistent spacing between Card children.
- Replace placeholder Card stories with realistic, styled content.
- Extend the shared content hierarchy test to cover the Card spacing contract.

## Why

The shared Card surface had no internal padding. Text-only stories therefore collapsed into a roughly 26px-high pill, making the component look visually broken and leaving composed child content without a safe default rhythm.

## Impact

Card content now has comfortable spacing on mobile and desktop, long content wraps without horizontal overflow, and existing full-width, border, disabled, and dark-mode variants remain intact.

## Validation

- `mise run check` (79 test files, 515 tests)
- `npm run build:storybook`
- Visual Storybook checks for desktop, iPhone 5 width, and dark mode