### PR TITLE
Highlight card and deck rows on hover

### DIFF
--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -108,8 +108,9 @@ export const Card: React.FC<{ className?: string; card: Card } & CardActionsProp
       {...handlers}
       aria-busy={disabled}
       className={cx(
-        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 sm:gap-3 sm:px-4 dark:border-black",
+        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 transition-colors duration-fast ease-calm last:border-b-0 sm:gap-3 sm:px-4 dark:border-black",
         disabled ? "bg-surface-muted" : "bg-surface",
+        !disabled && "hover:bg-surface-muted",
         props.className
       )}
     >

--- a/src/features/card/components/templates/CardListTemplate.stories.tsx
+++ b/src/features/card/components/templates/CardListTemplate.stories.tsx
@@ -111,6 +111,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const HoverHighlight: Story = {
+  play: async ({ canvas, userEvent }) => {
+    const firstCard = canvas.getAllByRole("button", { name: /^View / })[0];
+    if (firstCard == null) throw new Error("HoverHighlight requires at least one card");
+    await userEvent.hover(firstCard);
+  },
+};
+
 export const RemovableSelectedTags: Story = {
   args: { onRemoveTag: fn() },
   render: (args) => <RemovableSelectedTagsExample onRemoveTag={args.onRemoveTag} />,

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -78,7 +78,7 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
   return (
     <article
       aria-busy={pending}
-      className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 dark:border-black"
+      className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 transition-colors duration-fast ease-calm last:border-b-0 hover:bg-surface-muted dark:border-black"
     >
       <div className="min-w-0 flex-1 px-1 py-1">
         <button

--- a/src/features/deck/components/DeckCard.tsx
+++ b/src/features/deck/components/DeckCard.tsx
@@ -4,6 +4,7 @@
  * outside the view.
  */
 
+import cx from "classnames";
 import * as React from "react";
 import { AiFillCaretRight, AiOutlineCloud } from "react-icons/ai";
 
@@ -78,7 +79,10 @@ export const DeckCard: React.FC<DeckCardProps> = (props) => {
   return (
     <article
       aria-busy={pending}
-      className="relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 transition-colors duration-fast ease-calm last:border-b-0 hover:bg-surface-muted dark:border-black"
+      className={cx(
+        "relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 transition-colors duration-fast ease-calm last:border-b-0 dark:border-black",
+        pending ? "bg-surface-muted" : "hover:bg-surface-muted"
+      )}
     >
       <div className="min-w-0 flex-1 px-1 py-1">
         <button

--- a/src/features/deck/components/templates/DeckListTemplate.stories.tsx
+++ b/src/features/deck/components/templates/DeckListTemplate.stories.tsx
@@ -66,6 +66,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const HoverHighlight: Story = {
+  play: async ({ canvas, userEvent }) => {
+    const firstDeck = canvas.getAllByRole("button", { name: /^View / })[0];
+    if (firstDeck == null) throw new Error("HoverHighlight requires at least one deck");
+    await userEvent.hover(firstDeck);
+  },
+};
+
 export const Inactive: Story = {
   args: { sections: { studying: [], other: otherItems(fixture.decks.default) } },
 };


### PR DESCRIPTION
## Summary

- highlight enabled card rows and deck rows on mouse hover
- use the shared muted surface token with a short color transition
- add interactive hover stories for both list templates

## Testing

- `mise run check`
- `mise run test-storybook`