### PR TITLE
Remove GitHub access token configuration

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -42,7 +42,6 @@ export const e2eConfig = {
   cardSwipeRight: "GoToNextCard",
   darkMode: false,
   selectedTags: [],
-  githubAccessToken: "",
 };
 
 export const seedConfig = async (page: Page, config: typeof e2eConfig = e2eConfig) => {

--- a/e2e/remote-read.e2e.ts
+++ b/e2e/remote-read.e2e.ts
@@ -96,7 +96,6 @@ const persistedConfig = {
   cardSwipeRight: "GoToNextCard",
   darkMode: false,
   selectedTags: [],
-  githubAccessToken: "",
 };
 
 const seedAuth = async (page: Page, uid: string, nextUid?: string) => {

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -12,16 +12,14 @@ import { clearStudyStore, studyStore, type StudyState } from "@/features/study/s
 import { publishAuthenticatedUser, suspendAnonymousBootstrap } from "@/auth/AuthContext";
 import { auth } from "@/firebase";
 import { remoteStore } from "@/store/remoteStore";
-import { configStore } from "@/store/configStore";
 
 interface LogoutCleanupProgress {
   remote: boolean;
   study: boolean;
-  credentials: boolean;
   studyStateAfterClear?: StudyState;
 }
 
-type LogoutCleanupStep = "remote" | "study" | "credentials";
+type LogoutCleanupStep = "remote" | "study";
 
 /**
  * Represents the logout cleanup error condition used by the application.
@@ -68,7 +66,6 @@ const runLogout = async (
     };
 
     await run("remote", () => remoteStore.getState().stop(confirmedUid));
-    await run("credentials", () => configStore.getState().updateConfig({ githubAccessToken: "" }));
     await run("study", async () => {
       if (progress.studyStateAfterClear && studyStore.getState() !== progress.studyStateAfterClear) return;
       const cleanup = clearStudyStore();
@@ -88,7 +85,7 @@ const runLogout = async (
  * If local cleanup fails, the returned error carries a retry that resumes the unfinished steps.
  */
 export const logout = (confirmedUid: string): Promise<void> =>
-  runLogout(confirmedUid, { remote: false, study: false, credentials: false }, true);
+  runLogout(confirmedUid, { remote: false, study: false }, true);
 
 /**
  * Upgrades the current anonymous Firebase user to a Google-authenticated account.

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -7,13 +7,12 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createCard, createConfig, createDeck } from "@/test/factories";
+import { createCard, createDeck } from "@/test/factories";
 import type { DeckImportResult } from "@/features/import/components/deckImportTypes";
 import { CardBulkMutationError } from "@/services/cardCommands";
 
 const mocks = vi.hoisted(() => ({
   uid: "uid-a",
-  config: {} as ConfigState,
   remoteStatus: "ready" as "idle" | "loading" | "ready" | "error" | "blocked",
   syncStatus: "synced" as "cached" | "pending" | "synced" | undefined,
   decks: [] as Deck[],
@@ -28,7 +27,6 @@ const mocks = vi.hoisted(() => ({
   bulkUpsert: vi.fn(),
 }));
 
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
 vi.mock("@/auth/AuthContext", () => ({
   useAuth: () =>
     mocks.uid === "" ? { status: "anonymous" } : { status: "authenticated", uid: mocks.uid, user: { uid: mocks.uid } },
@@ -68,7 +66,6 @@ describe("useDeckImport", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.uid = "uid-a";
-    mocks.config = createConfig({ githubAccessToken: "" });
     mocks.remoteStatus = "ready";
     mocks.syncStatus = "synced";
     mocks.decks = [];
@@ -234,30 +231,13 @@ describe("useDeckImport", () => {
     expect(mocks.createDeck).not.toHaveBeenCalled();
   });
 
-  it("does not send a GitHub token to an unapproved URL", async () => {
-    mocks.config = createConfig({ githubAccessToken: "secret" });
+  it("fetches a public import URL without credentials", async () => {
     const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"front","back","","key"'));
     const { result } = renderHook(useDeckImport);
 
     await act(async () => result.current.importUrl("https://example.test/deck.csv"));
 
-    expect(fetch).toHaveBeenCalledWith(new URL("https://example.test/deck.csv"), { headers: {} });
-  });
-
-  it("sends a GitHub token only to the repository contents API", async () => {
-    mocks.config = createConfig({ githubAccessToken: "secret" });
-    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"front","back","","key"'));
-    const { result } = renderHook(useDeckImport);
-    const url = "https://api.github.com/repos/owner/repository/contents/deck.csv";
-
-    await act(async () => result.current.importUrl(url));
-
-    expect(fetch).toHaveBeenCalledWith(new URL(url), {
-      headers: {
-        Accept: "application/vnd.github.raw",
-        Authorization: "Bearer secret",
-      },
-    });
+    expect(fetch).toHaveBeenCalledWith(new URL("https://example.test/deck.csv"));
   });
 
   it("rejects a second import while the first is pending", async () => {

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -12,7 +12,6 @@ import { useAuth } from "@/auth/AuthContext";
 import { useCardMutations } from "@/features/card/hooks/useCardMutations";
 import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
-import { useConfig } from "@/hooks/useConfig";
 import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/components/deckImportTypes";
 import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
 import { CardBulkMutationError } from "@/services/cardCommands";
@@ -35,10 +34,6 @@ type ImportRequest =
 const SAMPLE_DECK_NAME = "Sample Deck";
 const SAMPLE_VERSION = 1;
 
-const isGitHubContentsApiUrl = (url: URL): boolean =>
-  url.protocol === "https:" &&
-  url.hostname === "api.github.com" &&
-  /^\/repos\/[^/]+\/[^/]+\/contents\/.+/.test(url.pathname);
 /**
  * Builds the stable sample deck id used by the import feature.
  * Centralizing the format prevents different callers from producing incompatible identifiers.
@@ -270,7 +265,6 @@ const previewDeckImportFile = async (
  */
 export const useDeckImport = () => {
   const auth = useAuth();
-  const config = useConfig();
   const remote = useRemoteCollections();
   const deckMutations = useDeckMutations();
   const cardMutations = useCardMutations();
@@ -422,20 +416,12 @@ export const useDeckImport = () => {
     return run({ kind: "content", name: preview.deckName, rows: preview.analysis.rows });
   };
 
-  /**
-   * Downloads card CSV data from a URL and runs it through the normal import workflow.
-   * A configured GitHub token is attached for private raw-content requests.
-   */
+  /** Downloads card CSV data from a public URL and runs it through the normal import workflow. */
   const importUrl = async (url: string, name?: string) => {
     const operationGeneration = generation.current;
     const operationUid = uid;
-    const headers: Record<string, string> = {};
     const parsedUrl = new URL(url);
-    if (config.githubAccessToken !== "" && isGitHubContentsApiUrl(parsedUrl)) {
-      headers.Accept = "application/vnd.github.raw";
-      headers.Authorization = `Bearer ${config.githubAccessToken}`;
-    }
-    const response = await fetch(parsedUrl, { headers });
+    const response = await fetch(parsedUrl);
     if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
     const cards = await action.deck.parseCsv(await response.text());
     if (generation.current !== operationGeneration || dependenciesRef.current?.uid !== operationUid) {

--- a/src/features/settings/components/ConfigForm.spec.tsx
+++ b/src/features/settings/components/ConfigForm.spec.tsx
@@ -1,8 +1,8 @@
 /**
  * @file Verifies the "ConfigForm" contract with automated examples.
  * The examples make the expected behavior concrete with cases such as "groups every auto-saved
- * setting in the unified settings list", "preserves all switch, slider, token, and metadata
- * values", "forwards switch, slider, and token changes to their field callbacks".
+ * setting in the unified settings list", "preserves all switch, slider, and metadata values",
+ * "forwards switch and slider changes to their field callbacks".
  */
 
 import type React from "react";
@@ -30,7 +30,6 @@ function createFields(): ConfigFormFields {
     maxNumberOfCardsToLearn: { name: "maxNumberOfCardsToLearn", value: "24", min: 1, max: 100, onChange: vi.fn() },
     defaultAutoPlay: { name: "defaultAutoPlay", checked: false, onChange: vi.fn() },
     cardInterval: { name: "cardInterval", value: "7", min: 1, max: 60, onChange: vi.fn() },
-    githubAccessToken: { name: "githubAccessToken", value: "github-token", onChange: vi.fn() },
   };
 }
 
@@ -74,7 +73,7 @@ describe("ConfigForm", () => {
     expect(view.queryByText("Show Heaer")).not.toBeInTheDocument();
   });
 
-  it("preserves all switch, slider, token, and metadata values", () => {
+  it("preserves all switch, slider, and metadata values", () => {
     const view = render(
       <ConfigForm {...createProps({ identity: { uid: "user-123", displayName: "Settings User" }, isLoggedIn: true })} />
     );
@@ -85,13 +84,12 @@ describe("ConfigForm", () => {
     expect(view.getByRole("slider", { name: "Maximum cards" })).toHaveValue("24");
     expect(view.getByRole("slider", { name: "Autoplay interval" })).toHaveValue("7");
     expect(view.getByRole("slider", { name: "Autoplay interval" })).toHaveAttribute("aria-valuetext", "7 seconds");
-    expect(view.container.querySelector("input[name='githubAccessToken']")).toHaveValue("github-token");
     expect(view.getByText("24")).toBeInTheDocument();
     expect(view.getByText("7s")).toBeInTheDocument();
 
     const details = view.getByRole("heading", { level: 2, name: "Advanced" }).closest("details");
     expect(details).not.toHaveAttribute("open");
-    expect(details).toContainElement(view.getByDisplayValue("github-token"));
+    expect(details).not.toHaveTextContent("Github Access Token");
     expect(details).toHaveTextContent("1.2.3");
     expect(details).toHaveTextContent("user-123");
   });
@@ -105,39 +103,29 @@ describe("ConfigForm", () => {
     expect(view.queryByText("Wait between automatic card changes")).not.toBeInTheDocument();
   });
 
-  it("forwards switch, slider, and token changes to their field callbacks", async () => {
+  it("forwards switch and slider changes to their field callbacks", async () => {
     let switchArguments: { name: string; checked: boolean } | undefined;
     let sliderArguments: { name: string; value: string } | undefined;
-    let tokenArguments: { name: string; value: string } | undefined;
     const showHeader = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
       switchArguments = { name: event.target.name, checked: event.target.checked };
     });
     const maxNumberOfCardsToLearn = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
       sliderArguments = { name: event.target.name, value: event.target.value };
     });
-    const githubAccessToken = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
-      tokenArguments = { name: event.target.name, value: event.target.value };
-    });
     const fields = createFields();
     fields.showHeader.onChange = showHeader;
     fields.maxNumberOfCardsToLearn.onChange = maxNumberOfCardsToLearn;
-    fields.githubAccessToken.onChange = githubAccessToken;
     const view = render(<ConfigForm {...createProps({ fields })} />);
 
     await userEvent.click(view.container.querySelector("input[name='showHeader']") as HTMLInputElement);
     fireEvent.change(view.container.querySelector("input[name='maxNumberOfCardsToLearn']") as HTMLInputElement, {
       target: { value: "31" },
     });
-    fireEvent.change(view.container.querySelector("input[name='githubAccessToken']") as HTMLInputElement, {
-      target: { value: "updated-token" },
-    });
 
     expect(showHeader).toHaveBeenCalledOnce();
     expect(switchArguments).toEqual({ name: "showHeader", checked: false });
     expect(maxNumberOfCardsToLearn).toHaveBeenCalledOnce();
     expect(sliderArguments).toEqual({ name: "maxNumberOfCardsToLearn", value: "31" });
-    expect(githubAccessToken).toHaveBeenCalledOnce();
-    expect(tokenArguments).toEqual({ name: "githubAccessToken", value: "updated-token" });
   });
 
   it("keeps section heading relationships unique across multiple instances", () => {

--- a/src/features/settings/components/ConfigForm.stories.tsx
+++ b/src/features/settings/components/ConfigForm.stories.tsx
@@ -29,15 +29,6 @@ const fields: ConfigFormFields = {
     max: 60,
     onChange: () => undefined,
   },
-  githubAccessToken: { value: fixture.config.default.githubAccessToken, onChange: () => undefined },
-};
-
-const longFields: ConfigFormFields = {
-  ...fields,
-  githubAccessToken: {
-    value: "github_pat_story_token_with_an_intentionally_long_value_for_responsive_review_1234567890",
-    onChange: () => undefined,
-  },
 };
 
 const meta = {
@@ -76,7 +67,7 @@ export const LongContent: Story = {
       uid: "settings-user-with-an-intentionally-long-identifier-for-responsive-review-1234567890",
       displayName: "A settings user with an intentionally long display name for responsive review",
     },
-    fields: longFields,
+    fields,
     version: "2026.07.16-calm-focus-settings-presentation-long-metadata",
   },
 };

--- a/src/features/settings/components/ConfigForm.tsx
+++ b/src/features/settings/components/ConfigForm.tsx
@@ -9,7 +9,7 @@ import { useId } from "react";
 import { AiOutlineDown, AiOutlineEye, AiOutlinePlayCircle, AiOutlineTool, AiOutlineUser } from "react-icons/ai";
 
 import { SettingsRow, SettingsSection } from "@/features/settings/components/SettingsSection";
-import { Button, Input, Slider, Switch } from "@/components";
+import { Button, Slider, Switch } from "@/components";
 
 export interface ConfigFormFields {
   showHeader: React.ComponentProps<typeof Switch>;
@@ -21,7 +21,6 @@ export interface ConfigFormFields {
   maxNumberOfCardsToLearn: React.ComponentProps<typeof Slider>;
   defaultAutoPlay: React.ComponentProps<typeof Switch>;
   cardInterval: React.ComponentProps<typeof Slider>;
-  githubAccessToken: React.ComponentProps<typeof Input>;
 }
 
 export interface ConfigFormProps {
@@ -55,7 +54,6 @@ export const ConfigForm: React.FC<ConfigFormProps> = (props) => {
     useCardInterval: `${idPrefix}-use-card-interval`,
     defaultAutoPlay: `${idPrefix}-start-autoplay`,
     cardInterval: `${idPrefix}-autoplay-interval`,
-    githubAccessToken: `${idPrefix}-github-access-token`,
   };
   const advancedHeadingId = `${idPrefix}-advanced-heading`;
   /**
@@ -228,7 +226,7 @@ export const ConfigForm: React.FC<ConfigFormProps> = (props) => {
             <h2 id={advancedHeadingId} className="text-body font-bold text-ink">
               Advanced
             </h2>
-            <span className="block text-caption text-ink-muted">Version, token, and user ID</span>
+            <span className="block text-caption text-ink-muted">Version and user ID</span>
           </span>
           <AiOutlineDown
             aria-hidden="true"
@@ -239,18 +237,6 @@ export const ConfigForm: React.FC<ConfigFormProps> = (props) => {
           <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
             <span className="text-body font-medium text-ink">Version</span>
             <span className="min-w-0 break-all text-right text-caption text-ink-muted">{props.version}</span>
-          </div>
-          <div className="px-4 py-3">
-            <label htmlFor={inputIds.githubAccessToken} className="text-body font-medium text-ink">
-              Github Access Token
-            </label>
-            <span className="block text-caption text-ink-muted">Used when importing private GitHub content</span>
-            <Input
-              className="mt-2"
-              {...props.fields.githubAccessToken}
-              id={inputIds.githubAccessToken}
-              type="password"
-            />
           </div>
           <div className="flex min-h-touch items-start justify-between gap-4 px-4 py-3">
             <span className="shrink-0 text-body font-medium text-ink">User ID</span>

--- a/src/features/settings/components/templates/ConfigFormTemplate.spec.tsx
+++ b/src/features/settings/components/templates/ConfigFormTemplate.spec.tsx
@@ -22,7 +22,6 @@ const fields: ConfigFormFields = {
   maxNumberOfCardsToLearn: { name: "maxNumberOfCardsToLearn", value: "10", onChange: () => undefined },
   defaultAutoPlay: { name: "defaultAutoPlay" },
   cardInterval: { name: "cardInterval", value: "5", onChange: () => undefined },
-  githubAccessToken: { name: "githubAccessToken" },
 };
 
 describe("ConfigFormTemplate", () => {

--- a/src/features/settings/components/templates/ConfigFormTemplate.stories.tsx
+++ b/src/features/settings/components/templates/ConfigFormTemplate.stories.tsx
@@ -31,15 +31,6 @@ const fields: ConfigFormFields = {
     max: 60,
     onChange: () => undefined,
   },
-  githubAccessToken: { value: fixture.config.default.githubAccessToken, onChange: () => undefined },
-};
-
-const longFields: ConfigFormFields = {
-  ...fields,
-  githubAccessToken: {
-    value: "github_pat_story_token_with_an_intentionally_long_value_for_responsive_review_1234567890",
-    onChange: () => undefined,
-  },
 };
 
 const meta = {
@@ -92,7 +83,7 @@ export const LongContent: Story = {
         displayName: "A settings user with an intentionally long display name for responsive review",
       },
       config: fixture.config.longUserName,
-      fields: longFields,
+      fields,
       maxNumberOfCardsToLearn: fixture.config.longUserName.maxNumberOfCardsToLearn,
       cardInterval: fixture.config.longUserName.cardInterval,
       version: "2026.07.16-calm-focus-settings-presentation-long-metadata",

--- a/src/features/settings/hooks/useConfigFormState.spec.tsx
+++ b/src/features/settings/hooks/useConfigFormState.spec.tsx
@@ -41,7 +41,6 @@ describe("ConfigForm with useConfigFormState", () => {
     defaultAutoPlay: false,
     maxNumberOfCardsToLearn: 0,
     cardInterval: 0,
-    githubAccessToken: "",
   } as ConfigState;
   it("auto-submits boolean and numeric field changes", async () => {
     const onSubmit = vi.fn();

--- a/src/features/settings/hooks/useConfigFormState.ts
+++ b/src/features/settings/hooks/useConfigFormState.ts
@@ -83,7 +83,6 @@ export const useConfigFormState = ({
         min: 0,
         max: 60,
       },
-      githubAccessToken: register("githubAccessToken"),
     },
   };
 };

--- a/src/store/configSchema.ts
+++ b/src/store/configSchema.ts
@@ -26,7 +26,6 @@ export const defaultConfig: ConfigState = Object.freeze({
   cardSwipeRight: "GoToNextCard",
   darkMode: false,
   selectedTags: Object.freeze([]) as unknown as string[],
-  githubAccessToken: "",
 });
 
 const cardSwipeSchema = z.enum([
@@ -60,7 +59,6 @@ export const configSchema: z.ZodType<ConfigState> = z
     cardSwipeRight: cardSwipeSchema.catch(defaultConfig.cardSwipeRight),
     darkMode: z.boolean().catch(defaultConfig.darkMode),
     selectedTags: z.array(z.string()).catch([...defaultConfig.selectedTags]),
-    githubAccessToken: z.string().catch(defaultConfig.githubAccessToken),
   })
   .catch(defaultConfig);
 
@@ -71,7 +69,4 @@ const persistedConfigStateSchema = z.object({ config: configSchema }).catch({ co
  * Malformed input is reported before downstream code relies on the result.
  */
 export const parsePersistedConfig = (persistedState: unknown): ConfigState =>
-  configSchema.parse({
-    ...persistedConfigStateSchema.parse(persistedState).config,
-    githubAccessToken: "",
-  });
+  configSchema.parse(persistedConfigStateSchema.parse(persistedState).config);

--- a/src/store/configStore.spec.ts
+++ b/src/store/configStore.spec.ts
@@ -42,9 +42,8 @@ describe("config store", () => {
     store.getState().updateConfig({ darkMode: true });
 
     const persisted = JSON.parse(storage.getItem(CONFIG_STORAGE_KEY) ?? "{}");
-    const { githubAccessToken: _githubAccessToken, ...persistedDefaultConfig } = defaultConfig;
     expect(persisted).toEqual({
-      state: { config: { ...persistedDefaultConfig, darkMode: true } },
+      state: { config: { ...defaultConfig, darkMode: true } },
       version: 2,
     });
     expect(persisted.state).not.toHaveProperty("deck");
@@ -57,24 +56,6 @@ describe("config store", () => {
     expect(restored.getState().config).toEqual({ ...defaultConfig, darkMode: true });
     expect(restored.getState().updateConfig).toBeTypeOf("function");
     expect(restored.getState().toggleConfig).toBeTypeOf("function");
-  });
-
-  it("never persists a GitHub access token and drops legacy persisted tokens", async () => {
-    const storage = createMemoryStorage();
-    const store = createConfigStore({ storage, skipHydration: true });
-
-    store.getState().updateConfig({ githubAccessToken: "secret" });
-    expect(storage.getItem(CONFIG_STORAGE_KEY)).not.toContain("secret");
-
-    storage.setItem(
-      CONFIG_STORAGE_KEY,
-      JSON.stringify({ state: { config: { ...defaultConfig, githubAccessToken: "legacy-secret" } }, version: 1 })
-    );
-    await store.persist.rehydrate();
-
-    expect(store.getState().config.githubAccessToken).toBe("");
-    expect(storage.getItem(CONFIG_STORAGE_KEY)).not.toContain("legacy-secret");
-    expect(JSON.parse(storage.getItem(CONFIG_STORAGE_KEY) ?? "{}")).toMatchObject({ version: 2 });
   });
 
   it("validates numeric ranges during updates", () => {
@@ -97,6 +78,7 @@ describe("config store", () => {
             cardInterval: 15,
             darkMode: "yes",
             removedSetting: true,
+            githubAccessToken: "legacy-secret",
           },
         },
         version: 1,
@@ -111,6 +93,7 @@ describe("config store", () => {
       cardInterval: 15,
     });
     expect(store.getState().config).not.toHaveProperty("removedSetting");
+    expect(store.getState().config).not.toHaveProperty("githubAccessToken");
   });
 
   it("uses current defaults when persisted config is not an object", async () => {

--- a/src/store/configStore.ts
+++ b/src/store/configStore.ts
@@ -23,9 +23,8 @@ export interface ConfigStoreState {
   toggleConfig: (key: BooleanConfigKey) => void;
 }
 
-type PersistedConfig = Omit<ConfigState, "githubAccessToken">;
 interface PersistedConfigState {
-  config: PersistedConfig;
+  config: ConfigState;
 }
 
 interface CreateConfigStoreOptions {
@@ -59,14 +58,7 @@ export const createConfigStore = ({ storage, skipHydration }: CreateConfigStoreO
         version: CONFIG_STORAGE_VERSION,
         storage: persistStorage,
         ...(skipHydration !== undefined ? { skipHydration } : {}),
-        migrate: (persistedState) => {
-          const { githubAccessToken: _githubAccessToken, ...config } = parsePersistedConfig(persistedState);
-          return { config };
-        },
-        partialize: ({ config }) => {
-          const { githubAccessToken: _githubAccessToken, ...persistedConfig } = config;
-          return { config: persistedConfig };
-        },
+        migrate: (persistedState) => ({ config: parsePersistedConfig(persistedState) }),
         merge: (persistedState, currentState) => ({
           ...currentState,
           config: parsePersistedConfig(persistedState),

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -69,7 +69,6 @@ export const createConfig = (overrides: Partial<ConfigState> = {}): ConfigState 
   cardSwipeRight: "GoToNextCard",
   darkMode: false,
   selectedTags: [],
-  githubAccessToken: "",
   ...overrides,
 });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -140,5 +140,4 @@ type ConfigState = SwipeState & {
   cardInterval: number;
   darkMode: boolean;
   selectedTags: string[];
-  githubAccessToken: string;
 };


### PR DESCRIPTION
## Summary

- remove the GitHub access token field from settings and application configuration
- stop attaching user-provided credentials to URL imports while preserving public URL imports
- discard legacy persisted token values during config migration

## Testing

- `mise run check`