### PR TITLE
Enable type-aware Biome lint rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,10 +39,17 @@
         },
         "noUnresolvedImports": "error"
       },
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noMisusedPromises": "error",
+        "useAwaitThenable": "error",
+        "useExhaustiveSwitchCases": "error"
+      },
       "suspicious": {
         "noDeprecatedImports": "error",
         "noImportCycles": "error",
-        "noLeakedRender": "error"
+        "noLeakedRender": "error",
+        "noUnnecessaryConditions": "error"
       }
     }
   },

--- a/e2e/swipe.e2e.ts
+++ b/e2e/swipe.e2e.ts
@@ -1,6 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
 import { getDocument, routeAnonymousAuth, seedConfig, seedDeckAndCards } from "./fixtures";
 
+type SeedCard = Record<string, unknown> & { id: string };
+
 const e2eDeck = {
   id: "swipe-e2e-deck",
   name: "E2E Deck",
@@ -48,7 +50,7 @@ const e2eCards = [
     updatedAt: 0,
     deletedAt: null,
   },
-];
+] satisfies [SeedCard, SeedCard];
 
 const persistedStudy = {
   state: {
@@ -126,7 +128,7 @@ test("updates study progress with a mastered deck swipe", async ({ page }) => {
   await page.getByRole("button", { name: "Swipe up" }).click();
 
   await expect(page.getByText("banana")).toBeVisible();
-  await expect.poll(async () => persistedCard(e2eCards[0]?.id ?? "")).toMatchObject({ score: 1, numberOfSeen: 1 });
+  await expect.poll(async () => persistedCard(e2eCards[0].id)).toMatchObject({ score: 1, numberOfSeen: 1 });
   await expect.poll(async () => persistedStudyEnvelope(page)).toMatchObject({
     state: {
       sessionsByDeckId: {

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -13,6 +13,9 @@ import { publishAuthenticatedUser, suspendAnonymousBootstrap } from "@/auth/Auth
 import { auth } from "@/firebase";
 import { remoteStore } from "@/store/remoteStore";
 
+const { getState: getRemoteState } = remoteStore;
+const { getState: getStudyState } = studyStore;
+
 interface LogoutCleanupProgress {
   remote: boolean;
   study: boolean;
@@ -65,11 +68,11 @@ const runLogout = async (
       }
     };
 
-    await run("remote", () => remoteStore.getState().stop(confirmedUid));
+    await run("remote", () => getRemoteState().stop(confirmedUid));
     await run("study", async () => {
-      if (progress.studyStateAfterClear && studyStore.getState() !== progress.studyStateAfterClear) return;
+      if (progress.studyStateAfterClear && getStudyState() !== progress.studyStateAfterClear) return;
       const cleanup = clearStudyStore();
-      progress.studyStateAfterClear = studyStore.getState();
+      progress.studyStateAfterClear = getStudyState();
       await cleanup;
     });
     if (errors.length > 0) {

--- a/src/adapters/firestore/dto.ts
+++ b/src/adapters/firestore/dto.ts
@@ -106,7 +106,8 @@ export const mapDeckDocument = (id: DeckId, value: unknown): Deck => {
     category: document.category,
     convertToBr: document.convertToBr,
   };
-  if (document.url !== undefined) deck.url = document.url;
+  const documentUrl = document.url;
+  if (documentUrl !== undefined) deck.url = documentUrl;
   return deck;
 };
 
@@ -169,7 +170,8 @@ export const mapCardDocument = (id: CardId, value: unknown): Card => {
   if (document.lastSeenAt !== undefined) card.lastSeenAt = document.lastSeenAt;
   if (document.nextSeeingAt !== undefined) card.nextSeeingAt = document.nextSeeingAt;
   if (document.interval !== undefined) card.interval = document.interval;
-  if (document.url !== undefined) card.url = document.url;
+  const documentUrl = document.url;
+  if (documentUrl !== undefined) card.url = documentUrl;
   if (document.startLine !== undefined) card.startLine = document.startLine;
   if (document.endLine !== undefined) card.endLine = document.endLine;
   return card;

--- a/src/features/card/components/CardForm.spec.tsx
+++ b/src/features/card/components/CardForm.spec.tsx
@@ -82,7 +82,7 @@ describe("CardForm", () => {
 
     expect(props.fields.frontText.onChange).toHaveBeenCalledOnce();
     expect(props.fields.backText.onChange).toHaveBeenCalledOnce();
-    expect(props.fields.tags[1]?.input.onChange).toHaveBeenCalledOnce();
+    expect(props.fields.tags.find((field) => field.value === "travel")?.input.onChange).toHaveBeenCalledOnce();
   });
 
   it("uses unique section heading relationships for each form instance", () => {

--- a/src/features/import/lib/deckImportAnalysis.spec.ts
+++ b/src/features/import/lib/deckImportAnalysis.spec.ts
@@ -69,19 +69,18 @@ describe("parseDeckImportCsv", () => {
 });
 
 describe("buildDeckImportPlan", () => {
-  const rows = [
-    {
-      rowNumber: 1,
-      card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
-    },
-  ];
+  const row = {
+    rowNumber: 1,
+    card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
+  };
+  const rows = [row];
 
   it("plans an initial import as a create", () => {
     expect(buildDeckImportPlan(rows, [])).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
   });
 
   it("plans an identical re-import as unchanged", () => {
-    expect(buildDeckImportPlan(rows, [createCard(rows[0]?.card)])).toMatchObject({
+    expect(buildDeckImportPlan(rows, [createCard(row.card)])).toMatchObject({
       created: 0,
       updated: 0,
       unchanged: 1,
@@ -90,7 +89,7 @@ describe("buildDeckImportPlan", () => {
 
   it("plans changed content with the same unique key as an update", () => {
     expect(
-      buildDeckImportPlan(rows, [createCard({ ...rows[0]?.card, frontText: "previous front", uniqueKey: "key-1" })])
+      buildDeckImportPlan(rows, [createCard({ ...row.card, frontText: "previous front", uniqueKey: "key-1" })])
     ).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
   });
 });

--- a/src/features/settings/hooks/useAccountOperations.spec.tsx
+++ b/src/features/settings/hooks/useAccountOperations.spec.tsx
@@ -59,6 +59,29 @@ describe("useAccountOperations", () => {
     expect(result.current.pending).toBe(false);
   });
 
+  it("shares a pending login promise when logout is unavailable", async () => {
+    const request = deferred<void>();
+    const login = vi.fn(() => request.promise);
+    const { result } = renderHook(() => useAccountOperations({ login }), { wrapper: StrictModeWrapper });
+
+    let loginPromise!: Promise<void>;
+    let logoutPromise!: Promise<void>;
+    act(() => {
+      loginPromise = result.current.login();
+      logoutPromise = result.current.logout();
+    });
+
+    expect(logoutPromise).toBe(loginPromise);
+    expect(result.current).toMatchObject({ kind: "login", pending: true, error: null });
+
+    await act(async () => {
+      request.resolve();
+      await logoutPromise;
+    });
+
+    expect(result.current.pending).toBe(false);
+  });
+
   it("shares the logout promise while logout is pending", async () => {
     const request = deferred<void>();
     const logout = vi.fn(() => request.promise);

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -125,16 +125,17 @@ const createAccountOperationController = () => {
    * Concurrent callers share the in-flight promise, and late results cannot update a newer screen
    * generation.
    */
-  const run = (kind: AccountOperationKind, retryOperation?: FailedOperation): Promise<void> => {
+  const run = (
+    kind: AccountOperationKind,
+    operation: () => Promise<void>,
+    maySignOut: boolean,
+    handoffAvailable: boolean
+  ): Promise<void> => {
     if (inFlight != null) return inFlight.promise;
-
-    const operation = retryOperation?.operation ?? (kind === "login" ? dependencies.login : dependencies.logout);
-    if (operation == null) return Promise.resolve();
 
     failedOperation = null;
     logoutHandoffAvailable = false;
     const operationGeneration = generation;
-    const maySignOut = retryOperation?.maySignOut ?? kind === "logout";
     const operationEpoch = scopeEpoch;
     let currentOperation!: InFlightOperation;
     setState({ kind, pending: true, error: null });
@@ -163,7 +164,7 @@ const createAccountOperationController = () => {
     );
     currentOperation = {
       promise,
-      handoffAvailable: retryOperation?.handoffAvailable ?? maySignOut,
+      handoffAvailable,
     };
     inFlight = currentOperation;
     void promise.then(
@@ -202,9 +203,15 @@ const createAccountOperationController = () => {
     setDependencies: (nextDependencies: AccountOperationDependencies) => {
       dependencies = nextDependencies;
     },
-    login: () => run("login"),
-    logout: () => run("logout"),
-    retry: () => (failedOperation == null || state.kind == null ? Promise.resolve() : run(state.kind, failedOperation)),
+    login: () => run("login", dependencies.login, false, false),
+    logout: () => {
+      const operation = dependencies.logout;
+      return operation == null ? Promise.resolve() : run("logout", operation, true, true);
+    },
+    retry: () =>
+      failedOperation == null || state.kind == null
+        ? Promise.resolve()
+        : run(state.kind, failedOperation.operation, failedOperation.maySignOut, failedOperation.handoffAvailable),
   };
 };
 

--- a/src/features/settings/hooks/useAccountOperations.ts
+++ b/src/features/settings/hooks/useAccountOperations.ts
@@ -205,6 +205,7 @@ const createAccountOperationController = () => {
     },
     login: () => run("login", dependencies.login, false, false),
     logout: () => {
+      if (inFlight != null) return inFlight.promise;
       const operation = dependencies.logout;
       return operation == null ? Promise.resolve() : run("logout", operation, true, true);
     },

--- a/src/features/study/hooks/useStudyHydrated.spec.ts
+++ b/src/features/study/hooks/useStudyHydrated.spec.ts
@@ -10,6 +10,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useStudyHydrated } from "@/features/study/hooks/useStudyHydrated";
 import { studyStore } from "@/features/study/state/studyStore";
 
+const { getState, persist } = studyStore;
+
 describe("useStudyHydrated", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -19,15 +21,15 @@ describe("useStudyHydrated", () => {
     let hydrated = false;
     let notifyStart: (() => void) | undefined;
     let notifyFinish: (() => void) | undefined;
-    vi.spyOn(studyStore.persist, "hasHydrated").mockImplementation(() => hydrated);
-    vi.spyOn(studyStore.persist, "onHydrate").mockImplementation((listener) => {
-      notifyStart = () => listener(studyStore.getState());
+    vi.spyOn(persist, "hasHydrated").mockImplementation(() => hydrated);
+    vi.spyOn(persist, "onHydrate").mockImplementation((listener) => {
+      notifyStart = () => listener(getState());
       return () => {
         notifyStart = undefined;
       };
     });
-    vi.spyOn(studyStore.persist, "onFinishHydration").mockImplementation((listener) => {
-      notifyFinish = () => listener(studyStore.getState());
+    vi.spyOn(persist, "onFinishHydration").mockImplementation((listener) => {
+      notifyFinish = () => listener(getState());
       return () => {
         notifyFinish = undefined;
       };

--- a/src/features/study/hooks/useStudyHydrated.ts
+++ b/src/features/study/hooks/useStudyHydrated.ts
@@ -8,19 +8,21 @@ import { useSyncExternalStore } from "react";
 
 import { studyStore } from "@/features/study/state/studyStore";
 
+const { persist } = studyStore;
+
 /**
  * Reports whether the persisted study store has finished loading from browser storage.
  * React uses this value to avoid rendering a session from incomplete state.
  */
-const getStudyHydrationSnapshot = () => studyStore.persist.hasHydrated();
+const getStudyHydrationSnapshot = () => persist.hasHydrated();
 
 /**
  * Subscribes to the start and finish of study-store hydration.
  * The returned cleanup function removes both persistence listeners together.
  */
 const subscribeToStudyHydration = (onStoreChange: () => void) => {
-  const unsubscribeStart = studyStore.persist.onHydrate(onStoreChange);
-  const unsubscribeFinish = studyStore.persist.onFinishHydration(onStoreChange);
+  const unsubscribeStart = persist.onHydrate(onStoreChange);
+  const unsubscribeFinish = persist.onFinishHydration(onStoreChange);
   return () => {
     unsubscribeStart();
     unsubscribeFinish();

--- a/src/lib/realtimeChange.ts
+++ b/src/lib/realtimeChange.ts
@@ -15,17 +15,18 @@ export const applyRealtimeChange = <T extends { id: string }>(
   prevById: Readonly<Record<string, T | undefined>>,
   event: { added?: T[]; modified?: T[]; removed?: string[] }
 ): Record<string, T | undefined> => {
-  if ((event.added?.length ?? 0) === 0 && (event.modified?.length ?? 0) === 0 && (event.removed?.length ?? 0) === 0) {
+  const { added = [], modified = [], removed = [] } = event;
+  if (added.length === 0 && modified.length === 0 && removed.length === 0) {
     return prevById as Record<string, T | undefined>;
   }
   const next = { ...prevById };
-  (event.added ?? []).forEach((item) => {
+  added.forEach((item) => {
     next[item.id] = item;
   });
-  (event.modified ?? []).forEach((item) => {
+  modified.forEach((item) => {
     next[item.id] = item;
   });
-  (event.removed ?? []).forEach((id) => {
+  removed.forEach((id) => {
     delete next[id];
   });
   return next;


### PR DESCRIPTION
## Summary

- enable `noFloatingPromises`, `noMisusedPromises`, `useAwaitThenable`, `useExhaustiveSwitchCases`, and `noUnnecessaryConditions` individually as errors
- resolve the resulting unnecessary-condition diagnostics while preserving DTO boundary checks and async operation behavior
- avoid a Biome 2.5.3 type-resolver panic by keeping Zustand persistence member access local

## Why

These rules use Biome's type inference to catch unhandled promises, promise misuse, invalid awaits, incomplete union switches, and statically unnecessary conditions. Enabling only the selected rules keeps the lint scope intentional without turning on the full nursery or types domain.

The installed Biome 2.5.3 schema and rule explainers confirm that all five rules are available in the `types` domain. Four remain nursery rules; `noUnnecessaryConditions` is in the suspicious group.

## Impact

Type-aware linting now fails the build on these bug patterns. A direct local Biome comparison increased from about 0.79s to 0.95s.

## Validation

- `npm run lint`
- `mise run check`
- 78 unit test files passed
- 504 unit tests passed

Closes #444