### PR TITLE
Fix redirect after deck import

### DIFF
--- a/src/features/import/containers/DeckImportContainer.spec.tsx
+++ b/src/features/import/containers/DeckImportContainer.spec.tsx
@@ -2,10 +2,10 @@
  * @file Verifies the "DeckImportContainer" contract with automated examples.
  * The examples make the expected behavior concrete with cases such as "selects a CSV without
  * importing or navigating automatically", "adds the bundled sample without navigating
- * automatically", "imports the preview explicitly and navigates only from Back to decks".
+ * automatically", "navigates to the Deck list after importing the preview".
  */
 
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -134,18 +134,13 @@ describe("DeckImportContainer", () => {
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
-  it("imports the preview explicitly and navigates only from Back to decks", async () => {
+  it("navigates to the Deck list after importing the preview", async () => {
     mocks.preview = preview;
-    mocks.data = { created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" };
     const view = render(<DeckImportContainer />);
 
     await userEvent.click(view.getByRole("button", { name: "Import" }));
 
     expect(mocks.importPreview).toHaveBeenCalledOnce();
-    expect(mocks.navigate).not.toHaveBeenCalled();
-
-    await userEvent.click(view.getByRole("button", { name: "Back to decks" }));
-
-    expect(mocks.navigate).toHaveBeenCalledWith(-1);
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith("/"));
   });
 });

--- a/src/features/import/containers/DeckImportContainer.spec.tsx
+++ b/src/features/import/containers/DeckImportContainer.spec.tsx
@@ -2,7 +2,8 @@
  * @file Verifies the "DeckImportContainer" contract with automated examples.
  * The examples make the expected behavior concrete with cases such as "selects a CSV without
  * importing or navigating automatically", "adds the bundled sample without navigating
- * automatically", "navigates to the Deck list after importing the preview".
+ * automatically", "navigates to the Deck list after importing the preview", "stays on the import
+ * page when importing fails".
  */
 
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
@@ -142,5 +143,17 @@ describe("DeckImportContainer", () => {
 
     expect(mocks.importPreview).toHaveBeenCalledOnce();
     await waitFor(() => expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith("/"));
+  });
+
+  it("stays on the import page when importing fails", async () => {
+    mocks.preview = preview;
+    mocks.importPreview.mockRejectedValue(new Error("Import failed"));
+    const view = render(<DeckImportContainer />);
+
+    await userEvent.click(view.getByRole("button", { name: "Import" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.importPreview).toHaveBeenCalledOnce();
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/features/import/containers/DeckImportContainer.tsx
+++ b/src/features/import/containers/DeckImportContainer.tsx
@@ -36,7 +36,10 @@ export const DeckImportContainer: React.FC = () => {
         void deckImport.addSample().catch(() => undefined);
       }}
       onImport={() => {
-        void deckImport.importPreview().catch(() => undefined);
+        void deckImport
+          .importPreview()
+          .then(() => navigate("/"))
+          .catch(() => undefined);
       }}
       onRetry={deckImport.retry}
       onBack={() => navigate(-1)}


### PR DESCRIPTION
## Summary
- redirect to the deck list after a successful import
- keep failed imports on the import page
- update the container test for the success redirect

## Testing
- `mise run check`