### PR TITLE
Automate Dependabot patch and minor merges

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,60 @@
+name: Dependabot Auto-merge
+
+on:
+  workflow_run:
+    workflows:
+      - Test
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    name: Merge Dependabot update
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge patch or minor update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPOSITORY: ${{ github.repository }}
+          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")"
+
+          if [ "$(jq -r '.user.login' <<< "$pr")" != "dependabot[bot]" ]; then
+            exit 0
+          fi
+
+          if [ "$(jq -r '.head.sha' <<< "$pr")" != "$TESTED_SHA" ]; then
+            echo "PR head changed after CI; skipping merge."
+            exit 0
+          fi
+
+          title="$(jq -r '.title' <<< "$pr")"
+
+          if [[ ! "$title" =~ [[:space:]]from[[:space:]]v?([0-9]+)(\.[^[:space:]]+)?[[:space:]]to[[:space:]]v?([0-9]+)(\.[^[:space:]]+)?([[:space:]]|$) ]]; then
+            echo "Could not determine update type from Dependabot PR title; skipping merge."
+            exit 0
+          fi
+
+          old_major="${BASH_REMATCH[1]}"
+          new_major="${BASH_REMATCH[3]}"
+
+          if [ "$old_major" != "$new_major" ]; then
+            echo "Major update detected; leaving PR for manual review."
+            exit 0
+          fi
+
+          gh api \
+            --method PUT \
+            "repos/$REPOSITORY/pulls/$PR_NUMBER/merge" \
+            -f merge_method=squash \
+            -f sha="$TESTED_SHA"


### PR DESCRIPTION
## Summary

- add a dedicated Dependabot auto-merge workflow
- run it only after the existing `Test` workflow completes successfully
- automatically squash-merge Dependabot patch/minor updates
- leave major updates for manual review
- verify the PR head still matches the SHA that passed CI before merging

## Why

The repository has auto-merge enabled, but the current `main` ruleset does not require status checks. Enabling GitHub auto-merge directly from a Dependabot PR could therefore fail to guarantee that CI has passed first.

Dependabot-triggered pull request workflows also receive a read-only `GITHUB_TOKEN`. Using a `workflow_run` workflow after `Test` completes gives the merge step a write token without checking out or executing untrusted PR code.

## Behavior

A Dependabot PR is merged only when all of the following are true:

1. the `Test` workflow completed successfully
2. the workflow run belongs to a pull request
3. the PR author is `dependabot[bot]`
4. the current PR head SHA is exactly the SHA that passed CI
5. the Dependabot title indicates the major version is unchanged

If the version cannot be classified safely, the workflow skips the merge.

## Validation

- compared the branch against `main`; the PR contains one new workflow file only
- verified the workflow uses the existing `Test` workflow as its CI gate
- no repository code is checked out or executed by the privileged `workflow_run` job
