### PR TITLE
refactor: simplify Vitest configuration

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,75 +1,64 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import babel from '@rolldown/plugin-babel'
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
-import { reactCompilerPreset } from '@vitejs/plugin-react'
 import { playwright } from '@vitest/browser-playwright'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
 
-const dirname = path.dirname(fileURLToPath(import.meta.url))
-
-// https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [babel({ presets: [reactCompilerPreset()] })],
-  resolve: {
-    tsconfigPaths: true,
-  },
-  define: {
-    '__APP_VERSION__': JSON.stringify(process.env.npm_package_version),
-  },
-  test: {
-    coverage: {
-      provider: 'v8',
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: [
-        'src/**/*.d.ts',
-        'src/**/*.spec.{ts,tsx}',
-        'src/**/*.stories.{ts,tsx}',
-        'src/storybook/**',
-      ],
-      reporter: ['text', 'html', 'lcov', 'json-summary'],
-      reportOnFailure: true,
-      thresholds: {
-        statements: 86,
-        branches: 78,
-        functions: 85,
-        lines: 92,
-      },
-    },
-    projects: [
-      {
-        extends: true,
-        test: {
-          name: 'unit',
-          globals: true,
-          include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}'],
-          environment: 'jsdom',
-        },
-      },
-      {
-        extends: true,
-        optimizeDeps: {
-          include: ['storybook/test'],
-        },
-        plugins: [
-          storybookTest({
-            configDir: path.join(dirname, '.storybook'),
-            storybookScript: 'npm run storybook -- --no-open',
-          }),
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      coverage: {
+        provider: 'v8',
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: [
+          'src/**/*.d.ts',
+          'src/**/*.spec.{ts,tsx}',
+          'src/**/*.stories.{ts,tsx}',
+          'src/storybook/**',
         ],
-        test: {
-          name: 'storybook',
-          attachmentsDir: 'test-results/storybook/attachments',
-          browser: {
-            enabled: true,
-            provider: playwright({}),
-            headless: true,
-            instances: [{ browser: 'chromium' }],
-            screenshotFailures: true,
-            screenshotDirectory: 'test-results/storybook',
+        reporter: ['text', 'html', 'lcov', 'json-summary'],
+        reportOnFailure: true,
+        thresholds: {
+          statements: 86,
+          branches: 78,
+          functions: 85,
+          lines: 92,
+        },
+      },
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            globals: true,
+            include: ['src/**/*.spec.{ts,tsx}', '*.spec.{ts,tsx}'],
+            environment: 'jsdom',
           },
         },
-      },
-    ],
-  },
-})
+        {
+          extends: true,
+          optimizeDeps: {
+            include: ['storybook/test'],
+          },
+          plugins: [
+            storybookTest({
+              storybookScript: 'npm run storybook -- --no-open',
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            attachmentsDir: 'test-results/storybook/attachments',
+            browser: {
+              enabled: true,
+              provider: playwright({}),
+              headless: true,
+              instances: [{ browser: 'chromium' }],
+              screenshotFailures: true,
+              screenshotDirectory: 'test-results/storybook',
+            },
+          },
+        },
+      ],
+    },
+  }),
+)


### PR DESCRIPTION
## Summary

- reuse the Vite configuration instead of duplicating React Compiler, path resolution, and app version settings
- rely on the default Storybook config directory while preserving unit, coverage, and browser project behavior

## Testing

- mise run check
- npm run test:storybook