### PR TITLE
refactor: consolidate TypeScript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:check": "npm run lint",
     "lint:markdown": "markdownlint-cli2",
     "lint:react": "eslint --max-warnings=0 'src/**/*.{ts,tsx}'",
-    "lint:tsc": "tsc -p tsconfig.json --pretty false && tsc -p tsconfig.tools.json --pretty false",
+    "lint:tsc": "tsc -p tsconfig.json --pretty false",
     "storybook": "storybook dev",
     "build-storybook": "npm run build:storybook"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "*.ts", ".storybook/**/*", "e2e/**/*"]
 }

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["*.ts", ".storybook/**/*", "e2e/**/*"]
-}


### PR DESCRIPTION
## Summary

- merge the TypeScript file coverage from `tsconfig.tools.json` into `tsconfig.json`
- remove the redundant `tsconfig.tools.json`
- simplify `lint:tsc` to run `tsc` once

## Why

`tsconfig.tools.json` only extended `tsconfig.json` and changed `include`; it did not define a distinct compiler or runtime environment. Keeping two configs therefore added another file and a second `tsc` invocation without providing configuration isolation.

The merged `include` preserves the existing source, root tooling, Storybook, and E2E coverage.

## Validation

- compared the branch with `main`: only `tsconfig.json`, `package.json`, and removal of `tsconfig.tools.json` are changed
- the merged `include` is the union of the two previous configs

Local execution was not available in this environment, so CI should provide the final type-check validation.