### PR TITLE
Keep score badges circular

### DIFF
--- a/src/components/content/Score.tsx
+++ b/src/components/content/Score.tsx
@@ -7,6 +7,8 @@
 import cx from "classnames";
 import type * as React from "react";
 
+const scoreDisplayLimit = 99;
+
 /**
  * Renders the Score user interface.
  * Formats a numeric score as an accessible status and changes its visual cue for positive,
@@ -14,6 +16,9 @@ import type * as React from "react";
  */
 export const Score: React.FC<{ score?: number; large?: boolean; className?: string }> = (props) => {
   const score = props.score ?? 0;
+  const displayScore =
+    score > scoreDisplayLimit ? `>${scoreDisplayLimit}` : score < -scoreDisplayLimit ? `<-${scoreDisplayLimit}` : score;
+  const isDisplayBounded = Math.abs(score) > scoreDisplayLimit;
   const cue = score > 0 ? "positive" : score < 0 ? "negative" : "neutral";
   return (
     <div
@@ -22,8 +27,10 @@ export const Score: React.FC<{ score?: number; large?: boolean; className?: stri
       className={cx(
         "inline-flex justify-center rounded-pill font-semibold text-ink-inverse",
         {
-          "size-5 text-caption": !props.large,
-          "size-10 text-lg": props.large,
+          "size-8 text-caption": !props.large && !isDisplayBounded,
+          "size-8 text-xs": !props.large && isDisplayBounded,
+          "size-10 text-lg": props.large && !isDisplayBounded,
+          "size-10 text-sm": props.large && isDisplayBounded,
           "bg-info": score === 0,
           "bg-success": score > 0,
           "bg-danger": score < 0,
@@ -31,7 +38,7 @@ export const Score: React.FC<{ score?: number; large?: boolean; className?: stri
         props.className
       )}
     >
-      <span className="self-center">{score}</span>
+      <span className="self-center">{displayScore}</span>
     </div>
   );
 };

--- a/src/components/content/Score.tsx
+++ b/src/components/content/Score.tsx
@@ -20,10 +20,10 @@ export const Score: React.FC<{ score?: number; large?: boolean; className?: stri
       role="status"
       aria-label={`Score ${score}, ${cue}`}
       className={cx(
-        "flex justify-center rounded-pill font-semibold text-ink-inverse",
+        "inline-flex justify-center rounded-pill font-semibold text-ink-inverse",
         {
-          "h-5 min-w-5 px-1 text-caption": !props.large,
-          "h-10 min-w-10 px-2 text-lg": props.large,
+          "size-5 text-caption": !props.large,
+          "size-10 text-lg": props.large,
           "bg-info": score === 0,
           "bg-success": score > 0,
           "bg-danger": score < 0,

--- a/src/components/content/StatusContent.spec.tsx
+++ b/src/components/content/StatusContent.spec.tsx
@@ -26,6 +26,15 @@ describe("shared status content", () => {
   });
 
   it.each([
+    [100, ">99", "positive"],
+    [-100, "<-99", "negative"],
+  ] as const)("bounds score %s visually while preserving its accessible value", (score, displayScore, cue) => {
+    render(<Score score={score} />);
+    const status = screen.getByLabelText(`Score ${score}, ${cue}`);
+    expect(status).toHaveTextContent(displayScore);
+  });
+
+  it.each([
     ["neutral", "Information", "bg-info"],
     ["success", "Success", "bg-success"],
     ["warning", "Warning", "bg-warning"],


### PR DESCRIPTION
## Summary

- Render scores as inline-flex badges.
- Use fixed square dimensions for default and large variants so rounded badges stay circular.

## Testing

- mise run check