### PR TITLE
ci: add Hadolint repository check

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,26 @@ name: Update Docker Image
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
+  lint:
+    name: Lint Dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: hadolint
+
+      - run: mise run lint-docker
+
   changes:
     name: Check Docker Image Changes
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.changed.outputs.any_modified }}
@@ -27,8 +42,8 @@ jobs:
 
   push:
     name: Update Docker Image
-    needs: changes
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.image == 'true') }}
+    needs: [changes, lint]
+    if: ${{ !cancelled() && needs.lint.result == 'success' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.image == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,11 +14,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v4
-        with:
-          install_args: hadolint
+      - name: Install Hadolint
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HADOLINT_VERSION: 2.15.1
+        run: |
+          gh release download "v${HADOLINT_VERSION}" \
+            --repo hadolint/hadolint \
+            --pattern checksums.sha256 \
+            --pattern hadolint-linux-x86_64 \
+            --dir "$RUNNER_TEMP"
+          (
+            cd "$RUNNER_TEMP"
+            grep 'hadolint-linux-x86_64$' checksums.sha256 | sha256sum --check
+          )
+          chmod +x "$RUNNER_TEMP/hadolint-linux-x86_64"
+          mv "$RUNNER_TEMP/hadolint-linux-x86_64" "$RUNNER_TEMP/hadolint"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
-      - run: mise run lint-docker
+      - run: hadolint --failure-threshold warning Dockerfile sample/Dockerfile
 
   changes:
     name: Check Docker Image Changes

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,25 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Hadolint
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HADOLINT_VERSION: 2.15.1
-        run: |
-          gh release download "v${HADOLINT_VERSION}" \
-            --repo hadolint/hadolint \
-            --pattern checksums.sha256 \
-            --pattern hadolint-linux-x86_64 \
-            --dir "$RUNNER_TEMP"
-          (
-            cd "$RUNNER_TEMP"
-            grep 'hadolint-linux-x86_64$' checksums.sha256 | sha256sum --check
-          )
-          chmod +x "$RUNNER_TEMP/hadolint-linux-x86_64"
-          mv "$RUNNER_TEMP/hadolint-linux-x86_64" "$RUNNER_TEMP/hadolint"
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-
-      - run: hadolint --failure-threshold warning Dockerfile sample/Dockerfile
+      - uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
+        with:
+          dockerfile: Dockerfile
+          recursive: true
+          failure-threshold: warning
 
   changes:
     name: Check Docker Image Changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: hadolint
+
+      - run: mise run lint-docker
+
       - name: Log into registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v4
-        with:
-          install_args: hadolint
-
-      - run: mise run lint-docker
-
       - name: Log into registry
         uses: docker/login-action@v2
         with:

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+hadolint = "2.15.1"
 node = "24.15.0"
 npm = "12.0.1"
 watchexec = "2.5.1"
@@ -110,6 +111,9 @@ alias = "l"
 depends = ["build-sample"]
 run = "npm run lint:check"
 
+[tasks.lint-docker]
+run = "hadolint --failure-threshold warning Dockerfile sample/Dockerfile"
+
 [tasks.build-sample]
 sources = [
   "sample/generate.py",
@@ -147,7 +151,7 @@ docker compose run --rm --remove-orphans --env CI --entrypoint npm dev run e2e
 
 [tasks.check]
 depends = ["init"]
-run = [{ tasks = ["fmt-check", "lint", "test-unit"] }]
+run = [{ tasks = ["fmt-check", "lint", "lint-docker", "test-unit"] }]
 
 [tasks.ci]
 alias = "c"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-hadolint = "2.15.1"
+hadolint = "2.15.0"
 node = "24.15.0"
 npm = "12.0.1"
 watchexec = "2.5.1"

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -9,6 +9,5 @@ RUN \
   --mount=type=cache,target=/root/.cache \
   --mount=type=bind,source=Pipfile,target=Pipfile \
   --mount=type=bind,source=Pipfile.lock,target=Pipfile.lock \
-  pip install --upgrade pip \
-  && pip install pipenv \
+  pip install --no-cache-dir pipenv==2026.7.1 \
   && pipenv sync --dev


### PR DESCRIPTION
## Summary

- pin Hadolint 2.15.0 in mise and add a `lint-docker` task for the root and sample Dockerfiles
- run `hadolint/hadolint-action` v3.4.0 from `.github/workflows/docker.yml`, pinned to its immutable commit SHA and configured to fail on warnings
- keep `.github/workflows/test.yml` focused on application tests
- pin Pipenv 2026.7.1 and disable its pip download cache in the sample image

## Why

The repository did not have a Dockerfile lint gate, and the sample image installed an unpinned Pipenv version while retaining pip's download cache. This left Dockerfile maintenance and dependency reproducibility issues undetected during repository checks.

## Impact

Local checks and the Docker workflow use Hadolint 2.15.0, while CI remains independent of mise. The GitHub Action recursively checks the root and sample Dockerfiles without global ignores or rule disables, the application test workflow remains focused on app checks, and the sample image remains buildable with a reproducible Pipenv version.

## Validation

- `mise run lint-docker`
- `mise run check` (78 test files, 504 tests)
- `mise x actionlint@1.7.12 -- actionlint -ignore 'docker/login-action@v2' .github/workflows/docker.yml .github/workflows/test.yml`
- `docker compose -f sample/docker-compose.yml build base`
- `docker build --tag tango:issue-481-check .`

Closes #481
