### PR TITLE
Run actionlint in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,17 @@ env:
   VITE_DB_HOST: localhost
 
 jobs:
+  actionlint:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+          ./actionlint -color
+
   e2e:
     name: E2E
     uses: ./.github/workflows/e2e.yaml


### PR DESCRIPTION
## Summary
- run actionlint as a dedicated job in the existing Test workflow
- pin actionlint to `1.7.12`
- use actionlint's official CI download script
- avoid Docker and additional package dependencies

## Why
This keeps the repository change minimal while validating GitHub Actions workflows on every pull request. The actionlint binary is downloaded and executed directly on the GitHub-hosted runner.

Closes #479

## Validation
- `.github/workflows/test.yml` only
- actionlint runs as part of the existing pull request workflow
