### PR TITLE
docs: finalize FSD architecture migration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,12 @@
 # Architecture
 
-Tango is migrating to [Feature-Sliced Design (FSD)](https://fsd.how/docs/reference/layers/).
-The target rules in this document are normative. The migration inventory records temporary legacy
-structure that later pull requests must remove without changing observable behavior.
+Tango uses an architecture based on
+[Feature-Sliced Design (FSD)](https://fsd.how/docs/reference/layers/). The rules in this document are
+normative and are enforced by `npm run lint:architecture`.
 
-## Target layers
+## Layers
 
-The initial source tree contains only the layers that have an identified responsibility:
+The source tree contains only the layers that have an identified responsibility:
 
 ```text
 src/
@@ -67,19 +67,19 @@ implementation details to presentation, or retain an interaction that is reused 
 Different Feature slices do not coordinate by importing each other; their Page or, when justified,
 a Widget coordinates them.
 
-The target route map is:
+The route map is:
 
-| Route | Current Page | Current primary container | Target Page slice |
-| --- | --- | --- | --- |
-| `/` | `DeckListPage` | `DeckListContainer` | `pages/deck-list` |
-| `/deck/:id` | `CardListPage` | `CardListContainer` | `pages/card-list` |
-| `/deck/:id/edit` | `DeckFormPage` | `DeckFormContainer` | `pages/deck-form` |
-| `/deck/:id/start` | `DeckStartPage` | `DeckStartContainer` | `pages/deck-start` |
-| `/deck/:id/study` | `DeckSwiperPage` | `DeckSwiperContainer` | `pages/deck-swiper` |
-| `/card/:id` | `CardViewPage` | `CardViewContainer` | `pages/card-view` |
-| `/card/:id/edit` | `CardFormPage` | `CardFormContainer` | `pages/card-form` |
-| `/settings` | `ConfigPage` | `ConfigContainer` | `pages/settings` |
-| `/import` | `DeckImportPage` | `DeckImportContainer` | `pages/deck-import` |
+| Route | Page slice |
+| --- | --- |
+| `/` | `pages/deck-list` |
+| `/deck/:id` | `pages/card-list` |
+| `/deck/:id/edit` | `pages/deck-form` |
+| `/deck/:id/start` | `pages/deck-start` |
+| `/deck/:id/study` | `pages/deck-swiper` |
+| `/card/:id` | `pages/card-view` |
+| `/card/:id/edit` | `pages/card-form` |
+| `/settings` | `pages/settings` |
+| `/import` | `pages/deck-import` |
 
 Each Page slice exposes its Page from a root `index.ts`. The App router imports each slice directly:
 
@@ -113,7 +113,7 @@ Feature slices may use the following directories when the responsibility exists:
 | --- | --- |
 | `containers` | Connect slice Hooks to Components through simple prop mapping |
 | `hooks` | Feature-local React lifecycle, interaction, and side effects |
-| `component` | Stateless presentation that receives plain props |
+| `components` | Stateless presentation that receives plain props |
 | `queries` | Read-only external data access |
 | `mutations` | One-purpose external writes |
 | `subscriptions` | Continuous external subscriptions |
@@ -132,117 +132,48 @@ route state. Exported presentation Components normally have an adjacent behavior
 Storybook story. Stories use args, fixtures, and callback spies instead of real stores, Firebase,
 or the network.
 
-### Deck List pilot decisions
+### Ownership decisions
 
-The Deck List pilot established these ownership decisions for later Page migrations:
+The Deck List implementation established ownership decisions that apply to every Page:
 
 - screen-specific sections, deck-row presentation, dialogs, keyboard shortcuts, and lower-layer
   coordination belong to `pages/deck-list` rather than a route-sized Deck Feature;
 - the Page consumes Deck mutation, sample import, and study-session behavior through each Feature
   root, while each Feature keeps its store and command implementation private;
-- Deck and Card contracts begin at `entities/deck` and `entities/card`; remaining ambient consumers
-  migrate to those contracts as their owning Page moves;
+- Deck and Card contracts live at `entities/deck` and `entities/card`; consumers import those
+  contracts explicitly;
 - reusable controls use focused `shared/ui/*` public APIs, and Firebase initialization and runtime
-  ownership lives at `shared/firebase` rather than a business adapter or top-level module;
-- legacy compatibility barrels may re-export migrated Shared contracts temporarily, but migrated
-  slices import the focused Shared public API directly.
+  ownership lives at `shared/firebase` rather than a business adapter or top-level module.
 
-## Migration inventory
+## Automated enforcement
 
-This inventory describes `origin/main` at `be13411` before the FSD migration. Every source file is
-covered by a path below; adjacent specifications and stories move with the code they verify.
+`npm run lint:architecture` runs as part of `npm run lint` and `mise run check`. It parses TypeScript
+imports and exports and rejects:
 
-### Current dependency graph
+- source entries outside App, Pages, Features, Entities, Shared, and `vite-env.d.ts`;
+- catch-all directory names, global layer barrels, segment barrels, and wildcard exports;
+- dependencies on a higher layer or a different slice on the same layer;
+- lower-layer deep imports and same-slice imports through the slice public API;
+- Shared deep imports that bypass a focused public API;
+- presentation imports of routing, stores, Auth, or Firebase;
+- removed legacy aliases such as `@/components`, `@/hooks`, and `@/store`.
 
-```text
-main.tsx
-  -> Firebase initialization and Auth providers
-  -> App router
-       -> global page barrel
-            -> pass-through Page
-                 -> feature container
-                      -> feature UI, hooks, and other feature slices
-                      -> global hooks, actions, services, and stores
-                           -> Firestore adapters and Firebase
-```
+Specifications and stories may import private contracts to test them, so dependency-direction and
+public-API checks skip those files. Source-tree, directory, barrel, and legacy-alias rules still
+apply to them. The checker has fixture-based regression tests beside its implementation.
 
-The temporary graph violates the target in these known places:
+### Related architecture work
 
-| From slice | To slice | Current imports |
-| --- | --- | --- |
-| `features/deck` | `features/import` | `DeckListContainer` uses sample-deck bootstrap |
-| `features/deck` | `features/study` | Deck-list composition and section building use study Hooks and state |
-| `features/card` | `features/deck` | `CardListContainer` composes deck start and filter behavior |
-| `features/import` | `features/card` | Deck import calls Card mutation behavior |
-| `features/import` | `features/deck` | Deck import calls Deck mutation behavior |
-| `features/study` | `features/deck` | `DeckStartContainer` composes deck form and filter behavior |
-| `features/study` | `features/card` | Deck swiper composes Card UI and calls Card mutation behavior |
-
-The App imports the wildcard `src/page/index.ts` barrel. Every current Page deep-imports a
-`features/*/containers` segment, and those segment barrels mostly use wildcard exports. Feature
-internals, tests, and stories also rely on file-level deep imports. `src/components/index.ts` is a
-single wildcard barrel for unrelated UI modules. These are migration inputs, not permitted target
-patterns.
-
-### Current ownership and destinations
-
-| Current files | Current responsibility and route use | Target owner candidate |
-| --- | --- | --- |
-| `App.tsx`, `App.spec.tsx`, `main.tsx`, `index.css` | Entrypoint, router, auth shell, global theme, and styles for every route | `app/entrypoint`, `app/routes`, `app/providers`, `app/styles` |
-| `auth/**` | Auth provider, bootstrap, UID transition, and logout integration | `app/providers` and app bootstrap; reusable Firebase primitives stay Shared |
-| `page/**` | Nine pass-through route components, global Page story, and wildcard barrel | The nine `pages/*` slices in the route map; remove the global barrel |
-| `features/deck/**` | Deck list/form UI and interactions used by `/`, deck edit, card list, and deck start | Split among Deck List/Form Pages, reusable deck Features, and `entities/deck` |
-| `features/card/**` | Card list/form/view UI and interactions used by card routes and study | Split among Card List/Form/View Pages, reusable card Features, and `entities/card` |
-| `features/import/**` | Import screen plus sample-deck bootstrap used on `/` | `pages/deck-import` plus a Feature only for interactions reused by another Page |
-| `features/settings/**` | Settings screen and account/configuration interaction used only by `/settings` | `pages/settings`; app-wide configuration contracts move to App |
-| `features/study/**` | Start/study screens, resumable study state, and behavior also observed on `/` | Deck Start/Swiper Pages plus reusable study Features; add an Entity only after reuse is demonstrated |
-| `components/content/**`, `components/forms/**`, `components/feedback/**`, `components/layout/**`, `components/index.ts` | Business-independent presentation and layout, currently exposed by one global barrel | Focused `shared/ui/*` modules with per-component public APIs |
-| `action/card*`, `action/deck*` | Deck/Card construction, CSV mapping, import/export, and file download | Split Deck/Card rules and mappers into Entities; import/export interaction into its owning Feature |
-| `action/event*` | Login, logout, and cross-store cleanup | App auth workflow, depending on lower-layer public contracts |
-| `action/index.ts` | Wildcard action barrel | Remove after callers use owner slice public APIs |
-| `adapters/firestore/card*`, `deck*`, `dto*`, `event*` | Deck/Card Firestore reads, writes, mapping, and subscriptions | `entities/card` and `entities/deck`, with explicit cross-entity coordination above them |
-| Other `adapters/firestore/**`, `firebase.ts`, `firebase.spec.ts` | Generic Firebase initialization, runtime, persistence, and metadata | `shared/firebase` |
-| `store/remoteStore*`, `store/remoteSelectors*` | Combined Deck/Card subscription state and selectors | Split by Entity where practical; compose combined Page read models above Entities |
-| `store/remoteMutationLocks.ts` | Generic keyed concurrency plus Deck membership locks | Generic lock primitive in Shared; business lock keys and rules in Entities or Features |
-| `store/configSchema.ts`, `store/configStore*`, `hooks/useConfig.ts` | App-wide validated and persisted configuration | `app/store` and an App-facing Hook; presentation receives plain props |
-| `hooks/useActions.ts` | Global route navigation plus auth, config, and download actions | Split route wiring into Pages/App and interactions into their owning slices |
-| `hooks/useAsyncAction*` | Generic React async-action lifecycle | Focused Shared library or Hook public API |
-| `hooks/useRemoteCollections*` | Auth-aware Deck/Card subscription facade and scheduling | Split Entity access from Page/Feature-specific selection and coordination |
-| `services/cardCommands*`, `services/deckCommands*` | Card/Deck write workflows, mutation locks, and remote acknowledgement | Feature or Entity `commands`/`mutations`, according to interaction ownership |
-| `services/remoteWrite*` | Generic remote-write acknowledgement timeout | Focused Shared library |
-| `domain/remoteSnapshot.ts`, `lib/realtimeChange*` | Generic remote snapshot contracts and pure reconciliation | Focused Shared library |
-| `lib/study*` | Study scheduling, swipe rules, and Card transitions | Study Feature rules; stable Card invariants move to `entities/card` |
-| `lib/interactionAccessibility.spec.tsx` | Cross-screen accessibility regression coverage | Split into behavior tests beside the UI contracts it verifies |
-| `constant.ts`, `util.ts` | Rich-content language mapping, CSV sample data, and category selection | Split focused Shared formatting from Card/Deck/import-specific contracts |
-| `styles/**` | Shared visual stylesheet | App global style or the owning Shared UI module |
-| `storybook/**` | App decorators, Firebase mocks, Page fixtures, and generic viewport helpers | Split app-wide Storybook setup, owner-local fixtures, and focused Shared test support |
-| `test/**` | React test utility and Deck/Card/config factories | Focused Shared test support and owner-local Entity/App factories |
-| `vite-env.d.ts` | Vite declarations plus ambient Page, Deck, Card, study, and config business types | Keep only build declarations; move business types to explicit Entity, Feature, or App modules |
-
-### Related work order
-
-| Issue | Relationship to this migration |
+| Issue | Integrated decision |
 | --- | --- |
-| [#284](https://github.com/her0e1c1/tango/issues/284) | Its Page, layout, and Template decisions follow this document: every route keeps a Page slice, Pages own composition, and pass-through Templates are not required |
-| [#337](https://github.com/her0e1c1/tango/issues/337) | Enforce same-layer Feature isolation in Phase 6 after cross-Feature imports have moved to Pages or lower-layer contracts |
-| [#442](https://github.com/her0e1c1/tango/issues/442) | Continue as the static-analysis parent; its architecture checks must use the final FSD layer names and rules |
-| [#445](https://github.com/her0e1c1/tango/issues/445) | Replace the legacy domain/presentation proposal with lower-layer-only, public-API, and presentation boundaries after target paths exist |
-
-Migration pull requests proceed in this order:
-
-1. Establish App and Page slice public boundaries without behavior changes.
-2. Move Deck List as a vertical Page/Feature/Entity/Shared pilot and resolve its cross-Feature imports.
-3. Move the remaining routes one Page at a time.
-4. Finish classifying Feature, Entity, and Shared ownership and remove ambient business types.
-5. Enforce layer direction, slice isolation, public APIs, and forbidden legacy directories.
-6. Delete empty legacy top-level directories, aliases, barrels, and temporary exceptions.
-
-Each pull request must be independently reviewable and revertible. Do not combine directory
-migration with UI, route URL, Firebase model, or state-management changes.
+| [#284](https://github.com/her0e1c1/tango/issues/284) | Every route keeps a Page slice, Pages own composition, and pass-through Templates are unnecessary. |
+| [#337](https://github.com/her0e1c1/tango/issues/337) | Different Feature slices cannot import one another; Pages coordinate them through public contracts. |
+| [#442](https://github.com/her0e1c1/tango/issues/442) | Static analysis uses the final FSD layer names and runs in the normal lint command. |
+| [#445](https://github.com/her0e1c1/tango/issues/445) | Lower-layer-only dependencies, public APIs, and presentation boundaries replace the legacy domain/presentation split. |
 
 ## Preserved behavior contracts
 
-The FSD migration changes ownership and import paths, not these runtime contracts.
+Architecture changes preserve these runtime contracts.
 
 ### State ownership
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -8,6 +8,27 @@ import ts from "typescript";
 const SOURCE_LAYERS = ["shared", "entities", "features", "pages", "app"];
 const SLICED_LAYERS = new Set(["pages", "features", "entities"]);
 const ALLOWED_TOP_LEVEL_ENTRIES = new Set([...SOURCE_LAYERS, "vite-env.d.ts"]);
+const LEGACY_IMPORT_ROOTS = new Set([
+  "App",
+  "action",
+  "adapters",
+  "auth",
+  "components",
+  "constant",
+  "domain",
+  "firebase",
+  "hooks",
+  "index.css",
+  "lib",
+  "main",
+  "page",
+  "services",
+  "store",
+  "storybook",
+  "styles",
+  "test",
+  "util",
+]);
 const FORBIDDEN_DIRECTORY_NAMES = new Set([
   "common",
   "core",
@@ -117,6 +138,11 @@ const errorAt = (source, location, rule, message) => ({
   message,
 });
 
+const isLegacyImport = (specifier) => {
+  if (!specifier.startsWith("@/")) return false;
+  return LEGACY_IMPORT_ROOTS.has(specifier.slice(2).split("/")[0]);
+};
+
 export const validateArchitecture = (rootDirectory = process.cwd()) => {
   const sourceDirectory = path.join(rootDirectory, "src");
   const errors = [];
@@ -198,6 +224,13 @@ export const validateArchitecture = (rootDirectory = process.cwd()) => {
         ts.forEachChild(node, visit);
       };
       visit(sourceFile);
+    }
+    for (const dependency of imports) {
+      if (isLegacyImport(dependency.specifier)) {
+        errors.push(
+          errorAt(source, dependency, "legacy-import", `legacy import "${dependency.specifier}" is forbidden`)
+        );
+      }
     }
     if (VERIFICATION_FILE.test(filePath)) continue;
 

--- a/scripts/check-architecture.spec.mjs
+++ b/scripts/check-architecture.spec.mjs
@@ -105,3 +105,17 @@ test("requires focused public APIs between Shared modules", () =>
       assert.match(errors[0].message, /focused public API/);
     }
   ));
+
+test("rejects removed legacy aliases, including in verification files", () =>
+  withFixture(
+    {
+      ...validTree,
+      "src/features/study/components/StudyButton.spec.tsx":
+        'import { Button } from "@/components";\nexport const subject = Button;\n',
+    },
+    (root) => {
+      const errors = validateArchitecture(root).filter(({ rule }) => rule === "legacy-import");
+      assert.equal(errors.length, 1);
+      assert.match(errors[0].message, /@\/components/);
+    }
+  ));


### PR DESCRIPTION
## Summary
- reject legacy source aliases and structural compatibility paths
- align the architecture document with the implemented FSD directory layout
- finalize the migration contract and remove temporary legacy guidance

## Stack
- Position: 13 of 13
- Base: `codex/issue-482-architecture-boundaries`
- Head: `codex/issue-482-remove-legacy-structure`
- Parent: https://github.com/her0e1c1/tango/pull/499

## Testing
- `mise run check`
- `mise run test`
- `mise run build`
- `mise run test-storybook`
- `mise run e2e` — 19 passed; 1 pre-existing Deck List continuation failure remains at `e2e/deck-list.e2e.ts:76`

Closes #482.