### PR TITLE
chore: simplify package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:knip": "knip",
     "lint:markdown": "markdownlint-cli2",
     "lint:react": "eslint --max-warnings=0 'src/**/*.{ts,tsx}'",
-    "lint:tsc": "tsc -p tsconfig.json --pretty false",
+    "lint:tsc": "tsc",
     "storybook": "storybook dev",
     "build-storybook": "npm run build:storybook"
   },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "lint:markdown": "markdownlint-cli2",
     "lint:react": "eslint --max-warnings=0 'src/**/*.{ts,tsx}'",
     "lint:tsc": "tsc",
-    "storybook": "storybook dev",
-    "build-storybook": "npm run build:storybook"
+    "storybook": "storybook dev"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.7.1",


### PR DESCRIPTION
Simplifies `package.json` scripts:
- Simplifies `lint:tsc` from `tsc -p tsconfig.json --pretty false` to `tsc`.
- Removes the redundant `build-storybook` script alias.