### PR TITLE
refactor: simplify Firestore runtime initialization

### DIFF
--- a/src/shared/firebase/firestore-runtime/index.spec.ts
+++ b/src/shared/firebase/firestore-runtime/index.spec.ts
@@ -49,9 +49,7 @@ describe("Firestore runtime", () => {
 
     runtime.initialize(db);
 
-    expect(() => runtime.block(new Error("late failure"))).toThrow(
-      "Firestore runtime is already initialized"
-    );
+    expect(() => runtime.block(new Error("late failure"))).toThrow("Firestore runtime is already initialized");
     expect(runtime.getDb()).toBe(db);
     await expect(runtime.waitForInitialization()).resolves.toEqual({ status: "ready" });
   });

--- a/src/shared/firebase/firestore-runtime/index.spec.ts
+++ b/src/shared/firebase/firestore-runtime/index.spec.ts
@@ -1,16 +1,15 @@
-/**
- * @file Verifies the "Firestore runtime" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "keeps one injected instance
- * and rejects a different duplicate initialization", "waits until the injected Firestore instance
- * is ready", "preserves a blocking initialization error without allowing memory fallback".
- */
-
 import type { Firestore } from "firebase/firestore";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createFirestoreRuntime } from ".";
 
 describe("Firestore runtime", () => {
+  it("rejects reads before initialization", () => {
+    const runtime = createFirestoreRuntime();
+
+    expect(() => runtime.getDb()).toThrow("Firestore is not initialized");
+  });
+
   it("keeps one injected instance and rejects a different duplicate initialization", () => {
     const runtime = createFirestoreRuntime();
     const db = { name: "first" } as unknown as Firestore;
@@ -19,7 +18,6 @@ describe("Firestore runtime", () => {
     runtime.initialize(db);
 
     expect(runtime.getDb()).toBe(db);
-    expect(runtime.getState()).toEqual({ status: "ready" });
     expect(() => runtime.initialize({ name: "second" } as unknown as Firestore)).toThrow(
       "Firestore runtime is already initialized"
     );
@@ -28,25 +26,33 @@ describe("Firestore runtime", () => {
   it("waits until the injected Firestore instance is ready", async () => {
     const runtime = createFirestoreRuntime();
     const db = { name: "persistent" } as unknown as Firestore;
-    const onChange = vi.fn();
-    runtime.subscribe(onChange);
 
-    expect(runtime.getState()).toEqual({ status: "initializing" });
     runtime.initialize(db);
 
     await expect(runtime.waitForInitialization()).resolves.toEqual({ status: "ready" });
-    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves a blocking initialization error without allowing memory fallback", async () => {
+  it("preserves a blocking initialization error without allowing initialization", async () => {
     const runtime = createFirestoreRuntime();
     const error = new Error("persistent cache unavailable");
 
     runtime.block(error);
 
-    expect(runtime.getState()).toEqual({ status: "blocked", error });
     expect(() => runtime.getDb()).toThrow(error);
     expect(() => runtime.initialize({} as Firestore)).toThrow(error);
     await expect(runtime.waitForInitialization()).resolves.toEqual({ status: "blocked", error });
+  });
+
+  it("keeps ready as a terminal state", async () => {
+    const runtime = createFirestoreRuntime();
+    const db = { name: "persistent" } as unknown as Firestore;
+
+    runtime.initialize(db);
+
+    expect(() => runtime.block(new Error("late failure"))).toThrow(
+      "Firestore runtime is already initialized"
+    );
+    expect(runtime.getDb()).toBe(db);
+    await expect(runtime.waitForInitialization()).resolves.toEqual({ status: "ready" });
   });
 });

--- a/src/shared/firebase/firestore-runtime/index.ts
+++ b/src/shared/firebase/firestore-runtime/index.ts
@@ -2,9 +2,7 @@
 
 import type { Firestore } from "firebase/firestore";
 
-export type FirestoreInitializationResult =
-  | { status: "ready" }
-  | { status: "blocked"; error: Error };
+export type FirestoreInitializationResult = { status: "ready" } | { status: "blocked"; error: Error };
 
 type FirestoreRuntimeState =
   | { status: "initializing" }

--- a/src/shared/firebase/firestore-runtime/index.ts
+++ b/src/shared/firebase/firestore-runtime/index.ts
@@ -1,95 +1,53 @@
-/**
- * @file Owns the shared Firestore runtime lifecycle without initializing a Firebase client.
- * This boundary translates between Tango's application models and Firebase so feature code does
- * not handle database details directly.
- */
+/** Coordinates the one-time availability of the shared Firestore instance. */
 
 import type { Firestore } from "firebase/firestore";
 
-export type FirestoreInitializationState =
-  | { status: "initializing" }
+export type FirestoreInitializationResult =
   | { status: "ready" }
   | { status: "blocked"; error: Error };
 
-/**
- * Creates an isolated Firestore runtime that tracks initialization state and subscribers.
- * It exposes the database only after initialization succeeds and preserves a blocking error when
- * persistence cannot be trusted.
- */
+type FirestoreRuntimeState =
+  | { status: "initializing" }
+  | { status: "ready"; db: Firestore }
+  | { status: "blocked"; error: Error };
+
 export const createFirestoreRuntime = () => {
-  let db: Firestore | undefined;
-  let state: FirestoreInitializationState = { status: "initializing" };
-  /**
-   * Stores the resolver that completes the Firestore initialization promise.
-   * The placeholder is replaced when the runtime is created and called exactly when initialization
-   * succeeds or is blocked.
-   */
-  let resolveInitialization: (state: FirestoreInitializationState) => void = () => undefined;
-  const listeners = new Set<Callback>();
-  const initialization = new Promise<FirestoreInitializationState>((resolve) => {
+  let state: FirestoreRuntimeState = { status: "initializing" };
+  let resolveInitialization: (result: FirestoreInitializationResult) => void = () => undefined;
+  const initialization = new Promise<FirestoreInitializationResult>((resolve) => {
     resolveInitialization = resolve;
   });
 
   return {
-    initialize: (nextDb: Firestore) => {
+    initialize: (db: Firestore) => {
       if (state.status === "blocked") throw state.error;
-      if (db && db !== nextDb) throw new Error("Firestore runtime is already initialized");
-      db = nextDb;
-      state = { status: "ready" };
-      resolveInitialization(state);
-      listeners.forEach((listener) => {
-        listener();
-      });
+      if (state.status === "ready") {
+        if (state.db !== db) throw new Error("Firestore runtime is already initialized");
+        return;
+      }
+
+      state = { status: "ready", db };
+      resolveInitialization({ status: "ready" });
     },
     block: (error: Error) => {
       if (state.status === "blocked") return;
-      db = undefined;
+      if (state.status === "ready") throw new Error("Firestore runtime is already initialized");
+
       state = { status: "blocked", error };
-      resolveInitialization(state);
-      listeners.forEach((listener) => {
-        listener();
-      });
+      resolveInitialization({ status: "blocked", error });
     },
     getDb: () => {
-      if (db) return db;
+      if (state.status === "ready") return state.db;
       if (state.status === "blocked") throw state.error;
       throw new Error("Firestore is not initialized");
     },
-    getState: () => state,
     waitForInitialization: () => initialization,
-    subscribe: (listener: Callback) => {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    },
   };
 };
 
 const firestoreRuntime = createFirestoreRuntime();
 
-/**
- * Initializes firestore runtime for use by the Firestore adapter.
- * Required defaults and services are connected before callers receive control.
- */
 export const initializeFirestoreRuntime = firestoreRuntime.initialize;
-/**
- * Marks the Firestore runtime as unavailable because initialization could not be trusted.
- * Readers then receive the same blocking error instead of silently using a partially initialized
- * database.
- */
 export const blockFirestoreRuntime = firestoreRuntime.block;
-/**
- * Returns the initialized Firestore database instance.
- * Calling it before initialization, or after persistence was blocked, produces the corresponding
- * startup error.
- */
 export const getDb = firestoreRuntime.getDb;
-/**
- * Returns the current Firestore initialization snapshot.
- * Consumers use this synchronous value to decide whether remote reads may start.
- */
-export const getFirestoreInitializationState = firestoreRuntime.getState;
-/**
- * Returns the promise that settles when Firestore becomes ready or blocked.
- * Startup code can await one shared result instead of racing individual initialization steps.
- */
 export const waitForFirestoreInitialization = firestoreRuntime.waitForInitialization;

--- a/src/shared/firebase/index.spec.ts
+++ b/src/shared/firebase/index.spec.ts
@@ -95,16 +95,32 @@ describe("Firebase singletons", () => {
     expect(persistentLocalCache).not.toHaveBeenCalled();
   });
 
-  it("exposes a blocking startup state instead of falling back when persistence initialization fails", async () => {
+  it("blocks startup when the Firestore emulator connection fails", async () => {
+    vi.stubEnv("PROD", false);
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_DB_HOST", "127.0.0.1");
+    vi.stubEnv("VITE_DB_PORT", "8080");
+    const failure = new Error("emulator connection failed");
+    vi.mocked(connectFirestoreEmulator).mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    const firebase = await import("@/shared/firebase");
+
+    await expect(firebase.waitForFirestoreInitialization()).resolves.toEqual({ status: "blocked", error: failure });
+    expect(() => firebase.getDb()).toThrow(failure);
+  });
+
+  it("exposes a blocking startup result instead of falling back when persistence initialization fails", async () => {
     vi.stubEnv("PROD", true);
     const failure = new Error("single-tab persistence unavailable");
     vi.mocked(initializeFirestore).mockImplementationOnce(() => {
       throw failure;
     });
 
-    const { getDb, getFirestoreInitializationState } = await import("@/shared/firebase");
+    const { getDb, waitForFirestoreInitialization } = await import("@/shared/firebase");
 
-    expect(getFirestoreInitializationState()).toEqual({ status: "blocked", error: failure });
+    await expect(waitForFirestoreInitialization()).resolves.toEqual({ status: "blocked", error: failure });
     expect(() => getDb()).toThrow(failure);
     expect(memoryLocalCache).not.toHaveBeenCalled();
   });

--- a/src/shared/firebase/index.ts
+++ b/src/shared/firebase/index.ts
@@ -7,7 +7,7 @@
 import { initializeApp } from "firebase/app";
 import { connectAuthEmulator, getAuth } from "firebase/auth";
 import { initializeFirestoreAdapter } from "./initializeFirestore";
-import { getDb, getFirestoreInitializationState, waitForFirestoreInitialization } from "./firestore-runtime";
+import { getDb, waitForFirestoreInitialization } from "./firestore-runtime";
 
 const projectId = import.meta.env.VITE_PROJECT_ID;
 const apiKey = import.meta.env.VITE_WEB_API_KEY;
@@ -22,8 +22,8 @@ export const app = initializeApp({
 export const auth = getAuth(app);
 initializeFirestoreAdapter(app);
 
-export { getDb, getFirestoreInitializationState, waitForFirestoreInitialization };
-export type { FirestoreInitializationState } from "./firestore-runtime";
+export { getDb, waitForFirestoreInitialization };
+export type { FirestoreInitializationResult } from "./firestore-runtime";
 
 const authHost = import.meta.env.VITE_AUTH_HOST;
 const authPort = import.meta.env.VITE_AUTH_PORT;

--- a/src/shared/firebase/initializeFirestore.ts
+++ b/src/shared/firebase/initializeFirestore.ts
@@ -1,8 +1,4 @@
-/**
- * @file Implements the Firestore adapter responsibility for Initialize.
- * This boundary translates between Tango's application models and Firebase so feature code does
- * not handle database details directly.
- */
+/** Initializes the shared Firestore instance and verifies production persistence before exposing it. */
 
 import type { FirebaseApp } from "firebase/app";
 import {
@@ -18,11 +14,8 @@ import {
 import { verifyFirestorePersistence } from "./firestorePersistence";
 import { blockFirestoreRuntime, initializeFirestoreRuntime } from "./firestore-runtime";
 
-/**
- * Initializes Firestore persistence and connects the database to Tango's runtime adapter.
- * If persistent storage cannot be trusted, the adapter is blocked instead of silently using a
- * different storage mode.
- */
+const toError = (value: unknown): Error => (value instanceof Error ? value : new Error(String(value)));
+
 export const initializeFirestoreAdapter = (app: FirebaseApp): Firestore | undefined => {
   let db: Firestore | undefined;
 
@@ -31,31 +24,33 @@ export const initializeFirestoreAdapter = (app: FirebaseApp): Firestore | undefi
       ? persistentLocalCache({ tabManager: persistentSingleTabManager({}) })
       : memoryLocalCache();
     db = initializeFirestore(app, { localCache });
+
+    if (import.meta.env.DEV) {
+      const host = import.meta.env.VITE_DB_HOST;
+      const port = import.meta.env.VITE_DB_PORT;
+      connectFirestoreEmulator(db, host, parseInt(port, 10));
+    }
+
     if (import.meta.env.PROD) {
       const initializedDb = db;
-      void verifyFirestorePersistence(initializedDb)
-        .then(() => {
+      void verifyFirestorePersistence(initializedDb).then(
+        () => {
           initializeFirestoreRuntime(initializedDb);
-        })
-        .catch(async (error) => {
+        },
+        async (error) => {
           try {
             await terminate(initializedDb);
           } catch {
             // Preserve the persistence failure while terminating best-effort.
           }
-          blockFirestoreRuntime(error instanceof Error ? error : new Error(String(error)));
-        });
+          blockFirestoreRuntime(toError(error));
+        }
+      );
     } else {
       initializeFirestoreRuntime(db);
     }
   } catch (error) {
-    blockFirestoreRuntime(error instanceof Error ? error : new Error(String(error)));
-  }
-
-  if (import.meta.env.DEV && db) {
-    const host = import.meta.env.VITE_DB_HOST;
-    const port = import.meta.env.VITE_DB_PORT;
-    connectFirestoreEmulator(db, host, parseInt(port, 10));
+    blockFirestoreRuntime(toError(error));
   }
 
   return db;

--- a/src/shared/firebase/test/initializeTestFirestore.ts
+++ b/src/shared/firebase/test/initializeTestFirestore.ts
@@ -1,8 +1,4 @@
-/**
- * @file Initializes the Firestore emulator runtime for adapter integration tests.
- * This boundary translates between Tango's application models and Firebase so feature code does
- * not handle database details directly.
- */
+/** Initializes the Firestore emulator before exposing it to adapter integration tests. */
 
 import { initializeApp } from "firebase/app";
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
@@ -13,7 +9,7 @@ initializeApp({
 });
 
 const db = getFirestore();
-initializeFirestoreRuntime(db);
 connectFirestoreEmulator(db, import.meta.env.VITE_DB_HOST, parseInt(import.meta.env.VITE_DB_PORT, 10), {
   mockUserToken: { user_id: "uid" },
 });
+initializeFirestoreRuntime(db);

--- a/src/store/remoteStore.reads.spec.ts
+++ b/src/store/remoteStore.reads.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { FirestoreInitializationState } from "@/shared/firebase/firestore-runtime";
+import type { FirestoreInitializationResult } from "@/shared/firebase/firestore-runtime";
 import type { RemoteSubscriptionProps } from "@/domain/remoteSnapshot";
 import { createRemoteStore, type RemoteReadDependencies } from "@/store/remoteStore";
 import { createCard, createDeck } from "@/test/factories";
@@ -221,8 +221,8 @@ describe("remote store reads", () => {
   });
 
   it("lets the latest start own subscriptions", async () => {
-    let resolveInitialization!: (state: FirestoreInitializationState) => void;
-    const initialization = new Promise<FirestoreInitializationState>((resolve) => {
+    let resolveInitialization!: (result: FirestoreInitializationResult) => void;
+    const initialization = new Promise<FirestoreInitializationResult>((resolve) => {
       resolveInitialization = resolve;
     });
     const harness = createHarness(vi.fn(() => initialization));

--- a/src/store/remoteStore.ts
+++ b/src/store/remoteStore.ts
@@ -2,7 +2,7 @@ import type { StoreApi } from "zustand";
 import { createStore } from "zustand/vanilla";
 
 import { subscribeCardReads, subscribeDeckReads } from "@/adapters/firestore/event";
-import { type FirestoreInitializationState, waitForFirestoreInitialization } from "@/shared/firebase/firestore-runtime";
+import { type FirestoreInitializationResult, waitForFirestoreInitialization } from "@/shared/firebase/firestore-runtime";
 import {
   type RemoteById,
   type RemoteSnapshot,
@@ -16,7 +16,7 @@ import { applyRealtimeChange } from "@/lib/realtimeChange";
 type Unsubscribe = () => void;
 
 export interface RemoteReadDependencies {
-  waitForInitialization: () => Promise<FirestoreInitializationState>;
+  waitForInitialization: () => Promise<FirestoreInitializationResult>;
   subscribeDecks: (props: RemoteSubscriptionProps<Deck>) => Unsubscribe;
   subscribeCards: (props: RemoteSubscriptionProps<Card>) => Unsubscribe;
 }
@@ -112,7 +112,7 @@ export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreAp
         error: undefined,
       });
 
-      let initialization: FirestoreInitializationState;
+      let initialization: FirestoreInitializationResult;
       try {
         initialization = await dependencies.waitForInitialization();
       } catch (cause) {

--- a/src/store/remoteStore.ts
+++ b/src/store/remoteStore.ts
@@ -2,7 +2,10 @@ import type { StoreApi } from "zustand";
 import { createStore } from "zustand/vanilla";
 
 import { subscribeCardReads, subscribeDeckReads } from "@/adapters/firestore/event";
-import { type FirestoreInitializationResult, waitForFirestoreInitialization } from "@/shared/firebase/firestore-runtime";
+import {
+  type FirestoreInitializationResult,
+  waitForFirestoreInitialization,
+} from "@/shared/firebase/firestore-runtime";
 import {
   type RemoteById,
   type RemoteSnapshot,

--- a/src/storybook/firestoreRuntime.ts
+++ b/src/storybook/firestoreRuntime.ts
@@ -4,17 +4,15 @@
  * instead of opening a real Firestore connection or waiting for production initialization.
  */
 
-export type FirestoreInitializationState =
-  | { status: "initializing" }
+export type FirestoreInitializationResult =
   | { status: "ready" }
   | { status: "blocked"; error: Error };
 
-const ready = { status: "ready" } as const satisfies FirestoreInitializationState;
+const ready = { status: "ready" } as const satisfies FirestoreInitializationResult;
 
 export const initializeFirestoreRuntime = (_db: unknown): void => undefined;
 export const blockFirestoreRuntime = (_error: Error): void => undefined;
 export const getDb = (): never => {
   throw new Error("Firestore is unavailable in Storybook page stories");
 };
-export const getFirestoreInitializationState = (): FirestoreInitializationState => ready;
-export const waitForFirestoreInitialization = async (): Promise<FirestoreInitializationState> => ready;
+export const waitForFirestoreInitialization = async (): Promise<FirestoreInitializationResult> => ready;

--- a/src/storybook/firestoreRuntime.ts
+++ b/src/storybook/firestoreRuntime.ts
@@ -4,9 +4,7 @@
  * instead of opening a real Firestore connection or waiting for production initialization.
  */
 
-export type FirestoreInitializationResult =
-  | { status: "ready" }
-  | { status: "blocked"; error: Error };
+export type FirestoreInitializationResult = { status: "ready" } | { status: "blocked"; error: Error };
 
 const ready = { status: "ready" } as const satisfies FirestoreInitializationResult;
 


### PR DESCRIPTION
## Summary

- simplify the Firestore runtime into a one-shot initialization gate with `ready` and `blocked` as terminal states
- narrow `waitForFirestoreInitialization()` to completed initialization results and remove unused synchronous state/subscription APIs
- keep the Firestore instance inside the `ready` runtime state so status and database availability cannot diverge
- connect the Firestore emulator before exposing the runtime as ready and keep persistence rejection handling scoped to the persistence check itself
- update Remote Store, Storybook, emulator test setup, and regression tests for the narrower contract

## Why

The previous runtime mixed a one-shot initialization promise with mutable observable state. That allowed the synchronous state to move from `ready` to `blocked` after the promise had already resolved as `ready`, and typed the promise as though it could resolve with `initializing`. Development initialization also marked the runtime ready before `connectFirestoreEmulator()` completed.

This change makes the lifecycle match the actual contract: initialization completes exactly once as either `ready` or `blocked`.

## Impact

- Remote Store can no longer treat an impossible `initializing` completion result as ready
- late blocking cannot invalidate an already-resolved ready result
- emulator connection failures block startup instead of leaving an exposed ready runtime
- the runtime API and comments are smaller and aligned with their actual responsibility

## Validation

- GitHub Actions `Test`: passed
  - `npm run ci`: passed
  - Storybook tests: passed
- GitHub Actions `E2E / E2E`: passed
- GitHub Actions `Update Docker Image`: passed
