### PR TITLE
Document development tool management policy

### DIFF
--- a/docs/adr/20260811-manage-development-tools-by-responsibility.md
+++ b/docs/adr/20260811-manage-development-tools-by-responsibility.md
@@ -1,0 +1,18 @@
+# Manage Development Tools by Responsibility
+
+Status: Accepted
+
+## Context
+
+Development tools have different installation and reproducibility requirements. Treating every development tool as an npm `devDependency` makes ownership unclear and can add unnecessary project dependencies.
+
+## Decision
+
+Manage tools according to their responsibility and distribution model:
+
+- Use `devDependencies` for Node.js ecosystem tools required to build, lint, test, or otherwise reproduce project checks, such as TypeScript, Biome, ESLint, Vitest, Playwright, Storybook, and Knip.
+- Use `mise.toml` for language runtimes, package managers, and standalone CLI tools distributed outside npm, such as Node.js, npm, and Hadolint.
+- Manage tools used only inside containers within the container environment, rather than duplicating them in npm or mise.
+- Do not add optional, interactive, developer-specific tools to project dependencies. Tools such as React Developer Tools should be installed individually when needed.
+
+Prefer the tool's official distribution channel and avoid managing the same tool in multiple places unless reproducibility requires it.


### PR DESCRIPTION
## Summary

- add an ADR defining how development tools are managed
- use npm `devDependencies` for Node.js ecosystem tools required for reproducible project checks
- use `mise.toml` for runtimes, package managers, and standalone CLIs such as Hadolint
- keep container-only tooling in the container environment
- keep optional developer-specific tools such as React Developer Tools out of project dependencies

## Why

The repository uses multiple tool-management mechanisms. Documenting the boundary makes dependency ownership explicit, avoids unnecessary npm dependencies, and prevents the same tool from being managed in multiple places.

## Validation

- checked the ADR against `docs/adr/AGENTS.md`
- kept the ADR to `Context` and `Decision` only
- confirmed the PR changes only the new ADR file
