### PR TITLE
Fix stale Deck filter overwrites

### DIFF
--- a/src/adapters/firestore/deck.spec.ts
+++ b/src/adapters/firestore/deck.spec.ts
@@ -65,6 +65,18 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     expect(data).not.toHaveProperty("cardOrderIds");
   });
 
+  it("updates one filter field without overwriting concurrent Deck changes", async () => {
+    const deck = { ...newDeck, id: uuid(), name: "latest name", category: "latest category", scoreMax: 4 };
+    await deckAdapter.create(deck);
+
+    await deckAdapter.updateFilter(deck.id, { selectedTags: ["math"] });
+
+    expect((await getDoc(doc(db, "deck", deck.id))).data()).toEqual({
+      ...deck,
+      selectedTags: ["math"],
+    });
+  });
+
   it("should delete a deck", async () => {
     const d = { ...newDeck, id: uuid() };
     await deckAdapter.create(d);

--- a/src/adapters/firestore/deck.ts
+++ b/src/adapters/firestore/deck.ts
@@ -17,7 +17,13 @@ import {
   type Firestore,
 } from "firebase/firestore";
 import { getTimestamp } from "@/adapters/firestore/documentMetadata";
-import { buildDeckCreateDto, buildDeckUpdateDto, mapDeckDocument } from "@/adapters/firestore/dto";
+import {
+  buildDeckCreateDto,
+  buildDeckFilterUpdateDto,
+  buildDeckUpdateDto,
+  mapDeckDocument,
+} from "@/adapters/firestore/dto";
+import type { DeckFilterPatch } from "@/entities/deck";
 import { getDb } from "@/shared/firebase/firestore-runtime";
 
 /**
@@ -74,6 +80,13 @@ export const update = async (deck: DeckEdit) => {
   const ref = doc(db, "deck", deck.id);
   const updatedAt = getTimestamp();
   await updateDoc(ref, buildDeckUpdateDto(deck, updatedAt));
+};
+
+/** Updates one Deck filter field without overwriting concurrent changes to the rest of the Deck. */
+export const updateFilter = async (deckId: DeckId, patch: DeckFilterPatch) => {
+  const db = getDb();
+  const ref = doc(db, "deck", deckId);
+  await updateDoc(ref, buildDeckFilterUpdateDto(patch, getTimestamp()));
 };
 
 /**

--- a/src/adapters/firestore/dto.spec.ts
+++ b/src/adapters/firestore/dto.spec.ts
@@ -12,6 +12,7 @@ import {
   buildCardCreateDto,
   buildCardUpdateDto,
   buildDeckCreateDto,
+  buildDeckFilterUpdateDto,
   buildDeckUpdateDto,
   FirestoreDocumentValidationError,
   mapCardDocument,
@@ -233,6 +234,27 @@ describe("Firestore DTO builders", () => {
       category: "category",
       convertToBr: true,
     });
+  });
+
+  it("builds a Deck filter update from only the changed field and timestamp", () => {
+    expect(
+      buildDeckFilterUpdateDto(
+        { selectedTags: ["science"], name: "stale name" } as unknown as Parameters<typeof buildDeckFilterUpdateDto>[0],
+        102
+      )
+    ).toEqual({ selectedTags: ["science"], updatedAt: 102 });
+    expect(buildDeckFilterUpdateDto({ tagAndFilter: false }, 103)).toEqual({
+      tagAndFilter: false,
+      updatedAt: 103,
+    });
+    expect(buildDeckFilterUpdateDto({ scoreMin: null }, 104)).toEqual({ scoreMin: null, updatedAt: 104 });
+    expect(buildDeckFilterUpdateDto({ scoreMax: 5 }, 105)).toEqual({ scoreMax: 5, updatedAt: 105 });
+  });
+
+  it("rejects an empty Deck filter update", () => {
+    expect(() => buildDeckFilterUpdateDto({} as Parameters<typeof buildDeckFilterUpdateDto>[0], 106)).toThrow(
+      "must include a filter field"
+    );
   });
 
   it("allows only server card fields when creating", () => {

--- a/src/adapters/firestore/dto.ts
+++ b/src/adapters/firestore/dto.ts
@@ -7,6 +7,8 @@
 import type { Timestamp } from "firebase/firestore";
 import { z } from "zod";
 
+import type { DeckFilterPatch } from "@/entities/deck";
+
 const validDateSchema = z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date");
 const timestampSchema = z.custom<Timestamp>(
   (value) =>
@@ -56,9 +58,27 @@ const deckUpdateDtoSchema = deckDocumentSchema.omit({ id: true }).partial().exte
   updatedAt: z.number(),
 });
 
+const deckFilterUpdateDtoSchema = z
+  .object({
+    selectedTags: z.array(z.string()).optional(),
+    tagAndFilter: z.boolean().optional(),
+    scoreMax: z.number().nullable().optional(),
+    scoreMin: z.number().nullable().optional(),
+    updatedAt: z.number(),
+  })
+  .refine(
+    (value) =>
+      value.selectedTags !== undefined ||
+      value.tagAndFilter !== undefined ||
+      value.scoreMax !== undefined ||
+      value.scoreMin !== undefined,
+    "A Deck filter update must include a filter field"
+  );
+
 type DeckDocument = z.infer<typeof deckDocumentSchema>;
 export type DeckCreateDto = z.infer<typeof deckCreateDtoSchema>;
 export type DeckUpdateDto = z.infer<typeof deckUpdateDtoSchema>;
+export type DeckFilterUpdateDto = z.infer<typeof deckFilterUpdateDtoSchema>;
 
 export class FirestoreDocumentValidationError extends Error {
   constructor(
@@ -239,6 +259,14 @@ export const buildDeckUpdateDto = (deck: DeckEdit, updatedAt: number): DeckUpdat
       convertToBr: deck.convertToBr,
     })
   );
+
+/** Builds a narrow update containing only the filter field changed by an auto-save action. */
+export const buildDeckFilterUpdateDto = (patch: DeckFilterPatch, updatedAt: number): DeckFilterUpdateDto =>
+  deckFilterUpdateDtoSchema.parse({
+    ...patch,
+    ...("selectedTags" in patch ? { selectedTags: [...patch.selectedTags] } : {}),
+    updatedAt,
+  });
 
 /**
  * Builds card create dto from the supplied application values.

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,1 +1,2 @@
-export type { Deck, DeckId } from "./model/deck";
+export { deckFilterValuesFrom } from "./model/deck";
+export type { Deck, DeckFilterPatch, DeckFilterValues, DeckId } from "./model/deck";

--- a/src/entities/deck/model/deck.ts
+++ b/src/entities/deck/model/deck.ts
@@ -16,3 +16,18 @@ export interface Deck {
   category: string;
   convertToBr: boolean;
 }
+
+export type DeckFilterValues = Pick<Deck, "selectedTags" | "tagAndFilter" | "scoreMin" | "scoreMax">;
+
+export type DeckFilterPatch =
+  | Pick<DeckFilterValues, "selectedTags">
+  | Pick<DeckFilterValues, "tagAndFilter">
+  | Pick<DeckFilterValues, "scoreMin">
+  | Pick<DeckFilterValues, "scoreMax">;
+
+export const deckFilterValuesFrom = (deck: DeckFilterValues): DeckFilterValues => ({
+  selectedTags: [...deck.selectedTags],
+  tagAndFilter: deck.tagAndFilter,
+  scoreMin: deck.scoreMin,
+  scoreMax: deck.scoreMax,
+});

--- a/src/features/deck/hooks/useDeckActions.ts
+++ b/src/features/deck/hooks/useDeckActions.ts
@@ -6,6 +6,7 @@
 
 import { useNavigate } from "react-router-dom";
 
+import type { DeckFilterPatch } from "@/entities/deck";
 import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 
@@ -20,6 +21,7 @@ export const useDeckActions = (id: DeckId) => {
   const mutations = useDeckMutations();
   return {
     update: mutations.update,
+    updateFilter: (patch: DeckFilterPatch) => mutations.updateFilter(id, patch),
     updateAndGoToList: async (deck: Deck) => {
       try {
         await mutations.update(deck);

--- a/src/features/deck/hooks/useDeckFilterState.spec.tsx
+++ b/src/features/deck/hooks/useDeckFilterState.spec.tsx
@@ -12,6 +12,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
+import type { DeckFilterPatch } from "@/entities/deck";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
 import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
 import { createDeck } from "@/test/factories";
@@ -23,7 +24,7 @@ import { createDeck } from "@/test/factories";
 const DeckFilterHarness: React.FC<{
   deck: Deck;
   tags: string[];
-  onSubmit: (deck: Deck) => void;
+  onSubmit: (patch: DeckFilterPatch) => unknown;
 }> = ({ deck, tags, onSubmit }) => {
   const deckStartForm = useDeckFilterState({ deck, tags, onSubmit });
   return <DeckStartForm {...deckStartForm} />;
@@ -42,7 +43,7 @@ describe("DeckStartForm with useDeckFilterState", () => {
     cleanup();
   });
 
-  it("auto-submits score and tag filter changes", async () => {
+  it("auto-submits only the filter field changed by each control", async () => {
     const onSubmit = vi.fn();
     const view = render(<DeckFilterHarness onSubmit={onSubmit} deck={deck} tags={tags} />);
 
@@ -52,18 +53,21 @@ describe("DeckStartForm with useDeckFilterState", () => {
     fireEvent.change(view.container.querySelector("input[name='scoreMin']") as Element, {
       target: { value: -2 },
     });
-    await userEvent.click(view.container.querySelector("input[name='tag-filter-click-filter']") as Element);
-    await userEvent.click(view.getByRole("button", { name: /all/i }));
+    fireEvent.click(view.container.querySelector("input[name='tag-filter-click-filter']") as Element);
+    fireEvent.click(view.getByRole("button", { name: /all/i }));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({
-        ...deck,
-        scoreMax: 2,
-        scoreMin: -2,
-        tagAndFilter: true,
-        selectedTags: tags,
-      });
+      expect(onSubmit).toHaveBeenCalledWith({ scoreMax: 2 });
+      expect(onSubmit).toHaveBeenCalledWith({ scoreMin: -2 });
+      expect(onSubmit).toHaveBeenCalledWith({ tagAndFilter: true });
+      expect(onSubmit).toHaveBeenLastCalledWith({ selectedTags: tags });
     });
+    expect(onSubmit.mock.calls.flatMap(([patch]) => Object.keys(patch))).toEqual([
+      "scoreMax",
+      "scoreMin",
+      "tagAndFilter",
+      "selectedTags",
+    ]);
   });
 
   it("auto-submits score toggle and slider changes", async () => {
@@ -74,11 +78,11 @@ describe("DeckStartForm with useDeckFilterState", () => {
 
     await userEvent.click(view.container.querySelector("input[name='scoreMaxSwitch']") as Element);
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, scoreMax: 0, scoreMin: null });
+      expect(onSubmit).toHaveBeenLastCalledWith({ scoreMax: 0 });
     });
     await userEvent.click(view.container.querySelector("input[name='scoreMinSwitch']") as Element);
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, scoreMax: 0, scoreMin: 0 });
+      expect(onSubmit).toHaveBeenLastCalledWith({ scoreMin: 0 });
     });
 
     fireEvent.change(view.container.querySelector("input[name='scoreMax']") as Element, {
@@ -88,13 +92,15 @@ describe("DeckStartForm with useDeckFilterState", () => {
       target: { value: -2 },
     });
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, scoreMax: 2, scoreMin: -2 });
+      expect(onSubmit).toHaveBeenCalledWith({ scoreMax: 2 });
+      expect(onSubmit).toHaveBeenLastCalledWith({ scoreMin: -2 });
     });
 
     await userEvent.click(view.container.querySelector("input[name='scoreMaxSwitch']") as Element);
     await userEvent.click(view.container.querySelector("input[name='scoreMinSwitch']") as Element);
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, scoreMax: null, scoreMin: null });
+      expect(onSubmit).toHaveBeenCalledWith({ scoreMax: null });
+      expect(onSubmit).toHaveBeenLastCalledWith({ scoreMin: null });
     });
   });
 
@@ -104,17 +110,45 @@ describe("DeckStartForm with useDeckFilterState", () => {
 
     await userEvent.click(view.getByText("tag2"));
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, selectedTags: ["tag2"] });
+      expect(onSubmit).toHaveBeenLastCalledWith({ selectedTags: ["tag2"] });
     });
 
     await userEvent.click(view.getByRole("button", { name: /all/i }));
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, selectedTags: tags });
+      expect(onSubmit).toHaveBeenLastCalledWith({ selectedTags: tags });
     });
 
     await userEvent.click(view.getByRole("button", { name: /clear/i }));
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenLastCalledWith({ ...deck, selectedTags: [] });
+      expect(onSubmit).toHaveBeenLastCalledWith({ selectedTags: [] });
     });
+  });
+
+  it("syncs remote filter changes without submitting them again", async () => {
+    const onSubmit = vi.fn();
+    const view = render(<DeckFilterHarness onSubmit={onSubmit} deck={deck} tags={tags} />);
+
+    view.rerender(
+      <DeckFilterHarness
+        onSubmit={onSubmit}
+        deck={{ ...deck, selectedTags: ["tag2"], tagAndFilter: true }}
+        tags={tags}
+      />
+    );
+
+    await waitFor(() => {
+      expect(view.getByRole("checkbox", { name: "tag2" })).toBeChecked();
+      expect(view.getByRole("checkbox", { name: "Match all selected tags" })).toBeChecked();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("handles a rejected auto-save without leaving an unhandled rejection", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("save failed"));
+    const view = render(<DeckFilterHarness onSubmit={onSubmit} deck={deck} tags={tags} />);
+
+    await userEvent.click(view.getByText("tag2"));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledExactlyOnceWith({ selectedTags: ["tag2"] }));
   });
 });

--- a/src/features/deck/hooks/useDeckFilterState.ts
+++ b/src/features/deck/hooks/useDeckFilterState.ts
@@ -7,12 +7,13 @@
 import * as React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
+import { deckFilterValuesFrom, type DeckFilterPatch, type DeckFilterValues } from "@/entities/deck";
 import type { DeckStartFormProps } from "@/features/deck/components/DeckStartForm";
 
 export interface UseDeckFilterStateOptions {
   deck: Deck;
   tags: string[];
-  onSubmit?: (deck: Deck) => void;
+  onSubmit?: (patch: DeckFilterPatch) => unknown;
 }
 
 /**
@@ -21,20 +22,29 @@ export interface UseDeckFilterStateOptions {
  * services themselves.
  */
 export const useDeckFilterState = ({ deck, tags, onSubmit }: UseDeckFilterStateOptions): DeckStartFormProps => {
-  const [scoreMaxEnabled, setScoreMaxEnabled] = React.useState(deck.scoreMax != null);
-  const [scoreMinEnabled, setScoreMinEnabled] = React.useState(deck.scoreMin != null);
-  const { control, handleSubmit, register, setValue, subscribe } = useForm<Deck>({ defaultValues: deck });
+  const { control, register, reset, setValue } = useForm<DeckFilterValues>({
+    defaultValues: deckFilterValuesFrom(deck),
+  });
   const scoreMax = useWatch({ control, name: "scoreMax" });
   const scoreMin = useWatch({ control, name: "scoreMin" });
   const selectedTags = useWatch({ control, name: "selectedTags" });
   const tagAndFilter = useWatch({ control, name: "tagAndFilter" });
+  const remoteFilterKey = JSON.stringify(deckFilterValuesFrom(deck));
+  const previousRemoteFilterKey = React.useRef(remoteFilterKey);
+  const scoreMaxRegistration = register("scoreMax", { valueAsNumber: true });
+  const scoreMinRegistration = register("scoreMin", { valueAsNumber: true });
 
   React.useEffect(() => {
-    return subscribe({
-      formState: { values: true },
-      callback: () => void handleSubmit((data) => onSubmit?.(data))(),
-    });
-  }, [handleSubmit, onSubmit, subscribe]);
+    if (previousRemoteFilterKey.current === remoteFilterKey) return;
+    previousRemoteFilterKey.current = remoteFilterKey;
+    reset(deckFilterValuesFrom(deck));
+  }, [deck, remoteFilterKey, reset]);
+
+  const submit = (patch: DeckFilterPatch) => {
+    void Promise.resolve()
+      .then(() => onSubmit?.(patch))
+      .catch(() => undefined);
+  };
 
   /**
    * Handles the click filter callback for the deck feature.
@@ -43,6 +53,7 @@ export const useDeckFilterState = ({ deck, tags, onSubmit }: UseDeckFilterStateO
    */
   const onClickFilter = (value: boolean) => {
     setValue("tagAndFilter", value);
+    submit({ tagAndFilter: value });
   };
   /**
    * Handles the click all callback for the deck feature.
@@ -51,6 +62,7 @@ export const useDeckFilterState = ({ deck, tags, onSubmit }: UseDeckFilterStateO
    */
   const onClickAll = () => {
     setValue("selectedTags", tags);
+    submit({ selectedTags: tags });
   };
   /**
    * Handles the click clear callback for the deck feature.
@@ -59,6 +71,7 @@ export const useDeckFilterState = ({ deck, tags, onSubmit }: UseDeckFilterStateO
    */
   const onClickClear = () => {
     setValue("selectedTags", []);
+    submit({ selectedTags: [] });
   };
   /**
    * Handles the click tag callback for the deck feature.
@@ -67,42 +80,51 @@ export const useDeckFilterState = ({ deck, tags, onSubmit }: UseDeckFilterStateO
    */
   const onClickTag = (value: string[]) => {
     setValue("selectedTags", value);
+    submit({ selectedTags: value });
   };
 
   return {
-    scoreMax,
-    scoreMin,
+    scoreMax: scoreMax ?? null,
+    scoreMin: scoreMin ?? null,
     scoreMaxSwitchProps: {
       name: "scoreMaxSwitch",
-      checked: scoreMaxEnabled,
+      checked: scoreMax != null,
       onChange: (event) => {
-        const enabled = event.currentTarget.checked;
-        setValue("scoreMax", enabled ? 0 : null);
-        setScoreMaxEnabled(enabled);
+        const value = event.currentTarget.checked ? 0 : null;
+        setValue("scoreMax", value);
+        submit({ scoreMax: value });
       },
     },
     scoreMinSwitchProps: {
       name: "scoreMinSwitch",
-      checked: scoreMinEnabled,
+      checked: scoreMin != null,
       onChange: (event) => {
-        const enabled = event.currentTarget.checked;
-        setValue("scoreMin", enabled ? 0 : null);
-        setScoreMinEnabled(enabled);
+        const value = event.currentTarget.checked ? 0 : null;
+        setValue("scoreMin", value);
+        submit({ scoreMin: value });
       },
     },
     scoreMaxSliderProps: {
-      ...register("scoreMax", { valueAsNumber: true }),
+      ...scoreMaxRegistration,
       step: 1,
       max: 10,
       min: -10,
-      disabled: !scoreMaxEnabled,
+      disabled: scoreMax == null,
+      onChange: (event) => {
+        void scoreMaxRegistration.onChange(event);
+        submit({ scoreMax: event.currentTarget.valueAsNumber });
+      },
     },
     scoreMinSliderProps: {
-      ...register("scoreMin", { valueAsNumber: true }),
+      ...scoreMinRegistration,
       step: 1,
       max: 10,
       min: -10,
-      disabled: !scoreMinEnabled,
+      disabled: scoreMin == null,
+      onChange: (event) => {
+        void scoreMinRegistration.onChange(event);
+        submit({ scoreMin: event.currentTarget.valueAsNumber });
+      },
     },
     tagFilterProps: {
       tags,

--- a/src/features/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/features/deck/hooks/useDeckMutations.spec.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   uid: "uid-a",
   create: vi.fn(),
   update: vi.fn(),
+  updateFilter: vi.fn(),
   remove: vi.fn(),
 }));
 
@@ -20,6 +21,7 @@ vi.mock("@/auth/AuthContext", () => ({
 vi.mock("@/adapters/firestore/deck", () => ({
   create: mocks.create,
   update: mocks.update,
+  updateFilter: mocks.updateFilter,
   remove: mocks.remove,
 }));
 
@@ -31,6 +33,7 @@ describe("useDeckMutations", () => {
     mocks.uid = "uid-a";
     mocks.create.mockResolvedValue("deck-id");
     mocks.update.mockResolvedValue(undefined);
+    mocks.updateFilter.mockResolvedValue(undefined);
     mocks.remove.mockResolvedValue(undefined);
   });
 
@@ -117,6 +120,25 @@ describe("useDeckMutations", () => {
       expect(result.current.error).toBeNull();
     });
     expect(onRemoveSuccess).not.toHaveBeenCalled();
+  });
+
+  it("exposes and retries a failed Deck filter update", async () => {
+    const failure = new Error("filter update failed");
+    mocks.updateFilter.mockRejectedValueOnce(failure).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(useDeckMutations);
+
+    await actAsync(async () => {
+      await expect(result.current.updateFilter("deck", { tagAndFilter: true })).rejects.toBe(failure);
+    });
+    expect(result.current.error).toBe(failure);
+
+    act(() => result.current.retry());
+
+    await waitFor(() => {
+      expect(mocks.updateFilter).toHaveBeenCalledTimes(2);
+      expect(result.current.error).toBeNull();
+    });
+    expect(mocks.updateFilter).toHaveBeenLastCalledWith("deck", { tagAndFilter: true });
   });
 
   it("rejects writes without a confirmed user and exposes the error", async () => {

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 
 import { useAuth } from "@/auth/AuthContext";
+import type { DeckFilterPatch } from "@/entities/deck";
 import { useAsyncAction } from "@/hooks/useAsyncAction";
 import { deckCommands } from "@/services/deckCommands";
 
@@ -30,6 +31,8 @@ export const useDeckMutations = ({ onRemoveSuccess }: UseDeckMutationsOptions = 
 
   const create = (deck: Deck) => mutation.run([deck.id], `create:${deck.id}`, () => deckCommands.create(uid, deck));
   const update = (deck: DeckEdit) => mutation.run([deck.id], `update:${deck.id}`, () => deckCommands.update(uid, deck));
+  const updateFilter = (deckId: DeckId, patch: DeckFilterPatch) =>
+    mutation.run([deckId], `updateFilter:${deckId}`, () => deckCommands.updateFilter(uid, deckId, patch));
   const remove = (deck: Deck) => {
     const operationScope = scope.current;
     return mutation.run([deck.id], `remove:${deck.id}`, async () => {
@@ -41,6 +44,7 @@ export const useDeckMutations = ({ onRemoveSuccess }: UseDeckMutationsOptions = 
   return {
     create,
     update,
+    updateFilter,
     remove,
     pending: mutation.pending,
     isPending: mutation.isPending,

--- a/src/features/study/components/templates/DeckStartTemplate.spec.tsx
+++ b/src/features/study/components/templates/DeckStartTemplate.spec.tsx
@@ -25,6 +25,7 @@ const renderTemplate = (overrides: Partial<React.ComponentProps<typeof DeckStart
       maxNumberOfCardsToLearn={24}
       cardsLength={123}
       onClickStart={onClickStart}
+      feedbackSlot={<div>Filter feedback</div>}
       filterSlot={<div>Filter controls</div>}
       {...overrides}
     />
@@ -41,6 +42,7 @@ describe("DeckStartTemplate", () => {
     expect(view.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeInTheDocument();
     expect(view.getByRole("heading", { level: 2, name: "24 cards in this session" })).toBeInTheDocument();
     expect(view.getByText("123 cards match your filters.")).toBeInTheDocument();
+    expect(view.getByText("Filter feedback")).toBeInTheDocument();
     expect(view.getByText("Filter controls")).toBeInTheDocument();
 
     await userEvent.click(view.getByRole("button", { name: "Start 24 cards" }));

--- a/src/features/study/components/templates/DeckStartTemplate.tsx
+++ b/src/features/study/components/templates/DeckStartTemplate.tsx
@@ -13,6 +13,7 @@ export interface DeckStartTemplateProps {
   deckName: string;
   maxNumberOfCardsToLearn: number;
   cardsLength: number;
+  feedbackSlot?: React.ReactNode;
   filterSlot?: React.ReactNode;
   onClickStart?: () => void;
 }
@@ -38,6 +39,7 @@ export const DeckStartTemplate: React.FC<DeckStartTemplateProps> = (props) => {
 
   return (
     <Layout showHeader {...props.layout}>
+      {props.feedbackSlot}
       <div className="mx-auto w-full max-w-reading space-y-section-gap">
         <header>
           <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Study setup</p>

--- a/src/features/study/containers/DeckStartContainer.spec.tsx
+++ b/src/features/study/containers/DeckStartContainer.spec.tsx
@@ -5,6 +5,7 @@
  * "stops responding to Enter when a rerender has no matching cards".
  */
 
+import userEvent from "@testing-library/user-event";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -17,14 +18,22 @@ const mocks = vi.hoisted(() => {
   return {
     start,
     currentStart: start,
-    update: vi.fn(),
+    updateFilter: vi.fn(),
+    pending: false,
+    error: null as unknown,
+    retry: vi.fn(),
   };
 });
 vi.mock("@/hooks/useRemoteCollections", () => ({
   useRemoteCollections: vi.fn(),
 }));
 vi.mock("@/features/deck/hooks/useDeckActions", () => ({
-  useDeckActions: () => ({ update: mocks.update }),
+  useDeckActions: () => ({
+    updateFilter: mocks.updateFilter,
+    pending: mocks.pending,
+    error: mocks.error,
+    retry: mocks.retry,
+  }),
 }));
 vi.mock("@/features/study/hooks/useStudyActions", () => ({
   useStudyActions: () => ({ start: mocks.currentStart }),
@@ -64,12 +73,23 @@ describe("DeckStartContent", () => {
     cleanup();
     vi.clearAllMocks();
     mocks.currentStart = mocks.start;
+    mocks.pending = false;
+    mocks.error = null;
   });
 
   it("passes Deck and session context to the template", () => {
     const view = renderContent({ cards: [createCard()], config: createConfig({ maxNumberOfCardsToLearn: 1 }) });
     expect(view.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeInTheDocument();
     expect(view.getByRole("button", { name: "Start 1 card" })).toBeInTheDocument();
+  });
+
+  it("shows filter save failures and retries them", async () => {
+    mocks.error = new Error("filter write failed");
+    const view = renderContent();
+
+    expect(view.getByRole("alert")).toHaveTextContent("Unable to save filters.");
+    await userEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(mocks.retry).toHaveBeenCalledOnce();
   });
 
   it("starts from Enter when cards match and focus is not interactive", () => {

--- a/src/features/study/containers/DeckStartContainer.tsx
+++ b/src/features/study/containers/DeckStartContainer.tsx
@@ -10,7 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
-import { RemoteReadBoundary, RouteFeedback } from "@/components";
+import { RemoteMutationNotice, RemoteReadBoundary, RouteFeedback } from "@/components";
 import { DeckStartForm } from "@/features/deck/components/DeckStartForm";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
@@ -38,7 +38,7 @@ export const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: Con
   const studyActions = useStudyActions(deckId);
   const startStudy = studyActions.start;
   const actions = useActions();
-  const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
+  const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.updateFilter });
   /**
    * Starts the study session when Enter is pressed outside an interactive control.
    * The guard prevents the shortcut from stealing Enter presses intended for buttons or form
@@ -65,6 +65,15 @@ export const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: Con
       maxNumberOfCardsToLearn={config.maxNumberOfCardsToLearn}
       cardsLength={cards.length}
       onClickStart={startStudy}
+      feedbackSlot={
+        <RemoteMutationNotice
+          pending={deckActions.pending}
+          error={deckActions.error}
+          onRetry={deckActions.retry}
+          pendingLabel="Saving filters…"
+          errorLabel="Unable to save filters."
+        />
+      }
       filterSlot={<DeckStartForm {...deckStartForm} />}
     />
   );

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => ({
   pending: false,
   error: null as unknown,
   retry: vi.fn(),
+  deckPending: false,
+  deckError: null as unknown,
+  deckRetry: vi.fn(),
+  deckUpdateFilter: vi.fn(),
   goToCardEdit: vi.fn(),
   cardUpdateBy: vi.fn(),
   cardRemove: vi.fn(),
@@ -93,7 +97,12 @@ vi.mock("@/features/deck", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/deck")>();
   return {
     ...actual,
-    useDeckActions: () => ({ update: vi.fn() }),
+    useDeckActions: () => ({
+      updateFilter: mocks.deckUpdateFilter,
+      pending: mocks.deckPending,
+      error: mocks.deckError,
+      retry: mocks.deckRetry,
+    }),
     useDeckFilterState: () => ({
       scoreMax: mocks.filter.scoreMax,
       scoreMin: mocks.filter.scoreMin,
@@ -157,6 +166,10 @@ describe("CardListPage", () => {
     mocks.pending = false;
     mocks.error = null;
     mocks.retry.mockReset();
+    mocks.deckPending = false;
+    mocks.deckError = null;
+    mocks.deckRetry.mockReset();
+    mocks.deckUpdateFilter.mockReset();
     mocks.goToCardEdit.mockReset();
     mocks.cardUpdateBy.mockReset().mockResolvedValue(undefined);
     mocks.cardRemove.mockReset().mockResolvedValue(undefined);
@@ -228,6 +241,21 @@ describe("CardListPage", () => {
     expect(view.getByRole("alert")).toHaveTextContent("Unable to save changes.");
     await userEvent.click(view.getByRole("button", { name: "Retry" }));
     expect(mocks.retry).toHaveBeenCalledOnce();
+  });
+
+  it("shows Deck filter save progress and retry feedback", async () => {
+    mocks.deckPending = true;
+    const view = render(<CardListPage />);
+
+    expect(view.getByText("Saving filters…").closest('[role="status"]')).toBeInTheDocument();
+
+    mocks.deckPending = false;
+    mocks.deckError = new Error("filter write failed");
+    view.rerender(<CardListPage />);
+    expect(view.getByRole("alert")).toHaveTextContent("Unable to save filters.");
+
+    await userEvent.click(view.getByRole("button", { name: "Retry" }));
+    expect(mocks.deckRetry).toHaveBeenCalledOnce();
   });
 
   it("keeps a failed Card deletion explainable and retryable", async () => {

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -34,7 +34,7 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
     },
   });
   const deckActions = useDeckActions(deck.id);
-  const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.update });
+  const deckStartForm = useDeckFilterState({ deck, tags, onSubmit: deckActions.updateFilter });
   const closeCard = () => setShowCard(undefined);
   const category = showCard == null ? undefined : util.getCategory(deck.category, showCard.tags);
 
@@ -79,6 +79,13 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
       }}
       feedbackSlot={
         <>
+          <RemoteMutationNotice
+            pending={deckActions.pending}
+            error={deckActions.error}
+            onRetry={deckActions.retry}
+            pendingLabel="Saving filters…"
+            errorLabel="Unable to save filters."
+          />
           <RemoteMutationNotice
             pending={mutations.pending}
             error={mutations.error}

--- a/src/services/deckCommands.spec.ts
+++ b/src/services/deckCommands.spec.ts
@@ -6,6 +6,7 @@ import { createCard as createCardFixture, createDeck as createDeckFixture } from
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   update: vi.fn(),
+  updateFilter: vi.fn(),
   remove: vi.fn(),
 }));
 
@@ -19,6 +20,7 @@ const cardMocks = vi.hoisted(() => ({
 vi.mock("@/adapters/firestore/deck", () => ({
   create: mocks.create,
   update: mocks.update,
+  updateFilter: mocks.updateFilter,
   remove: mocks.remove,
 }));
 
@@ -40,6 +42,7 @@ describe("deck commands", () => {
     vi.clearAllMocks();
     mocks.create.mockResolvedValue("created");
     mocks.update.mockResolvedValue(undefined);
+    mocks.updateFilter.mockResolvedValue(undefined);
     mocks.remove.mockResolvedValue(undefined);
     cardMocks.create.mockResolvedValue("created");
     cardMocks.update.mockResolvedValue(undefined);
@@ -57,6 +60,12 @@ describe("deck commands", () => {
 
     expect(mocks.create).not.toHaveBeenCalled();
     expect(mocks.remove).not.toHaveBeenCalled();
+  });
+
+  it("writes only the requested Deck filter field", async () => {
+    await deckCommands.updateFilter("uid-a", "deck", { selectedTags: ["tag"] });
+
+    expect(mocks.updateFilter).toHaveBeenCalledExactlyOnceWith("deck", { selectedTags: ["tag"] });
   });
 
   it("serializes writes to the same Deck", async () => {

--- a/src/services/deckCommands.ts
+++ b/src/services/deckCommands.ts
@@ -2,7 +2,9 @@ import {
   create as createRemoteDeck,
   remove as removeRemoteDeck,
   update as updateRemoteDeck,
+  updateFilter as updateRemoteDeckFilter,
 } from "@/adapters/firestore/deck";
+import type { DeckFilterPatch } from "@/entities/deck";
 import {
   deckMembershipMutationLock,
   deckMutationLock,
@@ -35,6 +37,13 @@ export const deckCommands = {
     requireOwner(uid, deck.uid);
     await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
       waitForRemoteWrite(updateRemoteDeck(deck), "Deck update")
+    );
+  },
+
+  updateFilter: async (uid: string, deckId: DeckId, patch: DeckFilterPatch): Promise<void> => {
+    requireUid(uid);
+    await withMutationLocks([deckMutationLock(uid, deckId)], () =>
+      waitForRemoteWrite(updateRemoteDeckFilter(deckId, patch), "Deck filter update")
     );
   },
 


### PR DESCRIPTION
## Summary

- replace full-Deck filter auto-saves with single-field `DeckFilterPatch` writes
- synchronize remote filter changes into the local form without re-submitting them
- connect filter auto-save failures to the existing pending, error, and retry feedback on Deck Start and Card List screens
- add DTO, command, hook, UI, and Firestore regression coverage

## Root cause

`useDeckFilterState` stored the entire Deck in React Hook Form and submitted that stale snapshot through the generic Deck update path after every filter interaction. The Firestore DTO therefore wrote unrelated fields such as `name`, `url`, and `category`, which could overwrite newer changes from another client.

The filter path now sends only the field changed by the user plus `updatedAt`. Remote filter values reset the local form without triggering another write, and rejected auto-saves are caught after the mutation state records the error.

## Validation

- `mise run check` — 83 test files, 526 tests passed; formatting, TypeScript, ESLint, Biome, Knip, Markdown, and Docker lint passed
- `mise run test-firestore` — 9 test files, 81 tests passed

Closes #387