### PR TITLE
Adopt Feature-Sliced Design architecture

### DIFF
--- a/docs/adr/20260811-adopt-feature-sliced-design.md
+++ b/docs/adr/20260811-adopt-feature-sliced-design.md
@@ -1,0 +1,13 @@
+# Adopt Feature-Sliced Design
+
+Status: Accepted
+
+## Context
+
+The frontend is being organized around explicit architectural boundaries. A shared architectural baseline is needed so directory placement and dependency decisions are consistent as the codebase evolves.
+
+## Decision
+
+Adopt [Feature-Sliced Design (FSD)](https://feature-sliced.design/) as the baseline architectural methodology for the frontend.
+
+Follow FSD's core layering and dependency principles while allowing project-specific segment names and conventions when they make responsibilities clearer. Project-specific rules documented in ADRs take precedence when they intentionally differ from conventional FSD structure.


### PR DESCRIPTION
## Summary

- Add an ADR adopting Feature-Sliced Design (FSD) as the frontend architecture baseline.
- Link the official FSD documentation.
- Clarify that project-specific segment names and ADR-defined conventions may intentionally differ from conventional FSD structure.

## Why

The codebase is moving toward explicit FSD-style boundaries, but the architectural baseline was not documented. Recording the decision makes future directory placement and dependency decisions consistent without claiming strict or complete conformance during migration.

## Validation

- Confirmed the ADR follows the repository's `Context` / `Decision` convention.
- Documentation-only change; no runtime checks required.