### PR TITLE
refactor: move application config into shared module

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -24,7 +24,7 @@ vi.mock("zustand", () => ({
       config: { darkMode: mocks.darkMode },
     }),
 }));
-vi.mock("@/store/configStore", () => ({ configStore: {} }));
+vi.mock("@/shared/config/configStore", () => ({ configStore: {} }));
 vi.mock("@/action", () => ({ event: { init: mocks.init } }));
 vi.mock("@/auth/AuthContext", () => ({ useAuth: () => mocks.authState }));
 vi.mock("@/pages/card-form", () => ({ CardFormPage: () => null }));

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,7 +18,7 @@ import { DeckListPage } from "@/pages/deck-list";
 import { DeckStartPage } from "@/pages/deck-start";
 import { DeckSwiperPage } from "@/pages/deck-swiper";
 import { SettingsPage } from "@/pages/settings";
-import { configStore } from "@/store/configStore";
+import { configStore } from "@/shared/config/configStore";
 
 /**
  * Renders the Unknown Route user interface.

--- a/src/auth/AuthLogout.integration.spec.tsx
+++ b/src/auth/AuthLogout.integration.spec.tsx
@@ -56,7 +56,7 @@ vi.mock("@/features/study/state/studyStore", async (importOriginal) => {
   mocks.actualClearStudyStore = actual.clearStudyStore;
   return { ...actual, clearStudyStore: mocks.clearStudyStore };
 });
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
 vi.mock("@/hooks/useActions", () => ({ useActions: () => mocks.accountActions }));
 vi.mock("@/features/settings/hooks/useConfigFormState", () => ({
   useConfigFormState: (options: Record<string, unknown>) => options,

--- a/src/features/deck/containers/DeckFormContainer.spec.tsx
+++ b/src/features/deck/containers/DeckFormContainer.spec.tsx
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
 }));
 
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => mocks.config }));
 
 vi.mock("@/hooks/useRemoteCollections", () => ({
   useRemoteCollections: () => ({

--- a/src/features/deck/containers/DeckFormContainer.tsx
+++ b/src/features/deck/containers/DeckFormContainer.tsx
@@ -18,7 +18,7 @@ import { useActions } from "@/hooks/useActions";
 import { DeckFormTemplate } from "@/features/deck/components/templates/DeckFormTemplate";
 import { useDeckActions } from "@/features/deck/hooks/useDeckActions";
 import { deckFormSchema, type DeckFormValues } from "@/features/deck/lib/deckFormSchema";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 
 /**
  * Connects the Deck Form Content view to stores, remote data, route parameters, and mutations.

--- a/src/features/settings/containers/ConfigContainer.tsx
+++ b/src/features/settings/containers/ConfigContainer.tsx
@@ -13,7 +13,7 @@ import { useAccountOperations } from "@/features/settings/hooks/useAccountOperat
 import { useConfigFormState } from "@/features/settings/hooks/useConfigFormState";
 import { useActions } from "@/hooks/useActions";
 import { useAuth } from "@/auth/AuthContext";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 
 /**
  * Connects the Config Container view to stores, remote data, route parameters, and mutations.

--- a/src/features/study/containers/DeckStartContainer.tsx
+++ b/src/features/study/containers/DeckStartContainer.tsx
@@ -18,7 +18,7 @@ import { useDeckFilterState } from "@/features/deck/hooks/useDeckFilterState";
 import { DeckStartTemplate } from "@/features/study/components/templates/DeckStartTemplate";
 import { useStudyActions } from "@/features/study/hooks/useStudyActions";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 
 /**
  * Checks whether the supplied value satisfies the interactive shortcut target condition.

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@/hooks/useConfig", () => ({
+vi.mock("@/shared/config/useConfig", () => ({
   useConfig: () => {
     if (mocks.state == null) throw new Error("Mock state is not initialized");
     return mocks.state.config;

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -11,7 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { studyStore } from "@/features/study/state/studyStore";
 import { buildStudyPatch, buildStudySession, calculateNextIndex, resolveSwipeAction } from "@/lib/study";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 
 export interface StudyActions {
   start: () => void;

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -6,7 +6,7 @@
 
 import { useNavigate } from "react-router-dom";
 import * as action from "@/action";
-import { configStore } from "@/store/configStore";
+import { configStore } from "@/shared/config/configStore";
 
 /**
  * Provides application navigation and cross-feature actions to React components.

--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
 }));
 
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => mocks.config }));
 
 vi.mock("@/hooks/useRemoteCollections", () => ({
   useRemoteCollections: () => ({

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -5,7 +5,7 @@ import * as C from "@/constant";
 import type { Card } from "@/entities/card";
 import { useCardFormState, useCardMutations } from "@/features/card";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -51,7 +51,7 @@ vi.mock("@/features/card", async (importOriginal) => {
   };
 });
 
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => mocks.config }));
 
 vi.mock("@/hooks/useRemoteCollections", () => ({
   useRemoteCollections: () => {

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -8,7 +8,7 @@ import type { Deck } from "@/entities/deck";
 import { useCardMutations } from "@/features/card";
 import { DeckStartForm, useDeckActions, useDeckFilterState } from "@/features/deck";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";

--- a/src/pages/card-view/ui/CardViewPage.spec.tsx
+++ b/src/pages/card-view/ui/CardViewPage.spec.tsx
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
 vi.mock("@/hooks/useActions", () => ({
   useActions: () => ({
     setDarkMode: vi.fn(),

--- a/src/pages/card-view/ui/CardViewPage.tsx
+++ b/src/pages/card-view/ui/CardViewPage.tsx
@@ -5,7 +5,7 @@ import * as C from "@/constant";
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -47,7 +47,7 @@ vi.mock("@/features/import", () => ({
   }),
 }));
 
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => ({ darkMode: false }) }));
 
 vi.mock("react-use", () => ({
   useKey: mocks.useKey,

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -5,7 +5,7 @@ import { useKey } from "react-use";
 import * as C from "@/constant";
 import { useDeckImport } from "@/features/import";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 
 import { DeckImportView } from "./DeckImportView";
 

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -44,7 +44,7 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@/hooks/useConfig", () => ({ useConfig: () => mocks.config }));
+vi.mock("@/shared/config/useConfig", () => ({ useConfig: () => mocks.config }));
 vi.mock("@/features/study", () => ({
   discardStudySessionsMissingDecks: mocks.discardStudySessionsMissingDecks,
   removeStudySession: mocks.removeStudySession,

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -13,7 +13,7 @@ import {
   useStudySessions,
 } from "@/features/study";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -53,7 +53,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
 
-vi.mock("@/hooks/useConfig", () => ({
+vi.mock("@/shared/config/useConfig", () => ({
   useConfig: () => {
     if (mocks.state == null) throw new Error("Mock state is not initialized");
     return mocks.state.config;

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -15,7 +15,7 @@ import {
   useStudyStore,
 } from "@/features/study";
 import { useActions } from "@/hooks/useActions";
-import { useConfig } from "@/hooks/useConfig";
+import { useConfig } from "@/shared/config/useConfig";
 import { useRemoteCollections } from "@/hooks/useRemoteCollections";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";

--- a/src/shared/config/configSchema.ts
+++ b/src/shared/config/configSchema.ts
@@ -1,5 +1,5 @@
 /**
- * @file Defines application configuration behavior for Config Schema.
+ * @file Defines shared application configuration behavior for Config Schema.
  * It validates persisted settings and exposes a predictable store interface to the rest of the
  * application.
  */

--- a/src/shared/config/configStore.spec.ts
+++ b/src/shared/config/configStore.spec.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { CONFIG_STORAGE_KEY, createConfigStore, defaultConfig } from "@/store/configStore";
+import { CONFIG_STORAGE_KEY, createConfigStore, defaultConfig } from "@/shared/config/configStore";
 
 /**
  * Provides the create memory storage test helper used by this file.

--- a/src/shared/config/configStore.ts
+++ b/src/shared/config/configStore.ts
@@ -6,9 +6,9 @@
 
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
-import { configSchema, defaultConfig, parsePersistedConfig } from "@/store/configSchema";
+import { configSchema, defaultConfig, parsePersistedConfig } from "@/shared/config/configSchema";
 
-export { defaultConfig } from "@/store/configSchema";
+export { defaultConfig } from "@/shared/config/configSchema";
 
 export const CONFIG_STORAGE_KEY = "tango-config";
 const CONFIG_STORAGE_VERSION = 2;

--- a/src/shared/config/useConfig.ts
+++ b/src/shared/config/useConfig.ts
@@ -6,7 +6,7 @@
 
 import { useStore } from "zustand";
 
-import { configStore } from "@/store/configStore";
+import { configStore } from "@/shared/config/configStore";
 
 /**
  * Returns the current validated application configuration from the shared store.

--- a/src/storybook/PageDecorator.tsx
+++ b/src/storybook/PageDecorator.tsx
@@ -10,7 +10,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { AuthProvider, type AuthState, type AuthStore } from "@/auth/AuthContext";
 import { studyStore, type StudySession } from "@/features/study/state/studyStore";
-import { configStore, defaultConfig } from "@/store/configStore";
+import { configStore, defaultConfig } from "@/shared/config/configStore";
 import { remoteStore, toRemoteById } from "@/store/remoteStore";
 
 export const PAGE_STORY_UID = "storybook-user";


### PR DESCRIPTION
## Summary

- move the config schema, Zustand store, store tests, and React hook into `src/shared/config`
- update application, feature, page, Storybook, and test imports to use the shared config module
- leave the settings UI in `features/settings` because it also owns account settings, while separating it from the shared config state

## Why

Application configuration is cross-cutting state, but it was grouped under implementation-oriented `src/store` and `src/hooks` directories. Moving it into a responsibility-oriented shared module makes the dependency direction explicit and keeps config presentation separate from config state.

## Impact

This is a structural refactor only. The persisted storage key and version remain unchanged, so existing user settings continue to load without migration changes.

## Testing

- `mise run check`
- 83 test files passed
- 520 tests passed

Closes #528