### PR TITLE
fix(ui): standardize DestructiveActionDialog async error contract

### DIFF
--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
@@ -86,4 +86,35 @@ describe("DestructiveActionDialog", () => {
 
     expect(onConfirm).toHaveBeenCalledOnce();
   });
+
+  it("supports synchronous onConfirm callbacks", () => {
+    const onConfirm = vi.fn();
+    render(<DestructiveActionDialog {...defaultProps} onConfirm={onConfirm} />);
+    const confirm = screen.getByRole("button", { name: "Delete deck" });
+
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("handles rejected onConfirm promises without unhandled promise rejections", async () => {
+    let unhandledRejection: unknown;
+    const listener = (event: PromiseRejectionEvent) => {
+      unhandledRejection = event.reason;
+    };
+    window.addEventListener("unhandledrejection", listener);
+
+    const rejectionReason = new Error("Async failure");
+    const onConfirm = vi.fn(() => Promise.reject(rejectionReason));
+
+    render(<DestructiveActionDialog {...defaultProps} onConfirm={onConfirm} />);
+    const confirm = screen.getByRole("button", { name: "Delete deck" });
+
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledOnce();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    window.removeEventListener("unhandledrejection", listener);
+    expect(unhandledRejection).toBeUndefined();
+  });
 });

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -78,18 +78,13 @@ export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (
     if (props.pending || confirmingRef.current) return;
     confirmingRef.current = true;
     try {
-      const result = props.onConfirm();
-      if (result instanceof Promise || (result != null && typeof (result as { then?: unknown }).then === "function")) {
-        void Promise.resolve(result)
-          .catch(() => {
-            // Prevent unhandled floating promise rejections. Callers manage error state via props.
-          })
-          .finally(() => {
-            confirmingRef.current = false;
-          });
-      } else {
-        confirmingRef.current = false;
-      }
+      void Promise.resolve(props.onConfirm())
+        .catch(() => {
+          // Prevent unhandled floating promise rejections. Callers manage error state via props.
+        })
+        .finally(() => {
+          confirmingRef.current = false;
+        });
     } catch (error) {
       confirmingRef.current = false;
       throw error;

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -11,7 +11,7 @@ export interface DestructiveActionDialogProps {
   pending?: boolean;
   errorMessage?: string;
   onCancel: () => void;
-  onConfirm: () => unknown;
+  onConfirm: () => void | Promise<void>;
 }
 
 const focusableSelector = [
@@ -78,9 +78,18 @@ export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (
     if (props.pending || confirmingRef.current) return;
     confirmingRef.current = true;
     try {
-      void Promise.resolve(props.onConfirm()).finally(() => {
+      const result = props.onConfirm();
+      if (result instanceof Promise || (result != null && typeof (result as { then?: unknown }).then === "function")) {
+        void Promise.resolve(result)
+          .catch(() => {
+            // Prevent unhandled floating promise rejections. Callers manage error state via props.
+          })
+          .finally(() => {
+            confirmingRef.current = false;
+          });
+      } else {
         confirmingRef.current = false;
-      });
+      }
     } catch (error) {
       confirmingRef.current = false;
       throw error;


### PR DESCRIPTION
Closes #516

## Summary

Standardized `DestructiveActionDialog`'s `onConfirm` callback contract (`() => void | Promise<void>`) and safely handled async confirmation promise rejections on the dialog's internal promise handler.

## Proposed Changes

- Updated `DestructiveActionDialogProps.onConfirm` signature to `() => void | Promise<void>`.
- Updated `handleConfirm` to attach a `.catch(() => {})` handler when `props.onConfirm()` returns a promise, preventing floating unhandled promise rejections while preserving caller ownership of async state and error reporting (`pending`, `errorMessage`).
- Added unit tests verifying synchronous `onConfirm` execution and async promise rejection handling without floating unhandled promise rejections.

## Verification

- `npm test -- src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx` (7 tests passed)
- `mise run check` (All unit tests, Biome linting, Knip, and Markdownlint passed)