### PR TITLE
Add shared-layer FSD import boundary with Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -53,6 +53,28 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["src/shared/**/*.{ts,tsx}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["@/app/**", "@/entities/**", "@/features/**", "@/pages/**", "@/widgets/**"],
+                    "message": "Shared modules cannot import from higher FSD layers."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "assist": {
     "actions": {
       "source": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,22 @@ export default [
     },
   },
   {
+    files: ["src/shared/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@/app/**", "@/entities/**", "@/features/**", "@/pages/**"],
+              message: "Shared modules cannot import from higher FSD layers.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     ...testingLibrary.configs["flat/react"],
     files: ["src/**/*.spec.{ts,tsx}"],
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,7 +45,13 @@ export default [
         {
           patterns: [
             {
-              group: ["@/app/**", "@/entities/**", "@/features/**", "@/pages/**"],
+              group: [
+                "@/app/**",
+                "@/entities/**",
+                "@/features/**",
+                "@/pages/**",
+                "@/widgets/**",
+              ],
               message: "Shared modules cannot import from higher FSD layers.",
             },
           ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,28 +38,6 @@ export default [
     },
   },
   {
-    files: ["src/shared/**/*.{ts,tsx}"],
-    rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              group: [
-                "@/app/**",
-                "@/entities/**",
-                "@/features/**",
-                "@/pages/**",
-                "@/widgets/**",
-              ],
-              message: "Shared modules cannot import from higher FSD layers.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
     ...testingLibrary.configs["flat/react"],
     files: ["src/**/*.spec.{ts,tsx}"],
   },


### PR DESCRIPTION
## Summary

- prevent shared modules from importing app, pages, widgets, features, or entities via the @ alias
- enforce the boundary with Biome's noRestrictedImports rule
- cover the widgets layer before it is introduced

## Testing

- mise run check