### PR TITLE
Enforce FSD import boundaries with Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -73,6 +73,86 @@
           }
         }
       }
+    },
+    {
+      "includes": ["src/entities/**/*.{ts,tsx}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["@/app/**", "@/features/**", "@/pages/**", "@/widgets/**"],
+                    "message": "Entity modules cannot import from higher FSD layers."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/features/**/*.{ts,tsx}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["@/app/**", "@/pages/**", "@/widgets/**"],
+                    "message": "Feature modules cannot import from higher FSD layers."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/widgets/**/*.{ts,tsx}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["@/app/**", "@/pages/**"],
+                    "message": "Widget modules cannot import from higher FSD layers."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/pages/**/*.{ts,tsx}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["@/app/**"],
+                    "message": "Page modules cannot import from the app layer."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "assist": {


### PR DESCRIPTION
## Summary

- extend the existing Biome `noRestrictedImports` rule beyond `shared`
- prevent `entities`, `features`, `widgets`, and `pages` from importing higher FSD layers
- keep same-layer imports unchanged so this PR only enforces layer direction during the ongoing FSD migration

## Why

The project has adopted Feature-Sliced Design, but only the `shared` layer currently has an enforced import boundary. Adding per-layer restrictions makes upward dependencies fail during lint instead of relying on review.

## Validation

- confirmed the configuration uses Biome's supported `noRestrictedImports.patterns[].group` syntax
- change is limited to `biome.json`
