### PR TITLE
fix: preserve Google login failures in authentication flow

### DIFF
--- a/src/action/event.spec.ts
+++ b/src/action/event.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { linkWithPopup, signOut } from "firebase/auth";
+import { GoogleAuthProvider, linkWithPopup, signInWithCredential, signOut } from "firebase/auth";
+import { FirebaseError } from "firebase/app";
 
 import * as action from "@/action";
 import { STUDY_STORAGE_KEY, studyStore } from "@/features/study/state/studyStore";
@@ -79,6 +80,11 @@ describe("event action", () => {
     expect(studyStore.getState().sessionsByDeckId).toEqual({});
   });
 
+  it("rejects when no currentUser is present", async () => {
+    mocks.auth.currentUser = null;
+    await expect(action.event.loginGoogle()).rejects.toThrow("Anonymous user is required before Google sign-in");
+  });
+
   it("publishes a linked Firebase user without persisting identity", async () => {
     const user = { uid: "uid-a", isAnonymous: false, providerData: [] };
     mocks.auth.currentUser = {};
@@ -86,5 +92,51 @@ describe("event action", () => {
     await action.event.loginGoogle();
 
     expect(mocks.publishAuthenticatedUser).toHaveBeenCalledWith(user);
+  });
+
+  it("propagates non-Firebase errors during Google sign-in", async () => {
+    mocks.auth.currentUser = {};
+    const nonFirebaseError = new Error("Network error");
+    vi.mocked(linkWithPopup).mockRejectedValue(nonFirebaseError);
+
+    await expect(action.event.loginGoogle()).rejects.toThrow("Network error");
+  });
+
+  it("propagates Firebase errors when no credential can be recovered", async () => {
+    mocks.auth.currentUser = {};
+    const firebaseError = new FirebaseError("auth/popup-closed-by-user", "Popup closed");
+    vi.mocked(linkWithPopup).mockRejectedValue(firebaseError);
+    vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(null);
+
+    await expect(action.event.loginGoogle()).rejects.toThrow(firebaseError);
+  });
+
+  it("recovers credentials and publishes user when linkWithPopup fails with recoverable Firebase error", async () => {
+    mocks.auth.currentUser = {};
+    const firebaseError = new FirebaseError("auth/credential-already-in-use", "Credential already in use");
+    const credential = { providerId: "google.com" };
+    const user = { uid: "uid-b", isAnonymous: false, providerData: [] };
+
+    vi.mocked(linkWithPopup).mockRejectedValue(firebaseError);
+    vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(credential as never);
+    vi.mocked(signInWithCredential).mockResolvedValue({ user } as never);
+
+    await action.event.loginGoogle();
+
+    expect(signInWithCredential).toHaveBeenCalledWith(mocks.auth, credential);
+    expect(mocks.publishAuthenticatedUser).toHaveBeenCalledWith(user);
+  });
+
+  it("propagates failure when credential recovery fails", async () => {
+    mocks.auth.currentUser = {};
+    const firebaseError = new FirebaseError("auth/credential-already-in-use", "Credential already in use");
+    const credential = { providerId: "google.com" };
+    const recoveryError = new Error("SignInWithCredential failed");
+
+    vi.mocked(linkWithPopup).mockRejectedValue(firebaseError);
+    vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(credential as never);
+    vi.mocked(signInWithCredential).mockRejectedValue(recoveryError);
+
+    await expect(action.event.loginGoogle()).rejects.toThrow("SignInWithCredential failed");
   });
 });

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -98,23 +98,22 @@ export const logout = (confirmedUid: string): Promise<void> =>
 export const loginGoogle = async (): Promise<void> => {
   const currentUser = auth.currentUser;
   if (!currentUser) {
-    console.error("must sign in anonymously in advance");
-    return;
+    throw new Error("Anonymous user is required before Google sign-in");
   }
-  let result: UserCredential | null = null;
+
+  const provider = new GoogleAuthProvider();
+  let result: UserCredential;
+
   try {
-    result = await linkWithPopup(currentUser, new GoogleAuthProvider());
-  } catch (e) {
-    if (e instanceof FirebaseError) {
-      const credential = GoogleAuthProvider.credentialFromError(e);
-      if (credential) {
-        result = await signInWithCredential(auth, credential);
-      }
-    }
+    result = await linkWithPopup(currentUser, provider);
+  } catch (error) {
+    if (!(error instanceof FirebaseError)) throw error;
+
+    const credential = GoogleAuthProvider.credentialFromError(error);
+    if (credential == null) throw error;
+
+    result = await signInWithCredential(auth, credential);
   }
-  if (!result) {
-    throw Error("failed to login");
-  }
-  process.env.NODE_ENV !== "production" && console.log("LOGIN GOOGLE", result);
+
   publishAuthenticatedUser(result.user);
 };


### PR DESCRIPTION
## Goal

Preserve and rethrow Google authentication errors when sign-in cannot be completed.

Resolves #514
Parent: #474

## Changes

- Require an existing anonymous user before Google sign-in (`throw new Error("Anonymous user is required before Google sign-in")`).
- Propagate non-Firebase errors and unrecoverable Firebase errors during `linkWithPopup`.
- Propagate credential recovery failures from `signInWithCredential`.
- Added unit tests in `src/action/event.spec.ts` covering missing-user rejection, non-Firebase error preservation, unrecoverable Firebase error preservation, successful recovery, and recovery failure propagation.

## Verification

- `npx vitest run src/action/event.spec.ts`
- `mise run check`