### PR TITLE
Preserve Google login failures

### DIFF
--- a/src/action/event.spec.ts
+++ b/src/action/event.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { linkWithPopup, signOut } from "firebase/auth";
+import { FirebaseError } from "firebase/app";
+import { GoogleAuthProvider, linkWithPopup, signInWithCredential, signOut } from "firebase/auth";
 
 import * as action from "@/action";
 import { STUDY_STORAGE_KEY, studyStore } from "@/features/study/state/studyStore";
@@ -86,5 +87,58 @@ describe("event action", () => {
     await action.event.loginGoogle();
 
     expect(mocks.publishAuthenticatedUser).toHaveBeenCalledWith(user);
+  });
+
+  it("rejects Google login when no anonymous user exists", async () => {
+    await expect(action.event.loginGoogle()).rejects.toThrow("Anonymous user is required before Google sign-in");
+
+    expect(linkWithPopup).not.toHaveBeenCalled();
+    expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
+  });
+
+  it("preserves non-Firebase Google linking errors", async () => {
+    const error = new Error("popup failed");
+    mocks.auth.currentUser = {};
+    vi.mocked(linkWithPopup).mockRejectedValue(error);
+
+    await expect(action.event.loginGoogle()).rejects.toBe(error);
+    expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
+  });
+
+  it("preserves Firebase Google linking errors without a credential", async () => {
+    const error = new FirebaseError("auth/popup-closed-by-user", "Popup closed");
+    mocks.auth.currentUser = {};
+    vi.mocked(linkWithPopup).mockRejectedValue(error);
+    vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(null);
+
+    await expect(action.event.loginGoogle()).rejects.toBe(error);
+    expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
+  });
+
+  it("recovers a Google credential and publishes the authenticated user", async () => {
+    const error = new FirebaseError("auth/credential-already-in-use", "Credential already in use");
+    const credential = { providerId: "google.com" };
+    const user = { uid: "uid-a", isAnonymous: false, providerData: [] };
+    mocks.auth.currentUser = {};
+    vi.mocked(linkWithPopup).mockRejectedValue(error);
+    vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(credential as never);
+    vi.mocked(signInWithCredential).mockResolvedValue({ user } as never);
+
+    await action.event.loginGoogle();
+
+    expect(signInWithCredential).toHaveBeenCalledWith(mocks.auth, credential);
+    expect(mocks.publishAuthenticatedUser).toHaveBeenCalledWith(user);
+  });
+
+  it("propagates Google credential recovery failures", async () => {
+    const linkingError = new FirebaseError("auth/credential-already-in-use", "Credential already in use");
+    const recoveryError = new Error("credential recovery failed");
+    mocks.auth.currentUser = {};
+    vi.mocked(linkWithPopup).mockRejectedValue(linkingError);
+    vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue({} as never);
+    vi.mocked(signInWithCredential).mockRejectedValue(recoveryError);
+
+    await expect(action.event.loginGoogle()).rejects.toBe(recoveryError);
+    expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
   });
 });

--- a/src/action/event.spec.ts
+++ b/src/action/event.spec.ts
@@ -82,7 +82,7 @@ describe("event action", () => {
 
   it("publishes a linked Firebase user without persisting identity", async () => {
     const user = { uid: "uid-a", isAnonymous: false, providerData: [] };
-    mocks.auth.currentUser = {};
+    mocks.auth.currentUser = { isAnonymous: true };
     vi.mocked(linkWithPopup).mockResolvedValue({ user } as never);
     await action.event.loginGoogle();
 
@@ -96,9 +96,17 @@ describe("event action", () => {
     expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
   });
 
+  it("rejects Google login when the current user is not anonymous", async () => {
+    mocks.auth.currentUser = { isAnonymous: false };
+
+    await expect(action.event.loginGoogle()).rejects.toThrow("Anonymous user is required before Google sign-in");
+    expect(linkWithPopup).not.toHaveBeenCalled();
+    expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
+  });
+
   it("preserves non-Firebase Google linking errors", async () => {
     const error = new Error("popup failed");
-    mocks.auth.currentUser = {};
+    mocks.auth.currentUser = { isAnonymous: true };
     vi.mocked(linkWithPopup).mockRejectedValue(error);
 
     await expect(action.event.loginGoogle()).rejects.toBe(error);
@@ -107,7 +115,7 @@ describe("event action", () => {
 
   it("preserves Firebase Google linking errors without a credential", async () => {
     const error = new FirebaseError("auth/popup-closed-by-user", "Popup closed");
-    mocks.auth.currentUser = {};
+    mocks.auth.currentUser = { isAnonymous: true };
     vi.mocked(linkWithPopup).mockRejectedValue(error);
     vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(null);
 
@@ -119,7 +127,7 @@ describe("event action", () => {
     const error = new FirebaseError("auth/credential-already-in-use", "Credential already in use");
     const credential = { providerId: "google.com" };
     const user = { uid: "uid-a", isAnonymous: false, providerData: [] };
-    mocks.auth.currentUser = {};
+    mocks.auth.currentUser = { isAnonymous: true };
     vi.mocked(linkWithPopup).mockRejectedValue(error);
     vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue(credential as never);
     vi.mocked(signInWithCredential).mockResolvedValue({ user } as never);
@@ -133,7 +141,7 @@ describe("event action", () => {
   it("propagates Google credential recovery failures", async () => {
     const linkingError = new FirebaseError("auth/credential-already-in-use", "Credential already in use");
     const recoveryError = new Error("credential recovery failed");
-    mocks.auth.currentUser = {};
+    mocks.auth.currentUser = { isAnonymous: true };
     vi.mocked(linkWithPopup).mockRejectedValue(linkingError);
     vi.mocked(GoogleAuthProvider.credentialFromError).mockReturnValue({} as never);
     vi.mocked(signInWithCredential).mockRejectedValue(recoveryError);

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -97,7 +97,7 @@ export const logout = (confirmedUid: string): Promise<void> =>
  */
 export const loginGoogle = async (): Promise<void> => {
   const currentUser = auth.currentUser;
-  if (!currentUser) {
+  if (!currentUser?.isAnonymous) {
     throw new Error("Anonymous user is required before Google sign-in");
   }
   let result: UserCredential;

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -98,22 +98,18 @@ export const logout = (confirmedUid: string): Promise<void> =>
 export const loginGoogle = async (): Promise<void> => {
   const currentUser = auth.currentUser;
   if (!currentUser) {
-    console.error("must sign in anonymously in advance");
-    return;
+    throw new Error("Anonymous user is required before Google sign-in");
   }
-  let result: UserCredential | null = null;
+  let result: UserCredential;
   try {
     result = await linkWithPopup(currentUser, new GoogleAuthProvider());
-  } catch (e) {
-    if (e instanceof FirebaseError) {
-      const credential = GoogleAuthProvider.credentialFromError(e);
-      if (credential) {
-        result = await signInWithCredential(auth, credential);
-      }
-    }
-  }
-  if (!result) {
-    throw Error("failed to login");
+  } catch (error) {
+    if (!(error instanceof FirebaseError)) throw error;
+
+    const credential = GoogleAuthProvider.credentialFromError(error);
+    if (credential == null) throw error;
+
+    result = await signInWithCredential(auth, credential);
   }
   process.env.NODE_ENV !== "production" && console.log("LOGIN GOOGLE", result);
   publishAuthenticatedUser(result.user);


### PR DESCRIPTION
## Summary

- reject Google sign-in when no anonymous Firebase user exists
- preserve non-Firebase and unrecoverable Firebase linking errors
- recover reusable Google credentials and propagate recovery failures
- cover direct success, recovery, and failure paths with unit tests

## Why

`loginGoogle` previously returned successfully without signing in when no current user existed. Its catch path also swallowed linking errors or replaced them with a generic error, preventing callers from observing the original failure.

## Testing

- `mise run check` (88 unit test files, 541 tests)

Closes #514