### PR TITLE
refactor: move Card CSV import logic into features/import

### DIFF
--- a/src/action/card.spec.ts
+++ b/src/action/card.spec.ts
@@ -1,10 +1,9 @@
 /**
  * @file Verifies the "card action" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "should be fromRow" and
- * "should be empty".
+ * The examples make the expected CSV export behavior concrete.
  */
 
-import type { Card, CardRaw } from "@/entities/card";
+import type { Card } from "@/entities/card";
 
 import { expect, it, describe } from "vitest";
 
@@ -12,17 +11,6 @@ import * as card from "@/action/card";
 import { createCard } from "@/test/factories";
 
 describe("card action", () => {
-  describe.concurrent("fromRow", () => {
-    it("should be fromRow", async () => {
-      const c = { frontText: "front", backText: "back", tags: ["a", "b", "c"], uniqueKey: "123" } as Card;
-      expect(card.fromRow(["front", "back", "a,b,c", "123"])).toEqual(c);
-    });
-    it("should be empty", async () => {
-      const c = { frontText: "", backText: "", tags: [], uniqueKey: "" } satisfies CardRaw;
-      expect(card.fromRow([])).toEqual(c);
-    });
-  });
-
   describe.concurrent("toRow", () => {
     it("should be toRow", async () => {
       const c = { frontText: "front", backText: "back", tags: ["a", "b", "c"], uniqueKey: "123" } as Card;

--- a/src/action/card.ts
+++ b/src/action/card.ts
@@ -4,31 +4,7 @@
  * depending on React components.
  */
 
-import type { Card, CardRaw } from "@/entities/card";
-
-/**
- * Checks whether raw card input has neither front text nor back text.
- * CSV parsing uses this predicate to ignore blank rows while preserving cards that contain either
- * side.
- */
-export const isEmpty = (c: CardRaw): boolean => {
-  return c.frontText === "" && c.backText === "";
-};
-
-/**
- * Converts one CSV row into raw card input.
- * Column parsing and tag splitting happen here before the card receives domain defaults and
- * identifiers.
- */
-export const fromRow = (row: string[]): CardRaw => {
-  const tags = typeof row[2] === "string" ? row[2].split(",") : [];
-  return {
-    frontText: row[0] || "",
-    backText: row[1] || "",
-    tags,
-    uniqueKey: row[3] || "",
-  };
-};
+import type { Card } from "@/entities/card";
 
 /**
  * Converts a card into the ordered text columns used by CSV export.

--- a/src/action/deck.spec.ts
+++ b/src/action/deck.spec.ts
@@ -1,12 +1,9 @@
 /**
  * @file Verifies the "deck action" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "parses string content as
- * raw cards" and "rejects unsupported input at the parser boundary".
+ * The examples make the expected CSV export and download behavior concrete.
  */
 
-import type { CardRaw } from "@/entities/card";
-
-import { expect, expectTypeOf, it, describe, vi, beforeEach, afterEach } from "vitest";
+import { expect, it, describe, vi, beforeEach, afterEach } from "vitest";
 
 // import moment from "moment";
 import * as fileSaver from "file-saver";
@@ -29,21 +26,6 @@ describe("deck action", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe("parseCsv", () => {
-    it("parses string content as raw cards", async () => {
-      const cards = await action.deck.parseCsv("front,back");
-
-      expectTypeOf(cards).toEqualTypeOf<CardRaw[]>();
-      expect(cards).toEqual([{ frontText: "front", backText: "back", uniqueKey: "", tags: [] }]);
-    });
-
-    it("rejects unsupported input at the parser boundary", async () => {
-      await expect(action.deck.parseCsv({ content: "front,back" })).rejects.toThrow(
-        "CSV content must be a string or File"
-      );
-    });
   });
 
   describe("download", () => {

--- a/src/action/deck.ts
+++ b/src/action/deck.ts
@@ -4,7 +4,7 @@
  * depending on React components.
  */
 
-import type { Card, CardRaw } from "@/entities/card";
+import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 
 import * as Papa from "papaparse";
@@ -23,22 +23,4 @@ export const downloadData = (deck: Deck, cards: Card[]) => {
   const csv = Papa.unparse(cards.map(cardAction.toRow), { escapeFormulae: true });
   const fileName = deck.name.endsWith(".csv") ? deck.name : `${deck.name}.csv`;
   downloadTextFile(csv, fileName, CSV_MIME_TYPE);
-};
-
-/**
- * Parses csv into validated application data.
- * Malformed input is reported before downstream code relies on the result.
- */
-export const parseCsv = async (content: unknown): Promise<CardRaw[]> => {
-  if (typeof content !== "string" && !(typeof File !== "undefined" && content instanceof File)) {
-    throw new TypeError("CSV content must be a string or File");
-  }
-  return await new Promise((resolve) =>
-    Papa.parse(content, {
-      complete: async (results: { data: string[][] }) => {
-        const cards = results.data.map(cardAction.fromRow).filter((c) => !cardAction.isEmpty(c));
-        resolve(cards);
-      },
-    })
-  );
 };

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -63,9 +63,10 @@ vi.mock("@/features/import/lib/deckImportAnalysis", async (importOriginal) => {
     parseDeckImportCsv: (...args: Parameters<typeof actual.parseDeckImportCsv>) => mocks.parseDeckImportCsv(...args),
   };
 });
-vi.mock("@/action", () => ({
-  deck: { parseCsv: mocks.parseCsv },
-}));
+vi.mock("@/features/import/lib/cardCsv", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/import/lib/cardCsv")>();
+  return { ...actual, parseCsv: mocks.parseCsv };
+});
 vi.mock("@/adapters/firestore", () => ({
   documentMetadata: { generateDeckId: mocks.generateDeckId, generateCardId: mocks.generateCardId },
 }));

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -9,7 +9,6 @@ import type { Deck, DeckId } from "@/entities/deck";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import * as action from "@/action";
 import { documentMetadata as firestoreMetadata } from "@/adapters/firestore";
 import { createCard, selectCardsForDeck, useCards } from "@/entities/card";
 import { createDeck, useDecks } from "@/entities/deck";
@@ -17,6 +16,7 @@ import { useSession } from "@/entities/session";
 import { useCardMutations } from "@/features/card/hooks/useCardMutations";
 import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
 import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/components/deckImportTypes";
+import { parseCsv } from "@/features/import/lib/cardCsv";
 import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
 import { CardBulkMutationError } from "@/services/cardCommands";
 import sampleCards from "../../../../sample/build/output.json";
@@ -435,7 +435,7 @@ export const useDeckImport = () => {
     const parsedUrl = new URL(url);
     const response = await fetch(parsedUrl);
     if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
-    const cards = await action.deck.parseCsv(await response.text());
+    const cards = await parseCsv(await response.text());
     if (generation.current !== operationGeneration || dependenciesRef.current?.uid !== operationUid) {
       throw new Error("Deck import user changed before the import could start");
     }

--- a/src/features/import/lib/cardCsv.spec.ts
+++ b/src/features/import/lib/cardCsv.spec.ts
@@ -1,0 +1,46 @@
+import type { CardRaw } from "@/entities/card";
+
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { fromRow, isEmpty, parseCsv } from "@/features/import/lib/cardCsv";
+
+describe("card CSV import", () => {
+  describe("fromRow", () => {
+    it("maps CSV columns to raw card data", () => {
+      expect(fromRow(["front", "back", "a,b,c", "123"])).toEqual({
+        frontText: "front",
+        backText: "back",
+        tags: ["a", "b", "c"],
+        uniqueKey: "123",
+      });
+    });
+
+    it("uses empty values for missing columns", () => {
+      expect(fromRow([])).toEqual({ frontText: "", backText: "", tags: [], uniqueKey: "" });
+    });
+  });
+
+  describe("isEmpty", () => {
+    it("ignores tags and keys when both card sides are empty", () => {
+      expect(isEmpty({ frontText: "", backText: "", tags: ["tag"], uniqueKey: "key" })).toBe(true);
+    });
+
+    it("keeps a card when either side has content", () => {
+      expect(isEmpty({ frontText: "front", backText: "", tags: [], uniqueKey: "" })).toBe(false);
+      expect(isEmpty({ frontText: "", backText: "back", tags: [], uniqueKey: "" })).toBe(false);
+    });
+  });
+
+  describe("parseCsv", () => {
+    it("parses string content and removes empty rows", async () => {
+      const cards = await parseCsv("front,back\n,,tag,key");
+
+      expectTypeOf(cards).toEqualTypeOf<CardRaw[]>();
+      expect(cards).toEqual([{ frontText: "front", backText: "back", uniqueKey: "", tags: [] }]);
+    });
+
+    it("rejects unsupported input at the parser boundary", async () => {
+      await expect(parseCsv({ content: "front,back" })).rejects.toThrow("CSV content must be a string or File");
+    });
+  });
+});

--- a/src/features/import/lib/cardCsv.ts
+++ b/src/features/import/lib/cardCsv.ts
@@ -1,0 +1,23 @@
+import type { CardRaw } from "@/entities/card";
+
+import * as Papa from "papaparse";
+
+export const isEmpty = (card: CardRaw): boolean => card.frontText === "" && card.backText === "";
+
+export const fromRow = (row: string[]): CardRaw => ({
+  frontText: row[0] || "",
+  backText: row[1] || "",
+  tags: typeof row[2] === "string" ? row[2].split(",") : [],
+  uniqueKey: row[3] || "",
+});
+
+export const parseCsv = async (content: unknown): Promise<CardRaw[]> => {
+  if (typeof content !== "string" && !(typeof File !== "undefined" && content instanceof File)) {
+    throw new TypeError("CSV content must be a string or File");
+  }
+  return await new Promise((resolve) =>
+    Papa.parse(content, {
+      complete: (results: { data: string[][] }) => resolve(results.data.map(fromRow).filter((card) => !isEmpty(card))),
+    })
+  );
+};

--- a/src/features/import/lib/deckImportAnalysis.ts
+++ b/src/features/import/lib/deckImportAnalysis.ts
@@ -8,7 +8,6 @@ import type { Card, CardRaw } from "@/entities/card";
 
 import * as Papa from "papaparse";
 
-import * as cardAction from "@/action/card";
 import type {
   DeckImportAnalysis,
   DeckImportIssue,
@@ -16,6 +15,7 @@ import type {
   DeckImportPlanRow,
   DeckImportRow,
 } from "@/features/import/components/deckImportTypes";
+import { fromRow } from "@/features/import/lib/cardCsv";
 
 /**
  * Formats raw CSV columns for inclusion in a validation message.
@@ -81,7 +81,7 @@ export const parseDeckImportCsv = async (content: string | File): Promise<DeckIm
       return;
     }
 
-    const card = cardAction.fromRow(columns);
+    const card = fromRow(columns);
     card.uniqueKey = card.uniqueKey.trim();
     if (card.uniqueKey === "") {
       invalidRows.add(rowNumber);


### PR DESCRIPTION
## Summary

- move Card CSV row mapping, empty-card filtering, and parsing into `features/import`
- update URL imports and deck import analysis to use the import feature implementation
- relocate and expand unit coverage while leaving CSV export behavior in `src/action` for #565

## Why

CSV row formats and Papa Parse integration belong to the import use case, not the legacy action area. Keeping these concerns in `features/import` establishes the intended dependency direction toward `entities/card` without making the Card entity aware of CSV.

## Impact

CSV import behavior is unchanged. Empty rows are still removed based on front/back content, tags are still split from the third column, and unsupported parser inputs still reject with the same error.

## Testing

- `mise run check` (95 test files, 541 tests)

Closes #564