### PR TITLE
Refactor auth actions and logout orchestration

### DIFF
--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -1,6 +1,0 @@
-/**
- * @file Collects the public exports for the action area.
- * Callers can import from this boundary without depending on the area's internal folder layout.
- */
-
-export * as event from "@/action/event";

--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -13,7 +13,6 @@ import type { SessionState } from "@/entities/session";
 
 const mocks = vi.hoisted(() => ({
   darkMode: false,
-  init: vi.fn(),
   authState: { status: "initializing" } as SessionState,
 }));
 
@@ -24,8 +23,9 @@ vi.mock("zustand", () => ({
     }),
 }));
 vi.mock("@/shared/config/configStore", () => ({ configStore: {} }));
-vi.mock("@/action", () => ({ event: { init: mocks.init } }));
+vi.mock("@/app/auth/logout", () => ({ logout: vi.fn() }));
 vi.mock("@/entities/session", () => ({ useSession: () => mocks.authState }));
+vi.mock("@/features/auth", () => ({ loginGoogle: vi.fn() }));
 vi.mock("@/pages/card-form", () => ({ CardFormPage: () => null }));
 vi.mock("@/pages/card-list", () => ({ CardListPage: () => null }));
 vi.mock("@/pages/card-view", () => ({ CardViewPage: () => null }));
@@ -41,7 +41,6 @@ import App from "./App";
 describe("App", () => {
   beforeEach(() => {
     mocks.darkMode = false;
-    mocks.init.mockReset();
     mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
     document.documentElement.classList.remove("dark");
     window.history.replaceState({}, "", "/");
@@ -55,7 +54,6 @@ describe("App", () => {
     view.rerender(<App />);
 
     expect(document.documentElement.classList.contains("dark")).toBe(true);
-    expect(mocks.init).not.toHaveBeenCalled();
   });
 
   it("shows startup feedback for initializing and signed-out authentication", () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,7 +7,9 @@
 import React from "react";
 import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { useStore } from "zustand";
+import { logout } from "@/app/auth/logout";
 import { useSession } from "@/entities/session";
+import { loginGoogle } from "@/features/auth";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { CardFormPage } from "@/pages/card-form";
 import { CardListPage } from "@/pages/card-list";
@@ -50,7 +52,7 @@ export const AppRoutes: React.FC = () => (
     <Route path="/deck/:id/study" element={<DeckSwiperPage />} />
     <Route path="/card/:id" element={<CardViewPage />} />
     <Route path="/card/:id/edit" element={<CardFormPage />} />
-    <Route path="/settings" element={<SettingsPage />} />
+    <Route path="/settings" element={<SettingsPage login={loginGoogle} logout={logout} />} />
     <Route path="/import" element={<DeckImportPage />} />
     <Route path="*" element={<UnknownRoute />} />
   </Routes>

--- a/src/app/auth/logout.spec.ts
+++ b/src/app/auth/logout.spec.ts
@@ -1,58 +1,46 @@
-/**
- * @file Verifies the "event action" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "signs out before clearing
- * Query and study state", "preserves local state when sign-out fails", "clears study state after a
- * Query cleanup failure".
- */
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { signOut } from "firebase/auth";
 
-import * as action from "@/action";
+import { logout } from "@/app/auth/logout";
 import { STUDY_STORAGE_KEY, studyStore } from "@/features/study/state/studyStore";
 
 const mocks = vi.hoisted(() => ({
-  auth: { currentUser: null as object | null },
+  signOutCurrentUser: vi.fn(),
   suspendAnonymousBootstrap: vi.fn(),
   resumeAnonymousBootstrap: vi.fn(),
   stopRemoteReads: vi.fn(),
 }));
 
-vi.mock("firebase/auth");
-vi.mock("firebase/firestore");
-vi.mock("./firestore");
-vi.mock("@/shared/firebase", () => ({ auth: mocks.auth }));
 vi.mock("@/features/auth", () => ({
-  loginGoogle: vi.fn(),
+  signOutCurrentUser: mocks.signOutCurrentUser,
   suspendAnonymousBootstrap: mocks.suspendAnonymousBootstrap,
 }));
 vi.mock("@/store/remoteStore", () => ({
   remoteStore: { getState: () => ({ stop: mocks.stopRemoteReads }) },
 }));
 
-describe("event action", () => {
+describe("logout", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mocks.suspendAnonymousBootstrap.mockReturnValue(mocks.resumeAnonymousBootstrap);
-    mocks.auth.currentUser = null;
     localStorage.clear();
     studyStore.setState({ sessionsByDeckId: {}, showBackText: false, autoPlay: false, lastSwipe: undefined });
   });
 
-  it("signs out before clearing Query and study state", async () => {
+  it("signs out before clearing remote and study state", async () => {
     const operations: string[] = [];
     mocks.suspendAnonymousBootstrap.mockImplementation(() => {
       operations.push("suspend");
       return () => operations.push("resume");
     });
-    vi.mocked(signOut).mockImplementation(async () => {
+    mocks.signOutCurrentUser.mockImplementation(async () => {
       operations.push("sign-out");
     });
     mocks.stopRemoteReads.mockImplementation(() => {
       operations.push("stop-remote");
     });
     studyStore.getState().startStudy("deck", ["card"]);
-    await action.event.logout("uid-a");
+
+    await logout("uid-a");
 
     expect(operations).toEqual(["suspend", "sign-out", "stop-remote", "resume"]);
     expect(studyStore.getState().sessionsByDeckId).toEqual({});
@@ -61,8 +49,9 @@ describe("event action", () => {
 
   it("preserves local state when sign-out fails", async () => {
     studyStore.getState().startStudy("deck", ["card"]);
-    vi.mocked(signOut).mockRejectedValue(new Error("sign-out failed"));
-    await expect(action.event.logout("uid-a")).rejects.toThrow("sign-out failed");
+    mocks.signOutCurrentUser.mockRejectedValue(new Error("sign-out failed"));
+
+    await expect(logout("uid-a")).rejects.toThrow("sign-out failed");
 
     expect(mocks.stopRemoteReads).not.toHaveBeenCalled();
     expect(studyStore.getState().sessionsByDeckId).not.toEqual({});
@@ -73,7 +62,8 @@ describe("event action", () => {
     mocks.stopRemoteReads.mockImplementation(() => {
       throw new Error("cleanup failed");
     });
-    await expect(action.event.logout("uid-a")).rejects.toThrow("cleanup failed");
+
+    await expect(logout("uid-a")).rejects.toThrow("cleanup failed");
 
     expect(studyStore.getState().sessionsByDeckId).toEqual({});
   });

--- a/src/app/auth/logout.ts
+++ b/src/app/auth/logout.ts
@@ -1,17 +1,6 @@
-/**
- * @file Implements application-level Event operations.
- * The functions turn user intent into domain data or coordinated authentication work without
- * depending on React components.
- */
-
-import { signOut } from "firebase/auth";
-
-import { clearStudyStore, studyStore, type StudyState } from "@/features/study/state/studyStore";
-import { suspendAnonymousBootstrap } from "@/features/auth";
-import { auth } from "@/shared/firebase";
+import { signOutCurrentUser, suspendAnonymousBootstrap } from "@/features/auth";
+import { clearStudyStore, studyStore, type StudyState } from "@/features/study";
 import { remoteStore } from "@/store/remoteStore";
-
-export { loginGoogle } from "@/features/auth";
 
 const { getState: getRemoteState } = remoteStore;
 const { getState: getStudyState } = studyStore;
@@ -24,11 +13,6 @@ interface LogoutCleanupProgress {
 
 type LogoutCleanupStep = "remote" | "study";
 
-/**
- * Represents the logout cleanup error condition used by the application.
- * The class keeps related error details or behavior together so callers can recognize and handle
- * this specific case.
- */
 class LogoutCleanupError extends Error {
   constructor(
     readonly originalError: unknown,
@@ -39,10 +23,6 @@ class LogoutCleanupError extends Error {
   }
 }
 
-/**
- * Runs logout and local-data cleanup as a resumable sequence.
- * Completed cleanup steps are remembered so a retry does not repeat work that already succeeded.
- */
 const runLogout = async (
   confirmedUid: string,
   progress: LogoutCleanupProgress,
@@ -50,14 +30,9 @@ const runLogout = async (
 ): Promise<void> => {
   const resumeAnonymousBootstrap = suspendAnonymousBootstrap();
   try {
-    if (signOutRequired) await signOut(auth);
+    if (signOutRequired) await signOutCurrentUser();
 
     const errors: unknown[] = [];
-    /**
-     * Runs one logout cleanup step unless that step already succeeded.
-     * Failures are collected instead of stopping the next cleanup, allowing a retry to resume only
-     * unfinished work.
-     */
     const run = async (step: LogoutCleanupStep, cleanup: () => unknown | Promise<unknown>) => {
       if (progress[step]) return;
       try {
@@ -83,9 +58,5 @@ const runLogout = async (
   }
 };
 
-/**
- * Signs out the confirmed user and removes that user's remote and study state.
- * If local cleanup fails, the returned error carries a retry that resumes the unfinished steps.
- */
 export const logout = (confirmedUid: string): Promise<void> =>
   runLogout(confirmedUid, { remote: false, study: false }, true);

--- a/src/app/providers/auth/AuthLogout.integration.spec.tsx
+++ b/src/app/providers/auth/AuthLogout.integration.spec.tsx
@@ -72,7 +72,7 @@ vi.mock("@/features/settings/components/templates/ConfigFormTemplate", () => ({
 }));
 vi.mock("react-use", () => ({ useKey: vi.fn() }));
 
-import { logout } from "@/action/event";
+import { logout } from "@/app/auth/logout";
 import { AuthBootstrap, AuthProvider } from "@/app/providers/auth";
 import { useSession } from "@/entities/session";
 import { createAuthRuntime } from "@/features/auth";
@@ -100,7 +100,8 @@ beforeEach(() => {
  * Renders the test-only Authenticated Settings component with controlled state or providers.
  * Individual tests reuse it to exercise realistic interactions without repeating setup code.
  */
-const AuthenticatedSettings = () => (useSession().status === "authenticated" ? <ConfigContainer /> : null);
+const AuthenticatedSettings = () =>
+  useSession().status === "authenticated" ? <ConfigContainer login={vi.fn()} logout={logout} /> : null;
 
 const createTestRuntime = () =>
   createAuthRuntime({

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,4 @@
-export { loginGoogle } from "@/features/auth/model/authActions";
+export { loginGoogle, signOutCurrentUser } from "@/features/auth/model/authActions";
 export {
   authRuntime,
   createAuthRuntime,

--- a/src/features/auth/model/authActions.spec.ts
+++ b/src/features/auth/model/authActions.spec.ts
@@ -1,5 +1,5 @@
 import { FirebaseError } from "firebase/app";
-import { GoogleAuthProvider, linkWithPopup, signInWithCredential } from "firebase/auth";
+import { GoogleAuthProvider, linkWithPopup, signInWithCredential, signOut } from "firebase/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -13,7 +13,7 @@ vi.mock("@/features/auth/model/authController", () => ({
 }));
 vi.mock("firebase/auth");
 
-import { loginGoogle } from "@/features/auth/model/authActions";
+import { loginGoogle, signOutCurrentUser } from "@/features/auth/model/authActions";
 
 describe("loginGoogle", () => {
   beforeEach(() => {
@@ -84,5 +84,13 @@ describe("loginGoogle", () => {
 
     await expect(loginGoogle()).rejects.toBe(recoveryError);
     expect(mocks.publishAuthenticatedUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("signOutCurrentUser", () => {
+  it("signs out through Firebase Auth", async () => {
+    await signOutCurrentUser();
+
+    expect(signOut).toHaveBeenCalledWith(mocks.auth);
   });
 });

--- a/src/features/auth/model/authActions.ts
+++ b/src/features/auth/model/authActions.ts
@@ -1,5 +1,5 @@
 import { FirebaseError } from "firebase/app";
-import { GoogleAuthProvider, linkWithPopup, signInWithCredential, type UserCredential } from "firebase/auth";
+import { GoogleAuthProvider, linkWithPopup, signInWithCredential, signOut, type UserCredential } from "firebase/auth";
 
 import { publishAuthenticatedUser } from "@/features/auth/model/authController";
 import { auth } from "@/shared/firebase";
@@ -23,3 +23,5 @@ export const loginGoogle = async (): Promise<void> => {
   process.env.NODE_ENV !== "production" && console.log("LOGIN GOOGLE", result);
   publishAuthenticatedUser(result.user);
 };
+
+export const signOutCurrentUser = (): Promise<void> => signOut(auth);

--- a/src/features/settings/containers/ConfigContainer.spec.tsx
+++ b/src/features/settings/containers/ConfigContainer.spec.tsx
@@ -19,7 +19,6 @@ const mocks = vi.hoisted(() => ({
   retry: vi.fn(async () => undefined),
 }));
 
-vi.mock("@/action", () => ({ event: { loginGoogle: vi.fn(), logout: vi.fn() } }));
 vi.mock("@/entities/session", () => ({ useSession: () => ({ status: "initializing" as const }) }));
 vi.mock("@/shared/config", () => ({
   useConfig: () => mocks.config,
@@ -51,7 +50,7 @@ describe("ConfigContainer", () => {
   });
 
   it("preserves the top shortcut and forwards header actions", () => {
-    render(<ConfigContainer />);
+    render(<ConfigContainer login={vi.fn()} logout={vi.fn()} />);
 
     const topShortcut = mocks.useKey.mock.calls.find(([key]) => key === "t")?.[1];
     topShortcut?.();

--- a/src/features/settings/containers/ConfigContainer.tsx
+++ b/src/features/settings/containers/ConfigContainer.tsx
@@ -8,7 +8,6 @@ import type * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import * as action from "@/action";
 import { ConfigFormTemplate } from "@/features/settings/components/templates/ConfigFormTemplate";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { useAccountOperations } from "@/features/settings/hooks/useAccountOperations";
@@ -21,7 +20,12 @@ import { setDarkMode, updateConfig, useConfig } from "@/shared/config";
  * It prepares plain props for presentation components so those components remain independent of
  * application services.
  */
-export const ConfigContainer: React.FC = () => {
+interface ConfigContainerProps {
+  login: () => Promise<void>;
+  logout: (uid: string) => Promise<void>;
+}
+
+export const ConfigContainer: React.FC<ConfigContainerProps> = ({ login, logout }) => {
   const config = useConfig();
   const authState = useSession();
   const navigate = useNavigate();
@@ -34,8 +38,8 @@ export const ConfigContainer: React.FC = () => {
     generation: authenticated
       ? `authenticated:${authenticated.uid}:${authenticated.isAnonymous ? "anonymous" : "linked"}`
       : authState.status,
-    login: action.event.loginGoogle,
-    ...(authenticated ? { logout: () => action.event.logout(authenticated.uid) } : {}),
+    login,
+    ...(authenticated ? { logout: () => logout(authenticated.uid) } : {}),
   });
   const configForm = useConfigFormState({
     config,

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -13,4 +13,10 @@ export { useStudyCards } from "./hooks/useStudyCards";
 export { useStudyControllerState } from "./hooks/useStudyControllerState";
 export { useStudySessions } from "./hooks/useStudySessions";
 export { useStudyStore } from "./hooks/useStudyStore";
-export { selectStudySessionForRoute, type StudySession } from "./state/studyStore";
+export {
+  clearStudyStore,
+  selectStudySessionForRoute,
+  studyStore,
+  type StudySession,
+  type StudyState,
+} from "./state/studyStore";

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,3 +1,8 @@
 import { ConfigContainer } from "@/features/settings";
 
-export const SettingsPage = () => <ConfigContainer />;
+interface SettingsPageProps {
+  login: () => Promise<void>;
+  logout: (uid: string) => Promise<void>;
+}
+
+export const SettingsPage = (props: SettingsPageProps) => <ConfigContainer {...props} />;


### PR DESCRIPTION
## Summary

- keep Firebase login and sign-out details inside the auth feature
- move retryable remote and study cleanup orchestration into the app layer
- inject account actions through app composition and remove the legacy src/action boundary

## Testing

- mise run check

Closes #566