### PR TITLE
docs: remove stale src/action reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The test task starts the Firestore emulator and runs the application and sample 
 ```bash
 mise run test
 # You can also pass a specified file
-mise run test-unit -- ./src/action/xxx.spec.ts
+mise run test-unit -- ./src/entities/card/model/card.spec.ts
 ```
 
 Run a specific suite with:


### PR DESCRIPTION
## Summary

- update the README test example to use the current FSD-aligned card spec path
- remove the final stale `src/action` reference from the repository documentation

## Context

The `src/action` directory and `@/action` imports have already been removed by the preceding FSD migration work. The README still referenced `./src/action/xxx.spec.ts`, leaving an outdated path after the migration.

## Validation

- confirmed `src/action` no longer exists on `main`
- confirmed code search returns no `@/action` imports
- confirmed the remaining `src/action` reference was the README example updated here

Closes #567