### PR TITLE
refactor: group remote read lifecycle by session

### DIFF
--- a/src/store/remoteStore.reads.spec.ts
+++ b/src/store/remoteStore.reads.spec.ts
@@ -5,7 +5,7 @@ import type { RemoteSubscriptionProps } from "@/shared/api/remoteSnapshot";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FirestoreInitializationResult } from "@/shared/firebase/firestore-runtime";
-import { createRemoteStore, type RemoteReadDependencies } from "@/store/remoteStore";
+import { createRemoteStore, type RemoteReadDependencies, type RemoteStoreState } from "@/store/remoteStore";
 import { createCard, createDeck } from "@/test/factories";
 
 const synced = { size: 0, fromCache: false, hasPendingWrites: false };
@@ -135,13 +135,26 @@ describe("remote store reads", () => {
 
   it("stops listeners and ignores stale callbacks", async () => {
     const harness = createHarness();
+    const deck = createDeck({ id: "current" });
     await harness.store.getState().start("uid-a");
+    publishInitial(harness, [deck]);
     const staleDeckSubscription = harness.deckSubscriptions[0];
+    let decksDuringCleanup: RemoteStoreState["decksById"] | undefined;
+    harness.deckUnsubscribes[0]?.mockImplementation(() => {
+      staleDeckSubscription?.onSnapshot({
+        type: "replace",
+        items: [createDeck({ id: "stale-during-cleanup" })],
+        metadata: synced,
+      });
+      decksDuringCleanup = harness.store.getState().decksById;
+    });
 
+    harness.store.getState().stop("uid-a");
     harness.store.getState().stop("uid-a");
 
     expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
     expect(harness.cardUnsubscribes[0]).toHaveBeenCalledOnce();
+    expect(decksDuringCleanup).toEqual({ [deck.id]: deck });
     expect(harness.store.getState()).toMatchObject({
       uid: null,
       status: "idle",
@@ -162,6 +175,22 @@ describe("remote store reads", () => {
     const deck = createDeck({ id: "deck" });
     await harness.store.getState().start("uid-a");
     publishInitial(harness, [deck]);
+    const staleDeckSubscription = harness.deckSubscriptions[0];
+
+    harness.cardSubscriptions[0]?.onError(new Error("listener failed"));
+    staleDeckSubscription?.onSnapshot({
+      type: "replace",
+      items: [createDeck({ id: "stale" })],
+      metadata: synced,
+    });
+
+    expect(harness.store.getState()).toMatchObject({
+      uid: "uid-a",
+      status: "error",
+      decksById: { [deck.id]: deck },
+    });
+    expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
+    expect(harness.cardUnsubscribes[0]).toHaveBeenCalledOnce();
 
     const retry = harness.store.getState().retry();
     expect(harness.store.getState()).toMatchObject({
@@ -197,17 +226,45 @@ describe("remote store reads", () => {
     expect(harness.dependencies.subscribeCards).toHaveBeenCalledOnce();
   });
 
-  it("publishes blocked initialization", async () => {
+  it("publishes blocked initialization and retries the same user", async () => {
     const error = new Error("persistence blocked");
-    const harness = createHarness(
-      vi.fn<RemoteReadDependencies["waitForInitialization"]>(async () => ({ status: "blocked", error }))
-    );
+    const waitForInitialization = vi
+      .fn<RemoteReadDependencies["waitForInitialization"]>()
+      .mockResolvedValueOnce({ status: "blocked", error })
+      .mockResolvedValue({ status: "ready" });
+    const harness = createHarness(waitForInitialization);
 
     await harness.store.getState().start("uid-a");
 
     expect(harness.store.getState()).toMatchObject({ uid: "uid-a", status: "blocked", error });
     expect(harness.dependencies.subscribeDecks).not.toHaveBeenCalled();
     expect(harness.dependencies.subscribeCards).not.toHaveBeenCalled();
+
+    await harness.store.getState().retry();
+
+    expect(harness.dependencies.subscribeDecks).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ uid: "uid-a" })
+    );
+    expect(harness.dependencies.subscribeCards).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ uid: "uid-a" })
+    );
+  });
+
+  it("does not create listeners when stopped during initialization", async () => {
+    let resolveInitialization!: (result: FirestoreInitializationResult) => void;
+    const initialization = new Promise<FirestoreInitializationResult>((resolve) => {
+      resolveInitialization = resolve;
+    });
+    const harness = createHarness(vi.fn(() => initialization));
+
+    const start = harness.store.getState().start("uid-a");
+    harness.store.getState().stop("uid-a");
+    resolveInitialization({ status: "ready" });
+    await start;
+
+    expect(harness.dependencies.subscribeDecks).not.toHaveBeenCalled();
+    expect(harness.dependencies.subscribeCards).not.toHaveBeenCalled();
+    expect(harness.store.getState()).toMatchObject({ uid: null, status: "idle" });
   });
 
   it("closes a partial subscription when listener setup throws", async () => {
@@ -218,9 +275,35 @@ describe("remote store reads", () => {
     });
 
     await expect(harness.store.getState().start("uid-a")).rejects.toBe(failure);
+    expect(harness.store.getState()).toMatchObject({ status: "error", error: failure });
+
+    harness.store.getState().stop("uid-a");
 
     expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
-    expect(harness.store.getState()).toMatchObject({ status: "error", error: failure });
+  });
+
+  it("cleans partial subscriptions when superseded during listener setup", async () => {
+    const harness = createHarness();
+    const staleCardUnsubscribe = vi.fn();
+    let latestStart: Promise<void> | undefined;
+    vi.mocked(harness.dependencies.subscribeCards).mockImplementationOnce(() => {
+      latestStart = harness.store.getState().start("uid-b");
+      return staleCardUnsubscribe;
+    });
+
+    await harness.store.getState().start("uid-a");
+    await latestStart;
+
+    expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
+    expect(staleCardUnsubscribe).toHaveBeenCalledOnce();
+    expect(harness.dependencies.subscribeDecks).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
+    expect(harness.dependencies.subscribeCards).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
+
+    harness.store.getState().stop("uid-b");
+
+    expect(harness.deckUnsubscribes[1]).toHaveBeenCalledOnce();
+    expect(harness.cardUnsubscribes[0]).toHaveBeenCalledOnce();
+    expect(staleCardUnsubscribe).toHaveBeenCalledOnce();
   });
 
   it("lets the latest start own subscriptions", async () => {

--- a/src/store/remoteStore.ts
+++ b/src/store/remoteStore.ts
@@ -44,6 +44,12 @@ interface SnapshotMetadata {
   cards?: RemoteSnapshotMetadata;
 }
 
+interface ReadSession {
+  readonly uid: string;
+  readonly metadata: SnapshotMetadata;
+  readonly subscriptions: Unsubscribe[];
+}
+
 const initialReadState = (): Omit<RemoteStoreState, "start" | "stop" | "retry"> => ({
   uid: null,
   status: "idle",
@@ -79,38 +85,35 @@ const closeAll = (subscriptions: readonly Unsubscribe[]) => {
 };
 
 export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreApi<RemoteStoreState> => {
-  let activeUid: string | null = null;
-  let generation = 0;
-  let metadata: SnapshotMetadata = {};
-  let activeSubscriptions: Unsubscribe[] = [];
+  let activeSession: ReadSession | undefined;
 
-  const closeActiveSubscriptions = () => {
-    const subscriptions = activeSubscriptions;
-    activeSubscriptions = [];
+  const cleanupSession = (session: ReadSession | undefined) => {
+    if (session == null) return;
+    const subscriptions = session.subscriptions.splice(0);
     closeAll(subscriptions);
   };
 
   return createStore<RemoteStoreState>()((set, get) => {
-    const isCurrent = (uid: string, operationGeneration: number) =>
-      activeUid === uid && generation === operationGeneration;
+    const isCurrent = (session: ReadSession) => activeSession === session;
 
-    const fail = (uid: string, operationGeneration: number, status: "blocked" | "error", cause: unknown) => {
-      if (!isCurrent(uid, operationGeneration)) return;
-      generation += 1;
-      closeActiveSubscriptions();
+    const fail = (session: ReadSession, status: "blocked" | "error", cause: unknown) => {
+      if (!isCurrent(session)) return;
+      activeSession = undefined;
+      cleanupSession(session);
       set({ status, syncStatus: undefined, error: toError(cause) });
     };
 
     const start = async (uid: string): Promise<void> => {
-      const operationGeneration = ++generation;
       const previous = get();
-      closeActiveSubscriptions();
-      activeUid = uid;
-      metadata = {};
+      const previousSession = activeSession;
+      const session: ReadSession = { uid, metadata: {}, subscriptions: [] };
+      activeSession = session;
+      cleanupSession(previousSession);
+      if (!isCurrent(session)) return;
 
-      const retainCurrentData = previous.uid === uid;
+      const retainCurrentData = previous.uid === session.uid;
       set({
-        uid,
+        uid: session.uid,
         status: "loading",
         decksById: retainCurrentData ? previous.decksById : {},
         cardsById: retainCurrentData ? previous.cardsById : {},
@@ -122,35 +125,34 @@ export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreAp
       try {
         initialization = await dependencies.waitForInitialization();
       } catch (cause) {
-        fail(uid, operationGeneration, "error", cause);
+        fail(session, "error", cause);
         throw toError(cause);
       }
 
-      if (!isCurrent(uid, operationGeneration)) return;
+      if (!isCurrent(session)) return;
       if (initialization.status === "blocked") {
-        fail(uid, operationGeneration, "blocked", initialization.error);
+        fail(session, "blocked", initialization.error);
         return;
       }
 
-      const subscriptions: Unsubscribe[] = [];
       const readiness = () => {
-        const syncStatus = deriveSyncStatus(metadata);
+        const syncStatus = deriveSyncStatus(session.metadata);
         return {
           status: syncStatus == null ? ("loading" as const) : ("ready" as const),
           syncStatus,
           error: undefined,
         };
       };
-      const onError = (error: Error) => fail(uid, operationGeneration, "error", error);
+      const onError = (error: Error) => fail(session, "error", error);
 
       try {
-        subscriptions.push(
+        session.subscriptions.push(
           dependencies.subscribeDecks({
-            uid,
+            uid: session.uid,
             onError,
             onSnapshot: (snapshot) => {
-              if (!isCurrent(uid, operationGeneration)) return;
-              metadata = { ...metadata, decks: { ...snapshot.metadata } };
+              if (!isCurrent(session)) return;
+              session.metadata.decks = { ...snapshot.metadata };
               set({
                 decksById: applySnapshot(get().decksById, snapshot),
                 ...readiness(),
@@ -158,18 +160,18 @@ export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreAp
             },
           })
         );
-        if (!isCurrent(uid, operationGeneration)) {
-          closeAll(subscriptions);
+        if (!isCurrent(session)) {
+          cleanupSession(session);
           return;
         }
 
-        subscriptions.push(
+        session.subscriptions.push(
           dependencies.subscribeCards({
-            uid,
+            uid: session.uid,
             onError,
             onSnapshot: (snapshot) => {
-              if (!isCurrent(uid, operationGeneration)) return;
-              metadata = { ...metadata, cards: { ...snapshot.metadata } };
+              if (!isCurrent(session)) return;
+              session.metadata.cards = { ...snapshot.metadata };
               set({
                 cardsById: applySnapshot(get().cardsById, snapshot),
                 ...readiness(),
@@ -177,28 +179,32 @@ export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreAp
             },
           })
         );
-        if (!isCurrent(uid, operationGeneration)) {
-          closeAll(subscriptions);
+        if (!isCurrent(session)) {
+          cleanupSession(session);
           return;
         }
-        activeSubscriptions = subscriptions;
       } catch (cause) {
-        closeAll(subscriptions);
-        fail(uid, operationGeneration, "error", cause);
+        if (isCurrent(session)) {
+          fail(session, "error", cause);
+        } else {
+          cleanupSession(session);
+        }
         throw toError(cause);
       }
     };
 
     const stop = (uid?: string) => {
-      if (uid != null && activeUid !== uid) return;
-      generation += 1;
-      activeUid = null;
-      metadata = {};
-      closeActiveSubscriptions();
+      if (uid != null && get().uid !== uid) return;
+      const session = activeSession;
+      activeSession = undefined;
+      cleanupSession(session);
       set(initialReadState());
     };
 
-    const retry = () => (activeUid == null ? Promise.resolve() : start(activeUid));
+    const retry = () => {
+      const uid = get().uid;
+      return uid == null ? Promise.resolve() : start(uid);
+    };
 
     return {
       ...initialReadState(),


### PR DESCRIPTION
## Summary

- replace the distributed remote read lifecycle state and numeric generation checks with a single `ReadSession`
- invalidate sessions before cleanup and drain owned subscriptions idempotently
- preserve same-user retry data while clearing data for a different user
- cover stale callbacks, pending initialization stops, partial setup failures, setup supersession, retries, and one-time cleanup

## Why

The active read lifecycle was represented by separate UID, generation, metadata, and subscription variables. That made callback invalidation and retry ownership harder to reason about, especially when a listener setup was superseded synchronously.

## Impact

Remote read callbacks now use session identity to determine whether they are current. Failed sessions no longer remain active, while retries still use the UID retained in public store state.

## Testing

- `mise run check`
  - 94 unit test files passed
  - 543 unit tests passed
  - formatting, TypeScript, ESLint, Biome, Knip, Markdown, Hadolint, and sample checks passed

Closes #578