### PR TITLE
refactor: simplify remote read listener setup

### DIFF
--- a/src/store/remoteStore.reads.spec.ts
+++ b/src/store/remoteStore.reads.spec.ts
@@ -328,6 +328,7 @@ describe("remote store reads", () => {
       await harness.store.getState().start("uid-a");
       await latestStart;
 
+      if (listener === "card") expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
       expect(staleUnsubscribe).toHaveBeenCalledOnce();
       expect(harness.dependencies.subscribeDecks).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
       expect(harness.dependencies.subscribeCards).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));

--- a/src/store/remoteStore.reads.spec.ts
+++ b/src/store/remoteStore.reads.spec.ts
@@ -250,6 +250,33 @@ describe("remote store reads", () => {
     );
   });
 
+  it.each(["blocked", "error"] as const)("resets %s state only when the stop UID matches", async (status) => {
+    const error = new Error(`${status} read`);
+    const harness =
+      status === "blocked"
+        ? createHarness(vi.fn<RemoteReadDependencies["waitForInitialization"]>(async () => ({ status, error })))
+        : createHarness();
+
+    await harness.store.getState().start("uid-a");
+    if (status === "error") harness.cardSubscriptions[0]?.onError(error);
+
+    const failedState = harness.store.getState();
+    expect(failedState).toMatchObject({ uid: "uid-a", status, error });
+
+    harness.store.getState().stop("uid-b");
+    expect(harness.store.getState()).toBe(failedState);
+
+    harness.store.getState().stop("uid-a");
+    expect(harness.store.getState()).toMatchObject({
+      uid: null,
+      status: "idle",
+      decksById: {},
+      cardsById: {},
+      syncStatus: undefined,
+      error: undefined,
+    });
+  });
+
   it("does not create listeners when stopped during initialization", async () => {
     let resolveInitialization!: (result: FirestoreInitializationResult) => void;
     const initialization = new Promise<FirestoreInitializationResult>((resolve) => {
@@ -282,29 +309,34 @@ describe("remote store reads", () => {
     expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
   });
 
-  it("cleans partial subscriptions when superseded during listener setup", async () => {
-    const harness = createHarness();
-    const staleCardUnsubscribe = vi.fn();
-    let latestStart: Promise<void> | undefined;
-    vi.mocked(harness.dependencies.subscribeCards).mockImplementationOnce(() => {
-      latestStart = harness.store.getState().start("uid-b");
-      return staleCardUnsubscribe;
-    });
+  it.each(["deck", "card"] as const)(
+    "cleans a subscription when superseded during %s listener setup",
+    async (listener) => {
+      const harness = createHarness();
+      const staleUnsubscribe = vi.fn();
+      let latestStart: Promise<void> | undefined;
+      const supersede = () => {
+        latestStart = harness.store.getState().start("uid-b");
+        return staleUnsubscribe;
+      };
+      if (listener === "deck") {
+        vi.mocked(harness.dependencies.subscribeDecks).mockImplementationOnce(supersede);
+      } else {
+        vi.mocked(harness.dependencies.subscribeCards).mockImplementationOnce(supersede);
+      }
 
-    await harness.store.getState().start("uid-a");
-    await latestStart;
+      await harness.store.getState().start("uid-a");
+      await latestStart;
 
-    expect(harness.deckUnsubscribes[0]).toHaveBeenCalledOnce();
-    expect(staleCardUnsubscribe).toHaveBeenCalledOnce();
-    expect(harness.dependencies.subscribeDecks).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
-    expect(harness.dependencies.subscribeCards).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
+      expect(staleUnsubscribe).toHaveBeenCalledOnce();
+      expect(harness.dependencies.subscribeDecks).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
+      expect(harness.dependencies.subscribeCards).toHaveBeenLastCalledWith(expect.objectContaining({ uid: "uid-b" }));
 
-    harness.store.getState().stop("uid-b");
+      harness.store.getState().stop("uid-b");
 
-    expect(harness.deckUnsubscribes[1]).toHaveBeenCalledOnce();
-    expect(harness.cardUnsubscribes[0]).toHaveBeenCalledOnce();
-    expect(staleCardUnsubscribe).toHaveBeenCalledOnce();
-  });
+      expect(staleUnsubscribe).toHaveBeenCalledOnce();
+    }
+  );
 
   it("lets the latest start own subscriptions", async () => {
     let resolveInitialization!: (result: FirestoreInitializationResult) => void;

--- a/src/store/remoteStore.ts
+++ b/src/store/remoteStore.ts
@@ -72,6 +72,15 @@ const deriveSyncStatus = (metadata: SnapshotMetadata): RemoteSyncStatus | undefi
   return "synced";
 };
 
+const readinessState = (metadata: SnapshotMetadata): Pick<RemoteStoreState, "status" | "syncStatus" | "error"> => {
+  const syncStatus = deriveSyncStatus(metadata);
+  return {
+    status: syncStatus == null ? "loading" : "ready",
+    syncStatus,
+    error: undefined,
+  };
+};
+
 const toError = (value: unknown): Error => (value instanceof Error ? value : new Error(String(value)));
 
 const closeAll = (subscriptions: readonly Unsubscribe[]) => {
@@ -87,15 +96,22 @@ const closeAll = (subscriptions: readonly Unsubscribe[]) => {
 export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreApi<RemoteStoreState> => {
   let activeSession: ReadSession | undefined;
 
+  const isCurrent = (session: ReadSession) => activeSession === session;
+
   const cleanupSession = (session: ReadSession | undefined) => {
     if (session == null) return;
     const subscriptions = session.subscriptions.splice(0);
     closeAll(subscriptions);
   };
 
-  return createStore<RemoteStoreState>()((set, get) => {
-    const isCurrent = (session: ReadSession) => activeSession === session;
+  const addSubscription = (session: ReadSession, unsubscribe: Unsubscribe) => {
+    session.subscriptions.push(unsubscribe);
+    if (isCurrent(session)) return true;
+    cleanupSession(session);
+    return false;
+  };
 
+  return createStore<RemoteStoreState>()((set, get) => {
     const fail = (session: ReadSession, status: "blocked" | "error", cause: unknown) => {
       if (!isCurrent(session)) return;
       activeSession = undefined;
@@ -135,54 +151,36 @@ export const createRemoteStore = (dependencies: RemoteReadDependencies): StoreAp
         return;
       }
 
-      const readiness = () => {
-        const syncStatus = deriveSyncStatus(session.metadata);
-        return {
-          status: syncStatus == null ? ("loading" as const) : ("ready" as const),
-          syncStatus,
-          error: undefined,
-        };
-      };
       const onError = (error: Error) => fail(session, "error", error);
 
       try {
-        session.subscriptions.push(
-          dependencies.subscribeDecks({
-            uid: session.uid,
-            onError,
-            onSnapshot: (snapshot) => {
-              if (!isCurrent(session)) return;
-              session.metadata.decks = { ...snapshot.metadata };
-              set({
-                decksById: applySnapshot(get().decksById, snapshot),
-                ...readiness(),
-              });
-            },
-          })
-        );
-        if (!isCurrent(session)) {
-          cleanupSession(session);
-          return;
-        }
+        const deckSubscription = dependencies.subscribeDecks({
+          uid: session.uid,
+          onError,
+          onSnapshot: (snapshot) => {
+            if (!isCurrent(session)) return;
+            session.metadata.decks = { ...snapshot.metadata };
+            set({
+              decksById: applySnapshot(get().decksById, snapshot),
+              ...readinessState(session.metadata),
+            });
+          },
+        });
+        if (!addSubscription(session, deckSubscription)) return;
 
-        session.subscriptions.push(
-          dependencies.subscribeCards({
-            uid: session.uid,
-            onError,
-            onSnapshot: (snapshot) => {
-              if (!isCurrent(session)) return;
-              session.metadata.cards = { ...snapshot.metadata };
-              set({
-                cardsById: applySnapshot(get().cardsById, snapshot),
-                ...readiness(),
-              });
-            },
-          })
-        );
-        if (!isCurrent(session)) {
-          cleanupSession(session);
-          return;
-        }
+        const cardSubscription = dependencies.subscribeCards({
+          uid: session.uid,
+          onError,
+          onSnapshot: (snapshot) => {
+            if (!isCurrent(session)) return;
+            session.metadata.cards = { ...snapshot.metadata };
+            set({
+              cardsById: applySnapshot(get().cardsById, snapshot),
+              ...readinessState(session.metadata),
+            });
+          },
+        });
+        if (!addSubscription(session, cardSubscription)) return;
       } catch (cause) {
         if (isCurrent(session)) {
           fail(session, "error", cause);


### PR DESCRIPTION
## Summary

- centralize readiness state derivation for remote snapshots
- register Deck and Card subscriptions through one ownership and stale-session cleanup path
- cover Deck/Card setup supersession and blocked/error stop UID behavior

## Testing

- mise run check (95 unit test files, 551 tests)

Closes #579