### PR TITLE
refactor: make card-deck dependency Steiger-compatible

### DIFF
--- a/src/entities/card/model/card.ts
+++ b/src/entities/card/model/card.ts
@@ -1,4 +1,4 @@
-import type { Deck, DeckId } from "@/entities/deck";
+import type { DeckForCard, DeckId } from "@/entities/deck/@x/card";
 
 export type CardId = string;
 
@@ -23,7 +23,7 @@ export interface Card {
   endLine?: number;
 }
 
-export type CardDeck = Pick<Deck, "id" | "uid">;
+export type CardDeck = DeckForCard;
 export type CardRaw = Pick<Card, "frontText" | "backText" | "uniqueKey" | "tags">;
 export type CardNew = Omit<Card, "id">;
 export type CardEdit = Partial<Card> & Pick<Card, "id" | "deckId">;

--- a/src/entities/deck/@x/card.ts
+++ b/src/entities/deck/@x/card.ts
@@ -1,0 +1,4 @@
+import type { Deck } from "../model/deck";
+
+export type { DeckId } from "../model/deck";
+export type DeckForCard = Pick<Deck, "id" | "uid">;


### PR DESCRIPTION
## Summary

- expose `DeckId` and the minimal `{ id, uid }` Deck contract through `entities/deck/@x/card`
- update the Card model to consume the explicit FSD cross-reference API
- preserve the existing `CardDeck` type and Card/Deck behavior

## Why

The Card entity imported the normal Deck public API directly, which prevents enabling Steiger's `fsd/forbidden-imports` rule without an exception. The narrow `@x` API makes this intentional Entity relationship explicit without exposing the full Deck model.

## Impact

There is no runtime behavior change. Card creation and existing public Deck imports for other layers remain unchanged.

## Validation

- `mise run check`
- 103 unit test files passed (568 tests)

Closes #569