### PR TITLE
refactor: move Card and Deck commands into entity APIs

### DIFF
--- a/src/entities/card/api/commands.spec.ts
+++ b/src/entities/card/api/commands.spec.ts
@@ -1,4 +1,4 @@
-import type { Card } from "@/entities/card";
+import type { Card } from "../model/card";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,7 +19,7 @@ vi.mock("@/adapters/firestore/card", () => ({
   upsert: mocks.upsert,
 }));
 
-import { cardCommands } from "@/services/cardCommands";
+import { cardCommands } from "./commands";
 
 const createCard = (overrides: Partial<Card> = {}) => createCardFixture({ uid: "uid-a", ...overrides });
 

--- a/src/entities/card/api/commands.ts
+++ b/src/entities/card/api/commands.ts
@@ -1,5 +1,6 @@
-import type { Card, CardEdit, CardId } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
+import type { DeckId } from "@/entities/deck/@x/card";
+
+import type { Card, CardEdit, CardId } from "../model/card";
 
 import {
   create as createRemoteCard,

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,3 +1,4 @@
+export { CardBulkMutationError, cardCommands } from "./api/commands";
 export { createCard } from "./model/card";
 export type { Card, CardEdit, CardId, CardNew, CardRaw, CardTextKey } from "./model/card";
 export { useCards } from "./hooks/useCards";

--- a/src/entities/deck/api/commands.spec.ts
+++ b/src/entities/deck/api/commands.spec.ts
@@ -1,5 +1,5 @@
 import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
+import type { Deck } from "../model/deck";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -32,8 +32,8 @@ vi.mock("@/adapters/firestore/card", () => ({
   upsert: cardMocks.upsert,
 }));
 
-import { cardCommands } from "@/services/cardCommands";
-import { deckCommands } from "@/services/deckCommands";
+import { cardCommands } from "@/entities/card";
+import { deckCommands } from "./commands";
 
 const createDeck = (overrides: Partial<Deck> = {}) => createDeckFixture({ uid: "uid-a", ...overrides });
 const createCard = (overrides: Partial<Card> = {}) => createCardFixture({ uid: "uid-a", ...overrides });

--- a/src/entities/deck/api/commands.ts
+++ b/src/entities/deck/api/commands.ts
@@ -1,4 +1,4 @@
-import type { Deck, DeckEdit } from "@/entities/deck";
+import type { Deck, DeckEdit } from "../model/deck";
 
 import {
   create as createRemoteDeck,

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,3 +1,4 @@
+export { deckCommands } from "./api/commands";
 export { CATEGORY, getCategory, isHighlightLanguage } from "./model/category";
 export type { Category } from "./model/category";
 export { createDeck } from "./model/deck";

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -23,11 +23,15 @@ vi.mock("@/entities/session", () => ({
       ? { status: "signedOut" }
       : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
 }));
-vi.mock("@/entities/card", () => ({
-  useCards: () => ({
-    cardsById: mocks.card == null ? {} : { [mocks.card.id]: mocks.card },
-  }),
-}));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...actual,
+    useCards: () => ({
+      cardsById: mocks.card == null ? {} : { [mocks.card.id]: mocks.card },
+    }),
+  };
+});
 vi.mock("@/adapters/firestore/card", () => ({
   create: mocks.create,
   update: mocks.update,

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -4,10 +4,9 @@ import type { Card, CardEdit, CardId } from "@/entities/card";
 
 import { useEffect, useRef } from "react";
 
-import { useCards } from "@/entities/card";
+import { cardCommands, useCards } from "@/entities/card";
 import { useSession } from "@/entities/session";
 import { useAsyncAction } from "@/shared/hooks/useAsyncAction";
-import { cardCommands } from "@/services/cardCommands";
 
 type CardPatch = Partial<Omit<Card, "id" | "deckId" | "uid">>;
 

--- a/src/features/deck/hooks/useDeckMutations.ts
+++ b/src/features/deck/hooks/useDeckMutations.ts
@@ -4,9 +4,9 @@ import type { Deck, DeckEdit, DeckId } from "@/entities/deck";
 
 import { useEffect, useRef } from "react";
 
+import { deckCommands } from "@/entities/deck";
 import { useSession } from "@/entities/session";
 import { useAsyncAction } from "@/shared/hooks/useAsyncAction";
-import { deckCommands } from "@/services/deckCommands";
 
 interface UseDeckMutationsOptions {
   onRemoveSuccess?: (deck: Deck) => void;

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCard, createDeck } from "@/test/factories";
 import type { DeckImportResult } from "@/features/import/components/deckImportTypes";
-import { CardBulkMutationError } from "@/services/cardCommands";
+import { CardBulkMutationError } from "@/entities/card";
 import { actAsync } from "@/test/act";
 
 const mocks = vi.hoisted(() => ({
@@ -39,19 +39,27 @@ vi.mock("@/entities/session", () => ({
       ? { status: "signedOut" }
       : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
 }));
-vi.mock("@/entities/card", () => ({
-  createCard: (...args: unknown[]) => mocks.prepareCard(...args),
-  selectCardsForDeck: (cards: Card[], id: DeckId) => cards.filter((card) => card.deckId === id),
-  useCards: () => ({ status: mocks.cardRemoteStatus, syncStatus: mocks.cardSyncStatus, cards: mocks.cards }),
-}));
-vi.mock("@/entities/deck", () => ({
-  createDeck: (...args: unknown[]) => mocks.prepareDeck(...args),
-  useDecks: () => ({
-    status: mocks.deckRemoteStatus,
-    syncStatus: mocks.deckSyncStatus,
-    decks: mocks.decks,
-  }),
-}));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...actual,
+    createCard: (...args: unknown[]) => mocks.prepareCard(...args),
+    selectCardsForDeck: (cards: Card[], id: DeckId) => cards.filter((card) => card.deckId === id),
+    useCards: () => ({ status: mocks.cardRemoteStatus, syncStatus: mocks.cardSyncStatus, cards: mocks.cards }),
+  };
+});
+vi.mock("@/entities/deck", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/deck")>();
+  return {
+    ...actual,
+    createDeck: (...args: unknown[]) => mocks.prepareDeck(...args),
+    useDecks: () => ({
+      status: mocks.deckRemoteStatus,
+      syncStatus: mocks.deckSyncStatus,
+      decks: mocks.decks,
+    }),
+  };
+});
 vi.mock("@/features/deck/hooks/useDeckMutations", () => ({
   useDeckMutations: () => ({ create: mocks.createDeck }),
 }));

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -10,7 +10,7 @@ import type { Deck, DeckId } from "@/entities/deck";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { documentMetadata as firestoreMetadata } from "@/adapters/firestore";
-import { createCard, selectCardsForDeck, useCards } from "@/entities/card";
+import { CardBulkMutationError, createCard, selectCardsForDeck, useCards } from "@/entities/card";
 import { createDeck, useDecks } from "@/entities/deck";
 import { useSession } from "@/entities/session";
 import { useCardMutations } from "@/features/card/hooks/useCardMutations";
@@ -18,7 +18,6 @@ import { useDeckMutations } from "@/features/deck/hooks/useDeckMutations";
 import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/components/deckImportTypes";
 import { parseCsv } from "@/features/import/lib/cardCsv";
 import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
-import { CardBulkMutationError } from "@/services/cardCommands";
 import sampleCards from "../../../../sample/build/output.json";
 
 interface DeckImportAttempt {


### PR DESCRIPTION
## Summary

- move Card and Deck mutation commands and their tests from the global `src/services` bucket into the owning entity API segments
- export `cardCommands`, `CardBulkMutationError`, and `deckCommands` through entity public APIs, then migrate feature consumers and mocks
- update #414's planned Study command paths to `src/features/study/api` so the removed global services bucket is not recreated

## Impact

Card and Deck persistence behavior, ownership checks, mutation locking, and remote-write waiting are unchanged. Features now consume entity-owned commands through the FSD public APIs, and `src/services` is removed.

## Testing

- `mise run check` (103 test files, 568 tests)

Closes #549
Refs #543