### PR TITLE
chore: track Firestore index configuration

### DIFF
--- a/firebase.indexes.json
+++ b/firebase.indexes.json
@@ -1,0 +1,66 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "card",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "deletedAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "uid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "card",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "uid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "deck",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "uid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firebase.indexes.json"
   },
   "emulators": {
     "auth": {


### PR DESCRIPTION
## Summary

- add `firebase.indexes.json` and track the three currently deployed collection-scope Firestore indexes exactly as exported by `firebase firestore:indexes`
- configure `firebase.json` to use `firebase.indexes.json`
- keep `fieldOverrides` empty

Tracked indexes:

- `card`: `deletedAt ASC`, `uid ASC`, `updatedAt ASC`, `__name__ ASC`, `density: SPARSE_ALL`
- `card`: `uid ASC`, `updatedAt ASC`, `__name__ ASC`, `density: SPARSE_ALL`
- `deck`: `uid ASC`, `updatedAt DESC`, `__name__ DESC`, `density: SPARSE_ALL`

## Why

The Firebase project already has these three active indexes, but their deployed definitions were not version-controlled. Keeping the exported index configuration in the repository makes Firestore configuration reviewable and reproducible.

## Impact

- deployed Firestore composite-index state is represented in source control
- no application query behavior changes
- `firebase.json` explicitly points Firebase CLI to `firebase.indexes.json`

## Validation

- matched the current `firebase firestore:indexes --project tango-ts` output supplied for this change
- preserved explicit `__name__` ordering and `density: SPARSE_ALL` from the CLI export
- verified the PR contains one commit changing only `firebase.indexes.json` and `firebase.json`
- no automated tests run; configuration-only change