### PR TITLE
Complete Shared public APIs for Steiger

### DIFF
--- a/src/adapters/firestore/event.spec.ts
+++ b/src/adapters/firestore/event.spec.ts
@@ -6,7 +6,7 @@
 
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
-import type { RemoteSnapshot } from "@/shared/api/remoteSnapshot";
+import type { RemoteSnapshot } from "@/shared/api";
 
 import "@/shared/firebase/test/initializeTestFirestore";
 import { afterAll, describe, expect, it, vi } from "vitest";

--- a/src/adapters/firestore/event.ts
+++ b/src/adapters/firestore/event.ts
@@ -9,7 +9,7 @@ import { onSnapshot, where, collection, query } from "firebase/firestore";
 import { mapCardDocument, mapDeckDocument } from "@/adapters/firestore/dto";
 import type { Card } from "@/entities/card/model/card";
 import type { Deck } from "@/entities/deck/model/deck";
-import type { RemoteChange, RemoteSubscriptionProps } from "@/shared/api/remoteSnapshot";
+import type { RemoteChange, RemoteSubscriptionProps } from "@/shared/api";
 import { getDb } from "@/shared/firebase/firestore-runtime";
 
 type RemoteEntity = { id: string; updatedAt: number; deletedAt: number | null };

--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -16,13 +16,9 @@ const mocks = vi.hoisted(() => ({
   authState: { status: "initializing" } as SessionState,
 }));
 
-vi.mock("zustand", () => ({
-  useStore: (_store: unknown, select: (state: unknown) => unknown) =>
-    select({
-      config: { appearance: { darkMode: mocks.darkMode } },
-    }),
+vi.mock("@/shared/config", () => ({
+  useConfig: () => ({ appearance: { darkMode: mocks.darkMode } }),
 }));
-vi.mock("@/shared/config/configStore", () => ({ configStore: {} }));
 vi.mock("@/app/auth/logout", () => ({ logout: vi.fn() }));
 vi.mock("@/entities/session", () => ({ useSession: () => mocks.authState }));
 vi.mock("@/features/auth", () => ({ loginGoogle: vi.fn() }));

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,11 +6,10 @@
 
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
-import { useStore } from "zustand";
 
 import { AppRoutes } from "@/app/routes";
 import { useSession } from "@/entities/session";
-import { configStore } from "@/shared/config/configStore";
+import { useConfig } from "@/shared/config";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 
 /**
@@ -19,7 +18,7 @@ import { RouteFeedback } from "@/shared/ui/route-feedback";
  * when startup fails.
  */
 const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location.reload() }) => {
-  const darkMode = useStore(configStore, (state) => state.config.appearance.darkMode);
+  const { darkMode } = useConfig().appearance;
   const authState = useSession();
 
   React.useEffect(() => {

--- a/src/app/providers/remote-read/RemoteReadBootstrap.integration.spec.tsx
+++ b/src/app/providers/remote-read/RemoteReadBootstrap.integration.spec.tsx
@@ -34,7 +34,7 @@ vi.mock("@/app/providers/remote-read/remoteReadLifecycle", () => ({
 import { AuthProvider } from "@/app/providers/auth";
 import { RemoteReadBootstrap } from "@/app/providers/remote-read";
 import { createAuthRuntime } from "@/features/auth";
-import { useRemoteReadScopeUid } from "@/shared/lib/remote-read/RemoteReadScope";
+import { useRemoteReadScopeUid } from "@/shared/lib/remote-read";
 
 const ReadScopeProbe = () => <output data-testid="read-scope">{useRemoteReadScopeUid() ?? "signed-out"}</output>;
 

--- a/src/app/providers/remote-read/RemoteReadBootstrap.tsx
+++ b/src/app/providers/remote-read/RemoteReadBootstrap.tsx
@@ -3,7 +3,7 @@ import { type PropsWithChildren, useEffect, useState } from "react";
 import { createAuthTransitionController } from "@/app/providers/auth/authTransitionController";
 import { startRemoteReads, stopRemoteReads } from "@/app/providers/remote-read/remoteReadLifecycle";
 import { useSession } from "@/entities/session";
-import { RemoteReadScopeProvider } from "@/shared/lib/remote-read/RemoteReadScope";
+import { RemoteReadScopeProvider } from "@/shared/lib/remote-read";
 
 export const RemoteReadBootstrap = ({ children }: PropsWithChildren) => {
   const session = useSession();

--- a/src/entities/card/hooks/useCards.spec.tsx
+++ b/src/entities/card/hooks/useCards.spec.tsx
@@ -3,8 +3,7 @@ import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Card } from "@/entities/card/model/card";
-import type { RemoteReadStoreState } from "@/shared/lib/remote-read/createRemoteReadStore";
-import { RemoteReadScopeProvider } from "@/shared/lib/remote-read/RemoteReadScope";
+import { RemoteReadScopeProvider, type RemoteReadStoreState } from "@/shared/lib/remote-read";
 import { createCard } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({

--- a/src/entities/card/hooks/useCards.ts
+++ b/src/entities/card/hooks/useCards.ts
@@ -3,8 +3,8 @@ import { useStore } from "zustand";
 
 import type { Card } from "@/entities/card/model/card";
 import { cardRemoteReadStore } from "@/entities/card/model/remoteReadStore";
-import type { RemoteById } from "@/shared/api/remoteSnapshot";
-import { useRemoteReadScopeUid } from "@/shared/lib/remote-read/RemoteReadScope";
+import type { RemoteById } from "@/shared/api";
+import { useRemoteReadScopeUid } from "@/shared/lib/remote-read";
 
 const EMPTY_CARDS: RemoteById<Card> = {};
 

--- a/src/entities/card/model/remoteReadStore.spec.ts
+++ b/src/entities/card/model/remoteReadStore.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { Card } from "@/entities/card/model/card";
-import type { RemoteSubscriptionProps } from "@/shared/api/remoteSnapshot";
-import { createRemoteReadStore } from "@/shared/lib/remote-read/createRemoteReadStore";
+import type { RemoteSubscriptionProps } from "@/shared/api";
+import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { createCard } from "@/test/factories";
 
 const synced = { size: 0, fromCache: false, hasPendingWrites: false };

--- a/src/entities/card/model/remoteReadStore.ts
+++ b/src/entities/card/model/remoteReadStore.ts
@@ -1,7 +1,7 @@
 import { subscribeCardReads } from "@/adapters/firestore/event";
 import type { Card } from "@/entities/card/model/card";
 import { waitForFirestoreInitialization } from "@/shared/firebase/firestore-runtime";
-import { createRemoteReadStore } from "@/shared/lib/remote-read/createRemoteReadStore";
+import { createRemoteReadStore } from "@/shared/lib/remote-read";
 
 export const cardRemoteReadStore = createRemoteReadStore<Card>({
   waitForInitialization: waitForFirestoreInitialization,

--- a/src/entities/deck/hooks/useDeckMutations.ts
+++ b/src/entities/deck/hooks/useDeckMutations.ts
@@ -6,7 +6,7 @@ import { useEffect, useRef } from "react";
 
 import { deckCommands } from "../api/commands";
 import { useSession } from "@/entities/session";
-import { useAsyncAction } from "@/shared/hooks/useAsyncAction";
+import { useAsyncAction } from "@/shared/hooks";
 
 interface UseDeckMutationsOptions {
   onRemoveSuccess?: (deck: Deck) => void;

--- a/src/entities/deck/hooks/useDecks.spec.tsx
+++ b/src/entities/deck/hooks/useDecks.spec.tsx
@@ -3,8 +3,7 @@ import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Deck } from "@/entities/deck/model/deck";
-import type { RemoteReadStoreState } from "@/shared/lib/remote-read/createRemoteReadStore";
-import { RemoteReadScopeProvider } from "@/shared/lib/remote-read/RemoteReadScope";
+import { RemoteReadScopeProvider, type RemoteReadStoreState } from "@/shared/lib/remote-read";
 import { createDeck } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({

--- a/src/entities/deck/hooks/useDecks.ts
+++ b/src/entities/deck/hooks/useDecks.ts
@@ -3,8 +3,8 @@ import { useStore } from "zustand";
 
 import type { Deck } from "@/entities/deck/model/deck";
 import { deckRemoteReadStore } from "@/entities/deck/model/remoteReadStore";
-import type { RemoteById } from "@/shared/api/remoteSnapshot";
-import { useRemoteReadScopeUid } from "@/shared/lib/remote-read/RemoteReadScope";
+import type { RemoteById } from "@/shared/api";
+import { useRemoteReadScopeUid } from "@/shared/lib/remote-read";
 
 const EMPTY_DECKS: RemoteById<Deck> = {};
 

--- a/src/entities/deck/model/remoteReadStore.spec.ts
+++ b/src/entities/deck/model/remoteReadStore.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { Deck } from "@/entities/deck/model/deck";
-import type { RemoteSubscriptionProps } from "@/shared/api/remoteSnapshot";
-import { createRemoteReadStore } from "@/shared/lib/remote-read/createRemoteReadStore";
+import type { RemoteSubscriptionProps } from "@/shared/api";
+import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { createDeck } from "@/test/factories";
 
 const synced = { size: 0, fromCache: false, hasPendingWrites: false };

--- a/src/entities/deck/model/remoteReadStore.ts
+++ b/src/entities/deck/model/remoteReadStore.ts
@@ -1,7 +1,7 @@
 import { subscribeDeckReads } from "@/adapters/firestore/event";
 import type { Deck } from "@/entities/deck/model/deck";
 import { waitForFirestoreInitialization } from "@/shared/firebase/firestore-runtime";
-import { createRemoteReadStore } from "@/shared/lib/remote-read/createRemoteReadStore";
+import { createRemoteReadStore } from "@/shared/lib/remote-read";
 
 export const deckRemoteReadStore = createRemoteReadStore<Deck>({
   waitForInitialization: waitForFirestoreInitialization,

--- a/src/features/card/components/CardForm.stories.tsx
+++ b/src/features/card/components/CardForm.stories.tsx
@@ -9,7 +9,7 @@ import type { Card } from "@/entities/card";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { CardForm as Template, type CardFormFields } from "@/features/card/components/CardForm";
-import type { Option } from "@/shared/ui/forms/Select";
+import type { Option } from "@/shared/ui/forms";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 

--- a/src/features/card/hooks/useCardFormState.ts
+++ b/src/features/card/hooks/useCardFormState.ts
@@ -9,7 +9,7 @@ import type { Card } from "@/entities/card";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
-import type { Option } from "@/shared/ui/forms/Select";
+import type { Option } from "@/shared/ui/forms";
 import type { CardFormProps } from "@/features/card/components/CardForm";
 import { cardFormSchema, type CardFormValues } from "@/features/card/lib/cardFormSchema";
 

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -6,7 +6,7 @@ import { useEffect, useRef } from "react";
 
 import { cardCommands, useCards } from "@/entities/card";
 import { useSession } from "@/entities/session";
-import { useAsyncAction } from "@/shared/hooks/useAsyncAction";
+import { useAsyncAction } from "@/shared/hooks";
 
 type CardPatch = Partial<Omit<Card, "id" | "deckId" | "uid">>;
 

--- a/src/features/study/containers/DeckStartContainer.tsx
+++ b/src/features/study/containers/DeckStartContainer.tsx
@@ -23,7 +23,7 @@ import { useDeckFilterState } from "../hooks/useDeckFilterState";
 import { useStudyActions } from "../hooks/useStudyActions";
 import { useStudyCards } from "../hooks/useStudyCards";
 import { setDarkMode, useConfig } from "@/shared/config";
-import { combineRemoteReadStates } from "@/shared/lib/remote-read/combineRemoteReadStates";
+import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 
 /**
  * Checks whether the supplied value satisfies the interactive shortcut target condition.

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -35,7 +35,7 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@/shared/config/useConfig", () => ({
+vi.mock("@/shared/config", () => ({
   useConfig: () => {
     if (mocks.state == null) throw new Error("Mock state is not initialized");
     return mocks.state.config;

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -18,7 +18,7 @@ import { useStudyCards } from "@/features/study/hooks/useStudyCards";
 import { buildStudySession, calculateNextIndex } from "@/features/study/model/session";
 import { buildStudyPatch, resolveSwipeAction } from "@/features/study/model/swipe";
 import { studyStore } from "@/features/study/state/studyStore";
-import { useConfig } from "@/shared/config/useConfig";
+import { useConfig } from "@/shared/config";
 
 export interface StudyActions {
   start: () => void;

--- a/src/pages/card-form/ui/CardFormView.stories.tsx
+++ b/src/pages/card-form/ui/CardFormView.stories.tsx
@@ -8,7 +8,7 @@ import type { Card } from "@/entities/card";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import type { Option } from "@/shared/ui/forms/Select";
+import type { Option } from "@/shared/ui/forms";
 import type { CardFormFields } from "@/features/card";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -9,7 +9,7 @@ import { getCategory, isHighlightLanguage, type Deck, useDeckMutations, useDecks
 import { useCardMutations } from "@/features/card";
 import { DeckStartForm, useDeckFilterState, useStudyCards } from "@/features/study";
 import { setDarkMode, useConfig } from "@/shared/config";
-import { combineRemoteReadStates } from "@/shared/lib/remote-read/combineRemoteReadStates";
+import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
 import { Layout } from "@/shared/ui/layout";

--- a/src/pages/card-view/ui/CardViewPage.tsx
+++ b/src/pages/card-view/ui/CardViewPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { type Card, useCards } from "@/entities/card";
 import { getCategory, isHighlightLanguage, type Deck, useDecks } from "@/entities/deck";
 import { setDarkMode, useConfig } from "@/shared/config";
-import { combineRemoteReadStates } from "@/shared/lib/remote-read/combineRemoteReadStates";
+import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { Layout } from "@/shared/ui/layout";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -15,7 +15,7 @@ import {
   useStudySessions,
 } from "@/features/study";
 import { setDarkMode, useConfig } from "@/shared/config";
-import { combineRemoteReadStates } from "@/shared/lib/remote-read/combineRemoteReadStates";
+import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
 import { Layout } from "@/shared/ui/layout";

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -17,7 +17,7 @@ import {
   useStudyStore,
 } from "@/features/study";
 import { setDarkMode, toggleShowHeader, toggleShowSwipeButtonList, useConfig } from "@/shared/config";
-import { combineRemoteReadStates } from "@/shared/lib/remote-read/combineRemoteReadStates";
+import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,9 @@
+export { toRemoteById } from "./remoteSnapshot";
+export type {
+  RemoteById,
+  RemoteChange,
+  RemoteSnapshot,
+  RemoteSnapshotMetadata,
+  RemoteSubscriptionProps,
+  RemoteSyncStatus,
+} from "./remoteSnapshot";

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useAsyncAction } from "./useAsyncAction";

--- a/src/shared/lib/remote-read/createRemoteReadStore.spec.ts
+++ b/src/shared/lib/remote-read/createRemoteReadStore.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { RemoteSubscriptionProps } from "@/shared/api/remoteSnapshot";
+import type { RemoteSubscriptionProps } from "@/shared/api";
 import type { FirestoreInitializationResult } from "@/shared/firebase/firestore-runtime";
 import {
   createRemoteReadStore,

--- a/src/shared/lib/remote-read/createRemoteReadStore.ts
+++ b/src/shared/lib/remote-read/createRemoteReadStore.ts
@@ -1,14 +1,14 @@
 import type { StoreApi } from "zustand";
 import { createStore } from "zustand/vanilla";
 
-import type {
-  RemoteById,
-  RemoteSnapshot,
-  RemoteSnapshotMetadata,
-  RemoteSubscriptionProps,
-  RemoteSyncStatus,
-} from "@/shared/api/remoteSnapshot";
-import { toRemoteById } from "@/shared/api/remoteSnapshot";
+import {
+  toRemoteById,
+  type RemoteById,
+  type RemoteSnapshot,
+  type RemoteSnapshotMetadata,
+  type RemoteSubscriptionProps,
+  type RemoteSyncStatus,
+} from "@/shared/api";
 import type { FirestoreInitializationResult } from "@/shared/firebase/firestore-runtime";
 import { applyRealtimeChange } from "@/shared/lib/realtimeChange";
 

--- a/src/shared/lib/remote-read/index.ts
+++ b/src/shared/lib/remote-read/index.ts
@@ -1,0 +1,4 @@
+export { combineRemoteReadStates } from "./combineRemoteReadStates";
+export { createRemoteReadStore } from "./createRemoteReadStore";
+export type { RemoteReadStoreState } from "./createRemoteReadStore";
+export { RemoteReadScopeProvider, useRemoteReadScopeUid } from "./RemoteReadScope";

--- a/src/shared/ui/content/TagList.stories.tsx
+++ b/src/shared/ui/content/TagList.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Tag } from "@/shared/ui/forms/Tag";
+import { Tag } from "@/shared/ui/forms";
 import { TagList as Template } from "@/shared/ui/content/TagList";
 import * as fixture from "@/storybook/fixture";
 

--- a/src/shared/ui/content/index.ts
+++ b/src/shared/ui/content/index.ts
@@ -8,4 +8,5 @@ export { Section } from "./Section";
 export { Style } from "./Style";
 export { TagLabel } from "./TagLabel";
 export { TagList } from "./TagList";
+export { tagClassName } from "./tagStyles";
 export { Title } from "./Title";

--- a/src/shared/ui/forms/FormItem.tsx
+++ b/src/shared/ui/forms/FormItem.tsx
@@ -6,7 +6,7 @@
 
 import cx from "classnames";
 import type React from "react";
-import { Description } from "@/shared/ui/content/Description";
+import { Description } from "@/shared/ui/content";
 
 /**
  * Renders the Form Item user interface.

--- a/src/shared/ui/forms/Tag.tsx
+++ b/src/shared/ui/forms/Tag.tsx
@@ -7,7 +7,7 @@
 import cx from "classnames";
 import type * as React from "react";
 
-import { tagClassName } from "@/shared/ui/content/tagStyles";
+import { tagClassName } from "@/shared/ui/content";
 
 /**
  * Renders the Tag user interface.

--- a/src/shared/ui/layout/List.stories.tsx
+++ b/src/shared/ui/layout/List.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Card } from "@/shared/ui/content/Card";
+import { Card } from "@/shared/ui/content";
 import { List as Template } from "@/shared/ui/layout/List";
 
 const meta = {


### PR DESCRIPTION
## Summary

- add explicit public APIs for `shared/api`, `shared/hooks`, and `shared/lib/remote-read`
- route boundary-crossing consumers through Shared segment and subgroup entrypoints
- keep `shared/lib` and `shared/ui` unflattened while exposing only the contracts their external consumers use

## Why

Steiger's `fsd/public-api` and `fsd/no-public-api-sidestep` rules require consumers crossing a Shared boundary to use that boundary's public API. The affected callers depended on internal module paths, and three Shared entrypoints were missing.

## Impact

This is a structural refactor with no intended runtime behavior change. Shared implementation paths can now change without requiring updates in their external consumers.

## Validation

- `mise run check`
- 103 unit test files passed
- 568 unit tests passed

Closes #570