### PR TITLE
refactor: add StudyProgress entity

### DIFF
--- a/src/entities/card/@x/study-progress.ts
+++ b/src/entities/card/@x/study-progress.ts
@@ -1,0 +1,1 @@
+export type { CardId } from "../model/card";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,0 +1,2 @@
+export { createStudyProgress } from "./model/studyProgress";
+export type { StudyProgress, StudyProgressEdit } from "./model/studyProgress";

--- a/src/entities/study-progress/model/studyProgress.spec.ts
+++ b/src/entities/study-progress/model/studyProgress.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { createStudyProgress, type StudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+
+describe("createStudyProgress", () => {
+  it("creates study progress with the initial score and seen count", () => {
+    const progress: StudyProgress = createStudyProgress("card-id");
+
+    expect(progress).toEqual({
+      cardId: "card-id",
+      score: 0,
+      numberOfSeen: 0,
+    });
+  });
+
+  it("allows editing selected progress fields while retaining the card id", () => {
+    const edit: StudyProgressEdit = {
+      cardId: "card-id",
+      score: 3,
+      lastSeenAt: 1_786_512_000_000,
+    };
+
+    expect(edit).toEqual({
+      cardId: "card-id",
+      score: 3,
+      lastSeenAt: 1_786_512_000_000,
+    });
+  });
+});

--- a/src/entities/study-progress/model/studyProgress.ts
+++ b/src/entities/study-progress/model/studyProgress.ts
@@ -1,0 +1,18 @@
+import type { CardId } from "@/entities/card/@x/study-progress";
+
+export interface StudyProgress {
+  cardId: CardId;
+  score: number;
+  numberOfSeen: number;
+  lastSeenAt?: number;
+  nextSeeingAt?: Date;
+  interval?: number;
+}
+
+export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
+
+export const createStudyProgress = (cardId: CardId): StudyProgress => ({
+  cardId,
+  score: 0,
+  numberOfSeen: 0,
+});


### PR DESCRIPTION
## Summary

- add an independent `StudyProgress` domain model for card learning state
- expose `StudyProgress`, `StudyProgressEdit`, and `createStudyProgress` through the entity public API
- add an FSD cross-import for `CardId` and unit coverage for initial and editable state

This keeps the existing `Card` API and runtime behavior unchanged while establishing the domain boundary for follow-up study refactoring.

## Validation

- `mise run check` (104 test files, 570 tests)

Closes #601