### PR TITLE
refactor: remove remote snapshot metadata size

### DIFF
--- a/src/adapters/firestore/event.ts
+++ b/src/adapters/firestore/event.ts
@@ -34,7 +34,6 @@ const subscribeReads = <T extends RemoteEntity>(
       try {
         const changes = snapshot.docChanges();
         const metadata = {
-          size: initial ? snapshot.docs.length : changes.length,
           fromCache: snapshot.metadata.fromCache,
           hasPendingWrites: snapshot.metadata.hasPendingWrites,
         };

--- a/src/adapters/firestore/eventAdapter.spec.ts
+++ b/src/adapters/firestore/eventAdapter.spec.ts
@@ -117,7 +117,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenCalledWith({
       type: "replace",
       items: [],
-      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
+      metadata: { fromCache: false, hasPendingWrites: false },
     });
   });
 
@@ -132,7 +132,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenCalledWith({
       type: "replace",
       items: [expect.objectContaining({ id: "deck-a", name: "Remote Deck" })],
-      metadata: { size: 2, fromCache: false, hasPendingWrites: false },
+      metadata: { fromCache: false, hasPendingWrites: false },
     });
   });
 
@@ -162,7 +162,7 @@ describe("Firestore remote-read subscriptions", () => {
         modified: [expect.objectContaining({ id: "deck-modified" })],
         removed: ["deck-deleted", "deck-removed"],
       },
-      metadata: { size: 4, fromCache: true, hasPendingWrites: true },
+      metadata: { fromCache: true, hasPendingWrites: true },
     });
   });
 
@@ -181,7 +181,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenLastCalledWith({
       type: "replace",
       items: [expect.objectContaining({ id: "card-a", nextSeeingAt: new Date(50) })],
-      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
+      metadata: { fromCache: false, hasPendingWrites: false },
     });
 
     mocks.next?.(snapshot([], [{ type: "modified", doc: document("card-a", cardDocument({ frontText: "Updated" })) }]));
@@ -192,7 +192,7 @@ describe("Firestore remote-read subscriptions", () => {
         modified: [expect.objectContaining({ id: "card-a", frontText: "Updated" })],
         removed: [],
       },
-      metadata: { size: 1, fromCache: false, hasPendingWrites: false },
+      metadata: { fromCache: false, hasPendingWrites: false },
     });
   });
 
@@ -260,7 +260,7 @@ describe("Firestore remote-read subscriptions", () => {
     expect(onSnapshot).toHaveBeenCalledWith({
       type: "change",
       event: { added: [], modified: [], removed: [] },
-      metadata: { size: 0, fromCache: false, hasPendingWrites: false },
+      metadata: { fromCache: false, hasPendingWrites: false },
     });
   });
 

--- a/src/entities/card/model/remoteReadStore.spec.ts
+++ b/src/entities/card/model/remoteReadStore.spec.ts
@@ -5,7 +5,7 @@ import type { RemoteSubscriptionProps } from "@/shared/api";
 import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { createCard } from "@/test/factories";
 
-const synced = { size: 0, fromCache: false, hasPendingWrites: false };
+const synced = { fromCache: false, hasPendingWrites: false };
 
 const createHarness = () => {
   const subscriptions: Array<RemoteSubscriptionProps<Card>> = [];
@@ -33,7 +33,7 @@ describe("Card remote read store", () => {
     harness.subscriptions[0]?.onSnapshot({
       type: "replace",
       items: [card],
-      metadata: { ...synced, size: 1 },
+      metadata: synced,
     });
 
     expect(harness.store.getState()).toMatchObject({

--- a/src/entities/deck/model/remoteReadStore.spec.ts
+++ b/src/entities/deck/model/remoteReadStore.spec.ts
@@ -5,7 +5,7 @@ import type { RemoteSubscriptionProps } from "@/shared/api";
 import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { createDeck } from "@/test/factories";
 
-const synced = { size: 0, fromCache: false, hasPendingWrites: false };
+const synced = { fromCache: false, hasPendingWrites: false };
 
 const createHarness = () => {
   const subscriptions: Array<RemoteSubscriptionProps<Deck>> = [];
@@ -33,7 +33,7 @@ describe("Deck remote read store", () => {
     harness.subscriptions[0]?.onSnapshot({
       type: "replace",
       items: [deck],
-      metadata: { ...synced, size: 1, fromCache: true },
+      metadata: { ...synced, fromCache: true },
     });
 
     expect(harness.store.getState()).toMatchObject({

--- a/src/shared/api/remoteSnapshot.ts
+++ b/src/shared/api/remoteSnapshot.ts
@@ -6,7 +6,6 @@ export const toRemoteById = <T extends { id: string }>(items: readonly T[]): Rem
 export type RemoteSyncStatus = "cached" | "pending" | "synced";
 
 export interface RemoteSnapshotMetadata {
-  size: number;
   fromCache: boolean;
   hasPendingWrites: boolean;
 }

--- a/src/shared/lib/remote-read/createRemoteReadStore.spec.ts
+++ b/src/shared/lib/remote-read/createRemoteReadStore.spec.ts
@@ -13,7 +13,7 @@ interface Item {
   value: string;
 }
 
-const synced = { size: 0, fromCache: false, hasPendingWrites: false };
+const synced = { fromCache: false, hasPendingWrites: false };
 const createItem = (id: string): Item => ({ id, value: id });
 
 const createHarness = (
@@ -45,7 +45,7 @@ const publish = (harness: ReturnType<typeof createHarness>, items: Item[] = [], 
   harness.subscriptions.at(-1)?.onSnapshot({
     type: "replace",
     items,
-    metadata: { ...metadata, size: items.length },
+    metadata,
   });
 };
 


### PR DESCRIPTION
## Summary

- remove the ambiguous `size` field from `RemoteSnapshotMetadata`
- stop calculating snapshot sizes in the Firestore adapter
- update fixtures and expectations while preserving initial, incremental, and metadata-only behavior coverage

## Testing

- `mise run check`
- `npm test -- src/adapters/firestore/eventAdapter.spec.ts`

Closes #607