### PR TITLE
Move Firestore read infrastructure into Shared

### DIFF
--- a/src/adapters/firestore/card.spec.ts
+++ b/src/adapters/firestore/card.spec.ts
@@ -11,14 +11,14 @@ import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { getFirestore, doc, getDoc } from "firebase/firestore";
 import * as cardAdapter from "@/adapters/firestore/card";
 import * as deckAdapter from "@/adapters/firestore/deck";
-import { getTimestamp } from "@/adapters/firestore/documentMetadata";
+import { getTimestamp } from "@/shared/firebase/firestoreDocument";
 import * as UUID from "uuid";
 import { createCard, createDeck } from "@/test/factories";
 
 const uuid = UUID.v4;
 
-vi.mock("./documentMetadata", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./documentMetadata")>()),
+vi.mock("@/shared/firebase/firestoreDocument", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/firebase/firestoreDocument")>()),
   getTimestamp: vi.fn(),
 }));
 

--- a/src/adapters/firestore/card.ts
+++ b/src/adapters/firestore/card.ts
@@ -18,9 +18,9 @@ import {
   where,
   type Firestore,
 } from "firebase/firestore";
-import { getTimestamp } from "@/adapters/firestore/documentMetadata";
 import { buildCardCreateDto, buildCardUpdateDto, mapCardDocument } from "@/adapters/firestore/dto";
 import { getDb } from "@/shared/firebase/firestore-runtime";
+import { getTimestamp } from "@/shared/firebase/firestoreDocument";
 
 /**
  * Reads every active card owned by the requested user from Firestore.

--- a/src/adapters/firestore/deck.spec.ts
+++ b/src/adapters/firestore/deck.spec.ts
@@ -10,14 +10,14 @@ import "@/shared/firebase/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { doc, getDoc, getFirestore } from "firebase/firestore";
 import * as deckAdapter from "@/adapters/firestore/deck";
-import { getTimestamp } from "@/adapters/firestore/documentMetadata";
+import { getTimestamp } from "@/shared/firebase/firestoreDocument";
 import * as UUID from "uuid";
 import { createCard, createDeck } from "@/test/factories";
 
 const uuid = UUID.v4;
 
-vi.mock("./documentMetadata", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./documentMetadata")>()),
+vi.mock("@/shared/firebase/firestoreDocument", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/firebase/firestoreDocument")>()),
   getTimestamp: vi.fn(),
 }));
 

--- a/src/adapters/firestore/deck.ts
+++ b/src/adapters/firestore/deck.ts
@@ -18,9 +18,9 @@ import {
   setDoc,
   type Firestore,
 } from "firebase/firestore";
-import { getTimestamp } from "@/adapters/firestore/documentMetadata";
 import { buildDeckCreateDto, buildDeckUpdateDto, mapDeckDocument } from "@/adapters/firestore/dto";
 import { getDb } from "@/shared/firebase/firestore-runtime";
+import { getTimestamp } from "@/shared/firebase/firestoreDocument";
 
 /**
  * Reads every active deck owned by the requested user from Firestore.

--- a/src/adapters/firestore/documentMetadata.ts
+++ b/src/adapters/firestore/documentMetadata.ts
@@ -18,10 +18,3 @@ export const generateDeckId = (): string => doc(collection(getDb(), "deck")).id;
  * Only the identifier is returned; the card document is written later by the card adapter.
  */
 export const generateCardId = (): string => doc(collection(getDb(), "card")).id;
-
-/**
- * Returns the current time as a numeric timestamp.
- * Using one adapter helper keeps Firestore document timestamps consistent and easy to replace in
- * tests.
- */
-export const getTimestamp = () => Date.now();

--- a/src/adapters/firestore/dto.spec.ts
+++ b/src/adapters/firestore/dto.spec.ts
@@ -16,10 +16,10 @@ import {
   buildCardUpdateDto,
   buildDeckCreateDto,
   buildDeckUpdateDto,
-  FirestoreDocumentValidationError,
   mapCardDocument,
   mapDeckDocument,
 } from "@/adapters/firestore/dto";
+import { FirestoreDocumentValidationError } from "@/shared/firebase/firestoreDocument";
 import { createCard, createDeck } from "@/test/factories";
 
 describe("Firestore DTO builders", () => {

--- a/src/adapters/firestore/dto.ts
+++ b/src/adapters/firestore/dto.ts
@@ -6,33 +6,9 @@
 
 import type { Card, CardEdit, CardId } from "@/entities/card";
 import type { Deck, DeckEdit, DeckId } from "@/entities/deck";
+import { firestoreTimestampDateSchema, parseFirestoreDocument } from "@/shared/firebase/firestoreDocument";
 
-import type { Timestamp } from "firebase/firestore";
 import { z } from "zod";
-
-const validDateSchema = z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date");
-const timestampSchema = z.custom<Timestamp>(
-  (value) =>
-    typeof value === "object" &&
-    value !== null &&
-    typeof Reflect.get(value, "toDate") === "function" &&
-    Number.isInteger(Reflect.get(value, "seconds")) &&
-    Number.isInteger(Reflect.get(value, "nanoseconds")) &&
-    Reflect.get(value, "nanoseconds") >= 0 &&
-    Reflect.get(value, "nanoseconds") < 1_000_000_000,
-  "Expected a Firestore Timestamp"
-);
-const timestampOrDateSchema = z.union([validDateSchema, timestampSchema]).transform((value, context) => {
-  if (value instanceof Date) return value;
-  try {
-    const date = value.toDate();
-    if (!Number.isNaN(date.getTime())) return date;
-  } catch {
-    // The validation issue below keeps malformed Timestamp-like values inside the DTO error boundary.
-  }
-  context.addIssue({ code: "custom", message: "Invalid Firestore Timestamp" });
-  return z.NEVER;
-});
 
 const deckDocumentSchema = z.object({
   id: z.string().optional(),
@@ -63,30 +39,8 @@ type DeckDocument = z.infer<typeof deckDocumentSchema>;
 export type DeckCreateDto = z.infer<typeof deckCreateDtoSchema>;
 export type DeckUpdateDto = z.infer<typeof deckUpdateDtoSchema>;
 
-export class FirestoreDocumentValidationError extends Error {
-  constructor(
-    readonly collectionName: "deck" | "card",
-    readonly documentId: string,
-    readonly issues: z.core.$ZodIssue[]
-  ) {
-    const details = issues
-      .map((issue) => `${issue.path.length === 0 ? "<document>" : issue.path.join(".")}: ${issue.message}`)
-      .join("; ");
-    super(`Invalid Firestore ${collectionName} document "${documentId}": ${details}`);
-    this.name = "FirestoreDocumentValidationError";
-  }
-}
-
-const parseDocument = <T>(schema: z.ZodType<T>, collectionName: "deck" | "card", id: string, value: unknown): T => {
-  const result = schema.safeParse(value);
-  if (!result.success) {
-    throw new FirestoreDocumentValidationError(collectionName, id, result.error.issues);
-  }
-  return result.data;
-};
-
 const parseDeckDocument = (id: DeckId, value: unknown): DeckDocument =>
-  parseDocument(deckDocumentSchema, "deck", id, value);
+  parseFirestoreDocument(deckDocumentSchema, "deck", id, value);
 
 /**
  * Converts deck document into the shape used by the next application layer.
@@ -128,7 +82,7 @@ const cardDocumentSchema = z.object({
   score: z.number(),
   numberOfSeen: z.number(),
   lastSeenAt: z.number().optional(),
-  nextSeeingAt: timestampOrDateSchema.optional(),
+  nextSeeingAt: firestoreTimestampDateSchema.optional(),
   interval: z.number().optional(),
   url: z.string().optional(),
   startLine: z.number().optional(),
@@ -148,7 +102,7 @@ export type CardCreateDto = z.infer<typeof cardCreateDtoSchema>;
 export type CardUpdateDto = z.infer<typeof cardUpdateDtoSchema>;
 
 const parseCardDocument = (id: CardId, value: unknown): CardDocument =>
-  parseDocument(cardDocumentSchema, "card", id, value);
+  parseFirestoreDocument(cardDocumentSchema, "card", id, value);
 
 /**
  * Converts card document into the shape used by the next application layer.

--- a/src/adapters/firestore/event.spec.ts
+++ b/src/adapters/firestore/event.spec.ts
@@ -17,9 +17,8 @@ import * as deckAdapter from "@/adapters/firestore/deck";
 import * as eventAdapter from "@/adapters/firestore/event";
 import { createCard, createDeck } from "@/test/factories";
 
-vi.mock("./documentMetadata", () => ({
-  generateDeckId: vi.fn(() => "unused-deck-id"),
-  generateCardId: vi.fn(() => "unused-card-id"),
+vi.mock("@/shared/firebase/firestoreDocument", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/firebase/firestoreDocument")>()),
   getTimestamp: vi.fn(() => 100),
 }));
 

--- a/src/adapters/firestore/event.ts
+++ b/src/adapters/firestore/event.ts
@@ -4,78 +4,44 @@
  * not handle database details directly.
  */
 
-import { onSnapshot, where, collection, query } from "firebase/firestore";
+import { collection, query, where, type DocumentData } from "firebase/firestore";
 
 import { mapCardDocument, mapDeckDocument } from "@/adapters/firestore/dto";
 import type { Card } from "@/entities/card/model/card";
 import type { Deck } from "@/entities/deck/model/deck";
-import type { RemoteChange, RemoteSubscriptionProps } from "@/shared/api";
+import type { RemoteSubscriptionProps } from "@/shared/api";
 import { getDb } from "@/shared/firebase/firestore-runtime";
+import { subscribeReads } from "@/shared/firebase/subscribeReads";
 
-type RemoteEntity = { id: string; updatedAt: number; deletedAt: number | null };
+type RemoteEntity = { id: string; deletedAt: number | null };
 
 /**
- * Creates a Firestore listener that converts document changes into Tango remote snapshots.
- * The generic adapter handles initial data, incremental changes, metadata, and listener errors for
- * either entity type.
+ * Keeps entity-specific query and active-policy knowledge in the compatibility facade while Shared
+ * owns the listener lifecycle.
  */
-const subscribeReads = <T extends RemoteEntity>(
+const subscribeEntityReads = <T extends RemoteEntity>(
   collectionName: "deck" | "card",
   props: RemoteSubscriptionProps<T>,
-  mapDocument: (id: string, data: Record<string, unknown>) => T
-): (() => void) => {
-  const q = query(collection(getDb(), collectionName), where("uid", "==", props.uid));
-  let initial = true;
-  return onSnapshot(
-    q,
-    { includeMetadataChanges: true },
-    (snapshot) => {
-      // Treat each snapshot atomically so one invalid document cannot publish a partial collection.
-      try {
-        const changes = snapshot.docChanges();
-        const metadata = {
-          fromCache: snapshot.metadata.fromCache,
-          hasPendingWrites: snapshot.metadata.hasPendingWrites,
-        };
-        if (initial) {
-          const items = snapshot.docs
-            .map((document) => mapDocument(document.id, document.data()))
-            .filter((item) => item.deletedAt === null);
-          initial = false;
-          props.onSnapshot({ type: "replace", items, metadata });
-          return;
-        }
-
-        const event: RemoteChange<T> = { added: [], modified: [], removed: [] };
-        for (const change of changes) {
-          const item = mapDocument(change.doc.id, change.doc.data());
-          if (item.deletedAt !== null || change.type === "removed") {
-            event.removed.push(item.id);
-          } else if (change.type === "added") {
-            event.added.push(item);
-          } else {
-            event.modified.push(item);
-          }
-        }
-        props.onSnapshot({ type: "change", event, metadata });
-      } catch (cause) {
-        props.onError(cause instanceof Error ? cause : new Error(String(cause)));
-      }
-    },
-    props.onError
-  );
-};
+  mapDocument: (id: string, data: DocumentData) => T
+): (() => void) =>
+  subscribeReads({
+    query: query(collection(getDb(), collectionName), where("uid", "==", props.uid)),
+    mapDocument,
+    isActive: (item) => item.deletedAt === null,
+    onSnapshot: props.onSnapshot,
+    onError: props.onError,
+  });
 
 /**
  * Subscribes to active deck documents for one user.
  * Deck-specific mapping is supplied to the shared Firestore subscription adapter.
  */
 export const subscribeDeckReads = (props: RemoteSubscriptionProps<Deck>): (() => void) =>
-  subscribeReads("deck", props, mapDeckDocument);
+  subscribeEntityReads("deck", props, mapDeckDocument);
 
 /**
  * Subscribes to active card documents for one user.
  * Card-specific mapping is supplied to the shared Firestore subscription adapter.
  */
 export const subscribeCardReads = (props: RemoteSubscriptionProps<Card>): (() => void) =>
-  subscribeReads("card", props, mapCardDocument);
+  subscribeEntityReads("card", props, mapCardDocument);

--- a/src/shared/firebase/documentMetadata.ts
+++ b/src/shared/firebase/documentMetadata.ts
@@ -1,0 +1,10 @@
+import type { RemoteSnapshotMetadata } from "@/shared/api";
+
+import type { SnapshotMetadata } from "firebase/firestore";
+
+export const toRemoteSnapshotMetadata = (
+  metadata: Pick<SnapshotMetadata, "fromCache" | "hasPendingWrites">
+): RemoteSnapshotMetadata => ({
+  fromCache: metadata.fromCache,
+  hasPendingWrites: metadata.hasPendingWrites,
+});

--- a/src/shared/firebase/firestoreDocument.spec.ts
+++ b/src/shared/firebase/firestoreDocument.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Timestamp } from "firebase/firestore";
+import { z } from "zod";
+
+import {
+  FirestoreDocumentValidationError,
+  firestoreTimestampDateSchema,
+  getTimestamp,
+  parseFirestoreDocument,
+} from "./firestoreDocument";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Firestore document helpers", () => {
+  it("parses an arbitrary collection document", () => {
+    const schema = z.object({ title: z.string() });
+
+    expect(parseFirestoreDocument(schema, "note", "note-a", { title: "Hello" })).toEqual({ title: "Hello" });
+  });
+
+  it("reports validation details for an arbitrary collection", () => {
+    const schema = z.object({ title: z.string() });
+
+    expect(() => parseFirestoreDocument(schema, "note", "note-a", { title: 42 })).toThrowError(
+      expect.objectContaining({
+        name: "FirestoreDocumentValidationError",
+        collectionName: "note",
+        documentId: "note-a",
+        message: expect.stringContaining("title"),
+      })
+    );
+    expect(() => parseFirestoreDocument(schema, "note", "note-a", {})).toThrow(FirestoreDocumentValidationError);
+  });
+
+  it("converts Firestore timestamps and preserves valid legacy dates", () => {
+    const date = new Date(60);
+
+    expect(firestoreTimestampDateSchema.parse(Timestamp.fromMillis(50))).toEqual(new Date(50));
+    expect(firestoreTimestampDateSchema.parse(date)).toBe(date);
+  });
+
+  it("rejects malformed timestamp values", () => {
+    const malformed = { seconds: 0, nanoseconds: 0, toDate: () => new Date(Number.NaN) };
+
+    expect(() => firestoreTimestampDateSchema.parse(malformed)).toThrow();
+  });
+
+  it("returns the current numeric timestamp", () => {
+    vi.spyOn(Date, "now").mockReturnValue(123);
+
+    expect(getTimestamp()).toBe(123);
+  });
+});

--- a/src/shared/firebase/firestoreDocument.ts
+++ b/src/shared/firebase/firestoreDocument.ts
@@ -1,0 +1,58 @@
+import type { Timestamp } from "firebase/firestore";
+import { z } from "zod";
+
+const validDateSchema = z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date");
+const firestoreTimestampSchema = z.custom<Timestamp>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "toDate") === "function" &&
+    Number.isInteger(Reflect.get(value, "seconds")) &&
+    Number.isInteger(Reflect.get(value, "nanoseconds")) &&
+    Reflect.get(value, "nanoseconds") >= 0 &&
+    Reflect.get(value, "nanoseconds") < 1_000_000_000,
+  "Expected a Firestore Timestamp"
+);
+
+export const firestoreTimestampDateSchema = z
+  .union([validDateSchema, firestoreTimestampSchema])
+  .transform((value, context) => {
+    if (value instanceof Date) return value;
+    try {
+      const date = value.toDate();
+      if (!Number.isNaN(date.getTime())) return date;
+    } catch {
+      // Report malformed Timestamp implementations through the schema error boundary below.
+    }
+    context.addIssue({ code: "custom", message: "Invalid Firestore Timestamp" });
+    return z.NEVER;
+  });
+
+export class FirestoreDocumentValidationError extends Error {
+  constructor(
+    readonly collectionName: string,
+    readonly documentId: string,
+    readonly issues: z.core.$ZodIssue[]
+  ) {
+    const details = issues
+      .map((issue) => `${issue.path.length === 0 ? "<document>" : issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    super(`Invalid Firestore ${collectionName} document "${documentId}": ${details}`);
+    this.name = "FirestoreDocumentValidationError";
+  }
+}
+
+export const parseFirestoreDocument = <T>(
+  schema: z.ZodType<T>,
+  collectionName: string,
+  documentId: string,
+  value: unknown
+): T => {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new FirestoreDocumentValidationError(collectionName, documentId, result.error.issues);
+  }
+  return result.data;
+};
+
+export const getTimestamp = (): number => Date.now();

--- a/src/shared/firebase/subscribeReads.spec.ts
+++ b/src/shared/firebase/subscribeReads.spec.ts
@@ -1,0 +1,190 @@
+import type { RemoteSnapshot } from "@/shared/api";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentData, Query } from "firebase/firestore";
+
+import { subscribeReads, type SubscribeReadsOptions } from "./subscribeReads";
+
+type TestItem = { id: string; active: boolean; label: string };
+type TestDocument = { id: string; data: () => Record<string, unknown> };
+type TestChange = { type: "added" | "modified" | "removed"; doc: TestDocument };
+type TestSnapshot = {
+  docs: TestDocument[];
+  docChanges: () => TestChange[];
+  metadata: { fromCache: boolean; hasPendingWrites: boolean };
+};
+
+const mocks = vi.hoisted(() => ({
+  next: undefined as ((snapshot: TestSnapshot) => void) | undefined,
+  error: undefined as ((error: Error) => void) | undefined,
+  unsubscribe: vi.fn(),
+  onSnapshot: vi.fn(
+    (_query: unknown, _options: unknown, next: (snapshot: TestSnapshot) => void, error: (received: Error) => void) => {
+      mocks.next = next;
+      mocks.error = error;
+      return mocks.unsubscribe;
+    }
+  ),
+}));
+
+vi.mock("firebase/firestore", () => ({ onSnapshot: mocks.onSnapshot }));
+
+const document = (id: string, data: Record<string, unknown>): TestDocument => ({ id, data: () => data });
+
+const snapshot = (
+  docs: TestDocument[],
+  changes: TestChange[] = [],
+  metadata: TestSnapshot["metadata"] = { fromCache: false, hasPendingWrites: false }
+): TestSnapshot => ({ docs, docChanges: () => changes, metadata });
+
+const createHarness = () => {
+  const query = {} as Query;
+  const mapDocument = vi.fn((id: string, data: DocumentData): TestItem => {
+    if (data.invalid === true) throw new Error(`Invalid ${id}`);
+    return {
+      id,
+      active: data.active === true,
+      label: typeof data.label === "string" ? data.label : "",
+    };
+  });
+  const isActive = vi.fn((item: TestItem) => item.active);
+  const onSnapshot = vi.fn<(received: RemoteSnapshot<TestItem>) => void>();
+  const onError = vi.fn<(error: Error) => void>();
+  const options: SubscribeReadsOptions<TestItem> = { query, mapDocument, isActive, onSnapshot, onError };
+  return { options, query, mapDocument, isActive, onSnapshot, onError };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.next = undefined;
+  mocks.error = undefined;
+});
+
+describe("Firestore read subscriptions", () => {
+  it("publishes an active initial replacement and returns the unsubscribe callback", () => {
+    const harness = createHarness();
+
+    const unsubscribe = subscribeReads(harness.options);
+    mocks.next?.(
+      snapshot([document("active", { active: true, label: "Active" }), document("inactive", { active: false })], [], {
+        fromCache: true,
+        hasPendingWrites: true,
+      })
+    );
+
+    expect(mocks.onSnapshot).toHaveBeenCalledWith(
+      harness.query,
+      { includeMetadataChanges: true },
+      expect.any(Function),
+      harness.onError
+    );
+    expect(unsubscribe).toBe(mocks.unsubscribe);
+    expect(harness.onSnapshot).toHaveBeenCalledWith({
+      type: "replace",
+      items: [{ id: "active", active: true, label: "Active" }],
+      metadata: { fromCache: true, hasPendingWrites: true },
+    });
+  });
+
+  it("classifies incremental changes with the injected active policy", () => {
+    const harness = createHarness();
+    subscribeReads(harness.options);
+    mocks.next?.(snapshot([]));
+    harness.onSnapshot.mockClear();
+
+    mocks.next?.(
+      snapshot(
+        [],
+        [
+          { type: "added", doc: document("added", { active: true, label: "Added" }) },
+          { type: "modified", doc: document("modified", { active: true, label: "Modified" }) },
+          { type: "modified", doc: document("inactive", { active: false }) },
+          { type: "removed", doc: document("removed", { active: true }) },
+        ],
+        { fromCache: false, hasPendingWrites: true }
+      )
+    );
+
+    expect(harness.onSnapshot).toHaveBeenCalledWith({
+      type: "change",
+      event: {
+        added: [{ id: "added", active: true, label: "Added" }],
+        modified: [{ id: "modified", active: true, label: "Modified" }],
+        removed: ["inactive", "removed"],
+      },
+      metadata: { fromCache: false, hasPendingWrites: true },
+    });
+  });
+
+  it("publishes metadata-only snapshots", () => {
+    const harness = createHarness();
+    subscribeReads(harness.options);
+    mocks.next?.(snapshot([], [], { fromCache: true, hasPendingWrites: true }));
+    harness.onSnapshot.mockClear();
+
+    mocks.next?.(snapshot([], [], { fromCache: false, hasPendingWrites: false }));
+
+    expect(harness.onSnapshot).toHaveBeenCalledWith({
+      type: "change",
+      event: { added: [], modified: [], removed: [] },
+      metadata: { fromCache: false, hasPendingWrites: false },
+    });
+  });
+
+  it("does not publish a partial initial replacement when mapping fails", () => {
+    const harness = createHarness();
+    subscribeReads(harness.options);
+
+    expect(() =>
+      mocks.next?.(
+        snapshot([document("valid", { active: true }), document("invalid", { active: true, invalid: true })])
+      )
+    ).not.toThrow();
+
+    expect(harness.onSnapshot).not.toHaveBeenCalled();
+    expect(harness.onError).toHaveBeenCalledWith(new Error("Invalid invalid"));
+  });
+
+  it("does not publish a partial delta when mapping fails", () => {
+    const harness = createHarness();
+    subscribeReads(harness.options);
+    mocks.next?.(snapshot([]));
+    harness.onSnapshot.mockClear();
+
+    mocks.next?.(
+      snapshot(
+        [],
+        [
+          { type: "added", doc: document("valid", { active: true }) },
+          { type: "modified", doc: document("invalid", { active: true, invalid: true }) },
+        ]
+      )
+    );
+
+    expect(harness.onSnapshot).not.toHaveBeenCalled();
+    expect(harness.onError).toHaveBeenCalledWith(new Error("Invalid invalid"));
+  });
+
+  it("maps and validates removed changes before publishing their ids", () => {
+    const harness = createHarness();
+    subscribeReads(harness.options);
+    mocks.next?.(snapshot([]));
+    harness.onSnapshot.mockClear();
+
+    mocks.next?.(snapshot([], [{ type: "removed", doc: document("invalid-removed", { invalid: true }) }]));
+
+    expect(harness.mapDocument).toHaveBeenLastCalledWith("invalid-removed", { invalid: true });
+    expect(harness.onSnapshot).not.toHaveBeenCalled();
+    expect(harness.onError).toHaveBeenCalledWith(new Error("Invalid invalid-removed"));
+  });
+
+  it("forwards listener errors", () => {
+    const harness = createHarness();
+    subscribeReads(harness.options);
+    const error = new Error("Listener failed");
+
+    mocks.error?.(error);
+
+    expect(harness.onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/shared/firebase/subscribeReads.ts
+++ b/src/shared/firebase/subscribeReads.ts
@@ -1,0 +1,53 @@
+import type { RemoteChange, RemoteSnapshot } from "@/shared/api";
+
+import { onSnapshot as subscribeToQuery, type DocumentData, type Query } from "firebase/firestore";
+import { toRemoteSnapshotMetadata } from "./documentMetadata";
+
+export interface SubscribeReadsOptions<T extends { id: string }> {
+  query: Query;
+  mapDocument: (id: string, data: DocumentData) => T;
+  isActive: (item: T) => boolean;
+  onSnapshot: (snapshot: RemoteSnapshot<T>) => void;
+  onError: (error: Error) => void;
+}
+
+export const subscribeReads = <T extends { id: string }>({
+  query,
+  mapDocument,
+  isActive,
+  onSnapshot,
+  onError,
+}: SubscribeReadsOptions<T>): (() => void) => {
+  let initial = true;
+  return subscribeToQuery(
+    query,
+    { includeMetadataChanges: true },
+    (snapshot) => {
+      try {
+        const metadata = toRemoteSnapshotMetadata(snapshot.metadata);
+        if (initial) {
+          const items = snapshot.docs.map((document) => mapDocument(document.id, document.data())).filter(isActive);
+          initial = false;
+          onSnapshot({ type: "replace", items, metadata });
+          return;
+        }
+
+        const event: RemoteChange<T> = { added: [], modified: [], removed: [] };
+        for (const change of snapshot.docChanges()) {
+          const item = mapDocument(change.doc.id, change.doc.data());
+          if (!isActive(item) || change.type === "removed") {
+            event.removed.push(item.id);
+          } else if (change.type === "added") {
+            event.added.push(item);
+          } else {
+            event.modified.push(item);
+          }
+        }
+        onSnapshot({ type: "change", event, metadata });
+      } catch (cause) {
+        onError(cause instanceof Error ? cause : new Error(String(cause)));
+      }
+    },
+    onError
+  );
+};


### PR DESCRIPTION
## Summary

- move the generic Firestore subscription lifecycle, snapshot metadata conversion, and document validation primitives into `src/shared/firebase`
- keep Card and Deck query construction, mappers, and active-document policy in the legacy adapter facade
- add focused Shared tests for initial and incremental snapshots, metadata-only updates, active-policy injection, atomic mapper failures, removed-change validation, listener errors, and unsubscribe handling
- move the generic document timestamp helper into Shared while leaving entity-specific ID generation outside Shared

## Why

The legacy Firestore event adapter mixed reusable Firebase mechanics with Tango-specific collection, query, mapping, and soft-delete knowledge. This change establishes the Shared boundary required for the later Card and Deck adapter migrations without changing the current callers.

Incremental `removed` changes still pass through the injected mapper and validation boundary before publishing their document IDs, preserving the behavior clarified in the issue comment.

## Impact

Existing Card and Deck subscriptions continue to use `src/adapters/firestore/event.ts` as a compatibility facade. The facade now delegates listener lifecycle, atomic snapshot conversion, metadata handling, error propagation, and unsubscribe behavior to the generic Shared helper.

## Validation

- `mise run check`
- `mise run test-firestore`

Closes #593