### PR TITLE
refactor: move study progress rules into StudyProgress

### DIFF
--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,2 +1,9 @@
-export { createStudyProgress } from "./model/studyProgress";
-export type { StudyProgress, StudyProgressEdit } from "./model/studyProgress";
+export {
+  compareStudyProgress,
+  createStudyProgress,
+  createStudyProgressFromCard,
+  getNextStudyAvailabilityAt,
+  isStudyProgressEligible,
+  recordStudyProgress,
+} from "./model/studyProgress";
+export type { StudyProgress, StudyProgressEdit, StudyRating } from "./model/studyProgress";

--- a/src/entities/study-progress/model/studyProgress.spec.ts
+++ b/src/entities/study-progress/model/studyProgress.spec.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { createStudyProgress, type StudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+import {
+  compareStudyProgress,
+  createStudyProgress,
+  createStudyProgressFromCard,
+  getNextStudyAvailabilityAt,
+  isStudyProgressEligible,
+  recordStudyProgress,
+  type StudyProgress,
+  type StudyProgressEdit,
+  type StudyRating,
+} from "@/entities/study-progress";
 
 describe("createStudyProgress", () => {
   it("creates study progress with the initial score and seen count", () => {
@@ -25,5 +35,83 @@ describe("createStudyProgress", () => {
       score: 3,
       lastSeenAt: 1_786_512_000_000,
     });
+  });
+
+  it("restores progress from a Card without copying Card content", () => {
+    const card = {
+      id: "card-id",
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 1_786_512_000_000,
+      nextSeeingAt: new Date(1_786_598_400_000),
+      interval: 86_400,
+      frontText: "not part of progress",
+    };
+    const progress = createStudyProgressFromCard(card);
+
+    expect(progress).toEqual({
+      cardId: "card-id",
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 1_786_512_000_000,
+      nextSeeingAt: new Date(1_786_598_400_000),
+      interval: 86_400,
+    });
+    expect(progress).not.toHaveProperty("frontText");
+  });
+});
+
+describe("recordStudyProgress", () => {
+  it.each<[number, StudyRating, number]>([
+    [0, "mastered", 1],
+    [3, "mastered", 4],
+    [-1, "mastered", 0],
+    [0, "not-mastered", -1],
+    [-2, "not-mastered", -3],
+    [2, "not-mastered", 0],
+    [3, "unrated", 3],
+  ])("updates score %i for a %s rating", (score, rating, expectedScore) => {
+    const progress = { ...createStudyProgress("card-id"), score, numberOfSeen: 2 };
+
+    expect(recordStudyProgress(progress, rating, 1_786_512_000_000)).toEqual({
+      cardId: "card-id",
+      score: expectedScore,
+      numberOfSeen: 3,
+      lastSeenAt: 1_786_512_000_000,
+    });
+  });
+});
+
+describe("study progress selection", () => {
+  const filter = {
+    minimumScore: -1,
+    maximumScore: 2,
+    respectNextSeeingAt: true,
+  };
+
+  it("applies score bounds and the next seeing time", () => {
+    expect(isStudyProgressEligible({ ...createStudyProgress("eligible"), score: 2 }, filter, 1_000)).toBe(true);
+    expect(isStudyProgressEligible({ ...createStudyProgress("high"), score: 3 }, filter, 1_000)).toBe(false);
+    expect(isStudyProgressEligible({ ...createStudyProgress("low"), score: -2 }, filter, 1_000)).toBe(false);
+    expect(
+      isStudyProgressEligible({ ...createStudyProgress("future"), nextSeeingAt: new Date(1_001) }, filter, 1_000)
+    ).toBe(false);
+  });
+
+  it("orders progress by seen count", () => {
+    const first = { ...createStudyProgress("first"), numberOfSeen: 1 };
+    const second = { ...createStudyProgress("second"), numberOfSeen: 3 };
+
+    expect([second, first].sort(compareStudyProgress)).toEqual([first, second]);
+  });
+
+  it("finds the nearest future seeing time", () => {
+    const progresses = [
+      { ...createStudyProgress("past"), nextSeeingAt: new Date(900) },
+      { ...createStudyProgress("later"), nextSeeingAt: new Date(2_000) },
+      { ...createStudyProgress("next"), nextSeeingAt: new Date(1_500) },
+    ];
+
+    expect(getNextStudyAvailabilityAt(progresses, 1_000)).toBe(1_500);
   });
 });

--- a/src/entities/study-progress/model/studyProgress.ts
+++ b/src/entities/study-progress/model/studyProgress.ts
@@ -11,8 +11,74 @@ export interface StudyProgress {
 
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
+export type StudyRating = "mastered" | "not-mastered" | "unrated";
+
+export interface StudyProgressFilter {
+  minimumScore: number | null;
+  maximumScore: number | null;
+  respectNextSeeingAt: boolean;
+}
+
+interface CardProgressFields {
+  id: CardId;
+  score: number;
+  numberOfSeen: number;
+  lastSeenAt?: number;
+  nextSeeingAt?: Date;
+  interval?: number;
+}
+
 export const createStudyProgress = (cardId: CardId): StudyProgress => ({
   cardId,
   score: 0,
   numberOfSeen: 0,
 });
+
+export const createStudyProgressFromCard = (card: CardProgressFields): StudyProgress => {
+  const progress = createStudyProgress(card.id);
+  progress.score = card.score;
+  progress.numberOfSeen = card.numberOfSeen;
+  if (card.lastSeenAt !== undefined) progress.lastSeenAt = card.lastSeenAt;
+  if (card.nextSeeingAt !== undefined) progress.nextSeeingAt = card.nextSeeingAt;
+  if (card.interval !== undefined) progress.interval = card.interval;
+  return progress;
+};
+
+const calculateScore = (score: number, rating: StudyRating): number => {
+  if (rating === "mastered") return score >= 0 ? score + 1 : 0;
+  if (rating === "not-mastered") return score <= 0 ? score - 1 : 0;
+  return score;
+};
+
+export const recordStudyProgress = (
+  progress: StudyProgress,
+  rating: StudyRating,
+  studiedAt: number
+): StudyProgressEdit => ({
+  cardId: progress.cardId,
+  score: calculateScore(progress.score, rating),
+  numberOfSeen: progress.numberOfSeen + 1,
+  lastSeenAt: studiedAt,
+});
+
+export const isStudyProgressEligible = (progress: StudyProgress, filter: StudyProgressFilter, now: number): boolean => {
+  if (filter.maximumScore != null && progress.score > filter.maximumScore) return false;
+  if (filter.minimumScore != null && progress.score < filter.minimumScore) return false;
+  if (filter.respectNextSeeingAt && progress.nextSeeingAt != null && progress.nextSeeingAt.getTime() > now) {
+    return false;
+  }
+  return true;
+};
+
+export const compareStudyProgress = (first: StudyProgress, second: StudyProgress): number =>
+  first.numberOfSeen - second.numberOfSeen;
+
+export const getNextStudyAvailabilityAt = (progresses: StudyProgress[], now: number): number | undefined => {
+  let next: number | undefined;
+  for (const progress of progresses) {
+    const candidate = progress.nextSeeingAt?.getTime();
+    if (candidate === undefined || candidate <= now || (next !== undefined && candidate >= next)) continue;
+    next = candidate;
+  }
+  return next;
+};

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -16,6 +16,7 @@ import { selectCardsForDeck, useCards } from "@/entities/card";
 import { useDecks } from "@/entities/deck";
 import { useStudyCards } from "@/features/study/hooks/useStudyCards";
 import { buildStudySession, calculateNextIndex } from "@/features/study/model/session";
+import { createStudyCard } from "@/features/study/model/studyCard";
 import { buildStudyPatch, resolveSwipeAction } from "@/features/study/model/swipe";
 import { studyStore } from "@/features/study/state/studyStore";
 import { useConfig } from "@/shared/config";
@@ -89,7 +90,7 @@ const runStudySwipe = async (
     state.hideBackText();
   }
 
-  const patch = buildStudyPatch(card, swipeAction, Date.now());
+  const patch = buildStudyPatch(createStudyCard(card), swipeAction, Date.now());
   const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
   const mutationToken = Symbol();
   mutationTokenRef.current = mutationToken;

--- a/src/features/study/hooks/useStudyCards.spec.tsx
+++ b/src/features/study/hooks/useStudyCards.spec.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCard, createConfig, createDeck } from "@/test/factories";
 
-import { nextCardAvailabilityAt, useStudyCards } from "@/features/study/hooks/useStudyCards";
+import { useStudyCards } from "@/features/study/hooks/useStudyCards";
 
 describe("useStudyCards", () => {
   beforeEach(() => vi.restoreAllMocks());
@@ -76,15 +76,5 @@ describe("useStudyCards", () => {
 
     act(() => vi.advanceTimersByTime(500));
     expect(result.current).toEqual([card]);
-  });
-
-  it("selects the nearest future review time", () => {
-    const cards = [
-      createCard({ id: "past", nextSeeingAt: new Date(900) }),
-      createCard({ id: "later", nextSeeingAt: new Date(2_000) }),
-      createCard({ id: "next", nextSeeingAt: new Date(1_500) }),
-    ];
-
-    expect(nextCardAvailabilityAt(cards, 1_000)).toBe(1_500);
   });
 });

--- a/src/features/study/hooks/useStudyCards.ts
+++ b/src/features/study/hooks/useStudyCards.ts
@@ -1,24 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
+import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
 import { filterCardsForDeck } from "@/features/study/model/cardSelection";
+import { createStudyCard } from "@/features/study/model/studyCard";
 import type { ConfigState } from "@/shared/config";
 
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
-export const nextCardAvailabilityAt = (cards: Card[], now: number): number | undefined => {
-  let next: number | undefined;
-  for (const card of cards) {
-    const candidate = card.nextSeeingAt?.getTime();
-    if (candidate === undefined || candidate <= now || (next !== undefined && candidate >= next)) continue;
-    next = candidate;
-  }
-  return next;
-};
-
 export const useStudyCards = (deck: Deck | undefined, cards: Card[], config: ConfigState): Card[] => {
   const [scheduleClock, setScheduleClock] = useState(() => Date.now());
+  const studyCards = useMemo(() => cards.map(createStudyCard), [cards]);
 
   useEffect(() => {
     const current = Date.now();
@@ -28,7 +21,10 @@ export const useStudyCards = (deck: Deck | undefined, cards: Card[], config: Con
 
   useEffect(() => {
     const current = Date.now();
-    const next = nextCardAvailabilityAt(cards, current);
+    const next = getNextStudyAvailabilityAt(
+      studyCards.map((card) => card.progress),
+      current
+    );
     const availability =
       next === undefined
         ? undefined
@@ -36,7 +32,7 @@ export const useStudyCards = (deck: Deck | undefined, cards: Card[], config: Con
     return () => {
       if (availability !== undefined) window.clearTimeout(availability);
     };
-  }, [cards, scheduleClock]);
+  }, [scheduleClock, studyCards]);
 
-  return deck == null ? [] : filterCardsForDeck(cards, deck, config.study, scheduleClock);
+  return deck == null ? [] : filterCardsForDeck(studyCards, deck, config.study, scheduleClock).map(({ card }) => card);
 };

--- a/src/features/study/model/cardSelection.spec.ts
+++ b/src/features/study/model/cardSelection.spec.ts
@@ -1,22 +1,22 @@
 import type { Card } from "@/entities/card";
+import { createStudyProgress, type StudyProgress } from "@/entities/study-progress";
+import type { StudyCard } from "@/features/study/model/studyCard";
 import type { StudyPreferences } from "@/shared/config";
 
 import { describe, expect, it } from "vitest";
 
 import { filterCardsForDeck } from "@/features/study/model/cardSelection";
-import { createDeck } from "@/test/factories";
+import { createCard, createDeck } from "@/test/factories";
 
 describe("filterCardsForDeck", () => {
   const now = 1_000;
-  const makeCard = (overrides: Partial<Card>): Card =>
-    ({
-      id: "c1",
-      score: 0,
-      numberOfSeen: 0,
-      tags: [],
-      nextSeeingAt: undefined,
-      ...overrides,
-    }) as Card;
+  const makeCard = (card: Partial<Card>, progress: Partial<StudyProgress> = {}): StudyCard => {
+    const content = createCard({ id: "c1", tags: [], ...card });
+    return {
+      card: content,
+      progress: { ...createStudyProgress(content.id), ...progress, cardId: content.id },
+    };
+  };
 
   const baseDeck = createDeck({
     selectedTags: [],
@@ -35,37 +35,37 @@ describe("filterCardsForDeck", () => {
   it("filters by tag (OR mode)", () => {
     const cards = [makeCard({ id: "a", tags: ["x"] }), makeCard({ id: "b", tags: ["y"] })];
     const deck = { ...baseDeck, selectedTags: ["x"], tagAndFilter: false };
-    expect(filterCardsForDeck(cards, deck, baseConfig, now).map((card) => card.id)).toEqual(["a"]);
+    expect(filterCardsForDeck(cards, deck, baseConfig, now).map(({ card }) => card.id)).toEqual(["a"]);
   });
 
   it("filters by tag (AND mode)", () => {
     const cards = [makeCard({ id: "a", tags: ["x", "y"] }), makeCard({ id: "b", tags: ["x"] })];
     const deck = { ...baseDeck, selectedTags: ["x", "y"], tagAndFilter: true };
-    expect(filterCardsForDeck(cards, deck, baseConfig, now).map((card) => card.id)).toEqual(["a"]);
+    expect(filterCardsForDeck(cards, deck, baseConfig, now).map(({ card }) => card.id)).toEqual(["a"]);
   });
 
   it("filters by scoreMax", () => {
-    const cards = [makeCard({ id: "a", score: 3 }), makeCard({ id: "b", score: 1 })];
+    const cards = [makeCard({ id: "a" }, { score: 3 }), makeCard({ id: "b" }, { score: 1 })];
     const deck = { ...baseDeck, scoreMax: 2 };
-    expect(filterCardsForDeck(cards, deck, baseConfig, now).map((card) => card.id)).toEqual(["b"]);
+    expect(filterCardsForDeck(cards, deck, baseConfig, now).map(({ card }) => card.id)).toEqual(["b"]);
   });
 
   it("filters by scoreMin", () => {
-    const cards = [makeCard({ id: "a", score: 1 }), makeCard({ id: "b", score: 3 })];
+    const cards = [makeCard({ id: "a" }, { score: 1 }), makeCard({ id: "b" }, { score: 3 })];
     const deck = { ...baseDeck, scoreMin: 2 };
-    expect(filterCardsForDeck(cards, deck, baseConfig, now).map((card) => card.id)).toEqual(["b"]);
+    expect(filterCardsForDeck(cards, deck, baseConfig, now).map(({ card }) => card.id)).toEqual(["b"]);
   });
 
   it("filters by card interval when useCardInterval is true", () => {
     const future = new Date(now + 100_000);
-    const cards = [makeCard({ id: "a", nextSeeingAt: future }), makeCard({ id: "b" })];
+    const cards = [makeCard({ id: "a" }, { nextSeeingAt: future }), makeCard({ id: "b" })];
     const config = { useCardInterval: true } as StudyPreferences;
-    expect(filterCardsForDeck(cards, baseDeck, config, now).map((card) => card.id)).toEqual(["b"]);
+    expect(filterCardsForDeck(cards, baseDeck, config, now).map(({ card }) => card.id)).toEqual(["b"]);
   });
 
   it("sorts by numberOfSeen ascending", () => {
-    const cards = [makeCard({ id: "a", numberOfSeen: 5 }), makeCard({ id: "b", numberOfSeen: 1 })];
+    const cards = [makeCard({ id: "a" }, { numberOfSeen: 5 }), makeCard({ id: "b" }, { numberOfSeen: 1 })];
     const result = filterCardsForDeck(cards, baseDeck, baseConfig, now);
-    expect(result.map((card) => card.id)).toEqual(["b", "a"]);
+    expect(result.map(({ card }) => card.id)).toEqual(["b", "a"]);
   });
 });

--- a/src/features/study/model/cardSelection.ts
+++ b/src/features/study/model/cardSelection.ts
@@ -1,14 +1,15 @@
-import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
+import { compareStudyProgress, isStudyProgressEligible } from "@/entities/study-progress";
+import type { StudyCard } from "@/features/study/model/studyCard";
 import type { StudyPreferences } from "@/shared/config";
 
-export const filterCardsForDeck = (
-  cards: Card[],
+export const filterCardsForDeck = <TCard extends StudyCard["card"]>(
+  cards: StudyCard<TCard>[],
   deck: Pick<Deck, "selectedTags" | "tagAndFilter" | "scoreMax" | "scoreMin">,
   study: Pick<StudyPreferences, "useCardInterval">,
   now: number
-): Card[] => {
-  const filtered = cards.filter((card) => {
+): StudyCard<TCard>[] => {
+  const filtered = cards.filter(({ card, progress }) => {
     const tags = deck.selectedTags;
     if (tags.length > 0) {
       if (deck.tagAndFilter && !tags.every((tag) => card.tags.includes(tag))) {
@@ -18,17 +19,16 @@ export const filterCardsForDeck = (
         return false;
       }
     }
-    if (deck.scoreMax != null && card.score > deck.scoreMax) {
-      return false;
-    }
-    if (deck.scoreMin != null && card.score < deck.scoreMin) {
-      return false;
-    }
-    if (study.useCardInterval && card.nextSeeingAt && card.nextSeeingAt.getTime() > now) {
-      return false;
-    }
-    return true;
+    return isStudyProgressEligible(
+      progress,
+      {
+        maximumScore: deck.scoreMax,
+        minimumScore: deck.scoreMin,
+        respectNextSeeingAt: study.useCardInterval,
+      },
+      now
+    );
   });
-  filtered.sort((first, second) => first.numberOfSeen - second.numberOfSeen);
+  filtered.sort((first, second) => compareStudyProgress(first.progress, second.progress));
   return filtered;
 };

--- a/src/features/study/model/studyCard.ts
+++ b/src/features/study/model/studyCard.ts
@@ -1,0 +1,20 @@
+import type { Card, CardEdit } from "@/entities/card";
+import type { DeckId } from "@/entities/deck";
+import { createStudyProgressFromCard, type StudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+
+type StudyCardContent = Omit<Card, keyof Omit<StudyProgress, "cardId">>;
+
+export interface StudyCard<TCard extends StudyCardContent = StudyCardContent> {
+  card: TCard;
+  progress: StudyProgress;
+}
+
+export const createStudyCard = <TCard extends Card>(card: TCard): StudyCard<TCard> => ({
+  card,
+  progress: createStudyProgressFromCard(card),
+});
+
+export const createCardProgressEdit = (deckId: DeckId, progress: StudyProgressEdit): CardEdit => {
+  const { cardId: id, ...edit } = progress;
+  return { id, deckId, ...edit };
+};

--- a/src/features/study/model/swipe.spec.ts
+++ b/src/features/study/model/swipe.spec.ts
@@ -1,9 +1,11 @@
-import type { Card } from "@/entities/card";
 import type { SwipeState } from "@/shared/config";
 
 import { describe, expect, it } from "vitest";
 
-import { buildStudyPatch, calculateCardScore, resolveSwipeAction } from "@/features/study/model/swipe";
+import { createStudyProgress } from "@/entities/study-progress";
+import type { StudyCard } from "@/features/study/model/studyCard";
+import { buildStudyPatch, resolveSwipeAction } from "@/features/study/model/swipe";
+import { createCard } from "@/test/factories";
 
 describe("resolveSwipeAction", () => {
   it("returns the swipe action for the given direction", () => {
@@ -20,41 +22,12 @@ describe("resolveSwipeAction", () => {
   });
 });
 
-describe("calculateCardScore", () => {
-  it("increments score for GoToNextCardMastered when score is non-negative", () => {
-    expect(calculateCardScore({ score: 0 } as Card, "GoToNextCardMastered")).toBe(1);
-    expect(calculateCardScore({ score: 3 } as Card, "GoToNextCardMastered")).toBe(4);
-  });
-
-  it("resets to 0 for GoToNextCardMastered when score is negative", () => {
-    expect(calculateCardScore({ score: -1 } as Card, "GoToNextCardMastered")).toBe(0);
-  });
-
-  it("decrements score for GoToNextCardNotMastered when score is non-positive", () => {
-    expect(calculateCardScore({ score: 0 } as Card, "GoToNextCardNotMastered")).toBe(-1);
-    expect(calculateCardScore({ score: -2 } as Card, "GoToNextCardNotMastered")).toBe(-3);
-  });
-
-  it("resets to 0 for GoToNextCardNotMastered when score is positive", () => {
-    expect(calculateCardScore({ score: 2 } as Card, "GoToNextCardNotMastered")).toBe(0);
-  });
-
-  it("applies same logic as NotMastered for GoToNextCardToggleMastered", () => {
-    expect(calculateCardScore({ score: 0 } as Card, "GoToNextCardToggleMastered")).toBe(-1);
-    expect(calculateCardScore({ score: 2 } as Card, "GoToNextCardToggleMastered")).toBe(0);
-  });
-
-  it("leaves score unchanged for navigation-only actions", () => {
-    expect(calculateCardScore({ score: 3 } as Card, "GoToNextCard")).toBe(3);
-    expect(calculateCardScore({ score: 3 } as Card, "GoToPrevCard")).toBe(3);
-    expect(calculateCardScore({ score: 3 } as Card, "GoBack")).toBe(3);
-    expect(calculateCardScore({ score: 3 } as Card, "DoNothing")).toBe(3);
-  });
-});
-
 describe("buildStudyPatch", () => {
   const now = new Date(1999, 10, 1).getTime();
-  const card = { id: "c1", deckId: "d1", score: 0, numberOfSeen: 2 } as Card;
+  const card: StudyCard = {
+    card: createCard({ id: "c1", deckId: "d1" }),
+    progress: { ...createStudyProgress("c1"), numberOfSeen: 2 },
+  };
 
   it("builds a patch with incremented numberOfSeen and computed score", () => {
     const patch = buildStudyPatch(card, "GoToNextCardMastered", now);
@@ -72,4 +45,11 @@ describe("buildStudyPatch", () => {
     expect(patch.score).toBe(0);
     expect(patch.numberOfSeen).toBe(3);
   });
+
+  it.each(["GoToNextCardNotMastered", "GoToNextCardToggleMastered"] as const)(
+    "records %s as not mastered",
+    (action) => {
+      expect(buildStudyPatch(card, action, now)).toMatchObject({ score: -1 });
+    }
+  );
 });

--- a/src/features/study/model/swipe.ts
+++ b/src/features/study/model/swipe.ts
@@ -1,29 +1,21 @@
-import type { Card, CardEdit } from "@/entities/card";
+import type { CardEdit } from "@/entities/card";
+import { recordStudyProgress, type StudyRating } from "@/entities/study-progress";
+import { createCardProgressEdit, type StudyCard } from "@/features/study/model/studyCard";
 import type { SwipeAction, SwipeDirection, SwipeState } from "@/shared/config";
 
 export const resolveSwipeAction = (controls: SwipeState, direction: SwipeDirection): SwipeAction => {
   return controls[direction];
 };
 
-export const calculateCardScore = (card: Pick<Card, "score">, swipeAction: SwipeAction): number => {
-  if (swipeAction === "GoToNextCardMastered") {
-    return card.score >= 0 ? card.score + 1 : 0;
-  } else if (swipeAction === "GoToNextCardNotMastered" || swipeAction === "GoToNextCardToggleMastered") {
-    return card.score <= 0 ? card.score - 1 : 0;
+const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
+  if (swipeAction === "GoToNextCardMastered") return "mastered";
+  if (swipeAction === "GoToNextCardNotMastered" || swipeAction === "GoToNextCardToggleMastered") {
+    return "not-mastered";
   }
-  return card.score;
+  return "unrated";
 };
 
-export const buildStudyPatch = (
-  card: Pick<Card, "id" | "deckId" | "score" | "numberOfSeen">,
-  swipeAction: SwipeAction,
-  now: number
-): CardEdit => {
-  return {
-    id: card.id,
-    deckId: card.deckId,
-    score: calculateCardScore(card, swipeAction),
-    numberOfSeen: card.numberOfSeen + 1,
-    lastSeenAt: now,
-  };
+export const buildStudyPatch = (studyCard: StudyCard, swipeAction: SwipeAction, now: number): CardEdit => {
+  const progress = recordStudyProgress(studyCard.progress, resolveStudyRating(swipeAction), now);
+  return createCardProgressEdit(studyCard.card.deckId, progress);
 };


### PR DESCRIPTION
## Summary

- add `StudyProgress` APIs for restoring, recording, filtering, ordering, and scheduling progress
- compose `Card` content with `StudyProgress` in the study feature instead of reading progress fields directly
- keep the existing Card mutation boundary while deriving updates from `StudyProgressEdit`
- move progress-rule coverage to entity tests and preserve study hook behavior coverage

## Why

The study feature owned score, seen-count, and next-seeing-time rules even though those rules belong to the StudyProgress domain. This change makes the entity responsible for progress decisions and leaves the feature responsible for study-session orchestration.

## Impact

Study behavior and the Firestore document schema are unchanged. Production code under `features/study` no longer directly reads Card progress fields.

## Validation

- `mise run check`
- 106 unit test files, 589 tests passed

Closes #602