### PR TITLE
Enforce throwing Error objects

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ export default [
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-return": "error",
+      "@typescript-eslint/only-throw-error": "error",
     },
   },
   {


### PR DESCRIPTION
## Summary

- enable `@typescript-eslint/only-throw-error` for production TypeScript
- reuse the existing type-aware ESLint configuration
- enforce a consistent contract that thrown values are Error objects

## Why

TypeScript permits throwing arbitrary values, which makes stack traces, causes, and error typing inconsistent. The new rule statically rejects non-Error values without adding blanket suppressions or duplicating the type-aware lint setup from #533.

No existing production violations required migration.

## Validation

- `npm run lint:eslint`
- confirmed `throw "error"` is rejected by `@typescript-eslint/only-throw-error`
- `mise run check` (106 test files, 583 tests)

Closes #534