### PR TITLE
Route sliced imports through FSD public APIs

### DIFF
--- a/src/adapters/firestore/event.ts
+++ b/src/adapters/firestore/event.ts
@@ -7,8 +7,8 @@
 import { collection, query, where, type DocumentData } from "firebase/firestore";
 
 import { mapCardDocument, mapDeckDocument } from "@/adapters/firestore/dto";
-import type { Card } from "@/entities/card/model/card";
-import type { Deck } from "@/entities/deck/model/deck";
+import type { Card } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
 import type { RemoteSubscriptionProps } from "@/shared/api";
 import { getDb } from "@/shared/firebase/firestore-runtime";
 import { subscribeReads } from "@/shared/firebase/subscribeReads";

--- a/src/app/auth/logout.spec.ts
+++ b/src/app/auth/logout.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { logout } from "@/app/auth/logout";
-import { STUDY_STORAGE_KEY, studyStore } from "@/features/study/state/studyStore";
+import { studyStore } from "@/features/study";
 
 const mocks = vi.hoisted(() => ({
   signOutCurrentUser: vi.fn(),
@@ -44,7 +44,7 @@ describe("logout", () => {
 
     expect(operations).toEqual(["suspend", "sign-out", "stop-remote", "resume"]);
     expect(studyStore.getState().sessionsByDeckId).toEqual({});
-    expect(localStorage.getItem(STUDY_STORAGE_KEY)).toBeNull();
+    expect(localStorage).toHaveLength(0);
   });
 
   it("preserves local state when sign-out fails", async () => {

--- a/src/app/auth/logout.spec.ts
+++ b/src/app/auth/logout.spec.ts
@@ -27,6 +27,8 @@ describe("logout", () => {
   });
 
   it("signs out before clearing remote and study state", async () => {
+    const unrelatedStorageKey = "unrelated-preference";
+    const unrelatedStorageValue = "preserve-me";
     const operations: string[] = [];
     mocks.suspendAnonymousBootstrap.mockImplementation(() => {
       operations.push("suspend");
@@ -38,13 +40,16 @@ describe("logout", () => {
     mocks.stopRemoteReads.mockImplementation(() => {
       operations.push("stop-remote");
     });
+    localStorage.setItem(unrelatedStorageKey, unrelatedStorageValue);
     studyStore.getState().startStudy("deck", ["card"]);
+    expect(localStorage).toHaveLength(2);
 
     await logout("uid-a");
 
     expect(operations).toEqual(["suspend", "sign-out", "stop-remote", "resume"]);
     expect(studyStore.getState().sessionsByDeckId).toEqual({});
-    expect(localStorage).toHaveLength(0);
+    expect(localStorage.getItem(unrelatedStorageKey)).toBe(unrelatedStorageValue);
+    expect(localStorage).toHaveLength(1);
   });
 
   it("preserves local state when sign-out fails", async () => {

--- a/src/app/providers/auth/AuthLogout.integration.spec.tsx
+++ b/src/app/providers/auth/AuthLogout.integration.spec.tsx
@@ -45,8 +45,8 @@ vi.mock("@/app/providers/remote-read/remoteReadLifecycle", () => ({
   startRemoteReads: mocks.startRemoteReads,
   stopRemoteReads: mocks.cleanupUid,
 }));
-vi.mock("@/features/study/state/studyStore", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/features/study/state/studyStore")>();
+vi.mock("@/features/study", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/study")>();
   mocks.actualClearStudyStore = actual.clearStudyStore;
   return { ...actual, clearStudyStore: mocks.clearStudyStore };
 });
@@ -79,7 +79,7 @@ import { RemoteReadBootstrap } from "@/app/providers/remote-read";
 import { useSession } from "@/entities/session";
 import { createAuthRuntime } from "@/features/auth";
 import { ConfigContainer } from "@/features/settings";
-import { studyStore } from "@/features/study/state/studyStore";
+import { studyStore } from "@/features/study";
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -61,7 +61,7 @@ vi.mock("@/entities/deck", async (importOriginal) => {
     }),
   };
 });
-vi.mock("@/features/card/hooks/useCardMutations", () => ({
+vi.mock("@/features/card", () => ({
   useCardMutations: () => ({ bulkUpsert: mocks.bulkUpsert }),
 }));
 vi.mock("@/features/import/lib/deckImportAnalysis", async (importOriginal) => {

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -13,7 +13,7 @@ import { documentMetadata as firestoreMetadata } from "@/adapters/firestore";
 import { CardBulkMutationError, createCard, selectCardsForDeck, useCards } from "@/entities/card";
 import { createDeck, useDeckMutations, useDecks } from "@/entities/deck";
 import { useSession } from "@/entities/session";
-import { useCardMutations } from "@/features/card/hooks/useCardMutations";
+import { useCardMutations } from "@/features/card";
 import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/components/deckImportTypes";
 import { parseCsv } from "@/features/import/lib/cardCsv";
 import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";


### PR DESCRIPTION
## Summary

- route Firestore entity type imports through the Card and Deck public APIs
- consume Card and Study feature contracts through slice roots, including test mocks
- preserve Entity cross-import ownership for #569 and leave Shared public APIs to #570
- leave the Study to Deck ownership work assigned to #526 untouched

## Testing

- mise run check
- focused Vitest runs: 36 tests passed
- Steiger report: no non-Shared fsd/no-public-api-sidestep violations remain

Closes #571