### PR TITLE
fix: update .dockerignore to exclude build and test outputs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,14 @@
 .git
 .worktrees
 node_modules
-dist
+build
 storybook-static
 coverage
+playwright-report
+test-results
+.firebase
+.superpowers
+.DS_Store
+*.log
 .env*
 !.env.example
-npm-debug.log*


### PR DESCRIPTION
## Summary
- Replace `dist` with `build` to match Vite's `outDir` setting in `vite.config.ts`.
- Exclude test output directories (`playwright-report`, `test-results`).
- Exclude additional temp/system files (`.firebase`, `.superpowers`, `.DS_Store`, `*.log`).