### PR TITLE
Restrict Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,4 @@
-.git
-.worktrees
-node_modules
-dist
-storybook-static
-coverage
-.env*
-!.env.example
-npm-debug.log*
+# Keep the build context limited to files consumed by the root Dockerfile.
+**
+!package.json
+!package-lock.json

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,7 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
+            .dockerignore
             Dockerfile
             package.json
             package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-bookworm AS base
+FROM node:24-bookworm
 
 WORKDIR /workspace
 
@@ -8,18 +8,7 @@ ENV PATH=/workspace/node_modules/.bin:$PATH
 
 RUN npm install -g npm@11.6.0
 
-FROM base AS deps
-
 COPY package.json package-lock.json ./
 
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
-
-FROM base AS app
-
-COPY --from=deps /workspace/node_modules ./node_modules
-COPY . .
-
-EXPOSE 5173
-
-CMD ["npm", "run", "start", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary

- simplify the root Dockerfile to install dependencies only
- remove `COPY . .` so application sources are supplied by the existing Compose bind mount instead of being baked into the image
- replace the `.dockerignore` denylist with an allowlist containing only `package.json` and `package-lock.json`
- rebuild the Docker image when `.dockerignore` changes

## Why

The root image is used as the development/E2E dependency image, while `.devcontainer/compose.yaml` bind-mounts the repository into `/workspace`. Copying the entire repository into the image is therefore redundant and makes `.dockerignore` responsible for continuously tracking every generated, local, or sensitive path.

Restricting the build context to the two files actually consumed by the Dockerfile prevents `.env`, Git metadata, generated outputs, and future unrelated files from being sent as build context by default.

## Impact

The development and E2E Compose services continue to receive source files through the existing `/workspace` bind mount. The published root image becomes explicitly dependency-only rather than a standalone Vite application image.

## Validation

- compared the branch against `main`; only `Dockerfile`, `.dockerignore`, and `.github/workflows/docker.yml` are changed
- branch is based directly on the current `main` and is not behind it
- GitHub Actions on this pull request will run the existing Dockerfile lint/build checks
