### PR TITLE
Unify CSV import validation

### DIFF
--- a/src/features/card/lib/cardFormSchema.ts
+++ b/src/features/card/lib/cardFormSchema.ts
@@ -6,11 +6,13 @@
 
 import * as z from "zod";
 
+import { isNonBlank } from "@/shared/lib/isNonBlank";
+
 /**
  * Creates a validation rule that rejects card text containing only whitespace.
  * The caller supplies the message shown beside the invalid form field.
  */
-const requiredCardText = (message: string) => z.string().refine((value) => value.trim().length > 0, { message });
+const requiredCardText = (message: string) => z.string().refine(isNonBlank, { message });
 
 export const cardFormSchema = z.object({
   frontText: requiredCardText("Front text is required."),

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -254,24 +254,19 @@ describe("useDeckImport", () => {
 
   it("uses the same CSV analysis pipeline for File and URL input", async () => {
     const csv = '"front","back"," foo,foo "," key "';
+    const normalizedCard = { frontText: "front", backText: "back", tags: ["foo"], uniqueKey: "key" };
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(csv));
     const { result } = renderHook(useDeckImport);
 
     await actAsync(async () => result.current.selectFile(new File([csv], "deck.csv")));
-    await actAsync(async () => result.current.importUrl("https://example.test/deck.csv"));
+    expect(result.current.preview?.analysis.rows).toEqual([{ rowNumber: 1, card: normalizedCard }]);
 
-    expect(mocks.parseCsv).toHaveBeenNthCalledWith(1, csv);
-    expect(mocks.parseCsv).toHaveBeenNthCalledWith(2, csv);
+    await actAsync(async () => result.current.importUrl("https://example.test/deck.csv"));
+    expect(mocks.prepareCard).toHaveBeenCalledWith(normalizedCard, expect.anything(), mocks.generateCardId);
   });
 
   it("does not write when URL CSV validation fails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"","back","","key"'));
-    mocks.parseCsv.mockResolvedValueOnce({
-      rows: [],
-      skippedRows: [],
-      issues: [{ rowNumber: 1, message: "frontText is required.", context: '["","back","","key"]' }],
-      invalidCount: 1,
-    });
     const { result } = renderHook(useDeckImport);
 
     await expect(result.current.importUrl("https://example.test/invalid.csv")).rejects.toThrow("Fix invalid CSV rows");

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -23,7 +23,6 @@ const mocks = vi.hoisted(() => ({
   deckSyncStatus: "synced" as "cached" | "pending" | "synced" | undefined,
   decks: [] as Deck[],
   cards: [] as Card[],
-  parseDeckImportCsv: vi.fn(),
   parseCsv: vi.fn(),
   prepareDeck: vi.fn(),
   prepareCard: vi.fn(),
@@ -66,13 +65,6 @@ vi.mock("@/entities/deck", async (importOriginal) => {
     }),
   };
 });
-vi.mock("@/features/import/lib/deckImportAnalysis", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/features/import/lib/deckImportAnalysis")>();
-  return {
-    ...actual,
-    parseDeckImportCsv: (...args: Parameters<typeof actual.parseDeckImportCsv>) => mocks.parseDeckImportCsv(...args),
-  };
-});
 vi.mock("@/features/import/lib/cardCsv", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/import/lib/cardCsv")>();
   return { ...actual, parseCsv: mocks.parseCsv };
@@ -93,13 +85,12 @@ describe("useDeckImport", () => {
     mocks.deckSyncStatus = "synced";
     mocks.decks = [];
     mocks.cards = [];
-    mocks.parseDeckImportCsv.mockImplementation(async (content: string | File) => {
-      const { parseDeckImportCsv } = await vi.importActual<typeof import("@/features/import/lib/deckImportAnalysis")>(
-        "@/features/import/lib/deckImportAnalysis"
+    mocks.parseCsv.mockImplementation(async (content: string) => {
+      const { parseCsv } = await vi.importActual<typeof import("@/features/import/lib/cardCsv")>(
+        "@/features/import/lib/cardCsv"
       );
-      return parseDeckImportCsv(content);
+      return parseCsv(content);
     });
-    mocks.parseCsv.mockResolvedValue([{ frontText: "front", backText: "back", tags: [], uniqueKey: "key" }]);
     mocks.prepareDeck.mockReturnValue(createDeck({ id: "deck", uid: "uid-a" }));
     mocks.prepareCard.mockReturnValue(createCard({ id: "card", deckId: "deck" }));
     mocks.createDeck.mockResolvedValue(undefined);
@@ -261,6 +252,34 @@ describe("useDeckImport", () => {
     expect(fetch).toHaveBeenCalledWith(new URL("https://example.test/deck.csv"));
   });
 
+  it("uses the same CSV analysis pipeline for File and URL input", async () => {
+    const csv = '"front","back"," foo,foo "," key "';
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(csv));
+    const { result } = renderHook(useDeckImport);
+
+    await actAsync(async () => result.current.selectFile(new File([csv], "deck.csv")));
+    await actAsync(async () => result.current.importUrl("https://example.test/deck.csv"));
+
+    expect(mocks.parseCsv).toHaveBeenNthCalledWith(1, csv);
+    expect(mocks.parseCsv).toHaveBeenNthCalledWith(2, csv);
+  });
+
+  it("does not write when URL CSV validation fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"","back","","key"'));
+    mocks.parseCsv.mockResolvedValueOnce({
+      rows: [],
+      skippedRows: [],
+      issues: [{ rowNumber: 1, message: "frontText is required.", context: '["","back","","key"]' }],
+      invalidCount: 1,
+    });
+    const { result } = renderHook(useDeckImport);
+
+    await expect(result.current.importUrl("https://example.test/invalid.csv")).rejects.toThrow("Fix invalid CSV rows");
+
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
   it("rejects a second import while the first is pending", async () => {
     let finish!: () => void;
     mocks.bulkUpsert.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));
@@ -408,8 +427,8 @@ describe("useDeckImport", () => {
   });
 
   it("does not publish or import a file preview after an A-to-B-to-A UID transition", async () => {
-    let finishParse!: (analysis: Awaited<ReturnType<typeof mocks.parseDeckImportCsv>>) => void;
-    mocks.parseDeckImportCsv.mockReturnValueOnce(
+    let finishParse!: (analysis: Awaited<ReturnType<typeof mocks.parseCsv>>) => void;
+    mocks.parseCsv.mockReturnValueOnce(
       new Promise((resolve) => {
         finishParse = resolve;
       })

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -22,7 +22,7 @@ import { createDeck, useDeckMutations, useDecks } from "@/entities/deck";
 import { useSession } from "@/entities/session";
 import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/components/deckImportTypes";
 import { parseCsv } from "@/features/import/lib/cardCsv";
-import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
+import { buildDeckImportPlan } from "@/features/import/lib/deckImportAnalysis";
 import sampleCards from "../../../../sample/build/output.json";
 
 interface DeckImportAttempt {
@@ -259,7 +259,7 @@ const previewDeckImportFile = async (
   setPreview(undefined);
   reset();
   try {
-    const analysis = await parseDeckImportCsv(file);
+    const analysis = await parseCsv(await file.text());
     if (!isCurrent()) throw new Error("Deck import user changed before the preview could finish");
     const deck = decks.find((candidate) => candidate.name === file.name);
     const existing = deck == null ? [] : cardsByDeckId(deck.id);
@@ -459,14 +459,16 @@ export const useDeckImport = () => {
     const parsedUrl = new URL(url);
     const response = await fetch(parsedUrl);
     if (!response.ok) throw new Error(`Unable to fetch Deck CSV (${response.status})`);
-    const cards = await parseCsv(await response.text());
+    const analysis = await parseCsv(await response.text());
     if (generation.current !== operationGeneration || dependenciesRef.current?.uid !== operationUid) {
       throw new Error("Deck import user changed before the import could start");
     }
+    if (analysis.invalidCount > 0) throw new Error("Fix invalid CSV rows before importing");
+    if (analysis.rows.length === 0) throw new Error("The CSV file has no valid rows");
     return await run({
       kind: "content",
       name: name ?? url.split("/").pop() ?? "no name",
-      rows: rowsFromCards(cards),
+      rows: analysis.rows,
     });
   };
 

--- a/src/features/import/lib/cardCsv.spec.ts
+++ b/src/features/import/lib/cardCsv.spec.ts
@@ -1,6 +1,4 @@
-import type { CardRaw } from "@/entities/card";
-
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { fromRow, isEmpty, parseCsv } from "@/features/import/lib/cardCsv";
 
@@ -18,6 +16,15 @@ describe("card CSV import", () => {
     it("uses empty values for missing columns", () => {
       expect(fromRow([])).toEqual({ frontText: "", backText: "", tags: [], uniqueKey: "" });
     });
+
+    it("normalizes tags and the unique key without changing card text", () => {
+      expect(fromRow(["  front  ", " back ", " foo,foo, bar , ,Foo ", " key "])).toEqual({
+        frontText: "  front  ",
+        backText: " back ",
+        tags: ["foo", "bar", "Foo"],
+        uniqueKey: "key",
+      });
+    });
   });
 
   describe("isEmpty", () => {
@@ -32,15 +39,41 @@ describe("card CSV import", () => {
   });
 
   describe("parseCsv", () => {
-    it("parses string content and removes empty rows", async () => {
-      const cards = await parseCsv("front,back\n,,tag,key");
+    it("parses, normalizes, and validates string content", async () => {
+      const analysis = await parseCsv('"front","back"," foo,foo, bar "," key "\n,,,');
 
-      expectTypeOf(cards).toEqualTypeOf<CardRaw[]>();
-      expect(cards).toEqual([{ frontText: "front", backText: "back", uniqueKey: "", tags: [] }]);
+      expect(analysis).toEqual({
+        rows: [
+          {
+            rowNumber: 1,
+            card: { frontText: "front", backText: "back", uniqueKey: "key", tags: ["foo", "bar"] },
+          },
+        ],
+        skippedRows: [2],
+        issues: [],
+        invalidCount: 0,
+      });
+    });
+
+    it("rejects whitespace-only card sides and trimmed duplicate keys", async () => {
+      const analysis = await parseCsv('" ","back",""," same "\n"front"," ","","same"');
+
+      expect(analysis.invalidCount).toBe(2);
+      expect(analysis.rows).toEqual([]);
+      expect(analysis.issues).toEqual([
+        { rowNumber: 1, message: "frontText is required.", context: '[" ","back",""," same "]' },
+        { rowNumber: 2, message: "backText is required.", context: '["front"," ","","same"]' },
+        {
+          rowNumber: 2,
+          message: 'uniqueKey "same" is duplicated in this file.',
+          context: '["front"," ","","same"]',
+        },
+      ]);
     });
 
     it("rejects unsupported input at the parser boundary", async () => {
-      await expect(parseCsv({ content: "front,back" })).rejects.toThrow("CSV content must be a string or File");
+      // @ts-expect-error Verifies the runtime boundary for untyped callers.
+      await expect(parseCsv({ content: "front,back" })).rejects.toThrow("CSV content must be a string");
     });
   });
 });

--- a/src/features/import/lib/cardCsv.ts
+++ b/src/features/import/lib/cardCsv.ts
@@ -2,22 +2,107 @@ import type { CardRaw } from "@/entities/card";
 
 import * as Papa from "papaparse";
 
+import type { DeckImportAnalysis, DeckImportIssue, DeckImportRow } from "@/features/import/components/deckImportTypes";
+import { isNonBlank } from "@/shared/lib/isNonBlank";
+
 export const isEmpty = (card: CardRaw): boolean => card.frontText === "" && card.backText === "";
 
 export const fromRow = (row: string[]): CardRaw => ({
   frontText: row[0] || "",
   backText: row[1] || "",
-  tags: typeof row[2] === "string" ? row[2].split(",") : [],
-  uniqueKey: row[3] || "",
+  tags:
+    typeof row[2] === "string"
+      ? [
+          ...new Set(
+            row[2]
+              .split(",")
+              .map((tag) => tag.trim())
+              .filter(Boolean)
+          ),
+        ]
+      : [],
+  uniqueKey: (row[3] || "").trim(),
 });
 
-export const parseCsv = async (content: unknown): Promise<CardRaw[]> => {
-  if (typeof content !== "string" && !(typeof File !== "undefined" && content instanceof File)) {
-    throw new TypeError("CSV content must be a string or File");
+const rowContext = (columns: string[]) => JSON.stringify(columns);
+
+const validateCard = (columns: string[], rowNumber: number, uniqueKeys: Set<string>) => {
+  const card = fromRow(columns);
+  const context = rowContext(columns);
+  const issues: DeckImportIssue[] = [];
+  if (!isNonBlank(card.frontText)) {
+    issues.push({ rowNumber, message: "frontText is required.", context });
   }
-  return await new Promise((resolve) =>
-    Papa.parse(content, {
-      complete: (results: { data: string[][] }) => resolve(results.data.map(fromRow).filter((card) => !isEmpty(card))),
-    })
-  );
+  if (!isNonBlank(card.backText)) {
+    issues.push({ rowNumber, message: "backText is required.", context });
+  }
+  if (card.uniqueKey === "") {
+    issues.push({ rowNumber, message: "uniqueKey is required.", context });
+  } else if (uniqueKeys.has(card.uniqueKey)) {
+    issues.push({ rowNumber, message: `uniqueKey "${card.uniqueKey}" is duplicated in this file.`, context });
+  } else {
+    uniqueKeys.add(card.uniqueKey);
+  }
+  return { card, issues };
+};
+
+export const parseCsv = async (content: string): Promise<DeckImportAnalysis> => {
+  if (typeof content !== "string") throw new TypeError("CSV content must be a string");
+
+  const parsed = await new Promise<Papa.ParseResult<string[]>>((resolve, reject) => {
+    Papa.parse<string[]>(content, { delimiter: ",", complete: resolve, error: reject });
+  });
+  const rows: DeckImportRow[] = [];
+  const skippedRows: number[] = [];
+  const issues: DeckImportIssue[] = [];
+  const invalidRows = new Set<number>();
+  const parseErrorRows = new Set<number>();
+  const uniqueKeys = new Set<string>();
+  let fileIssueCount = 0;
+
+  parsed.errors.forEach((error) => {
+    if (error.row == null) {
+      fileIssueCount += 1;
+      issues.push({ message: error.message });
+      return;
+    }
+    const rowNumber = error.row + 1;
+    invalidRows.add(rowNumber);
+    parseErrorRows.add(error.row);
+    issues.push({ rowNumber, message: error.message, context: rowContext(parsed.data[error.row] ?? []) });
+  });
+
+  parsed.data.forEach((columns, index) => {
+    const rowNumber = index + 1;
+    if (parseErrorRows.has(index)) return;
+    if (columns.every((column) => column.trim() === "")) {
+      skippedRows.push(rowNumber);
+      return;
+    }
+    if (columns.length !== 4) {
+      invalidRows.add(rowNumber);
+      issues.push({
+        rowNumber,
+        message: `Expected 4 columns, found ${columns.length}.`,
+        context: rowContext(columns),
+      });
+      return;
+    }
+
+    const { card, issues: rowIssues } = validateCard(columns, rowNumber, uniqueKeys);
+
+    if (rowIssues.length > 0) {
+      invalidRows.add(rowNumber);
+      issues.push(...rowIssues);
+    } else {
+      rows.push({ rowNumber, card });
+    }
+  });
+
+  if (rows.length === 0 && issues.length === 0) {
+    fileIssueCount += 1;
+    issues.push({ message: "The CSV file is empty." });
+  }
+
+  return { rows, skippedRows, issues, invalidCount: invalidRows.size + fileIssueCount };
 };

--- a/src/features/import/lib/deckImportAnalysis.ts
+++ b/src/features/import/lib/deckImportAnalysis.ts
@@ -6,22 +6,8 @@
 
 import type { Card, CardRaw } from "@/entities/card";
 
-import * as Papa from "papaparse";
-
-import type {
-  DeckImportAnalysis,
-  DeckImportIssue,
-  DeckImportPlan,
-  DeckImportPlanRow,
-  DeckImportRow,
-} from "@/features/import/components/deckImportTypes";
-import { fromRow } from "@/features/import/lib/cardCsv";
-
-/**
- * Formats raw CSV columns for inclusion in a validation message.
- * Keeping the original values visible helps users identify the row that needs correction.
- */
-const rowContext = (columns: string[]) => JSON.stringify(columns);
+import type { DeckImportPlan, DeckImportPlanRow, DeckImportRow } from "@/features/import/components/deckImportTypes";
+import { parseCsv } from "@/features/import/lib/cardCsv";
 
 /**
  * Checks whether two imported card values contain the same user-editable content.
@@ -36,84 +22,7 @@ const sameCardContent = (left: CardRaw, right: CardRaw) =>
  * Parses deck import csv into validated application data.
  * Malformed input is reported before downstream code relies on the result.
  */
-export const parseDeckImportCsv = async (content: string | File): Promise<DeckImportAnalysis> => {
-  const parsed = await new Promise<Papa.ParseResult<string[]>>((resolve, reject) => {
-    Papa.parse<string[]>(content, { delimiter: ",", complete: resolve, error: reject });
-  });
-  const rows: DeckImportRow[] = [];
-  const skippedRows: number[] = [];
-  const issues: DeckImportIssue[] = [];
-  const invalidRows = new Set<number>();
-  const parseErrorRows = new Set<number>();
-  const uniqueKeys = new Set<string>();
-  let fileIssueCount = 0;
-
-  parsed.errors.forEach((error) => {
-    if (error.row == null) {
-      fileIssueCount += 1;
-      issues.push({ message: error.message });
-      return;
-    }
-    const rowNumber = error.row + 1;
-    invalidRows.add(rowNumber);
-    parseErrorRows.add(error.row);
-    issues.push({
-      rowNumber,
-      message: error.message,
-      context: rowContext(parsed.data[error.row] ?? []),
-    });
-  });
-
-  parsed.data.forEach((columns, index) => {
-    const rowNumber = index + 1;
-    if (parseErrorRows.has(index)) return;
-    if (columns.every((column) => column.trim() === "")) {
-      skippedRows.push(rowNumber);
-      return;
-    }
-    if (columns.length !== 4) {
-      invalidRows.add(rowNumber);
-      issues.push({
-        rowNumber,
-        message: `Expected 4 columns, found ${columns.length}.`,
-        context: rowContext(columns),
-      });
-      return;
-    }
-
-    const card = fromRow(columns);
-    card.uniqueKey = card.uniqueKey.trim();
-    if (card.uniqueKey === "") {
-      invalidRows.add(rowNumber);
-      issues.push({ rowNumber, message: "uniqueKey is required.", context: rowContext(columns) });
-      return;
-    }
-    if (uniqueKeys.has(card.uniqueKey)) {
-      invalidRows.add(rowNumber);
-      issues.push({
-        rowNumber,
-        message: `uniqueKey "${card.uniqueKey}" is duplicated in this file.`,
-        context: rowContext(columns),
-      });
-      return;
-    }
-
-    uniqueKeys.add(card.uniqueKey);
-    rows.push({ rowNumber, card });
-  });
-
-  if (rows.length === 0 && issues.length === 0) {
-    fileIssueCount += 1;
-    issues.push({ message: "The CSV file is empty." });
-  }
-
-  return {
-    rows,
-    skippedRows,
-    issues,
-    invalidCount: invalidRows.size + fileIssueCount,
-  };
-};
+export const parseDeckImportCsv = parseCsv;
 
 /**
  * Builds deck import plan from the supplied application values.

--- a/src/shared/lib/isNonBlank.ts
+++ b/src/shared/lib/isNonBlank.ts
@@ -1,0 +1,1 @@
+export const isNonBlank = (value: string): boolean => value.trim().length > 0;


### PR DESCRIPTION
## Summary

- route CSV strings, selected files, and URL responses through one parse, normalization, and validation pipeline
- normalize tags and unique keys while preserving card body text
- share whitespace-aware required-text validation with the Card form
- reject an entire URL import before creating a Deck or writing Cards when any validation issue exists
- cover source parity, normalization, validation, and invalid URL behavior with tests

## Root cause

File previews used `parseDeckImportCsv`, while URL imports called the lower-level `cardCsv.parseCsv` path directly. The two paths therefore applied different parsing and domain validation rules.

## Validation

- `mise run check`
- 107 test files passed
- 597 tests passed

Closes #388