### PR TITLE
refactor(shared-ui): remove deprecated Button compatibility props (#631)

### DIFF
--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -19,14 +19,6 @@ export type ButtonProps = {
   hidden?: boolean;
   variant?: ButtonVariant;
   size?: ButtonSize;
-  /** @deprecated Use size="sm". */
-  small?: boolean;
-  /** @deprecated Use size="lg". */
-  large?: boolean;
-  /** @deprecated The secondary variant is the default. */
-  default?: boolean;
-  /** @deprecated Use variant="primary". */
-  primary?: boolean;
   children?: React.ReactNode;
   onClick?: () => void;
 };
@@ -44,9 +36,8 @@ const sizeClasses: Record<ButtonSize, string> = {
   lg: "min-h-touch min-w-touch px-6 py-3 font-bold text-lg",
 };
 
-const resolveVariant = (props: ButtonProps): ButtonVariant =>
-  props.variant ?? (props.primary ? "primary" : "secondary");
-const resolveSize = (props: ButtonProps): ButtonSize => props.size ?? (props.small ? "sm" : props.large ? "lg" : "md");
+const resolveVariant = (props: ButtonProps): ButtonVariant => props.variant ?? "secondary";
+const resolveSize = (props: ButtonProps): ButtonSize => props.size ?? "md";
 const getLoadingAnnouncement = (content: React.ReactNode) =>
   typeof content === "string" || typeof content === "number" ? `Loading ${content}` : "Loading";
 

--- a/src/shared/ui/forms/ActionControl.spec.tsx
+++ b/src/shared/ui/forms/ActionControl.spec.tsx
@@ -94,13 +94,10 @@ describe("Button action control", () => {
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
-  it.each([
-    [{ primary: true }, "bg-accent-primary"],
-    [{ small: true }, "px-3"],
-    [{ large: true }, "px-6"],
-  ] as const)("temporarily supports legacy props", (legacyProps, expectedClass) => {
-    render(<Button {...legacyProps}>Legacy</Button>);
+  it("uses secondary variant and md size by default", () => {
+    render(<Button>Default</Button>);
 
-    expect(screen.getByRole("button", { name: "Legacy" })).toHaveClass(expectedClass);
+    const button = screen.getByRole("button", { name: "Default" });
+    expect(button).toHaveClass("bg-accent-secondary", "px-4", "text-body");
   });
 });

--- a/src/shared/ui/remote-mutation-notice/RemoteMutationNotice.tsx
+++ b/src/shared/ui/remote-mutation-notice/RemoteMutationNotice.tsx
@@ -28,7 +28,7 @@ export const RemoteMutationNotice = (props: RemoteMutationNoticeProps) => {
     return (
       <div role="alert" className="my-2 flex items-center justify-between rounded border border-red-300 p-2 text-sm">
         <span>{errorLabel}</span>
-        <Button small onClick={props.onRetry}>
+        <Button size="sm" onClick={props.onRetry}>
           Retry
         </Button>
       </div>

--- a/src/shared/ui/remote-read-boundary/RemoteReadBoundary.tsx
+++ b/src/shared/ui/remote-read-boundary/RemoteReadBoundary.tsx
@@ -29,7 +29,7 @@ const ErrorNotice = ({ hasData, onRetry }: Pick<RemoteReadBoundaryProps, "hasDat
     className="mb-4 flex items-center justify-between gap-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
   >
     <span>{hasData ? "Sync interrupted. Showing current data." : "Unable to load data."}</span>
-    <Button small onClick={onRetry}>
+    <Button size="sm" onClick={onRetry}>
       Retry
     </Button>
   </div>


### PR DESCRIPTION
## Summary

Closes #631

This PR removes the legacy boolean compatibility API (`small`, `large`, `default`, `primary`) from `ButtonProps` in `src/shared/ui/button/Button.tsx`.

## Changes

- Removed `small`, `large`, `default`, and `primary` boolean props from `ButtonProps`.
- Simplified `resolveVariant` to `props.variant ?? "secondary"` and `resolveSize` to `props.size ?? "md"`.
- Updated callers (`RemoteReadBoundary.tsx`, `RemoteMutationNotice.tsx`) to use the canonical `size="sm"` prop.
- Updated `ActionControl.spec.tsx` to remove legacy prop tests and add explicit coverage for default variant (`secondary`) and size (`md`).

## Verification

- `mise run check` passed cleanly (all linters, typecheck, and 595 unit tests passed).