### PR TITLE
test(deck): cover membership lock on removal

### DIFF
--- a/src/entities/deck/api/commands.spec.ts
+++ b/src/entities/deck/api/commands.spec.ts
@@ -3,6 +3,7 @@ import type { Deck } from "../model/deck";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { REMOTE_WRITE_TIMEOUT_MS } from "@/shared/lib/remoteWrite";
+import { deckMembershipMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
 import { createDeck as createDeckFixture } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -79,6 +80,30 @@ describe("deck commands", () => {
 
     finishFirst();
     await Promise.all([firstUpdate, secondUpdate]);
+  });
+
+  it("waits to remove a Deck while its membership is shared-locked", async () => {
+    let finishShared!: () => void;
+    const sharedStarted = vi.fn();
+    const blockedDeck = createDeck({ id: "blocked" });
+    const unrelatedDeck = createDeck({ id: "unrelated" });
+    const shared = withDeckMembershipLocks([deckMembershipMutationLock("uid-a", blockedDeck.id)], "shared", () => {
+      sharedStarted();
+      return new Promise<void>((resolve) => {
+        finishShared = resolve;
+      });
+    });
+    await vi.waitFor(() => expect(sharedStarted).toHaveBeenCalledOnce());
+
+    const blockedRemoval = deckCommands.remove("uid-a", blockedDeck);
+    const unrelatedRemoval = deckCommands.remove("uid-a", unrelatedDeck);
+
+    await vi.waitFor(() => expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(unrelatedDeck.id, "uid-a"));
+    expect(mocks.remove).not.toHaveBeenCalledWith(blockedDeck.id, "uid-a");
+
+    finishShared();
+    await Promise.all([shared, blockedRemoval, unrelatedRemoval]);
+    expect(mocks.remove).toHaveBeenCalledWith(blockedDeck.id, "uid-a");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- add Deck-side regression coverage for `deckCommands.remove()` acquiring the exclusive membership lock
- verify removal waits for an active shared membership operation
- verify removal of an unrelated Deck can still proceed independently

## Why

PR #616 moved Card-side lock coverage into the Card slice, leaving the complementary `deckCommands.remove()` contract without direct regression coverage. The new test uses the shared lock API as the seam and avoids importing Card persistence internals into the Deck slice.

## Impact

This is a test-only change. It protects Deck/Card membership coordination from regressions without changing delete behavior or lock implementation.

## Validation

- `npm run test:unit -- src/entities/deck/api/commands.spec.ts`
- `mise run check` (110 test files, 609 tests)

Closes #620