### PR TITLE
Centralize overlay focusable element selectors

### DIFF
--- a/src/shared/lib/focusableElementSelector.ts
+++ b/src/shared/lib/focusableElementSelector.ts
@@ -1,0 +1,8 @@
+export const focusableElementSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"]):not([disabled])',
+].join(",");

--- a/src/shared/ui/actions-menu/ActionsMenu.spec.tsx
+++ b/src/shared/ui/actions-menu/ActionsMenu.spec.tsx
@@ -149,6 +149,34 @@ describe("ActionsMenu", () => {
     expect(screen.getByRole("button", { name: "Previous control" })).toHaveFocus();
   });
 
+  it("skips disabled, hidden, and inert controls before focusing an explicit tab stop", async () => {
+    render(
+      <>
+        <ControlledMenu {...labels} items={items()} />
+        <button type="button" disabled tabIndex={0}>
+          Disabled control
+        </button>
+        <div hidden>
+          <button type="button">Hidden control</button>
+        </div>
+        <div inert>
+          <button type="button">Inert control</button>
+        </div>
+        <details>
+          <summary tabIndex={0}>Explicit tab stop</summary>
+        </details>
+        <button type="button">Next enabled control</button>
+      </>
+    );
+    fireEvent.click(screen.getByRole("button", { name: labels.triggerLabel }));
+    const edit = screen.getByRole("menuitem", { name: "Edit" });
+    await waitFor(() => expect(edit).toHaveFocus());
+
+    await actAsync(async () => fireEvent.keyDown(edit, { key: "Tab" }));
+
+    expect(screen.getByText("Explicit tab stop")).toHaveFocus();
+  });
+
   it("keeps the menu open when an ambiguous blur settles inside", async () => {
     render(<ControlledMenu {...labels} items={items()} />);
     fireEvent.click(screen.getByRole("button", { name: labels.triggerLabel }));

--- a/src/shared/ui/actions-menu/ActionsMenu.tsx
+++ b/src/shared/ui/actions-menu/ActionsMenu.tsx
@@ -7,6 +7,8 @@
 import type * as React from "react";
 import { AiOutlineMore } from "react-icons/ai";
 
+import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
+
 export interface ActionsMenuItem {
   key: string;
   label: string;
@@ -35,15 +37,6 @@ const triggerClassName =
 const menuClassName =
   "absolute right-0 top-full z-20 min-w-40 rounded-control border border-border bg-surface py-1 shadow-elevated";
 
-const focusableSelector = [
-  "a[href]",
-  "button:not([disabled])",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(",");
-
 /**
  * Moves keyboard focus to the menu item next to the trigger button.
  * This preserves an intuitive focus position when an actions menu opens from either direction.
@@ -52,7 +45,7 @@ const focusAdjacentToTrigger = (menu: HTMLElement, direction: -1 | 1) => {
   const trigger = menu.parentElement?.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
   if (trigger == null) return;
 
-  const focusable = Array.from(document.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+  const focusable = Array.from(document.querySelectorAll<HTMLElement>(focusableElementSelector)).filter(
     (element) => element.tabIndex >= 0 && element.closest("[hidden], [inert]") == null
   );
   const triggerIndex = focusable.indexOf(trigger);

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
@@ -45,6 +45,51 @@ describe("DestructiveActionDialog", () => {
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
+  it("excludes disabled controls and includes explicit tab stops in the focus trap", () => {
+    render(
+      <DestructiveActionDialog
+        {...defaultProps}
+        description={
+          <>
+            <button type="button" disabled tabIndex={0}>
+              Disabled detail
+            </button>
+            <details>
+              <summary tabIndex={0}>Focusable detail</summary>
+            </details>
+          </>
+        }
+      />
+    );
+    const detail = screen.getByText("Focusable detail");
+    const confirm = screen.getByRole("button", { name: "Delete deck" });
+    detail.focus();
+
+    expect(fireEvent.keyDown(detail, { key: "Tab", shiftKey: true })).toBe(false);
+    expect(confirm).toHaveFocus();
+  });
+
+  it.each([
+    [
+      "hidden",
+      <div hidden>
+        <button type="button">Hidden detail</button>
+      </div>,
+    ],
+    [
+      "inert",
+      <div inert>
+        <button type="button">Inert detail</button>
+      </div>,
+    ],
+  ])("preserves the dialog's unfiltered %s descendant semantics", (_kind, description) => {
+    render(<DestructiveActionDialog {...defaultProps} description={description} />);
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+
+    expect(fireEvent.keyDown(cancel, { key: "Tab", shiftKey: true })).toBe(true);
+    expect(cancel).toHaveFocus();
+  });
+
   it("restores focus to the control that opened it", async () => {
     const Example = () => {
       const [open, setOpen] = React.useState(false);

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
 import { Button } from "@/shared/ui/button";
 
 export interface DestructiveActionDialogProps {
@@ -13,15 +14,6 @@ export interface DestructiveActionDialogProps {
   onCancel: () => void;
   onConfirm: () => void | Promise<void>;
 }
-
-const focusableSelector = [
-  "button:not([disabled])",
-  "a[href]",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(",");
 
 export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (props) => {
   const dialogRef = React.useRef<HTMLDivElement>(null);
@@ -45,7 +37,7 @@ export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (
   }, []);
 
   const handleDialogTabKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? []);
+    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableElementSelector) ?? []);
     if (focusable.length === 0) {
       event.preventDefault();
       return;


### PR DESCRIPTION
## Summary

- centralize the native focusable-element selector shared by `ActionsMenu` and `DestructiveActionDialog`
- keep each consumer's existing query scope and hidden/inert filtering behavior
- exclude disabled elements even when they declare an explicit tab stop
- add focused accessibility coverage for enabled, disabled, hidden, inert, and explicit-tabindex elements

## Impact

Menu adjacent-focus navigation and dialog focus trapping now use the same native element definition without combining their separate interaction algorithms.

## Testing

- `mise run check` (110 test files, 613 tests)

Closes #643