### PR TITLE
fix(deck): restrict editable deck fields

### DIFF
--- a/src/adapters/firestore/dto.spec.ts
+++ b/src/adapters/firestore/dto.spec.ts
@@ -224,17 +224,14 @@ describe("Firestore DTO builders", () => {
     });
   });
 
-  it("omits the id, undefined values, and client state when updating a deck", () => {
+  it("allows only editable fields and the adapter timestamp when updating a deck", () => {
     const deckEdit: DeckEdit = deck;
     const dto: DeckUpdateDto = buildDeckUpdateDto(deckEdit, 101);
 
     expect(dto).toEqual({
       name: "Deck",
       isPublic: true,
-      uid: "user-1",
-      createdAt: 1,
       updatedAt: 101,
-      deletedAt: null,
       scoreMax: 3,
       scoreMin: -2,
       selectedTags: ["math"],

--- a/src/entities/deck/api/commands.spec.ts
+++ b/src/entities/deck/api/commands.spec.ts
@@ -44,6 +44,12 @@ describe("deck commands", () => {
     expect(mocks.remove).not.toHaveBeenCalled();
   });
 
+  it("updates without ownership metadata in the edit input", async () => {
+    await deckCommands.update("uid-a", { id: "deck", name: "Updated" });
+
+    expect(mocks.update).toHaveBeenCalledExactlyOnceWith({ id: "deck", name: "Updated" });
+  });
+
   it("serializes writes to the same Deck", async () => {
     let finishUpdate!: () => void;
     mocks.update.mockReturnValueOnce(

--- a/src/entities/deck/api/commands.ts
+++ b/src/entities/deck/api/commands.ts
@@ -14,8 +14,8 @@ const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
 };
 
-const requireOwner = (uid: string, entityUid: string | undefined) => {
-  if (entityUid != null && entityUid !== uid) {
+const requireOwner = (uid: string, entityUid: string) => {
+  if (entityUid !== uid) {
     throw new Error("Deck owner does not match the authenticated user");
   }
 };
@@ -31,7 +31,6 @@ export const deckCommands = {
 
   update: async (uid: string, deck: DeckEdit): Promise<void> => {
     requireUid(uid);
-    requireOwner(uid, deck.uid);
     await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
       waitForRemoteWrite(updateRemoteDeck(deck), "Deck update")
     );

--- a/src/entities/deck/api/firestoreDocument.ts
+++ b/src/entities/deck/api/firestoreDocument.ts
@@ -25,9 +25,22 @@ const deckCreateDtoSchema = deckDocumentSchema.extend({
   id: z.string(),
 });
 
-const deckUpdateDtoSchema = deckDocumentSchema.omit({ id: true }).partial().extend({
-  updatedAt: z.number(),
-});
+const deckUpdateDtoSchema = deckDocumentSchema
+  .pick({
+    name: true,
+    url: true,
+    isPublic: true,
+    scoreMax: true,
+    scoreMin: true,
+    selectedTags: true,
+    tagAndFilter: true,
+    category: true,
+    convertToBr: true,
+  })
+  .partial()
+  .extend({
+    updatedAt: z.number(),
+  });
 
 type DeckDocument = z.infer<typeof deckDocumentSchema>;
 export type DeckCreateDto = z.infer<typeof deckCreateDtoSchema>;
@@ -92,10 +105,7 @@ export const buildDeckUpdateDto = (deck: DeckEdit, updatedAt: number): DeckUpdat
       name: deck.name,
       url: deck.url,
       isPublic: deck.isPublic,
-      uid: deck.uid,
-      createdAt: deck.createdAt,
       updatedAt,
-      deletedAt: deck.deletedAt,
       scoreMax: deck.scoreMax,
       scoreMin: deck.scoreMin,
       selectedTags: deck.selectedTags,

--- a/src/entities/deck/model/deck.ts
+++ b/src/entities/deck/model/deck.ts
@@ -20,7 +20,21 @@ export interface Deck {
 }
 
 export type DeckRaw = Pick<Deck, "name">;
-export type DeckEdit = Partial<Deck> & Pick<Deck, "id">;
+export type DeckEdit = Pick<Deck, "id"> &
+  Partial<
+    Pick<
+      Deck,
+      | "name"
+      | "url"
+      | "isPublic"
+      | "scoreMax"
+      | "scoreMin"
+      | "selectedTags"
+      | "tagAndFilter"
+      | "category"
+      | "convertToBr"
+    >
+  >;
 
 export const createDeck = (deck: DeckRaw, uid: string, generateId: () => string): Deck => ({
   ...deck,


### PR DESCRIPTION
## Summary

- define `DeckEdit` from an explicit allowlist of editable fields
- prevent ownership and metadata fields from entering Deck update DTOs
- remove the ineffective owner check from updates while preserving create and remove validation

## Why

`DeckEdit` previously extended `Partial<Deck>`, which allowed callers to supply ownership and metadata fields such as `uid`, `createdAt`, `updatedAt`, and `deletedAt`. The Firestore DTO builder also forwarded those fields, making the update boundary broader than intended.

This narrows both the TypeScript input and Firestore payload while keeping `updatedAt` adapter-owned.

## Impact

Deck updates can now change only user-editable fields. Deck creation and removal continue to validate ownership.

## Testing

- `mise run check`
- `npx vitest run --project=unit src/entities/deck/api/commands.spec.ts src/entities/deck/api/firestoreDocument.spec.ts src/adapters/firestore/dto.spec.ts --no-file-parallelism`

Closes #559