### PR TITLE
Extract generic keyed task serializer

### DIFF
--- a/src/entities/card/api/commands.ts
+++ b/src/entities/card/api/commands.ts
@@ -8,12 +8,8 @@ import {
   update as updateRemoteCard,
   upsert as upsertRemoteCard,
 } from "./firestore";
-import {
-  cardMutationLock,
-  deckMembershipMutationLock,
-  withDeckMembershipLocks,
-  withMutationLocks,
-} from "@/store/remoteMutationLocks";
+import { cardMutationLock, deckMembershipMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
+import { runSerially } from "@/shared/lib/runSerially";
 import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
 
 const requireUid = (uid: string) => {
@@ -27,7 +23,7 @@ const requireOwner = (uid: string, entityUid: string | undefined) => {
 };
 
 const withCardWriteLocks = <T>(uid: string, id: CardId, deckId: DeckId, task: () => Promise<T>): Promise<T> =>
-  withMutationLocks([cardMutationLock(uid, id)], () =>
+  runSerially(cardMutationLock(uid, id), () =>
     withDeckMembershipLocks([deckMembershipMutationLock(uid, deckId)], "shared", task)
   );
 

--- a/src/entities/deck/api/commands.ts
+++ b/src/entities/deck/api/commands.ts
@@ -1,11 +1,7 @@
 import type { Deck, DeckEdit } from "../model/deck";
 
-import {
-  deckMembershipMutationLock,
-  deckMutationLock,
-  withDeckMembershipLocks,
-  withMutationLocks,
-} from "@/store/remoteMutationLocks";
+import { deckMembershipMutationLock, deckMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
+import { runSerially } from "@/shared/lib/runSerially";
 import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
 import { create as createRemoteDeck, remove as removeRemoteDeck, update as updateRemoteDeck } from "./firestore";
 
@@ -23,22 +19,20 @@ export const deckCommands = {
   create: async (uid: string, deck: Deck): Promise<void> => {
     requireUid(uid);
     requireOwner(uid, deck.uid);
-    await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
+    await runSerially(deckMutationLock(uid, deck.id), () =>
       waitForRemoteWrite(createRemoteDeck(deck), "Deck creation")
     );
   },
 
   update: async (uid: string, deck: DeckEdit): Promise<void> => {
     requireUid(uid);
-    await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
-      waitForRemoteWrite(updateRemoteDeck(deck), "Deck update")
-    );
+    await runSerially(deckMutationLock(uid, deck.id), () => waitForRemoteWrite(updateRemoteDeck(deck), "Deck update"));
   },
 
   remove: async (uid: string, deck: Deck): Promise<void> => {
     requireUid(uid);
     requireOwner(uid, deck.uid);
-    await withMutationLocks([deckMutationLock(uid, deck.id)], () =>
+    await runSerially(deckMutationLock(uid, deck.id), () =>
       withDeckMembershipLocks([deckMembershipMutationLock(uid, deck.id)], "exclusive", () =>
         waitForRemoteWrite(removeRemoteDeck(deck.id, uid), "Deck deletion")
       )

--- a/src/shared/lib/runSerially.spec.ts
+++ b/src/shared/lib/runSerially.spec.ts
@@ -6,16 +6,17 @@ describe("runSerially", () => {
   it("runs tasks with the same key in order", async () => {
     let finishFirst!: () => void;
     const first = runSerially(
-      "key",
+      "order",
       () =>
         new Promise<void>((resolve) => {
           finishFirst = resolve;
         })
     );
     const secondTask = vi.fn(async () => undefined);
-    const second = runSerially("key", secondTask);
+    const second = runSerially("order", secondTask);
 
     expect(secondTask).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(finishFirst).toBeTypeOf("function"));
     finishFirst();
     await Promise.all([first, second]);
 
@@ -42,24 +43,44 @@ describe("runSerially", () => {
 
   it("continues after a task fails", async () => {
     const failure = new Error("failed");
-    const failed = runSerially("key", async () => {
+    const failed = runSerially("failure", async () => {
       throw failure;
     });
     const nextTask = vi.fn(async () => "completed");
-    const next = runSerially("key", nextTask);
+    const next = runSerially("failure", nextTask);
 
     await expect(failed).rejects.toBe(failure);
     await expect(next).resolves.toBe("completed");
     expect(nextTask).toHaveBeenCalledOnce();
   });
 
+  it("serializes a task enqueued from a running task", async () => {
+    let nested!: Promise<void>;
+    let outerRunning = false;
+    const nestedTask = vi.fn(async () => {
+      expect(outerRunning).toBe(false);
+    });
+    const outer = runSerially("reentrant", async () => {
+      outerRunning = true;
+      nested = runSerially("reentrant", nestedTask);
+
+      await Promise.resolve();
+      expect(nestedTask).not.toHaveBeenCalled();
+      outerRunning = false;
+    });
+
+    await outer;
+    await nested;
+
+    expect(nestedTask).toHaveBeenCalledOnce();
+  });
+
   it("cleans up an idle key", async () => {
-    await runSerially("key", async () => undefined);
+    await runSerially("cleanup", async () => undefined);
     const nextTask = vi.fn(async () => undefined);
 
-    const next = runSerially("key", nextTask);
+    await runSerially("cleanup", nextTask);
 
     expect(nextTask).toHaveBeenCalledOnce();
-    await next;
   });
 });

--- a/src/shared/lib/runSerially.spec.ts
+++ b/src/shared/lib/runSerially.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runSerially } from "@/shared/lib/runSerially";
+
+describe("runSerially", () => {
+  it("runs tasks with the same key in order", async () => {
+    let finishFirst!: () => void;
+    const first = runSerially(
+      "key",
+      () =>
+        new Promise<void>((resolve) => {
+          finishFirst = resolve;
+        })
+    );
+    const secondTask = vi.fn(async () => undefined);
+    const second = runSerially("key", secondTask);
+
+    expect(secondTask).not.toHaveBeenCalled();
+    finishFirst();
+    await Promise.all([first, second]);
+
+    expect(secondTask).toHaveBeenCalledOnce();
+  });
+
+  it("runs tasks with different keys concurrently", async () => {
+    let finishFirst!: () => void;
+    const first = runSerially(
+      "first",
+      () =>
+        new Promise<void>((resolve) => {
+          finishFirst = resolve;
+        })
+    );
+    const secondTask = vi.fn(async () => undefined);
+
+    await runSerially("second", secondTask);
+
+    expect(secondTask).toHaveBeenCalledOnce();
+    finishFirst();
+    await first;
+  });
+
+  it("continues after a task fails", async () => {
+    const failure = new Error("failed");
+    const failed = runSerially("key", async () => {
+      throw failure;
+    });
+    const nextTask = vi.fn(async () => "completed");
+    const next = runSerially("key", nextTask);
+
+    await expect(failed).rejects.toBe(failure);
+    await expect(next).resolves.toBe("completed");
+    expect(nextTask).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up an idle key", async () => {
+    await runSerially("key", async () => undefined);
+    const nextTask = vi.fn(async () => undefined);
+
+    const next = runSerially("key", nextTask);
+
+    expect(nextTask).toHaveBeenCalledOnce();
+    await next;
+  });
+});

--- a/src/shared/lib/runSerially.ts
+++ b/src/shared/lib/runSerially.ts
@@ -1,0 +1,25 @@
+const tails = new Map<unknown, Promise<void>>();
+
+const runTask = <T>(task: () => Promise<T>): Promise<T> => {
+  try {
+    return Promise.resolve(task());
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export const runSerially = async <Key, T>(key: Key, task: () => Promise<T>): Promise<T> => {
+  const previous = tails.get(key);
+  const operation = previous == null ? runTask(task) : previous.then(task);
+  const settled = operation.then(
+    () => undefined,
+    () => undefined
+  );
+  tails.set(key, settled);
+
+  try {
+    return await operation;
+  } finally {
+    if (tails.get(key) === settled) tails.delete(key);
+  }
+};

--- a/src/shared/lib/runSerially.ts
+++ b/src/shared/lib/runSerially.ts
@@ -1,16 +1,8 @@
 const tails = new Map<unknown, Promise<void>>();
 
-const runTask = <T>(task: () => Promise<T>): Promise<T> => {
-  try {
-    return Promise.resolve(task());
-  } catch (error) {
-    return Promise.reject(error);
-  }
-};
-
 export const runSerially = async <Key, T>(key: Key, task: () => Promise<T>): Promise<T> => {
   const previous = tails.get(key);
-  const operation = previous == null ? runTask(task) : previous.then(task);
+  const operation = (previous ?? Promise.resolve()).then(task);
   const settled = operation.then(
     () => undefined,
     () => undefined

--- a/src/store/remoteMutationLocks.ts
+++ b/src/store/remoteMutationLocks.ts
@@ -3,37 +3,11 @@
 import type { CardId } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 
-const tails = new Map<string, Promise<void>>();
 interface MembershipLockState {
   exclusive?: Promise<void>;
   shared: Set<Promise<void>>;
 }
 const membershipLocks = new Map<string, MembershipLockState>();
-
-/**
- * Serializes a task behind all earlier mutations that touch the same entity keys.
- * Locks are released after success or failure, allowing unrelated entities to continue in
- * parallel.
- */
-export const withMutationLocks = async <T>(keys: string[], task: () => Promise<T>): Promise<T> => {
-  const uniqueKeys = [...new Set(keys)];
-  const previous = uniqueKeys.map((key) => tails.get(key)).filter((tail): tail is Promise<void> => tail != null);
-  const operation = Promise.all(previous).then(task);
-  const settled = operation.then(
-    () => undefined,
-    () => undefined
-  );
-  uniqueKeys.forEach((key) => {
-    tails.set(key, settled);
-  });
-  try {
-    return await operation;
-  } finally {
-    uniqueKeys.forEach((key) => {
-      if (tails.get(key) === settled) tails.delete(key);
-    });
-  }
-};
 
 /**
  * Allows concurrent Card writes while giving Deck removal exclusive access to its membership.


### PR DESCRIPTION
## Summary

- add a generic `runSerially(key, task)` utility under `shared/lib`
- migrate Card and Deck same-entity mutation ordering to the shared serializer
- keep the existing Deck membership shared/exclusive lock infrastructure unchanged
- cover same-key ordering, unrelated-key concurrency, failure recovery, and idle-key cleanup

## Why

Same-entity mutation serialization was implemented inside `store/remoteMutationLocks.ts`, coupling a generic concurrency primitive to application-specific Card and Deck lock helpers. Moving the keyed serializer to `shared/lib` makes the primitive FSD-compatible while preserving the existing mutation behavior.

## Impact

Card and Deck writes for the same authenticated user and entity remain ordered. Writes for unrelated keys can still proceed concurrently, and a failed task no longer affects subsequent tasks. Completed idle keys are removed from serializer state.

## Validation

- `mise run check`
- 112 unit test files passed (613 tests)

Closes #651