### PR TITLE
Run Firestore integration tests in CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,28 @@
+name: Integration
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  COMPOSE_PROJECT_NAME: tango-integration
+  VITE_DB_HOST: localhost
+  VITE_DB_PORT: 8000
+
+jobs:
+  firestore:
+    name: Firestore
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - run: mise run init
+
+      - name: Run Firestore tests
+        run: mise run test-firestore
+
+      - name: Stop Firestore emulator
+        if: ${{ always() }}
+        run: mise run down

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 env:
+  COMPOSE_FILE: .devcontainer/compose.yaml:.devcontainer/compose.local.yaml
   COMPOSE_PROJECT_NAME: tango-integration
   VITE_DB_HOST: localhost
   VITE_DB_PORT: 8000
@@ -16,13 +17,22 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v4
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.15.0
+          cache: npm
 
-      - run: mise run init
+      - name: Install npm
+        run: npm install --global npm@12.0.1
+
+      - run: npm ci
+
+      - name: Start Firestore emulator
+        run: docker compose up --wait --wait-timeout 120 --remove-orphans -d db
 
       - name: Run Firestore tests
-        run: mise run test-firestore
+        run: npm run test:firestore
 
       - name: Stop Firestore emulator
         if: ${{ always() }}
-        run: mise run down
+        run: docker compose down --volumes --remove-orphans

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
     uses: ./.github/workflows/e2e.yaml
     secrets: inherit
 
+  integration:
+    name: Integration
+    uses: ./.github/workflows/integration.yaml
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a reusable `integration.yaml` workflow for Firestore tests
- install Node.js and npm directly in the workflow without mise
- start and stop the Firestore emulator with Docker Compose
- run the integration workflow as part of the main test workflow

## Why

Firestore integration tests existed locally but were not executed by GitHub Actions. This adds an isolated CI job so pull requests and deployment checks exercise them.

## Validation

- `mise run check`
- direct Docker Compose emulator startup and `npm run test:firestore` (8 files, 66 tests passed)