### PR TITLE
Remove Deck membership changes from Card edits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm --prefix functions ci
+
       - run: npm run ci
 
       - name: Install Storybook Chromium

--- a/src/entities/card/api/commands.spec.ts
+++ b/src/entities/card/api/commands.spec.ts
@@ -63,6 +63,20 @@ describe("card commands", () => {
     expect(mocks.update).toHaveBeenCalledOnce();
   });
 
+  it("allows writes to different Cards to proceed independently", async () => {
+    let finishCreate!: () => void;
+    mocks.create.mockReturnValueOnce(new Promise<string>((resolve) => (finishCreate = () => resolve("created"))));
+
+    const create = cardCommands.create("uid-a", createCard({ id: "first", deckId: "deck" }));
+    const update = cardCommands.update("uid-a", createCard({ id: "second", deckId: "deck", score: 2 }));
+
+    await expect(update).resolves.toBeUndefined();
+    expect(mocks.create).toHaveBeenCalledOnce();
+    expect(mocks.update).toHaveBeenCalledOnce();
+    finishCreate();
+    await create;
+  });
+
   it("reports only failed bulk upserts", async () => {
     const first = createCard({ id: "first" });
     const second = createCard({ id: "second" });

--- a/src/entities/card/api/firestoreDocument.spec.ts
+++ b/src/entities/card/api/firestoreDocument.spec.ts
@@ -98,10 +98,9 @@ describe("Card Firestore document", () => {
     expect(buildCardCreateDto(card, 200)).toEqual(
       expect.objectContaining({ id: "card-1", createdAt: 200, updatedAt: 200, deletedAt: null })
     );
-    expect(buildCardUpdateDto(card, 201)).toEqual(
-      expect.objectContaining({ deckId: "deck-1", createdAt: 1, updatedAt: 201 })
-    );
+    expect(buildCardUpdateDto(card, 201)).toEqual(expect.objectContaining({ createdAt: 1, updatedAt: 201 }));
     expect(buildCardUpdateDto(card, 201)).not.toHaveProperty("id");
+    expect(buildCardUpdateDto(card, 201)).not.toHaveProperty("deckId");
 
     const invalidCard = { ...card, tags: ["math", 42] } as unknown as Card;
     expect(() => buildCardCreateDto(invalidCard, 200)).toThrow();

--- a/src/entities/card/api/firestoreDocument.ts
+++ b/src/entities/card/api/firestoreDocument.ts
@@ -29,7 +29,7 @@ const cardCreateDtoSchema = cardDocumentSchema.extend({
   id: z.string(),
 });
 
-const cardUpdateDtoSchema = cardDocumentSchema.omit({ id: true }).partial().extend({
+const cardUpdateDtoSchema = cardDocumentSchema.omit({ id: true, deckId: true }).partial().extend({
   updatedAt: z.number(),
 });
 
@@ -105,7 +105,6 @@ export const buildCardUpdateDto = (card: CardEdit, updatedAt: number): CardUpdat
       backText: card.backText,
       tags: card.tags,
       uniqueKey: card.uniqueKey,
-      deckId: card.deckId,
       uid: card.uid,
       createdAt: card.createdAt,
       updatedAt,

--- a/src/entities/card/model/card.ts
+++ b/src/entities/card/model/card.ts
@@ -25,7 +25,7 @@ export interface Card {
 
 export type CardDeck = DeckForCard;
 export type CardRaw = Pick<Card, "frontText" | "backText" | "uniqueKey" | "tags">;
-export type CardEdit = Partial<Card> & Pick<Card, "id" | "deckId">;
+export type CardEdit = Partial<Omit<Card, "deckId">> & Pick<Card, "id">;
 
 export const createCard = (card: CardRaw, deck: CardDeck, generateId: () => string): Card => {
   const { uid, id: deckId } = deck;

--- a/src/entities/deck/api/subscribeDeckReads.firestore.spec.ts
+++ b/src/entities/deck/api/subscribeDeckReads.firestore.spec.ts
@@ -2,7 +2,6 @@ import type { Deck } from "../model/deck";
 import type { RemoteSnapshot } from "@/shared/api";
 
 import "@/test/firestore/initializeTestFirestore";
-import { deleteDoc, doc, getFirestore } from "firebase/firestore";
 import { describe, expect, it, vi } from "vitest";
 import * as UUID from "uuid";
 
@@ -16,8 +15,6 @@ vi.mock("@/shared/firestore", async (importOriginal) => ({
 }));
 
 describe("Deck Firestore subscription", () => {
-  const db = getFirestore();
-
   it("delivers initial, update, and delete snapshots", async () => {
     const snapshots: RemoteSnapshot<Deck>[] = [];
     const errors: Error[] = [];
@@ -53,7 +50,11 @@ describe("Deck Firestore subscription", () => {
         { timeout: 5_000 }
       );
 
-      await deleteDoc(doc(db, "deck", deck.id));
+      const response = await fetch(
+        `http://${import.meta.env.VITE_DB_HOST}:${import.meta.env.VITE_DB_PORT}/emulator/v1/projects/test/databases/(default)/documents`,
+        { method: "DELETE" }
+      );
+      expect(response.ok).toBe(true);
       await vi.waitFor(
         () => {
           expect(

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -69,7 +69,7 @@ describe("useCardMutations", () => {
 
     await actAsync(async () => result.current.updateBy(card.id, redirectingPatch));
 
-    expect(mocks.update).toHaveBeenCalledWith({ id: card.id, deckId: card.deckId, score: 2 });
+    expect(mocks.update).toHaveBeenCalledWith({ id: card.id, score: 2 });
   });
 
   it("rejects updateBy and remove when the Card is unavailable", async () => {

--- a/src/features/card/hooks/useCardMutations.ts
+++ b/src/features/card/hooks/useCardMutations.ts
@@ -38,7 +38,8 @@ export const useCardMutations = ({ onRemoveSuccess }: UseCardMutationsOptions = 
   const updateBy = (id: CardId, callback: (card: Card) => CardPatch) => {
     const card = cardsById[id];
     if (card == null) return Promise.reject(new Error(`Card ${id} is not available`));
-    return update({ ...callback(card), id: card.id, deckId: card.deckId });
+    const { id: _id, deckId: _deckId, uid: _uid, ...patch } = callback(card) as Partial<Card>;
+    return update({ ...patch, id: card.id });
   };
   const remove = (id: CardId) => {
     const card = cardsById[id];

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -198,7 +198,6 @@ describe("useStudyActions", () => {
 
     const patch = {
       id: card1.id,
-      deckId: deck.id,
       score: 1,
       numberOfSeen: 1,
       lastSeenAt: 946684800000,

--- a/src/features/study/model/studyCard.ts
+++ b/src/features/study/model/studyCard.ts
@@ -1,5 +1,4 @@
 import type { Card, CardEdit } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
 import { createStudyProgressFromCard, type StudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 
 type StudyCardContent = Omit<Card, keyof Omit<StudyProgress, "cardId">>;
@@ -14,7 +13,7 @@ export const createStudyCard = <TCard extends Card>(card: TCard): StudyCard<TCar
   progress: createStudyProgressFromCard(card),
 });
 
-export const createCardProgressEdit = (deckId: DeckId, progress: StudyProgressEdit): CardEdit => {
+export const createCardProgressEdit = (progress: StudyProgressEdit): CardEdit => {
   const { cardId: id, ...edit } = progress;
-  return { id, deckId, ...edit };
+  return { id, ...edit };
 };

--- a/src/features/study/model/swipe.spec.ts
+++ b/src/features/study/model/swipe.spec.ts
@@ -33,7 +33,6 @@ describe("buildStudyPatch", () => {
     const patch = buildStudyPatch(card, "GoToNextCardMastered", now);
     expect(patch).toEqual({
       id: "c1",
-      deckId: "d1",
       score: 1,
       numberOfSeen: 3,
       lastSeenAt: now,

--- a/src/features/study/model/swipe.ts
+++ b/src/features/study/model/swipe.ts
@@ -17,5 +17,5 @@ const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
 
 export const buildStudyPatch = (studyCard: StudyCard, swipeAction: SwipeAction, now: number): CardEdit => {
   const progress = recordStudyProgress(studyCard.progress, resolveStudyRating(swipeAction), now);
-  return createCardProgressEdit(studyCard.card.deckId, progress);
+  return createCardProgressEdit(progress);
 };


### PR DESCRIPTION
## Summary

- remove `deckId` from normal `CardEdit` patches and Firestore update DTOs
- strip identity and membership fields from callback-based Card edits at runtime
- keep Card writes locally serialized per Card while allowing unrelated Cards in the same Deck to proceed independently
- update the Deck subscription integration test to model physical deletion as a server-side operation

## Why

Deck membership changes need distributed coordination with Deck deletion. Normal Card edits should not implicitly move Cards between Decks, so this PR makes that boundary explicit and relies on the persistent deletion invariant provided by the base branch.

## Impact

Card content and study-progress updates continue to work, but they can no longer modify `deckId`. A future Deck move must use a dedicated coordinated operation.

## Validation

- `mise run check` (609 app unit tests; 4 Functions unit tests)
- `mise run test-firestore` (48 app/rules tests; 6 Functions emulator tests)

## Dependency

This is a stacked PR based on `codex/issue-606-firestore-cleanup`, the existing #363 implementation from #648. It intentionally does not duplicate the Deck deletion workflow.

Closes #652