### PR TITLE
test: rename test:firestore to test:integration

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ jobs:
         run: docker compose up --wait --wait-timeout 120 --remove-orphans -d db
 
       - name: Run Firestore tests
-        run: npm run test:firestore
+        run: npm run test:integration
 
       - name: Stop Firestore emulator
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Run a specific suite with:
 
 ```bash
 mise run test-unit
-mise run test-firestore
+mise run test-integration
 mise run test-sample
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -50,9 +50,9 @@ run = [
 depends = ["build-sample"]
 run = "npm run test:unit"
 
-[tasks.test-firestore]
+[tasks.test-integration]
 depends = ["up"]
-run = "npm run test:firestore"
+run = "npm run test:integration"
 
 [tasks.test-storybook]
 depends = ["build-sample"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "vitest run --project=unit --coverage --no-file-parallelism",
     "test:coverage:ci": "docker compose -f .devcontainer/compose.yaml -f .devcontainer/compose.local.yaml up --wait --wait-timeout 120 --remove-orphans -d db && npm run test:coverage",
     "test:unit": "vitest run --project=unit",
-    "test:firestore": "vitest run --project=integration --no-file-parallelism",
+    "test:integration": "vitest run --project=integration --no-file-parallelism",
     "test:sample": "docker compose -f sample/docker-compose.yml run --rm --remove-orphans --entrypoint py.test base",
     "test:storybook": "vitest run --project=storybook",
     "fix": "npm run fmt:fix && npm run lint:fix",


### PR DESCRIPTION
## Summary

Renamed the `test:firestore` script to `test:integration` in `package.json` and updated all references across the codebase.

## Changes

- Updated `package.json`: renamed `test:firestore` script to `test:integration`.
- Updated `mise.toml`: renamed task `[tasks.test-firestore]` to `[tasks.test-integration]` and updated the script call.
- Updated `.github/workflows/integration.yaml`: changed command to `npm run test:integration`.
- Updated `README.md`: updated `mise run test-integration` documentation example.

## Verification

- Verified via `mise run check` (linting, formatting, types, unit tests).