### PR TITLE
Move remote mutation locks into Deck entity

### DIFF
--- a/src/entities/card/api/commands.spec.ts
+++ b/src/entities/card/api/commands.spec.ts
@@ -2,8 +2,8 @@ import type { Card } from "../model/card";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { deckMembershipMutationLock, withDeckMembershipLocks } from "@/entities/deck/@x/card";
 import { REMOTE_WRITE_TIMEOUT_MS } from "@/shared/lib/remoteWrite";
-import { deckMembershipMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
 import { createCard as createCardFixture } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({

--- a/src/entities/card/api/commands.ts
+++ b/src/entities/card/api/commands.ts
@@ -1,4 +1,4 @@
-import type { DeckId } from "@/entities/deck/@x/card";
+import { type DeckId, deckMembershipMutationLock, withDeckMembershipLocks } from "@/entities/deck/@x/card";
 
 import type { Card, CardEdit, CardId } from "../model/card";
 
@@ -8,9 +8,10 @@ import {
   update as updateRemoteCard,
   upsert as upsertRemoteCard,
 } from "./firestore";
-import { cardMutationLock, deckMembershipMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
 import { runSerially } from "@/shared/lib/runSerially";
 import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
+
+const cardMutationLock = (uid: string, id: CardId) => `card:${uid}:${id}`;
 
 const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Card writes");

--- a/src/entities/deck/@x/card.ts
+++ b/src/entities/deck/@x/card.ts
@@ -2,3 +2,4 @@ import type { Deck } from "../model/deck";
 
 export type { DeckId } from "../model/deck";
 export type DeckForCard = Pick<Deck, "id" | "uid">;
+export { deckMembershipMutationLock, withDeckMembershipLocks } from "../api/remoteMutationLocks";

--- a/src/entities/deck/api/commands.spec.ts
+++ b/src/entities/deck/api/commands.spec.ts
@@ -3,8 +3,8 @@ import type { Deck } from "../model/deck";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { REMOTE_WRITE_TIMEOUT_MS } from "@/shared/lib/remoteWrite";
-import { deckMembershipMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
 import { createDeck as createDeckFixture } from "@/test/factories";
+import { deckMembershipMutationLock, withDeckMembershipLocks } from "./remoteMutationLocks";
 
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),

--- a/src/entities/deck/api/commands.ts
+++ b/src/entities/deck/api/commands.ts
@@ -1,9 +1,9 @@
 import type { Deck, DeckEdit } from "../model/deck";
 
-import { deckMembershipMutationLock, deckMutationLock, withDeckMembershipLocks } from "@/store/remoteMutationLocks";
 import { runSerially } from "@/shared/lib/runSerially";
 import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
 import { create as createRemoteDeck, remove as removeRemoteDeck, update as updateRemoteDeck } from "./firestore";
+import { deckMembershipMutationLock, deckMutationLock, withDeckMembershipLocks } from "./remoteMutationLocks";
 
 const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");

--- a/src/entities/deck/api/remoteMutationLocks.ts
+++ b/src/entities/deck/api/remoteMutationLocks.ts
@@ -1,7 +1,4 @@
-/** @file Serializes conflicting remote mutations. */
-
-import type { CardId } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
+import type { DeckId } from "../model/deck";
 
 interface MembershipLockState {
   exclusive?: Promise<void>;
@@ -52,6 +49,5 @@ export const withDeckMembershipLocks = async <T>(
   }
 };
 
-export const cardMutationLock = (uid: string, id: CardId) => `card:${uid}:${id}`;
 export const deckMembershipMutationLock = (uid: string, id: DeckId) => `deck-membership:${uid}:${id}`;
 export const deckMutationLock = (uid: string, id: DeckId) => `deck:${uid}:${id}`;


### PR DESCRIPTION
## Summary

- Move remote mutation coordination from the top-level store into the Deck entity.
- Expose Deck membership locks to the Card entity through its cross-import API and keep the Card lock key local.

## Testing

- mise run check