### PR TITLE
Restrict src top-level directories with ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import testingLibrary from "eslint-plugin-testing-library";
 
 const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
+const sourceLayers = ["app", "entities", "features", "pages", "shared", "store"];
 
 export default [
   {
@@ -32,12 +33,22 @@ export default [
     files: sourceFiles,
     settings: {
       ...boundariesRecommended.settings,
+      "boundaries/elements": sourceLayers.map((layer) => ({
+        type: layer,
+        pattern: `src/${layer}`,
+        partialMatch: false,
+      })),
+      "boundaries/ignore": ["src/vite-env.d.ts"],
       "boundaries/dependency-nodes": [
         "import",
         "export",
         "require",
         "dynamic-import",
       ],
+    },
+    rules: {
+      ...boundariesRecommended.rules,
+      "boundaries/no-unknown-files": "error",
     },
   }),
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,8 +35,8 @@ export default [
       ...boundariesRecommended.settings,
       "boundaries/elements": sourceLayers.map((layer) => ({
         type: layer,
-        pattern: `src/${layer}`,
-        partialMatch: false,
+        pattern: `src/${layer}/**/*`,
+        mode: "full",
       })),
       "boundaries/ignore": ["src/vite-env.d.ts"],
       "boundaries/dependency-nodes": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ import testingLibrary from "eslint-plugin-testing-library";
 
 const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
-const sourceLayers = ["app", "entities", "features", "pages", "shared", "store"];
+const sourceLayers = ["app", "entities", "features", "pages", "shared"];
 
 export default [
   {


### PR DESCRIPTION
## Summary

- define the allowed `src` top-level layers as `app`, `entities`, `features`, `pages`, and `shared`
- enable `boundaries/no-unknown-files` as an error
- ignore the existing `src/vite-env.d.ts` root declaration file

## Why

Prevent new source directories outside the intended FSD-oriented top-level structure from being introduced accidentally. `src/store` has already been migrated away, so it is intentionally not included in the allowlist and will be rejected if reintroduced.

## Impact

A new TypeScript/TSX file placed under an unrecognized `src/<directory>` will fail ESLint. Existing allowed source layers remain unaffected.

## Validation

- verified the branch contains only the intended `eslint.config.mjs` change