### PR TITLE
Add local branch cleanup task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,7 @@ test-sample = "mise run //sample:test"
 lint-docker = "hadolint --failure-threshold warning Dockerfile sample/Dockerfile"
 down = "docker compose down --remove-orphans"
 ps = "docker compose ps"
+cleanup-branches = "bash scripts/cleanup-branches.sh"
 
 [tasks.init]
 depends = ["init-deps"]

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,9 @@ test-sample = "mise run //sample:test"
 lint-docker = "hadolint --failure-threshold warning Dockerfile sample/Dockerfile"
 down = "docker compose down --remove-orphans"
 ps = "docker compose ps"
-cleanup-branches = "bash scripts/cleanup-branches.sh"
+
+[tasks.git-cleanup]
+file = "scripts/cleanup-branches.sh"
 
 [tasks.init]
 depends = ["init-deps"]

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current=$(git branch --show-current)
+
+gh pr list --state all --limit 1000 \
+  --json headRefName,state,isCrossRepository \
+  --jq '.[] | select(.state != "OPEN" and .isCrossRepository == false) | .headRefName' |
+  sort -u |
+  while IFS= read -r branch; do
+    [[ "$branch" == "$current" ]] && continue
+
+    if git show-ref --verify --quiet "refs/heads/$branch"; then
+      git branch -D "$branch"
+    fi
+  done

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-current=$(git branch --show-current)
+checked_out=$(git worktree list --porcelain | sed -n 's|^branch refs/heads/||p')
 
 gh pr list --state all --limit 1000 \
   --json headRefName,state,isCrossRepository \
-  --jq '.[] | select(.state != "OPEN" and .isCrossRepository == false) | .headRefName' |
-  sort -u |
+  --jq '[.[] | select(.isCrossRepository == false)] | group_by(.headRefName)[] | select(all(.state != "OPEN")) | .[0].headRefName' |
   while IFS= read -r branch; do
-    [[ "$branch" == "$current" ]] && continue
+    grep -Fxq "$branch" <<<"$checked_out" && continue
 
     if git show-ref --verify --quiet "refs/heads/$branch"; then
       git branch -D "$branch"


### PR DESCRIPTION
## What changed
- add `scripts/cleanup-branches.sh` to delete local branches whose same-repository GitHub PRs are all merged or closed
- keep a branch when any PR with the same head branch is still open
- skip branches checked out in any worktree and cross-repository PRs
- add `mise run git-cleanup` entrypoint

## Why
Local branches for completed PRs accumulate over time. This provides a concise, repeatable cleanup command without deleting branches that are still active or checked out in another worktree.

## Validation
- verified the jq grouping/filter logic with representative open/closed/merged PR data
- reviewed the worktree protection and `mise.toml` task wiring
- runtime execution against the repository was not performed because this environment does not have the repository checked out locally