### PR TITLE
Move Firestore test initializer to test directory

### DIFF
--- a/test/initializeTestFirestore.ts
+++ b/test/initializeTestFirestore.ts
@@ -2,7 +2,8 @@
 
 import { initializeApp } from "firebase/app";
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
-import { initializeFirestoreRuntime } from "../firestore-runtime";
+
+import { initializeFirestoreRuntime } from "@/shared/firebase/firestore-runtime";
 
 initializeApp({
   projectId: "test",

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -6,7 +6,7 @@
 
 import type { Card } from "@/entities/card";
 
-import "@/shared/firebase/test/initializeTestFirestore";
+import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { getFirestore, doc, getDoc } from "firebase/firestore";
 import * as cardAdapter from "@/entities/card/api/firestore";

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -5,7 +5,7 @@
 
 import type { Deck } from "@/entities/deck";
 
-import "@/shared/firebase/test/initializeTestFirestore";
+import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { doc, getDoc, getFirestore } from "firebase/firestore";
 import * as deckAdapter from "@/entities/deck/api/firestore";

--- a/test/integration/firestore/reads.spec.ts
+++ b/test/integration/firestore/reads.spec.ts
@@ -5,7 +5,7 @@
  * collections when the UID has no documents".
  */
 
-import "@/shared/firebase/test/initializeTestFirestore";
+import "@/test/initializeTestFirestore";
 import { readFileSync } from "node:fs";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { initializeTestEnvironment, type RulesTestEnvironment } from "@firebase/rules-unit-testing";

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,7 +8,7 @@ import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { RemoteSnapshot } from "@/shared/api";
 
-import "@/shared/firebase/test/initializeTestFirestore";
+import "@/test/initializeTestFirestore";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 


### PR DESCRIPTION
## Summary

- move the Firestore integration-test initializer under `test/`
- update integration-test imports to use the test alias

## Testing

- `mise run check`