### PR TITLE
Bound Card cleanup during Deck removal

### DIFF
--- a/src/entities/deck/api/commands.spec.ts
+++ b/src/entities/deck/api/commands.spec.ts
@@ -4,17 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { REMOTE_WRITE_TIMEOUT_MS } from "@/shared/lib/remoteWrite";
 import { createDeck as createDeckFixture } from "@/test/factories";
-import { deckMembershipMutationLock, withDeckMembershipLocks } from "./remoteMutationLocks";
 
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   update: vi.fn(),
-  remove: vi.fn(),
 }));
 
 vi.mock("./firestore", () => ({
   create: mocks.create,
-  remove: mocks.remove,
   update: mocks.update,
 }));
 
@@ -27,7 +24,6 @@ describe("deck commands", () => {
     vi.clearAllMocks();
     mocks.create.mockResolvedValue("created");
     mocks.update.mockResolvedValue(undefined);
-    mocks.remove.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -36,10 +32,9 @@ describe("deck commands", () => {
 
   it("rejects missing users and mismatched owners before writing", async () => {
     await expect(deckCommands.create("", createDeck())).rejects.toThrow("confirmed user");
-    await expect(deckCommands.remove("uid-a", createDeck({ uid: "uid-b" }))).rejects.toThrow("owner does not match");
+    await expect(deckCommands.create("uid-a", createDeck({ uid: "uid-b" }))).rejects.toThrow("owner does not match");
 
     expect(mocks.create).not.toHaveBeenCalled();
-    expect(mocks.remove).not.toHaveBeenCalled();
   });
 
   it("updates without ownership metadata in the edit input", async () => {
@@ -57,14 +52,13 @@ describe("deck commands", () => {
     );
     const deck = createDeck({ id: "deck" });
 
-    const update = deckCommands.update("uid-a", deck);
-    const remove = deckCommands.remove("uid-a", deck);
+    const firstUpdate = deckCommands.update("uid-a", deck);
+    const secondUpdate = deckCommands.update("uid-a", deck);
     await vi.waitFor(() => expect(mocks.update).toHaveBeenCalledOnce());
-    expect(mocks.remove).not.toHaveBeenCalled();
 
     finishUpdate();
-    await Promise.all([update, remove]);
-    expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(deck.id, "uid-a");
+    await Promise.all([firstUpdate, secondUpdate]);
+    expect(mocks.update).toHaveBeenCalledTimes(2);
   });
 
   it("allows writes to unrelated Decks to proceed independently", async () => {
@@ -86,34 +80,9 @@ describe("deck commands", () => {
     await Promise.all([firstUpdate, secondUpdate]);
   });
 
-  it("waits to remove a Deck while its membership is shared-locked", async () => {
-    let finishShared!: () => void;
-    const sharedStarted = vi.fn();
-    const blockedDeck = createDeck({ id: "blocked" });
-    const unrelatedDeck = createDeck({ id: "unrelated" });
-    const shared = withDeckMembershipLocks([deckMembershipMutationLock("uid-a", blockedDeck.id)], "shared", () => {
-      sharedStarted();
-      return new Promise<void>((resolve) => {
-        finishShared = resolve;
-      });
-    });
-    await vi.waitFor(() => expect(sharedStarted).toHaveBeenCalledOnce());
-
-    const blockedRemoval = deckCommands.remove("uid-a", blockedDeck);
-    const unrelatedRemoval = deckCommands.remove("uid-a", unrelatedDeck);
-
-    await vi.waitFor(() => expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(unrelatedDeck.id, "uid-a"));
-    expect(mocks.remove).not.toHaveBeenCalledWith(blockedDeck.id, "uid-a");
-
-    finishShared();
-    await Promise.all([shared, blockedRemoval, unrelatedRemoval]);
-    expect(mocks.remove).toHaveBeenCalledWith(blockedDeck.id, "uid-a");
-  });
-
   it.each([
     ["create", "Deck creation"],
     ["update", "Deck update"],
-    ["remove", "Deck deletion"],
   ] as const)("rejects a stalled Deck %s instead of leaving it pending", async (command, label) => {
     vi.useFakeTimers();
     mocks[command].mockReturnValueOnce(new Promise(() => undefined));

--- a/src/entities/deck/api/commands.ts
+++ b/src/entities/deck/api/commands.ts
@@ -2,8 +2,8 @@ import type { Deck, DeckEdit } from "../model/deck";
 
 import { runSerially } from "@/shared/lib/runSerially";
 import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
-import { create as createRemoteDeck, remove as removeRemoteDeck, update as updateRemoteDeck } from "./firestore";
-import { deckMembershipMutationLock, deckMutationLock, withDeckMembershipLocks } from "./remoteMutationLocks";
+import { create as createRemoteDeck, update as updateRemoteDeck } from "./firestore";
+import { deckMutationLock } from "./remoteMutationLocks";
 
 const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
@@ -27,15 +27,5 @@ export const deckCommands = {
   update: async (uid: string, deck: DeckEdit): Promise<void> => {
     requireUid(uid);
     await runSerially(deckMutationLock(uid, deck.id), () => waitForRemoteWrite(updateRemoteDeck(deck), "Deck update"));
-  },
-
-  remove: async (uid: string, deck: Deck): Promise<void> => {
-    requireUid(uid);
-    requireOwner(uid, deck.uid);
-    await runSerially(deckMutationLock(uid, deck.id), () =>
-      withDeckMembershipLocks([deckMembershipMutationLock(uid, deck.id)], "exclusive", () =>
-        waitForRemoteWrite(removeRemoteDeck(deck.id, uid), "Deck deletion")
-      )
-    );
   },
 };

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -37,8 +37,8 @@ export const update = async (deck: DeckEdit): Promise<void> => {
   await updateDoc(doc(getDb(), DECK_COLLECTION, deck.id), buildDeckUpdateDto(deck, getTimestamp()));
 };
 
-export const remove = async (deckId: string): Promise<void> => {
-  await deleteDoc(doc(getDb(), DECK_COLLECTION, deckId));
+export const remove = async (deckId: string, firestore: Firestore = getDb()): Promise<void> => {
+  await deleteDoc(doc(firestore, DECK_COLLECTION, deckId));
 };
 
 export const exists = async (id: string): Promise<boolean> =>

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -37,15 +37,8 @@ export const update = async (deck: DeckEdit): Promise<void> => {
   await updateDoc(doc(getDb(), DECK_COLLECTION, deck.id), buildDeckUpdateDto(deck, getTimestamp()));
 };
 
-export const remove = async (deckId: string, uid: string): Promise<void> => {
-  const db = getDb();
-  const cardQuery = query(collection(db, "card"), where("uid", "==", uid), where("deckId", "==", deckId));
-  const snapshot = await getDocs(cardQuery);
-  const childResults = await Promise.allSettled(snapshot.docs.map((document) => deleteDoc(document.ref)));
-  const childFailure = childResults.find((result): result is PromiseRejectedResult => result.status === "rejected");
-  if (childFailure != null) throw childFailure.reason;
-
-  await deleteDoc(doc(db, DECK_COLLECTION, deckId));
+export const remove = async (deckId: string): Promise<void> => {
+  await deleteDoc(doc(getDb(), DECK_COLLECTION, deckId));
 };
 
 export const exists = async (id: string): Promise<boolean> =>

--- a/src/entities/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/entities/deck/hooks/useDeckMutations.spec.tsx
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => ({
   uid: "uid-a",
   create: vi.fn(),
   update: vi.fn(),
-  remove: vi.fn(),
 }));
 
 vi.mock("@/entities/auth-session/@x/deck", () => ({
@@ -23,7 +22,6 @@ vi.mock("@/entities/auth-session/@x/deck", () => ({
 }));
 vi.mock("../api/firestore", () => ({
   create: mocks.create,
-  remove: mocks.remove,
   update: mocks.update,
 }));
 
@@ -35,7 +33,6 @@ describe("useDeckMutations", () => {
     mocks.uid = "uid-a";
     mocks.create.mockResolvedValue("deck-id");
     mocks.update.mockResolvedValue(undefined);
-    mocks.remove.mockResolvedValue(undefined);
   });
 
   it("exposes per-Deck pending state while an update is running", async () => {
@@ -61,54 +58,11 @@ describe("useDeckMutations", () => {
     expect(result.current.pending).toBe(false);
   });
 
-  it("invokes remove success after a removal", async () => {
-    let finish!: () => void;
-    mocks.remove.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));
-    const deck = createDeck({ id: "deck" });
-    const onRemoveSuccess = vi.fn();
-    const { result } = renderHook(() => useDeckMutations({ onRemoveSuccess }));
-
-    let operation!: Promise<void>;
-    act(() => {
-      operation = result.current.remove(deck);
-    });
-    await waitFor(() => expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(deck.id, "uid-a"));
-    await actAsync(async () => {
-      finish();
-      await operation;
-    });
-
-    expect(onRemoveSuccess).toHaveBeenCalledExactlyOnceWith(deck);
-    expect(result.current.pending).toBe(false);
-  });
-
-  it("does not invoke a removal callback after the hook unmounts", async () => {
-    const deck = createDeck({ id: "deck" });
-    const failure = new Error("remove failed");
-    let finishRetry!: () => void;
-    mocks.remove
-      .mockRejectedValueOnce(failure)
-      .mockReturnValueOnce(new Promise<void>((resolve) => (finishRetry = resolve)));
-    const onRemoveSuccess = vi.fn();
-    const { result, unmount } = renderHook(() => useDeckMutations({ onRemoveSuccess }));
-    await actAsync(async () => {
-      await expect(result.current.remove(deck)).rejects.toBe(failure);
-    });
-
-    act(() => result.current.retry());
-    await waitFor(() => expect(mocks.remove).toHaveBeenCalledTimes(2));
-    unmount();
-    finishRetry();
-
-    await waitFor(() => expect(onRemoveSuccess).not.toHaveBeenCalled());
-  });
-
-  it("retries the latest failed update without invoking remove success", async () => {
+  it("retries the latest failed update", async () => {
     const deck = createDeck({ id: "deck" });
     const failure = new Error("update failed");
     mocks.update.mockRejectedValueOnce(failure).mockResolvedValueOnce(undefined);
-    const onRemoveSuccess = vi.fn();
-    const { result } = renderHook(() => useDeckMutations({ onRemoveSuccess }));
+    const { result } = renderHook(useDeckMutations);
 
     await actAsync(async () => {
       await expect(result.current.update(deck)).rejects.toBe(failure);
@@ -120,7 +74,6 @@ describe("useDeckMutations", () => {
       expect(mocks.update).toHaveBeenCalledTimes(2);
       expect(result.current.error).toBeNull();
     });
-    expect(onRemoveSuccess).not.toHaveBeenCalled();
   });
 
   it("rejects writes without a confirmed user and exposes the error", async () => {
@@ -135,27 +88,5 @@ describe("useDeckMutations", () => {
     expect(result.current.error).toEqual(
       expect.objectContaining({ message: expect.stringContaining("confirmed user") })
     );
-  });
-
-  it("does not invoke remove success for an operation started before the UID changes", async () => {
-    let finish!: () => void;
-    mocks.remove.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));
-    const deck = createDeck({ id: "deck" });
-    const onRemoveSuccess = vi.fn();
-    const { result, rerender } = renderHook(() => useDeckMutations({ onRemoveSuccess }));
-
-    let operation!: Promise<void>;
-    act(() => {
-      operation = result.current.remove(deck);
-    });
-    await waitFor(() => expect(result.current.pending).toBe(true));
-    mocks.uid = "uid-b";
-    rerender();
-    finish();
-    await operation;
-
-    expect(result.current.pending).toBe(false);
-    expect(result.current.error).toBeNull();
-    expect(onRemoveSuccess).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/deck/hooks/useDeckMutations.ts
+++ b/src/entities/deck/hooks/useDeckMutations.ts
@@ -2,48 +2,21 @@
 
 import type { Deck, DeckEdit, DeckId } from "../model/deck";
 
-import { useEffect, useRef } from "react";
-
 import { deckCommands } from "../api/commands";
 import { useAuthSession } from "@/entities/auth-session/@x/deck";
 import { useAsyncAction } from "@/shared/hooks";
 
-interface UseDeckMutationsOptions {
-  onRemoveSuccess?: (deck: Deck) => void;
-}
-
-export const useDeckMutations = ({ onRemoveSuccess }: UseDeckMutationsOptions = {}) => {
+export const useDeckMutations = () => {
   const auth = useAuthSession();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const mutation = useAsyncAction<DeckId>(uid);
-  const scope = useRef({ uid });
-  const onRemoveSuccessRef = useRef(onRemoveSuccess);
-
-  useEffect(() => {
-    onRemoveSuccessRef.current = onRemoveSuccess;
-  }, [onRemoveSuccess]);
-
-  useEffect(() => {
-    scope.current = { uid };
-    return () => {
-      scope.current = { uid };
-    };
-  }, [uid]);
 
   const create = (deck: Deck) => mutation.run([deck.id], `create:${deck.id}`, () => deckCommands.create(uid, deck));
   const update = (deck: DeckEdit) => mutation.run([deck.id], `update:${deck.id}`, () => deckCommands.update(uid, deck));
-  const remove = (deck: Deck) => {
-    const operationScope = scope.current;
-    return mutation.run([deck.id], `remove:${deck.id}`, async () => {
-      await deckCommands.remove(uid, deck);
-      if (scope.current === operationScope) onRemoveSuccessRef.current?.(deck);
-    });
-  };
 
   return {
     create,
     update,
-    remove,
     pending: mutation.pending,
     isPending: mutation.isPending,
     error: mutation.error,

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,5 +1,7 @@
 export { CATEGORY, getCategory, isHighlightLanguage } from "./model/category";
 export type { Category } from "./model/category";
+export { remove as removeDeckDocument } from "./api/firestore";
+export { deckMembershipMutationLock, deckMutationLock, withDeckMembershipLocks } from "./api/remoteMutationLocks";
 export { generateDeckId } from "./api/firestore";
 export { createDeck } from "./model/deck";
 export type { Deck, DeckEdit, DeckId } from "./model/deck";

--- a/src/features/deck-removal/api/removeDeck.spec.ts
+++ b/src/features/deck-removal/api/removeDeck.spec.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  collection: vi.fn(() => "card-collection"),
+  getDocs: vi.fn(),
+  query: vi.fn(() => "card-query"),
+  removeDeckDocument: vi.fn(),
+  where: vi.fn((...parts: unknown[]) => parts),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: mocks.collection,
+  getDocs: mocks.getDocs,
+  query: mocks.query,
+  where: mocks.where,
+  writeBatch: mocks.writeBatch,
+}));
+vi.mock("@/entities/deck", () => ({ removeDeckDocument: mocks.removeDeckDocument }));
+vi.mock("@/shared/firestore", () => ({ getDb: () => "db" }));
+
+import { CARD_DELETE_BATCH_SIZE, removeDeckWithCards } from "./removeDeck";
+
+const documents = (count: number, start = 0) =>
+  Array.from({ length: count }, (_, index) => ({ ref: `card-${start + index}` }));
+
+const batch = () => ({ delete: vi.fn(), commit: vi.fn().mockResolvedValue(undefined) });
+
+describe("removeDeckWithCards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDocs.mockResolvedValue({ docs: [] });
+    mocks.removeDeckDocument.mockResolvedValue(undefined);
+  });
+
+  it("deletes an empty Deck without creating a Card batch", async () => {
+    await removeDeckWithCards("deck-id", "uid-a");
+
+    expect(mocks.collection).toHaveBeenCalledWith("db", "card");
+    expect(mocks.where).toHaveBeenNthCalledWith(1, "uid", "==", "uid-a");
+    expect(mocks.where).toHaveBeenNthCalledWith(2, "deckId", "==", "deck-id");
+    expect(mocks.getDocs).toHaveBeenCalledWith("card-query");
+    expect(mocks.writeBatch).not.toHaveBeenCalled();
+    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id", "db");
+  });
+
+  it("deletes one bounded Card batch before the Deck", async () => {
+    const cardBatch = batch();
+    mocks.getDocs.mockResolvedValue({ docs: documents(CARD_DELETE_BATCH_SIZE) });
+    mocks.writeBatch.mockReturnValue(cardBatch);
+
+    await removeDeckWithCards("deck-id", "uid-a");
+
+    expect(cardBatch.delete).toHaveBeenCalledTimes(CARD_DELETE_BATCH_SIZE);
+    expect(cardBatch.commit).toHaveBeenCalledOnce();
+    expect(cardBatch.commit.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.removeDeckDocument.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    );
+  });
+
+  it("commits multiple bounded Card batches serially", async () => {
+    const first = batch();
+    const second = batch();
+    let finishFirst!: () => void;
+    first.commit.mockReturnValueOnce(new Promise<void>((resolve) => (finishFirst = resolve)));
+    mocks.getDocs.mockResolvedValue({ docs: documents(CARD_DELETE_BATCH_SIZE + 1) });
+    mocks.writeBatch.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+    const operation = removeDeckWithCards("deck-id", "uid-a");
+    await vi.waitFor(() => expect(first.commit).toHaveBeenCalledOnce());
+    expect(mocks.writeBatch).toHaveBeenCalledOnce();
+    expect(second.commit).not.toHaveBeenCalled();
+    expect(mocks.removeDeckDocument).not.toHaveBeenCalled();
+
+    finishFirst();
+    await operation;
+
+    expect(first.delete).toHaveBeenCalledTimes(CARD_DELETE_BATCH_SIZE);
+    expect(second.delete).toHaveBeenCalledExactlyOnceWith(`card-${CARD_DELETE_BATCH_SIZE}`);
+    expect(second.commit).toHaveBeenCalledOnce();
+    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id", "db");
+  });
+
+  it("keeps the Deck after a batch failure and retries only remaining Cards", async () => {
+    const failure = new Error("batch failed");
+    const first = batch();
+    const failed = batch();
+    failed.commit.mockRejectedValueOnce(failure);
+    mocks.getDocs
+      .mockResolvedValueOnce({ docs: documents(CARD_DELETE_BATCH_SIZE + 1) })
+      .mockResolvedValueOnce({ docs: documents(1, CARD_DELETE_BATCH_SIZE) });
+    mocks.writeBatch.mockReturnValueOnce(first).mockReturnValueOnce(failed);
+
+    await expect(removeDeckWithCards("deck-id", "uid-a")).rejects.toBe(failure);
+    expect(first.commit).toHaveBeenCalledOnce();
+    expect(failed.commit).toHaveBeenCalledOnce();
+    expect(mocks.removeDeckDocument).not.toHaveBeenCalled();
+
+    const retry = batch();
+    mocks.writeBatch.mockReturnValueOnce(retry);
+    await removeDeckWithCards("deck-id", "uid-a");
+
+    expect(mocks.getDocs).toHaveBeenCalledTimes(2);
+    expect(retry.delete).toHaveBeenCalledExactlyOnceWith(`card-${CARD_DELETE_BATCH_SIZE}`);
+    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id", "db");
+  });
+});

--- a/src/features/deck-removal/api/removeDeck.ts
+++ b/src/features/deck-removal/api/removeDeck.ts
@@ -1,22 +1,25 @@
-import { collection, getDocs, query, where, writeBatch } from "firebase/firestore";
+import { collection, getDocs, query, where, writeBatch, type Firestore } from "firebase/firestore";
 
 import { removeDeckDocument } from "@/entities/deck";
 import { getDb } from "@/shared/firestore";
 
 export const CARD_DELETE_BATCH_SIZE = 450;
 
-export const removeDeckWithCards = async (deckId: string, uid: string): Promise<void> => {
-  const db = getDb();
-  const cardQuery = query(collection(db, "card"), where("uid", "==", uid), where("deckId", "==", deckId));
+export const removeDeckWithCards = async (
+  deckId: string,
+  uid: string,
+  firestore: Firestore = getDb()
+): Promise<void> => {
+  const cardQuery = query(collection(firestore, "card"), where("uid", "==", uid), where("deckId", "==", deckId));
   const snapshot = await getDocs(cardQuery);
 
   for (let offset = 0; offset < snapshot.docs.length; offset += CARD_DELETE_BATCH_SIZE) {
-    const batch = writeBatch(db);
+    const batch = writeBatch(firestore);
     snapshot.docs.slice(offset, offset + CARD_DELETE_BATCH_SIZE).forEach((document) => {
       batch.delete(document.ref);
     });
     await batch.commit();
   }
 
-  await removeDeckDocument(deckId);
+  await removeDeckDocument(deckId, firestore);
 };

--- a/src/features/deck-removal/api/removeDeck.ts
+++ b/src/features/deck-removal/api/removeDeck.ts
@@ -1,0 +1,22 @@
+import { collection, getDocs, query, where, writeBatch } from "firebase/firestore";
+
+import { removeDeckDocument } from "@/entities/deck";
+import { getDb } from "@/shared/firestore";
+
+export const CARD_DELETE_BATCH_SIZE = 450;
+
+export const removeDeckWithCards = async (deckId: string, uid: string): Promise<void> => {
+  const db = getDb();
+  const cardQuery = query(collection(db, "card"), where("uid", "==", uid), where("deckId", "==", deckId));
+  const snapshot = await getDocs(cardQuery);
+
+  for (let offset = 0; offset < snapshot.docs.length; offset += CARD_DELETE_BATCH_SIZE) {
+    const batch = writeBatch(db);
+    snapshot.docs.slice(offset, offset + CARD_DELETE_BATCH_SIZE).forEach((document) => {
+      batch.delete(document.ref);
+    });
+    await batch.commit();
+  }
+
+  await removeDeckDocument(deckId);
+};

--- a/src/features/deck-removal/hooks/useDeckRemoval.spec.tsx
+++ b/src/features/deck-removal/hooks/useDeckRemoval.spec.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDeck } from "@/test/factories";
+import { actAsync } from "@/test/act";
+
+const mocks = vi.hoisted(() => ({ uid: "uid-a", removeDeck: vi.fn() }));
+
+vi.mock("@/entities/session", () => ({
+  useSession: () =>
+    mocks.uid === ""
+      ? { status: "signedOut" }
+      : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
+}));
+vi.mock("../model/removeDeck", () => ({ removeDeck: mocks.removeDeck }));
+
+import { useDeckRemoval } from "./useDeckRemoval";
+
+describe("useDeckRemoval", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.uid = "uid-a";
+    mocks.removeDeck.mockResolvedValue(undefined);
+  });
+
+  it("exposes pending state and invokes success after removal", async () => {
+    let finish!: () => void;
+    mocks.removeDeck.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));
+    const deck = createDeck({ id: "deck", uid: mocks.uid });
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useDeckRemoval({ onSuccess }));
+
+    let operation!: Promise<void>;
+    act(() => {
+      operation = result.current.remove(deck);
+    });
+    await waitFor(() => expect(result.current.isPending(deck.id)).toBe(true));
+    finish();
+    await actAsync(() => operation);
+
+    expect(onSuccess).toHaveBeenCalledExactlyOnceWith(deck);
+    expect(result.current.pending).toBe(false);
+  });
+
+  it("retries a failed removal", async () => {
+    const deck = createDeck({ uid: mocks.uid });
+    const failure = new Error("remove failed");
+    mocks.removeDeck.mockRejectedValueOnce(failure).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(useDeckRemoval);
+
+    await actAsync(async () => {
+      await expect(result.current.remove(deck)).rejects.toBe(failure);
+    });
+    act(() => result.current.retry());
+
+    await waitFor(() => {
+      expect(mocks.removeDeck).toHaveBeenCalledTimes(2);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  it("does not invoke success after the authenticated user changes", async () => {
+    let finish!: () => void;
+    mocks.removeDeck.mockReturnValueOnce(new Promise<void>((resolve) => (finish = resolve)));
+    const deck = createDeck({ uid: mocks.uid });
+    const onSuccess = vi.fn();
+    const { result, rerender } = renderHook(() => useDeckRemoval({ onSuccess }));
+
+    let operation!: Promise<void>;
+    act(() => {
+      operation = result.current.remove(deck);
+    });
+    await waitFor(() => expect(result.current.pending).toBe(true));
+    mocks.uid = "uid-b";
+    rerender();
+    finish();
+    await operation;
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/deck-removal/hooks/useDeckRemoval.spec.tsx
+++ b/src/features/deck-removal/hooks/useDeckRemoval.spec.tsx
@@ -6,8 +6,8 @@ import { actAsync } from "@/test/act";
 
 const mocks = vi.hoisted(() => ({ uid: "uid-a", removeDeck: vi.fn() }));
 
-vi.mock("@/entities/session", () => ({
-  useSession: () =>
+vi.mock("@/entities/auth-session", () => ({
+  useAuthSession: () =>
     mocks.uid === ""
       ? { status: "signedOut" }
       : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },

--- a/src/features/deck-removal/hooks/useDeckRemoval.ts
+++ b/src/features/deck-removal/hooks/useDeckRemoval.ts
@@ -1,0 +1,46 @@
+import type { Deck, DeckId } from "@/entities/deck";
+
+import { useEffect, useRef } from "react";
+
+import { useSession } from "@/entities/session";
+import { useAsyncAction } from "@/shared/hooks";
+import { removeDeck } from "../model/removeDeck";
+
+interface UseDeckRemovalOptions {
+  onSuccess?: (deck: Deck) => void;
+}
+
+export const useDeckRemoval = ({ onSuccess }: UseDeckRemovalOptions = {}) => {
+  const auth = useSession();
+  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const mutation = useAsyncAction<DeckId>(uid);
+  const scope = useRef({ uid });
+  const onSuccessRef = useRef(onSuccess);
+
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+  }, [onSuccess]);
+
+  useEffect(() => {
+    scope.current = { uid };
+    return () => {
+      scope.current = { uid };
+    };
+  }, [uid]);
+
+  const remove = (deck: Deck) => {
+    const operationScope = scope.current;
+    return mutation.run([deck.id], `remove:${deck.id}`, async () => {
+      await removeDeck(uid, deck);
+      if (scope.current === operationScope) onSuccessRef.current?.(deck);
+    });
+  };
+
+  return {
+    remove,
+    pending: mutation.pending,
+    isPending: mutation.isPending,
+    error: mutation.error,
+    retry: mutation.retry,
+  };
+};

--- a/src/features/deck-removal/hooks/useDeckRemoval.ts
+++ b/src/features/deck-removal/hooks/useDeckRemoval.ts
@@ -2,7 +2,7 @@ import type { Deck, DeckId } from "@/entities/deck";
 
 import { useEffect, useRef } from "react";
 
-import { useSession } from "@/entities/session";
+import { useAuthSession } from "@/entities/auth-session";
 import { useAsyncAction } from "@/shared/hooks";
 import { removeDeck } from "../model/removeDeck";
 
@@ -11,7 +11,7 @@ interface UseDeckRemovalOptions {
 }
 
 export const useDeckRemoval = ({ onSuccess }: UseDeckRemovalOptions = {}) => {
-  const auth = useSession();
+  const auth = useAuthSession();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const mutation = useAsyncAction<DeckId>(uid);
   const scope = useRef({ uid });

--- a/src/features/deck-removal/index.ts
+++ b/src/features/deck-removal/index.ts
@@ -1,0 +1,1 @@
+export { useDeckRemoval } from "./hooks/useDeckRemoval";

--- a/src/features/deck-removal/model/removeDeck.spec.ts
+++ b/src/features/deck-removal/model/removeDeck.spec.ts
@@ -48,15 +48,38 @@ describe("removeDeck", () => {
     expect(mocks.removeDeckWithCards).toHaveBeenCalledExactlyOnceWith(deck.id, deck.uid);
   });
 
-  it("rejects a stalled removal", async () => {
+  it("reuses the original cleanup when retried after a timeout", async () => {
     vi.useFakeTimers();
-    mocks.removeDeckWithCards.mockReturnValueOnce(new Promise(() => undefined));
-    const deck = createDeck({ uid: "uid-a" });
-    const operation = removeDeck(deck.uid, deck);
-    const assertion = expect(operation).rejects.toThrow("Deck deletion did not finish");
+    let finishCleanup!: () => void;
+    mocks.removeDeckWithCards.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      })
+    );
+    const deck = createDeck({ id: "slow-deck", uid: "uid-a" });
+    const firstRemoval = removeDeck(deck.uid, deck);
+    const timeout = expect(firstRemoval).rejects.toThrow("Deck deletion did not finish");
 
     await vi.advanceTimersByTimeAsync(REMOTE_WRITE_TIMEOUT_MS);
+    await timeout;
 
-    await assertion;
+    const retry = removeDeck(deck.uid, deck);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mocks.removeDeckWithCards).toHaveBeenCalledOnce();
+
+    finishCleanup();
+    await retry;
+    expect(mocks.removeDeckWithCards).toHaveBeenCalledOnce();
+  });
+
+  it("starts a new cleanup when retried after the original fails", async () => {
+    const failure = new Error("cleanup failed");
+    mocks.removeDeckWithCards.mockRejectedValueOnce(failure).mockResolvedValueOnce(undefined);
+    const deck = createDeck({ id: "failed-deck", uid: "uid-a" });
+
+    await expect(removeDeck(deck.uid, deck)).rejects.toBe(failure);
+    await removeDeck(deck.uid, deck);
+
+    expect(mocks.removeDeckWithCards).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/features/deck-removal/model/removeDeck.spec.ts
+++ b/src/features/deck-removal/model/removeDeck.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { deckMembershipMutationLock, withDeckMembershipLocks } from "@/entities/deck";
+import { REMOTE_WRITE_TIMEOUT_MS } from "@/shared/lib/remoteWrite";
+import { createDeck } from "@/test/factories";
+
+const mocks = vi.hoisted(() => ({ removeDeckWithCards: vi.fn() }));
+
+vi.mock("../api/removeDeck", () => ({ removeDeckWithCards: mocks.removeDeckWithCards }));
+
+import { removeDeck } from "./removeDeck";
+
+describe("removeDeck", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.removeDeckWithCards.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects missing users and mismatched owners before writing", async () => {
+    await expect(removeDeck("", createDeck({ uid: "" }))).rejects.toThrow("confirmed user");
+    await expect(removeDeck("uid-a", createDeck({ uid: "uid-b" }))).rejects.toThrow("owner does not match");
+    expect(mocks.removeDeckWithCards).not.toHaveBeenCalled();
+  });
+
+  it("waits for the Deck membership lock before removing", async () => {
+    const deck = createDeck({ id: "deck", uid: "uid-a" });
+    let finishShared!: () => void;
+    const shared = withDeckMembershipLocks(
+      [deckMembershipMutationLock(deck.uid, deck.id)],
+      "shared",
+      () =>
+        new Promise<void>((resolve) => {
+          finishShared = resolve;
+        })
+    );
+    await vi.waitFor(() => expect(finishShared).toBeTypeOf("function"));
+
+    const removal = removeDeck(deck.uid, deck);
+    await Promise.resolve();
+    expect(mocks.removeDeckWithCards).not.toHaveBeenCalled();
+
+    finishShared();
+    await Promise.all([shared, removal]);
+    expect(mocks.removeDeckWithCards).toHaveBeenCalledExactlyOnceWith(deck.id, deck.uid);
+  });
+
+  it("rejects a stalled removal", async () => {
+    vi.useFakeTimers();
+    mocks.removeDeckWithCards.mockReturnValueOnce(new Promise(() => undefined));
+    const deck = createDeck({ uid: "uid-a" });
+    const operation = removeDeck(deck.uid, deck);
+    const assertion = expect(operation).rejects.toThrow("Deck deletion did not finish");
+
+    await vi.advanceTimersByTimeAsync(REMOTE_WRITE_TIMEOUT_MS);
+
+    await assertion;
+  });
+});

--- a/src/features/deck-removal/model/removeDeck.ts
+++ b/src/features/deck-removal/model/removeDeck.ts
@@ -5,6 +5,8 @@ import { runSerially } from "@/shared/lib/runSerially";
 import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
 import { removeDeckWithCards } from "../api/removeDeck";
 
+const activeRemovals = new Map<string, Promise<void>>();
+
 const requireUid = (uid: string) => {
   if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
 };
@@ -13,12 +15,26 @@ const requireOwner = (uid: string, entityUid: string) => {
   if (entityUid !== uid) throw new Error("Deck owner does not match the authenticated user");
 };
 
+const getOrStartRemoval = (uid: string, deckId: string): Promise<void> => {
+  const key = deckMutationLock(uid, deckId);
+  const active = activeRemovals.get(key);
+  if (active != null) return active;
+
+  const operation = runSerially(key, () =>
+    withDeckMembershipLocks([deckMembershipMutationLock(uid, deckId)], "exclusive", () =>
+      removeDeckWithCards(deckId, uid)
+    )
+  );
+  activeRemovals.set(key, operation);
+  const clear = () => {
+    if (activeRemovals.get(key) === operation) activeRemovals.delete(key);
+  };
+  void operation.then(clear, clear);
+  return operation;
+};
+
 export const removeDeck = async (uid: string, deck: Deck): Promise<void> => {
   requireUid(uid);
   requireOwner(uid, deck.uid);
-  await runSerially(deckMutationLock(uid, deck.id), () =>
-    withDeckMembershipLocks([deckMembershipMutationLock(uid, deck.id)], "exclusive", () =>
-      waitForRemoteWrite(removeDeckWithCards(deck.id, uid), "Deck deletion")
-    )
-  );
+  await waitForRemoteWrite(getOrStartRemoval(uid, deck.id), "Deck deletion");
 };

--- a/src/features/deck-removal/model/removeDeck.ts
+++ b/src/features/deck-removal/model/removeDeck.ts
@@ -1,0 +1,24 @@
+import type { Deck } from "@/entities/deck";
+
+import { deckMembershipMutationLock, deckMutationLock, withDeckMembershipLocks } from "@/entities/deck";
+import { runSerially } from "@/shared/lib/runSerially";
+import { waitForRemoteWrite } from "@/shared/lib/remoteWrite";
+import { removeDeckWithCards } from "../api/removeDeck";
+
+const requireUid = (uid: string) => {
+  if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
+};
+
+const requireOwner = (uid: string, entityUid: string) => {
+  if (entityUid !== uid) throw new Error("Deck owner does not match the authenticated user");
+};
+
+export const removeDeck = async (uid: string, deck: Deck): Promise<void> => {
+  requireUid(uid);
+  requireOwner(uid, deck.uid);
+  await runSerially(deckMutationLock(uid, deck.id), () =>
+    withDeckMembershipLocks([deckMembershipMutationLock(uid, deck.id)], "exclusive", () =>
+      waitForRemoteWrite(removeDeckWithCards(deck.id, uid), "Deck deletion")
+    )
+  );
+};

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -49,6 +49,18 @@ vi.mock("@/features/study", () => ({
   useStudySessions: () => mocks.sessionsByDeckId,
 }));
 vi.mock("@/features/export", () => ({ downloadDeckCsv: mocks.downloadDeckCsv }));
+vi.mock("@/features/deck-removal", () => ({
+  useDeckRemoval: (options?: { onSuccess?: (deck: Deck) => void }) => {
+    mocks.onRemoveSuccess = options?.onSuccess;
+    return {
+      remove: (deck: Deck) => mocks.remove(deck).then(() => mocks.onRemoveSuccess?.(deck)),
+      pending: mocks.pending,
+      isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
+      error: mocks.error,
+      retry: mocks.retry,
+    };
+  },
+}));
 vi.mock("@/entities/card", () => ({
   selectCardsForDeck: (cards: Card[], id: DeckId) => cards.filter((card) => card.deckId === id),
   useCards: () => {
@@ -64,16 +76,6 @@ vi.mock("@/entities/deck", () => ({
     decks: Object.values(mocks.decksById),
     decksById: mocks.decksById,
   }),
-  useDeckMutations: (options?: { onRemoveSuccess?: (deck: Deck) => void }) => {
-    mocks.onRemoveSuccess = options?.onRemoveSuccess;
-    return {
-      remove: (deck: Deck) => mocks.remove(deck).then(() => mocks.onRemoveSuccess?.(deck)),
-      pending: mocks.pending,
-      isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
-      error: mocks.error,
-      retry: mocks.retry,
-    };
-  },
 }));
 vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
 vi.mock("@/features/import", () => ({ useSampleDeckBootstrap: vi.fn() }));

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -4,7 +4,8 @@ import { useKey } from "react-use";
 
 import { selectCardsForDeck, useCards } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
-import { useDeckMutations, useDecks } from "@/entities/deck";
+import { useDecks } from "@/entities/deck";
+import { useDeckRemoval } from "@/features/deck-removal";
 import { downloadDeckCsv } from "@/features/export";
 import { useSampleDeckBootstrap } from "@/features/import";
 import {
@@ -33,8 +34,8 @@ export const DeckListPage: React.FC = () => {
   const readState = combineRemoteReadStates(cardRemote, deckRemote);
   const [deletionTarget, setDeletionTarget] = React.useState<{ deck: Deck; cardCount: number }>();
   const [successMessage, setSuccessMessage] = React.useState<string>();
-  const mutations = useDeckMutations({
-    onRemoveSuccess: (deck) => {
+  const mutations = useDeckRemoval({
+    onSuccess: (deck) => {
       removeStudySession(deck.id);
       setDeletionTarget((target) => (target?.deck.id === deck.id ? undefined : target));
       setSuccessMessage(`Deleted deck “${deck.name}”.`);

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -16,6 +16,7 @@ export default defineConfig([
     files: [
       "./src/entities/study-progress/**",
       "./src/features/deck-editor/**",
+      "./src/features/deck-removal/**",
       "./src/features/export/**",
       "./src/features/settings/**",
     ],

--- a/test/integration/firestore/deck.remove.spec.ts
+++ b/test/integration/firestore/deck.remove.spec.ts
@@ -1,109 +1,81 @@
-/** @file Verifies bounded, serial Card cleanup before Deck deletion. */
+import { readFileSync } from "node:fs";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { initializeTestEnvironment, type RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, type Firestore } from "firebase/firestore";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { v4 as uuid } from "uuid";
 
-const mocks = vi.hoisted(() => ({
-  collection: vi.fn(() => "card-collection"),
-  getDocs: vi.fn(),
-  query: vi.fn(() => "card-query"),
-  removeDeckDocument: vi.fn(),
-  where: vi.fn((...parts: unknown[]) => parts),
-  writeBatch: vi.fn(),
-}));
+import { buildCardCreateDto } from "@/entities/card/api/firestoreDocument";
+import { buildDeckCreateDto } from "@/entities/deck/api/firestoreDocument";
+import { removeDeckWithCards } from "@/features/deck-removal/api/removeDeck";
+import { createCard, createDeck } from "@/test/factories";
 
-vi.mock("firebase/firestore", () => ({
-  collection: mocks.collection,
-  getDocs: mocks.getDocs,
-  query: mocks.query,
-  where: mocks.where,
-  writeBatch: mocks.writeBatch,
-}));
-vi.mock("@/entities/deck", () => ({ removeDeckDocument: mocks.removeDeckDocument }));
-vi.mock("@/shared/firestore", () => ({ getDb: () => "db" }));
+describe("Deck removal with the Firestore emulator", () => {
+  let testEnv: RulesTestEnvironment;
+  let db: Firestore;
 
-import { CARD_DELETE_BATCH_SIZE, removeDeckWithCards } from "@/features/deck-removal/api/removeDeck";
+  const seed = async (collectionName: "deck" | "card", id: string, data: object) => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await setDoc(doc(context.firestore(), collectionName, id), data);
+    });
+  };
 
-const documents = (count: number, start = 0) =>
-  Array.from({ length: count }, (_, index) => ({ ref: `card-${start + index}` }));
+  const existsWithoutRules = async (collectionName: "deck" | "card", id: string) => {
+    let exists = false;
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      exists = (await getDoc(doc(context.firestore(), collectionName, id))).exists();
+    });
+    return exists;
+  };
 
-const batch = () => ({ delete: vi.fn(), commit: vi.fn().mockResolvedValue(undefined) });
-
-describe("firestore/deck.remove", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.getDocs.mockResolvedValue({ docs: [] });
-    mocks.removeDeckDocument.mockResolvedValue(undefined);
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: "test-deck-removal",
+      firestore: {
+        rules: readFileSync("./firestore.rules", "utf8"),
+        host: import.meta.env.VITE_DB_HOST,
+        port: parseInt(import.meta.env.VITE_DB_PORT, 10),
+      },
+    });
+    db = testEnv.authenticatedContext("uid").firestore() as unknown as Firestore;
   });
 
-  it("deletes an empty Deck without creating a Card batch", async () => {
-    await removeDeckWithCards("deck-id", "uid-a");
-
-    expect(mocks.collection).toHaveBeenCalledWith("db", "card");
-    expect(mocks.where).toHaveBeenNthCalledWith(1, "uid", "==", "uid-a");
-    expect(mocks.where).toHaveBeenNthCalledWith(2, "deckId", "==", "deck-id");
-    expect(mocks.getDocs).toHaveBeenCalledWith("card-query");
-    expect(mocks.writeBatch).not.toHaveBeenCalled();
-    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id");
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
   });
 
-  it("deletes one bounded Card batch before the Deck", async () => {
-    const cardBatch = batch();
-    mocks.getDocs.mockResolvedValue({ docs: documents(CARD_DELETE_BATCH_SIZE) });
-    mocks.writeBatch.mockReturnValue(cardBatch);
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
 
-    await removeDeckWithCards("deck-id", "uid-a");
+  it("deletes matching Cards before deleting their Deck", async () => {
+    const deck = createDeck({ id: uuid(), uid: "uid" });
+    const cards = [
+      createCard({ id: uuid(), deckId: deck.id, uid: deck.uid }),
+      createCard({ id: uuid(), deckId: deck.id, uid: deck.uid }),
+    ];
+    await seed("deck", deck.id, buildDeckCreateDto(deck, deck.createdAt));
+    await Promise.all(cards.map((card) => seed("card", card.id, buildCardCreateDto(card, card.createdAt))));
 
-    expect(cardBatch.delete).toHaveBeenCalledTimes(CARD_DELETE_BATCH_SIZE);
-    expect(cardBatch.commit).toHaveBeenCalledOnce();
-    expect(cardBatch.commit.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.removeDeckDocument.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    await removeDeckWithCards(deck.id, deck.uid, db);
+
+    await expect(existsWithoutRules("deck", deck.id)).resolves.toBe(false);
+    await Promise.all(
+      cards.map(async (card) => {
+        await expect(existsWithoutRules("card", card.id)).resolves.toBe(false);
+      })
     );
   });
 
-  it("commits multiple bounded Card batches serially", async () => {
-    const first = batch();
-    const second = batch();
-    let finishFirst!: () => void;
-    first.commit.mockReturnValueOnce(new Promise<void>((resolve) => (finishFirst = resolve)));
-    mocks.getDocs.mockResolvedValue({ docs: documents(CARD_DELETE_BATCH_SIZE + 1) });
-    mocks.writeBatch.mockReturnValueOnce(first).mockReturnValueOnce(second);
+  it("commits Card cleanup before a rejected Deck deletion", async () => {
+    const deck = createDeck({ id: uuid(), uid: "other-user" });
+    const card = createCard({ id: uuid(), deckId: deck.id, uid: "uid" });
+    await seed("deck", deck.id, buildDeckCreateDto(deck, deck.createdAt));
+    await seed("card", card.id, buildCardCreateDto(card, card.createdAt));
 
-    const operation = removeDeckWithCards("deck-id", "uid-a");
-    await vi.waitFor(() => expect(first.commit).toHaveBeenCalledOnce());
-    expect(mocks.writeBatch).toHaveBeenCalledOnce();
-    expect(second.commit).not.toHaveBeenCalled();
-    expect(mocks.removeDeckDocument).not.toHaveBeenCalled();
+    await expect(removeDeckWithCards(deck.id, card.uid, db)).rejects.toMatchObject({ code: "permission-denied" });
 
-    finishFirst();
-    await operation;
-
-    expect(first.delete).toHaveBeenCalledTimes(CARD_DELETE_BATCH_SIZE);
-    expect(second.delete).toHaveBeenCalledExactlyOnceWith(`card-${CARD_DELETE_BATCH_SIZE}`);
-    expect(second.commit).toHaveBeenCalledOnce();
-    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id");
-  });
-
-  it("keeps the Deck after a batch failure and retries only remaining Cards", async () => {
-    const failure = new Error("batch failed");
-    const first = batch();
-    const failed = batch();
-    failed.commit.mockRejectedValueOnce(failure);
-    mocks.getDocs
-      .mockResolvedValueOnce({ docs: documents(CARD_DELETE_BATCH_SIZE + 1) })
-      .mockResolvedValueOnce({ docs: documents(1, CARD_DELETE_BATCH_SIZE) });
-    mocks.writeBatch.mockReturnValueOnce(first).mockReturnValueOnce(failed);
-
-    await expect(removeDeckWithCards("deck-id", "uid-a")).rejects.toBe(failure);
-    expect(first.commit).toHaveBeenCalledOnce();
-    expect(failed.commit).toHaveBeenCalledOnce();
-    expect(mocks.removeDeckDocument).not.toHaveBeenCalled();
-
-    const retry = batch();
-    mocks.writeBatch.mockReturnValueOnce(retry);
-    await removeDeckWithCards("deck-id", "uid-a");
-
-    expect(mocks.getDocs).toHaveBeenCalledTimes(2);
-    expect(retry.delete).toHaveBeenCalledExactlyOnceWith(`card-${CARD_DELETE_BATCH_SIZE}`);
-    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id");
+    await expect(existsWithoutRules("card", card.id)).resolves.toBe(false);
+    await expect(existsWithoutRules("deck", deck.id)).resolves.toBe(true);
   });
 });

--- a/test/integration/firestore/deck.remove.spec.ts
+++ b/test/integration/firestore/deck.remove.spec.ts
@@ -1,96 +1,109 @@
-/** @file Verifies that Deck removal settles every child deletion before completing. */
+/** @file Verifies bounded, serial Card cleanup before Deck deletion. */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   collection: vi.fn(() => "card-collection"),
-  deleteDoc: vi.fn(),
-  doc: vi.fn(() => "deck-ref"),
   getDocs: vi.fn(),
   query: vi.fn(() => "card-query"),
+  removeDeckDocument: vi.fn(),
   where: vi.fn((...parts: unknown[]) => parts),
+  writeBatch: vi.fn(),
 }));
 
 vi.mock("firebase/firestore", () => ({
   collection: mocks.collection,
-  deleteDoc: mocks.deleteDoc,
-  doc: mocks.doc,
   getDocs: mocks.getDocs,
   query: mocks.query,
   where: mocks.where,
+  writeBatch: mocks.writeBatch,
 }));
-vi.mock("@/shared/firestore", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/shared/firestore")>()),
-  getDb: () => "db",
-}));
+vi.mock("@/entities/deck", () => ({ removeDeckDocument: mocks.removeDeckDocument }));
+vi.mock("@/shared/firestore", () => ({ getDb: () => "db" }));
 
-import { remove } from "@/entities/deck/api/firestore";
+import { CARD_DELETE_BATCH_SIZE, removeDeckWithCards } from "@/features/deck-removal/api/removeDeck";
+
+const documents = (count: number, start = 0) =>
+  Array.from({ length: count }, (_, index) => ({ ref: `card-${start + index}` }));
+
+const batch = () => ({ delete: vi.fn(), commit: vi.fn().mockResolvedValue(undefined) });
 
 describe("firestore/deck.remove", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getDocs.mockResolvedValue({ docs: [] });
+    mocks.removeDeckDocument.mockResolvedValue(undefined);
   });
 
-  it("deletes the Deck only after every matching child Card deletion settles", async () => {
-    let finishSecond!: () => void;
-    const secondDeletion = new Promise<void>((resolve) => {
-      finishSecond = resolve;
-    });
-    mocks.getDocs.mockResolvedValue({ docs: [{ ref: "card-a" }, { ref: "card-b" }] });
-    mocks.deleteDoc
-      .mockResolvedValueOnce(undefined)
-      .mockReturnValueOnce(secondDeletion)
-      .mockResolvedValueOnce(undefined);
-
-    const operation = remove("deck-id", "uid-a");
-    await vi.waitFor(() => expect(mocks.deleteDoc).toHaveBeenCalledTimes(2));
+  it("deletes an empty Deck without creating a Card batch", async () => {
+    await removeDeckWithCards("deck-id", "uid-a");
 
     expect(mocks.collection).toHaveBeenCalledWith("db", "card");
     expect(mocks.where).toHaveBeenNthCalledWith(1, "uid", "==", "uid-a");
     expect(mocks.where).toHaveBeenNthCalledWith(2, "deckId", "==", "deck-id");
-    expect(mocks.query).toHaveBeenCalledWith("card-collection", ["uid", "==", "uid-a"], ["deckId", "==", "deck-id"]);
     expect(mocks.getDocs).toHaveBeenCalledWith("card-query");
-    expect(mocks.doc).not.toHaveBeenCalled();
-
-    finishSecond();
-    await operation;
-
-    expect(mocks.doc).toHaveBeenCalledWith("db", "deck", "deck-id");
-    expect(mocks.deleteDoc).toHaveBeenNthCalledWith(3, "deck-ref");
+    expect(mocks.writeBatch).not.toHaveBeenCalled();
+    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id");
   });
 
-  it("waits for every child deletion and preserves the first useful error", async () => {
-    const error = new Error("first child failed");
-    let finishSecond!: () => void;
-    const secondDeletion = new Promise<void>((resolve) => {
-      finishSecond = resolve;
-    });
-    mocks.getDocs.mockResolvedValue({ docs: [{ ref: "card-a" }, { ref: "card-b" }] });
-    mocks.deleteDoc.mockRejectedValueOnce(error).mockReturnValueOnce(secondDeletion);
+  it("deletes one bounded Card batch before the Deck", async () => {
+    const cardBatch = batch();
+    mocks.getDocs.mockResolvedValue({ docs: documents(CARD_DELETE_BATCH_SIZE) });
+    mocks.writeBatch.mockReturnValue(cardBatch);
 
-    const operation = remove("deck-id", "uid-a");
-    const observed = operation.then(
-      () => undefined,
-      (cause: unknown) => cause
+    await removeDeckWithCards("deck-id", "uid-a");
+
+    expect(cardBatch.delete).toHaveBeenCalledTimes(CARD_DELETE_BATCH_SIZE);
+    expect(cardBatch.commit).toHaveBeenCalledOnce();
+    expect(cardBatch.commit.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.removeDeckDocument.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
     );
-    await vi.waitFor(() => expect(mocks.deleteDoc).toHaveBeenCalledTimes(2));
-    let settled = false;
-    void operation.then(
-      () => {
-        settled = true;
-      },
-      () => {
-        settled = true;
-      }
-    );
-    await Promise.resolve();
+  });
 
-    expect(settled).toBe(false);
-    expect(mocks.doc).not.toHaveBeenCalled();
+  it("commits multiple bounded Card batches serially", async () => {
+    const first = batch();
+    const second = batch();
+    let finishFirst!: () => void;
+    first.commit.mockReturnValueOnce(new Promise<void>((resolve) => (finishFirst = resolve)));
+    mocks.getDocs.mockResolvedValue({ docs: documents(CARD_DELETE_BATCH_SIZE + 1) });
+    mocks.writeBatch.mockReturnValueOnce(first).mockReturnValueOnce(second);
 
-    finishSecond();
-    expect(await observed).toBe(error);
-    expect(settled).toBe(true);
-    expect(mocks.doc).not.toHaveBeenCalled();
+    const operation = removeDeckWithCards("deck-id", "uid-a");
+    await vi.waitFor(() => expect(first.commit).toHaveBeenCalledOnce());
+    expect(mocks.writeBatch).toHaveBeenCalledOnce();
+    expect(second.commit).not.toHaveBeenCalled();
+    expect(mocks.removeDeckDocument).not.toHaveBeenCalled();
+
+    finishFirst();
+    await operation;
+
+    expect(first.delete).toHaveBeenCalledTimes(CARD_DELETE_BATCH_SIZE);
+    expect(second.delete).toHaveBeenCalledExactlyOnceWith(`card-${CARD_DELETE_BATCH_SIZE}`);
+    expect(second.commit).toHaveBeenCalledOnce();
+    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id");
+  });
+
+  it("keeps the Deck after a batch failure and retries only remaining Cards", async () => {
+    const failure = new Error("batch failed");
+    const first = batch();
+    const failed = batch();
+    failed.commit.mockRejectedValueOnce(failure);
+    mocks.getDocs
+      .mockResolvedValueOnce({ docs: documents(CARD_DELETE_BATCH_SIZE + 1) })
+      .mockResolvedValueOnce({ docs: documents(1, CARD_DELETE_BATCH_SIZE) });
+    mocks.writeBatch.mockReturnValueOnce(first).mockReturnValueOnce(failed);
+
+    await expect(removeDeckWithCards("deck-id", "uid-a")).rejects.toBe(failure);
+    expect(first.commit).toHaveBeenCalledOnce();
+    expect(failed.commit).toHaveBeenCalledOnce();
+    expect(mocks.removeDeckDocument).not.toHaveBeenCalled();
+
+    const retry = batch();
+    mocks.writeBatch.mockReturnValueOnce(retry);
+    await removeDeckWithCards("deck-id", "uid-a");
+
+    expect(mocks.getDocs).toHaveBeenCalledTimes(2);
+    expect(retry.delete).toHaveBeenCalledExactlyOnceWith(`card-${CARD_DELETE_BATCH_SIZE}`);
+    expect(mocks.removeDeckDocument).toHaveBeenCalledExactlyOnceWith("deck-id");
   });
 });

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -70,7 +70,7 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     const d = { ...newDeck, id: uuid() };
     await deckAdapter.create(d);
     expect((await getDoc(doc(db, "deck", d.id))).exists()).toBeTruthy();
-    await deckAdapter.remove(d.id, "uid");
+    await deckAdapter.remove(d.id);
     await expect(deckAdapter.exists(d.id)).rejects.toMatchObject({ code: "permission-denied" });
   });
 });

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -80,7 +80,7 @@ describe("Query realtime subscriptions", () => {
       });
 
       await cardAdapter.remove(card.id);
-      await deckAdapter.remove(deck.id, deck.uid);
+      await deckAdapter.remove(deck.id);
       await vi.waitFor(() => {
         expect(
           deckSnapshots.some((snapshot) => snapshot.type === "change" && snapshot.event.removed.includes(deck.id))


### PR DESCRIPTION
## Summary

- move the cross-entity Deck removal workflow into a dedicated feature boundary
- delete matching Cards in sequential Firestore batches capped at 450 writes
- keep the Deck when a Card batch fails so retries can resume from the remaining Cards
- cover empty, single-batch, multi-batch, and mid-cleanup failure behavior

## Impact

Deck deletion no longer starts an unbounded number of client-side Card deletes. Successful batches remain deleted after a later failure, and retrying re-queries Firestore before continuing cleanup.

## Testing

- `mise run check`
- `npm run test:integration -- --run test/integration/firestore/deck.remove.spec.ts`
- `npm run test:unit -- --run src/pages/deck-list/ui/DeckListPage.spec.tsx`

Closes #363