### PR TITLE
Move transition controller under remote-read

### DIFF
--- a/src/app/providers/remote-read/RemoteReadBootstrap.tsx
+++ b/src/app/providers/remote-read/RemoteReadBootstrap.tsx
@@ -1,14 +1,14 @@
 import { type PropsWithChildren, useEffect, useState } from "react";
 
-import { createAuthTransitionController } from "@/app/providers/auth/authTransitionController";
 import { startRemoteReads, stopRemoteReads } from "@/app/providers/remote-read/remoteReadLifecycle";
+import { createRemoteReadTransitionController } from "@/app/providers/remote-read/remoteReadTransitionController";
 import { useAuthSession } from "@/entities/auth-session";
 import { RemoteReadScopeProvider } from "@/shared/lib/remote-read";
 
 export const RemoteReadBootstrap = ({ children }: PropsWithChildren) => {
   const authSession = useAuthSession();
   const [controller] = useState(() =>
-    createAuthTransitionController({
+    createRemoteReadTransitionController({
       cleanupUid: stopRemoteReads,
       subscribeUid: startRemoteReads,
       reportError: (error) => console.error("Remote read transition failed", error),

--- a/src/app/providers/remote-read/remoteReadTransitionController.spec.ts
+++ b/src/app/providers/remote-read/remoteReadTransitionController.spec.ts
@@ -1,5 +1,5 @@
 /**
- * @file Verifies the "Auth transition controller" contract with automated examples.
+ * @file Verifies the "Remote read transition controller" contract with automated examples.
  * The examples make the expected behavior concrete with cases such as "ignores persisted identity
  * until Firebase confirms a user", "starts remote reads from the confirmed Firebase UID", "does
  * not duplicate work when StrictMode replays the same auth effect".
@@ -8,7 +8,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { AuthenticatedSession, AuthSessionState } from "@/entities/auth-session";
-import { createAuthTransitionController } from "@/app/providers/auth/authTransitionController";
+import { createRemoteReadTransitionController } from "@/app/providers/remote-read/remoteReadTransitionController";
 
 /**
  * Provides the create user test helper used by this file.
@@ -35,10 +35,10 @@ const createDependencies = () => ({
   reportError: vi.fn(),
 });
 
-describe("Auth transition controller", () => {
+describe("Remote read transition controller", () => {
   it("ignores persisted identity until Firebase confirms a user", async () => {
     const dependencies = createDependencies();
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     const persistedConfig = { uid: "stale-uid", isAnonymous: false };
 
     await controller.transition({ status: "initializing" });
@@ -50,7 +50,7 @@ describe("Auth transition controller", () => {
   it("starts remote reads from the confirmed Firebase UID", async () => {
     const dependencies = createDependencies();
     const user = createSession("uid-a");
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
 
     await controller.transition(authenticated(user));
 
@@ -60,7 +60,7 @@ describe("Auth transition controller", () => {
   it("does not duplicate work when StrictMode replays the same auth effect", async () => {
     const dependencies = createDependencies();
     const state = authenticated(createSession("uid-a"));
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
 
     const first = controller.transition(state);
     const replay = controller.transition(state);
@@ -74,7 +74,7 @@ describe("Auth transition controller", () => {
     const dependencies = createDependencies();
     dependencies.cleanupUid.mockImplementation((uid) => operations.push(`cleanup:${uid}`));
     dependencies.subscribeUid.mockImplementation((uid) => operations.push(`subscribe:${uid}`));
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     await controller.transition(authenticated(createSession("uid-a")));
     operations.length = 0;
 
@@ -88,7 +88,7 @@ describe("Auth transition controller", () => {
     "cleans the confirmed UID without subscribing for $status",
     async (state) => {
       const dependencies = createDependencies();
-      const controller = createAuthTransitionController(dependencies);
+      const controller = createRemoteReadTransitionController(dependencies);
       await controller.transition(authenticated(createSession("uid-a")));
       dependencies.cleanupUid.mockClear();
       dependencies.subscribeUid.mockClear();
@@ -114,7 +114,7 @@ describe("Auth transition controller", () => {
       cleanupStarted();
       return cleanup;
     });
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     await controller.transition(authenticated(createSession("uid-a")));
     dependencies.subscribeUid.mockClear();
 
@@ -143,7 +143,7 @@ describe("Auth transition controller", () => {
       cleanupStarted();
       return cleanup;
     });
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     const stateA = authenticated(createSession("uid-a"));
     await controller.transition(stateA);
     dependencies.subscribeUid.mockClear();
@@ -162,7 +162,7 @@ describe("Auth transition controller", () => {
 
   it("keeps same-UID metadata without cleanup or resubscription", async () => {
     const dependencies = createDependencies();
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     await controller.transition(authenticated(createSession("uid-a")));
     dependencies.cleanupUid.mockClear();
     dependencies.subscribeUid.mockClear();
@@ -176,7 +176,7 @@ describe("Auth transition controller", () => {
 
   it("recognizes a new same-UID metadata snapshot", async () => {
     const dependencies = createDependencies();
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     await controller.transition(authenticated(createSession("uid-a")));
     dependencies.cleanupUid.mockClear();
     dependencies.subscribeUid.mockClear();
@@ -191,7 +191,7 @@ describe("Auth transition controller", () => {
     const cleanupError = new Error("cleanup failed");
     const dependencies = createDependencies();
     dependencies.cleanupUid.mockRejectedValueOnce(cleanupError).mockResolvedValueOnce(undefined);
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     await controller.transition(authenticated(createSession("uid-a")));
     dependencies.subscribeUid.mockClear();
     const stateB = authenticated(createSession("uid-b"));
@@ -211,7 +211,7 @@ describe("Auth transition controller", () => {
     const subscribeError = new Error("subscribe failed");
     const dependencies = createDependencies();
     dependencies.subscribeUid.mockRejectedValueOnce(subscribeError).mockResolvedValueOnce(undefined);
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     const state = authenticated(createSession("uid-a"));
 
     const first = await controller.transition(state);
@@ -241,7 +241,7 @@ describe("Auth transition controller", () => {
         return cleanup;
       })
       .mockResolvedValueOnce(undefined);
-    const controller = createAuthTransitionController(dependencies);
+    const controller = createRemoteReadTransitionController(dependencies);
     await controller.transition(authenticated(createSession("uid-a")));
     dependencies.subscribeUid.mockClear();
 

--- a/src/app/providers/remote-read/remoteReadTransitionController.ts
+++ b/src/app/providers/remote-read/remoteReadTransitionController.ts
@@ -4,7 +4,7 @@ type AuthRequest =
   | { status: Exclude<AuthSessionState["status"], "authenticated"> }
   | { status: "authenticated"; identity: AuthenticatedSession };
 
-export type AuthTransitionDependencies = {
+export type RemoteReadTransitionDependencies = {
   cleanupUid: (uid: string) => unknown | Promise<unknown>;
   subscribeUid: (uid: string) => unknown | Promise<unknown>;
   reportError: (error: unknown) => void;
@@ -33,7 +33,7 @@ const processTransition = async (
   getGeneration: () => number,
   currentGeneration: number,
   activeIdentity: AuthenticatedSession | undefined,
-  dependencies: AuthTransitionDependencies,
+  dependencies: RemoteReadTransitionDependencies,
   cleanupActiveUid: () => Promise<void>
 ): Promise<AuthenticatedSession | undefined> => {
   if (state.status !== "authenticated") {
@@ -56,7 +56,7 @@ const processTransition = async (
   return nextIdentity;
 };
 
-export const createAuthTransitionController = (dependencies: AuthTransitionDependencies) => {
+export const createRemoteReadTransitionController = (dependencies: RemoteReadTransitionDependencies) => {
   let generation = 0;
   let requestedState: AuthRequest | undefined;
   let activeIdentity: AuthenticatedSession | undefined;


### PR DESCRIPTION
## Summary

- move the transition controller and its unit tests from `auth` to `remote-read`
- rename the public controller and dependency type to reflect remote-read lifecycle ownership
- update `RemoteReadBootstrap` without changing transition behavior

## Testing

- `mise run check`

Closes #689