### PR TITLE
Enforce relative imports within FSD slices

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,8 +9,8 @@ import testingLibrary from "eslint-plugin-testing-library";
 
 const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
-const slicedLayers = ["entities", "features"];
-const otherSourceLayers = ["app", "pages", "shared"];
+const sliceLayers = ["entities", "features", "pages"];
+const nonSliceLayers = ["app", "shared"];
 
 export default [
   {
@@ -40,13 +40,13 @@ export default [
     settings: {
       ...boundariesRecommended.settings,
       "boundaries/elements": [
-        ...slicedLayers.map((layer) => ({
+        ...sliceLayers.map((layer) => ({
           type: layer,
           pattern: `src/${layer}/*`,
           mode: "folder",
           capture: ["slice"],
         })),
-        ...otherSourceLayers.map((layer) => ({
+        ...nonSliceLayers.map((layer) => ({
           type: layer,
           pattern: `src/${layer}/**/*`,
           mode: "full",
@@ -69,7 +69,7 @@ export default [
           default: "allow",
           rules: [
             {
-              from: { type: slicedLayers },
+              from: { type: sliceLayers },
               disallow: {
                 dependency: {
                   relationship: { to: "internal" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,8 @@ import testingLibrary from "eslint-plugin-testing-library";
 
 const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
-const sourceLayers = ["app", "entities", "features", "pages", "shared"];
+const slicedLayers = ["entities", "features"];
+const otherSourceLayers = ["app", "pages", "shared"];
 
 export default [
   {
@@ -23,6 +24,11 @@ export default [
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    settings: {
+      "import/resolver": {
+        typescript: { project: "./tsconfig.json" },
+      },
+    },
   },
   {
     ...reactHooks.configs.flat["recommended-latest"],
@@ -33,11 +39,19 @@ export default [
     files: sourceFiles,
     settings: {
       ...boundariesRecommended.settings,
-      "boundaries/elements": sourceLayers.map((layer) => ({
-        type: layer,
-        pattern: `src/${layer}/**/*`,
-        mode: "full",
-      })),
+      "boundaries/elements": [
+        ...slicedLayers.map((layer) => ({
+          type: layer,
+          pattern: `src/${layer}/*`,
+          mode: "folder",
+          capture: ["slice"],
+        })),
+        ...otherSourceLayers.map((layer) => ({
+          type: layer,
+          pattern: `src/${layer}/**/*`,
+          mode: "full",
+        })),
+      ],
       "boundaries/ignore": ["src/vite-env.d.ts"],
       "boundaries/dependency-nodes": [
         "import",
@@ -48,6 +62,25 @@ export default [
     },
     rules: {
       ...boundariesRecommended.rules,
+      "boundaries/dependencies": [
+        "error",
+        {
+          checkInternals: true,
+          default: "allow",
+          rules: [
+            {
+              from: { type: slicedLayers },
+              disallow: {
+                dependency: {
+                  relationship: { to: "internal" },
+                  source: "@/**",
+                },
+              },
+              message: "Use a relative import within the same slice.",
+            },
+          ],
+        },
+      ],
       "boundaries/no-unknown-files": "error",
     },
   }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@vitest/coverage-v8": "4.1.10",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.7.0",
+        "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-boundaries": "^6.0.2",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-testing-library": "^7.16.2",
@@ -8412,6 +8413,353 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -11680,6 +12028,31 @@
         }
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -11700,6 +12073,41 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils": {
@@ -14579,6 +14987,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/is-callable": {
@@ -18509,6 +18940,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -21609,6 +22056,16 @@
         "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -23603,6 +24060,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/until-async": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@vitest/coverage-v8": "4.1.10",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.7.0",
+    "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-boundaries": "^6.0.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-testing-library": "^7.16.2",

--- a/src/entities/auth-session/index.ts
+++ b/src/entities/auth-session/index.ts
@@ -1,7 +1,7 @@
-export { AuthSessionProvider, useAuthSession } from "@/entities/auth-session/model/AuthSessionProvider";
+export { AuthSessionProvider, useAuthSession } from "./model/AuthSessionProvider";
 export {
   createAuthSessionStore,
   type AuthenticatedSession,
   type AuthSessionState,
   type AuthSessionStore,
-} from "@/entities/auth-session/model/authSessionStore";
+} from "./model/authSessionStore";

--- a/src/entities/auth-session/model/AuthSessionProvider.spec.tsx
+++ b/src/entities/auth-session/model/AuthSessionProvider.spec.tsx
@@ -2,8 +2,8 @@ import { act, renderHook } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { describe, expect, it } from "vitest";
 
-import { AuthSessionProvider, useAuthSession } from "@/entities/auth-session/model/AuthSessionProvider";
-import { createAuthSessionStore } from "@/entities/auth-session/model/authSessionStore";
+import { AuthSessionProvider, useAuthSession } from "./AuthSessionProvider";
+import { createAuthSessionStore } from "./authSessionStore";
 
 describe("AuthSessionProvider", () => {
   it("exposes session updates to React consumers", () => {

--- a/src/entities/auth-session/model/AuthSessionProvider.tsx
+++ b/src/entities/auth-session/model/AuthSessionProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useSyncExternalStore, type PropsWithChildren } from "react";
 
-import type { AuthSessionStore } from "@/entities/auth-session/model/authSessionStore";
+import type { AuthSessionStore } from "./authSessionStore";
 
 const AuthSessionContext = createContext<AuthSessionStore | null>(null);
 

--- a/src/entities/auth-session/model/authSessionStore.spec.ts
+++ b/src/entities/auth-session/model/authSessionStore.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createAuthSessionStore } from "@/entities/auth-session/model/authSessionStore";
+import { createAuthSessionStore } from "./authSessionStore";
 
 describe("authSessionStore", () => {
   it("starts without an identity", () => {

--- a/src/entities/card/hooks/useCards.spec.tsx
+++ b/src/entities/card/hooks/useCards.spec.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Card } from "@/entities/card/model/card";
+import type { Card } from "../model/card";
 import { RemoteReadScopeProvider, type RemoteReadStoreState } from "@/shared/lib/remote-read";
 import { createCard } from "@/test/factories";
 
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   retry: vi.fn(),
 }));
 
-vi.mock("@/entities/card/model/remoteReadStore", () => ({
+vi.mock("../model/remoteReadStore", () => ({
   cardRemoteReadStore: {
     subscribe: () => () => undefined,
     getState: () => Object.assign(mocks.state, { retry: mocks.retry }),
@@ -24,7 +24,7 @@ vi.mock("@/entities/card/model/remoteReadStore", () => ({
   },
 }));
 
-import { selectCardsForDeck, selectTagsForDeck, useCards } from "@/entities/card";
+import { selectCardsForDeck, selectTagsForDeck, useCards } from "../index";
 
 const authenticatedWrapper = ({ children }: PropsWithChildren) => (
   <RemoteReadScopeProvider uid="uid-a">{children}</RemoteReadScopeProvider>

--- a/src/entities/card/hooks/useCards.ts
+++ b/src/entities/card/hooks/useCards.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 import { useStore } from "zustand";
 
-import type { Card } from "@/entities/card/model/card";
-import { cardRemoteReadStore } from "@/entities/card/model/remoteReadStore";
+import type { Card } from "../model/card";
+import { cardRemoteReadStore } from "../model/remoteReadStore";
 import type { RemoteById } from "@/shared/api";
 import { useRemoteReadScopeUid } from "@/shared/lib/remote-read";
 

--- a/src/entities/card/model/remoteReadStore.spec.ts
+++ b/src/entities/card/model/remoteReadStore.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { Card } from "@/entities/card/model/card";
+import type { Card } from "./card";
 import type { RemoteSubscriptionProps } from "@/shared/api";
 import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { createCard } from "@/test/factories";

--- a/src/entities/card/model/remoteReadStore.ts
+++ b/src/entities/card/model/remoteReadStore.ts
@@ -1,4 +1,4 @@
-import type { Card } from "@/entities/card/model/card";
+import type { Card } from "./card";
 import { waitForFirestoreInitialization } from "@/shared/firestore";
 import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { subscribeCardReads } from "../api/subscribeCardReads";

--- a/src/entities/deck/hooks/useDeckMutations.spec.tsx
+++ b/src/entities/deck/hooks/useDeckMutations.spec.tsx
@@ -1,4 +1,4 @@
-import type { Deck } from "@/entities/deck";
+import type { Deck } from "../index";
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,7 +21,7 @@ vi.mock("@/entities/auth-session/@x/deck", () => ({
       ? { status: "signedOut" }
       : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
 }));
-vi.mock("@/entities/deck/api/firestore", () => ({
+vi.mock("../api/firestore", () => ({
   create: mocks.create,
   remove: mocks.remove,
   update: mocks.update,

--- a/src/entities/deck/hooks/useDecks.spec.tsx
+++ b/src/entities/deck/hooks/useDecks.spec.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Deck } from "@/entities/deck/model/deck";
+import type { Deck } from "../model/deck";
 import { RemoteReadScopeProvider, type RemoteReadStoreState } from "@/shared/lib/remote-read";
 import { createDeck } from "@/test/factories";
 
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   retry: vi.fn(),
 }));
 
-vi.mock("@/entities/deck/model/remoteReadStore", () => ({
+vi.mock("../model/remoteReadStore", () => ({
   deckRemoteReadStore: {
     subscribe: () => () => undefined,
     getState: () => Object.assign(mocks.state, { retry: mocks.retry }),
@@ -24,7 +24,7 @@ vi.mock("@/entities/deck/model/remoteReadStore", () => ({
   },
 }));
 
-import { useDecks } from "@/entities/deck";
+import { useDecks } from "../index";
 
 const authenticatedWrapper = ({ children }: PropsWithChildren) => (
   <RemoteReadScopeProvider uid="uid-a">{children}</RemoteReadScopeProvider>

--- a/src/entities/deck/hooks/useDecks.ts
+++ b/src/entities/deck/hooks/useDecks.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 import { useStore } from "zustand";
 
-import type { Deck } from "@/entities/deck/model/deck";
-import { deckRemoteReadStore } from "@/entities/deck/model/remoteReadStore";
+import type { Deck } from "../model/deck";
+import { deckRemoteReadStore } from "../model/remoteReadStore";
 import type { RemoteById } from "@/shared/api";
 import { useRemoteReadScopeUid } from "@/shared/lib/remote-read";
 

--- a/src/entities/deck/model/remoteReadStore.spec.ts
+++ b/src/entities/deck/model/remoteReadStore.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { Deck } from "@/entities/deck/model/deck";
+import type { Deck } from "./deck";
 import type { RemoteSubscriptionProps } from "@/shared/api";
 import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { createDeck } from "@/test/factories";

--- a/src/entities/deck/model/remoteReadStore.ts
+++ b/src/entities/deck/model/remoteReadStore.ts
@@ -1,4 +1,4 @@
-import type { Deck } from "@/entities/deck/model/deck";
+import type { Deck } from "./deck";
 import { waitForFirestoreInitialization } from "@/shared/firestore";
 import { createRemoteReadStore } from "@/shared/lib/remote-read";
 import { subscribeDeckReads } from "../api/subscribeDeckReads";

--- a/src/entities/study-progress/model/studyProgress.spec.ts
+++ b/src/entities/study-progress/model/studyProgress.spec.ts
@@ -10,7 +10,7 @@ import {
   type StudyProgress,
   type StudyProgressEdit,
   type StudyRating,
-} from "@/entities/study-progress";
+} from "../index";
 
 describe("createStudyProgress", () => {
   it("creates study progress with the initial score and seen count", () => {

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,7 +1,7 @@
-export { loginGoogle, signOutCurrentUser } from "@/features/auth/model/authActions";
+export { loginGoogle, signOutCurrentUser } from "./model/authActions";
 export {
   authRuntime,
   createAuthRuntime,
   suspendAnonymousBootstrap,
   type AuthRuntime,
-} from "@/features/auth/model/authController";
+} from "./model/authController";

--- a/src/features/auth/model/authActions.spec.ts
+++ b/src/features/auth/model/authActions.spec.ts
@@ -8,12 +8,12 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: mocks.auth }));
-vi.mock("@/features/auth/model/authController", () => ({
+vi.mock("./authController", () => ({
   publishAuthenticatedUser: mocks.publishAuthenticatedUser,
 }));
 vi.mock("firebase/auth");
 
-import { loginGoogle, signOutCurrentUser } from "@/features/auth/model/authActions";
+import { loginGoogle, signOutCurrentUser } from "./authActions";
 
 describe("loginGoogle", () => {
   beforeEach(() => {

--- a/src/features/auth/model/authActions.ts
+++ b/src/features/auth/model/authActions.ts
@@ -1,7 +1,7 @@
 import { FirebaseError } from "firebase/app";
 import { GoogleAuthProvider, linkWithPopup, signInWithCredential, signOut, type UserCredential } from "firebase/auth";
 
-import { publishAuthenticatedUser } from "@/features/auth/model/authController";
+import { publishAuthenticatedUser } from "./authController";
 import { auth } from "@/shared/firebase";
 
 export const loginGoogle = async (): Promise<void> => {

--- a/src/features/auth/model/authController.spec.ts
+++ b/src/features/auth/model/authController.spec.ts
@@ -15,7 +15,7 @@ vi.mock("firebase/auth", () => ({
   signInAnonymously: singletonMocks.signInAnonymously,
 }));
 
-import { createAuthController } from "@/features/auth/model/authController";
+import { createAuthController } from "./authController";
 
 const createUser = (
   uid: string,

--- a/src/features/card/components/BackText.spec.tsx
+++ b/src/features/card/components/BackText.spec.tsx
@@ -7,7 +7,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
-import { BackText } from "@/features/card/components/BackText";
+import { BackText } from "./BackText";
 
 describe("BackText", () => {
   it("preserves plain text and click behavior with long-content wrapping", () => {

--- a/src/features/card/components/BackText.stories.tsx
+++ b/src/features/card/components/BackText.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { BackText as Template } from "@/features/card/components/BackText";
+import { BackText as Template } from "./BackText";
 import * as fixture from "@/storybook/fixture";
 
 const meta = {

--- a/src/features/card/components/Card.spec.tsx
+++ b/src/features/card/components/Card.spec.tsx
@@ -11,7 +11,7 @@ import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
 import type { Card as CardEntity } from "@/entities/card";
-import { Card } from "@/features/card/components/Card";
+import { Card } from "./Card";
 
 const card = {
   id: "card-id",

--- a/src/features/card/components/Card.stories.tsx
+++ b/src/features/card/components/Card.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Card as Template } from "@/features/card/components/Card";
+import { Card as Template } from "./Card";
 import * as fixture from "@/storybook/fixture";
 
 const meta = {

--- a/src/features/card/components/Card.tsx
+++ b/src/features/card/components/Card.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { useSwipeable } from "react-swipeable";
 
 import type { Card as CardEntity, CardId } from "@/entities/card";
-import { CardActionsMenu } from "@/features/card/components/CardActionsMenu";
+import { CardActionsMenu } from "./CardActionsMenu";
 import { Score, TagLabel } from "@/shared/ui/content";
 
 export interface CardActionsProps {

--- a/src/features/card/components/CardActionsMenu.spec.tsx
+++ b/src/features/card/components/CardActionsMenu.spec.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
-import { CardActionsMenu } from "@/features/card/components/CardActionsMenu";
+import { CardActionsMenu } from "./CardActionsMenu";
 
 type ControlledMenuProps = Omit<React.ComponentProps<typeof CardActionsMenu>, "open" | "onToggle" | "onClose">;
 

--- a/src/features/card/components/CardForm.spec.tsx
+++ b/src/features/card/components/CardForm.spec.tsx
@@ -10,7 +10,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { CardForm, type CardFormProps } from "@/features/card/components/CardForm";
+import { CardForm, type CardFormProps } from "./CardForm";
 import { createCard } from "@/test/factories";
 
 const createdAt = Date.UTC(2026, 0, 2);

--- a/src/features/card/components/CardForm.stories.tsx
+++ b/src/features/card/components/CardForm.stories.tsx
@@ -8,7 +8,7 @@ import type { Card } from "@/entities/card";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { CardForm as Template, type CardFormFields } from "@/features/card/components/CardForm";
+import { CardForm as Template, type CardFormFields } from "./CardForm";
 import type { Option } from "@/shared/ui/forms";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";

--- a/src/features/card/components/CardOverlay.spec.tsx
+++ b/src/features/card/components/CardOverlay.spec.tsx
@@ -7,7 +7,7 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
-import { CardOverlay } from "@/features/card/components/CardOverlay";
+import { CardOverlay } from "./CardOverlay";
 import { createCard } from "@/test/factories";
 
 describe("CardOverlay", () => {

--- a/src/features/card/components/CardOverlay.stories.tsx
+++ b/src/features/card/components/CardOverlay.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { CardOverlay as Template } from "@/features/card/components/CardOverlay";
+import { CardOverlay as Template } from "./CardOverlay";
 import * as fixture from "@/storybook/fixture";
 
 const meta = {

--- a/src/features/card/components/FrontText.spec.tsx
+++ b/src/features/card/components/FrontText.spec.tsx
@@ -8,7 +8,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { expect, it, describe, vi } from "vitest";
 import "@testing-library/jest-dom";
 
-import { FrontText } from "@/features/card/components/FrontText";
+import { FrontText } from "./FrontText";
 
 describe("FrontText", () => {
   it("should swipe", async () => {

--- a/src/features/card/components/FrontText.stories.tsx
+++ b/src/features/card/components/FrontText.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { FrontText as Template } from "@/features/card/components/FrontText";
+import { FrontText as Template } from "./FrontText";
 import * as fixture from "@/storybook/fixture";
 
 const meta = {

--- a/src/features/card/hooks/useCardFormState.ts
+++ b/src/features/card/hooks/useCardFormState.ts
@@ -10,8 +10,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
 import type { Option } from "@/shared/ui/forms";
-import type { CardFormProps } from "@/features/card/components/CardForm";
-import { cardFormSchema, type CardFormValues } from "@/features/card/lib/cardFormSchema";
+import type { CardFormProps } from "../components/CardForm";
+import { cardFormSchema, type CardFormValues } from "../lib/cardFormSchema";
 
 export interface UseCardFormStateOptions {
   card: Card;

--- a/src/features/card/hooks/useCardMutations.spec.tsx
+++ b/src/features/card/hooks/useCardMutations.spec.tsx
@@ -48,7 +48,7 @@ vi.mock("@/entities/card", async (importOriginal) => {
   };
 });
 
-import { useCardMutations } from "@/features/card/hooks/useCardMutations";
+import { useCardMutations } from "./useCardMutations";
 
 describe("useCardMutations", () => {
   beforeEach(() => {

--- a/src/features/import/hooks/useDeckImport.spec.tsx
+++ b/src/features/import/hooks/useDeckImport.spec.tsx
@@ -11,7 +11,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCard, createDeck } from "@/test/factories";
-import type { DeckImportResult } from "@/features/import/model/deckImportTypes";
+import type { DeckImportResult } from "../model/deckImportTypes";
 import { CardBulkMutationError } from "@/entities/card";
 import { actAsync } from "@/test/act";
 
@@ -66,11 +66,11 @@ vi.mock("@/entities/deck", async (importOriginal) => {
     }),
   };
 });
-vi.mock("@/features/import/lib/cardCsv", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/features/import/lib/cardCsv")>();
+vi.mock("../lib/cardCsv", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/cardCsv")>();
   return { ...actual, parseCsv: mocks.parseCsv };
 });
-import { sampleDeckId, useDeckImport } from "@/features/import/hooks/useDeckImport";
+import { sampleDeckId, useDeckImport } from "./useDeckImport";
 
 describe("useDeckImport", () => {
   beforeEach(() => {
@@ -83,9 +83,7 @@ describe("useDeckImport", () => {
     mocks.decks = [];
     mocks.cards = [];
     mocks.parseCsv.mockImplementation(async (content: string) => {
-      const { parseCsv } = await vi.importActual<typeof import("@/features/import/lib/cardCsv")>(
-        "@/features/import/lib/cardCsv"
-      );
+      const { parseCsv } = await vi.importActual<typeof import("../lib/cardCsv")>("../lib/cardCsv");
       return parseCsv(content);
     });
     mocks.prepareDeck.mockReturnValue(createDeck({ id: "deck", uid: "uid-a" }));

--- a/src/features/import/hooks/useDeckImport.ts
+++ b/src/features/import/hooks/useDeckImport.ts
@@ -19,9 +19,9 @@ import {
 } from "@/entities/card";
 import { createDeck, generateDeckId, useDeckMutations, useDecks } from "@/entities/deck";
 import { useAuthSession } from "@/entities/auth-session";
-import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "@/features/import/model/deckImportTypes";
-import { parseCsv } from "@/features/import/lib/cardCsv";
-import { buildDeckImportPlan } from "@/features/import/lib/deckImportAnalysis";
+import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "../model/deckImportTypes";
+import { parseCsv } from "../lib/cardCsv";
+import { buildDeckImportPlan } from "../lib/deckImportAnalysis";
 import sampleCards from "../../../../sample/build/output.json";
 
 interface DeckImportAttempt {

--- a/src/features/import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -23,14 +23,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/entities/auth-session", () => ({ useAuthSession: () => mocks.auth }));
 vi.mock("@/entities/deck", () => ({ useDecks: () => mocks.remote }));
-vi.mock("@/features/import/hooks/useDeckImport", () => ({
+vi.mock("./useDeckImport", () => ({
   useDeckImport: () => ({ addSample: mocks.addSample }),
 }));
 
-import {
-  createSampleDeckBootstrapController,
-  useSampleDeckBootstrap,
-} from "@/features/import/hooks/useSampleDeckBootstrap";
+import { createSampleDeckBootstrapController, useSampleDeckBootstrap } from "./useSampleDeckBootstrap";
 
 /**
  * Provides the strict mode test helper used by this file.

--- a/src/features/import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/import/hooks/useSampleDeckBootstrap.ts
@@ -8,7 +8,7 @@ import { useEffect } from "react";
 
 import { useDecks } from "@/entities/deck";
 import { useAuthSession } from "@/entities/auth-session";
-import { useDeckImport } from "@/features/import/hooks/useDeckImport";
+import { useDeckImport } from "./useDeckImport";
 
 type AddSample = () => Promise<unknown>;
 

--- a/src/features/import/lib/cardCsv.spec.ts
+++ b/src/features/import/lib/cardCsv.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { fromRow, isEmpty, parseCsv } from "@/features/import/lib/cardCsv";
+import { fromRow, isEmpty, parseCsv } from "./cardCsv";
 
 describe("card CSV import", () => {
   describe("fromRow", () => {

--- a/src/features/import/lib/cardCsv.ts
+++ b/src/features/import/lib/cardCsv.ts
@@ -2,7 +2,7 @@ import type { CardRaw } from "@/entities/card";
 
 import * as Papa from "papaparse";
 
-import type { DeckImportAnalysis, DeckImportIssue, DeckImportRow } from "@/features/import/model/deckImportTypes";
+import type { DeckImportAnalysis, DeckImportIssue, DeckImportRow } from "../model/deckImportTypes";
 import { isNonBlank } from "@/shared/lib/isNonBlank";
 
 export const isEmpty = (card: CardRaw): boolean => card.frontText === "" && card.backText === "";

--- a/src/features/import/lib/deckImportAnalysis.spec.ts
+++ b/src/features/import/lib/deckImportAnalysis.spec.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { buildDeckImportPlan, parseDeckImportCsv } from "@/features/import/lib/deckImportAnalysis";
+import { buildDeckImportPlan, parseDeckImportCsv } from "./deckImportAnalysis";
 import { createCard } from "@/test/factories";
 
 describe("parseDeckImportCsv", () => {

--- a/src/features/import/lib/deckImportAnalysis.ts
+++ b/src/features/import/lib/deckImportAnalysis.ts
@@ -6,8 +6,8 @@
 
 import type { Card, CardRaw } from "@/entities/card";
 
-import type { DeckImportPlan, DeckImportPlanRow, DeckImportRow } from "@/features/import/model/deckImportTypes";
-import { parseCsv } from "@/features/import/lib/cardCsv";
+import type { DeckImportPlan, DeckImportPlanRow, DeckImportRow } from "../model/deckImportTypes";
+import { parseCsv } from "./cardCsv";
 
 /**
  * Checks whether two imported card values contain the same user-editable content.

--- a/src/features/import/sampleCsv.spec.ts
+++ b/src/features/import/sampleCsv.spec.ts
@@ -4,7 +4,7 @@ const mocks = vi.hoisted(() => ({ downloadTextFile: vi.fn() }));
 
 vi.mock("@/shared/files", () => ({ downloadTextFile: mocks.downloadTextFile }));
 
-import { downloadSampleCsv, SAMPLE_CSV_TEXT } from "@/features/import/sampleCsv";
+import { downloadSampleCsv, SAMPLE_CSV_TEXT } from "./sampleCsv";
 
 describe("sample CSV", () => {
   beforeEach(() => {

--- a/src/features/settings/model/hooks/useAccountOperations.spec.tsx
+++ b/src/features/settings/model/hooks/useAccountOperations.spec.tsx
@@ -8,7 +8,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import React, { type PropsWithChildren } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { useAccountOperations } from "@/features/settings/model/hooks/useAccountOperations";
+import { useAccountOperations } from "./useAccountOperations";
 import { actAsync } from "@/test/act";
 
 /**

--- a/src/features/settings/model/hooks/useConfigFormState.spec.tsx
+++ b/src/features/settings/model/hooks/useConfigFormState.spec.tsx
@@ -13,8 +13,8 @@ import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { expect, it, describe, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { ConfigForm } from "@/features/settings/ui/components/ConfigForm";
-import { useConfigFormState } from "@/features/settings/model/hooks/useConfigFormState";
+import { ConfigForm } from "../../ui/components/ConfigForm";
+import { useConfigFormState } from "./useConfigFormState";
 
 /**
  * Renders the test-only Config Form Harness component with controlled state or providers.

--- a/src/features/settings/model/hooks/useConfigFormState.ts
+++ b/src/features/settings/model/hooks/useConfigFormState.ts
@@ -9,7 +9,7 @@ import type { ConfigState } from "@/shared/config";
 import * as React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
-import type { ConfigFormProps } from "@/features/settings/ui/components/ConfigForm";
+import type { ConfigFormProps } from "../../ui/components/ConfigForm";
 
 export interface UseConfigFormStateOptions {
   config: ConfigState;

--- a/src/features/settings/ui/components/ConfigForm.spec.tsx
+++ b/src/features/settings/ui/components/ConfigForm.spec.tsx
@@ -12,7 +12,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { ConfigForm, type ConfigFormFields, type ConfigFormProps } from "@/features/settings/ui/components/ConfigForm";
+import { ConfigForm, type ConfigFormFields, type ConfigFormProps } from "./ConfigForm";
 import { createConfig } from "@/test/factories";
 
 /**

--- a/src/features/settings/ui/components/ConfigForm.stories.tsx
+++ b/src/features/settings/ui/components/ConfigForm.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ConfigForm as Template, type ConfigFormFields } from "@/features/settings/ui/components/ConfigForm";
+import { ConfigForm as Template, type ConfigFormFields } from "./ConfigForm";
 import * as fixture from "@/storybook/fixture";
 
 const fields: ConfigFormFields = {

--- a/src/features/settings/ui/components/ConfigForm.tsx
+++ b/src/features/settings/ui/components/ConfigForm.tsx
@@ -10,7 +10,7 @@ import type * as React from "react";
 import { useId } from "react";
 import { AiOutlineDown, AiOutlineEye, AiOutlinePlayCircle, AiOutlineTool, AiOutlineUser } from "react-icons/ai";
 
-import { SettingsRow, SettingsSection } from "@/features/settings/ui/components/SettingsSection";
+import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Button } from "@/shared/ui/button";
 import { Slider, Switch } from "@/shared/ui/forms";
 

--- a/src/features/settings/ui/components/SettingsSection.spec.tsx
+++ b/src/features/settings/ui/components/SettingsSection.spec.tsx
@@ -9,7 +9,7 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 
-import { SettingsRow, SettingsSection } from "@/features/settings/ui/components/SettingsSection";
+import { SettingsRow, SettingsSection } from "./SettingsSection";
 
 describe("settings presentation", () => {
   it("relates a settings section to its unique heading", () => {

--- a/src/features/study/components/Controller.stories.tsx
+++ b/src/features/study/components/Controller.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Controller as Template } from "@/features/study/components/Controller";
+import { Controller as Template } from "./Controller";
 
 const meta = {
   title: "Study/Controller",

--- a/src/features/study/components/SwipeButtonList.stories.tsx
+++ b/src/features/study/components/SwipeButtonList.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { SwipeButtonList as Template } from "@/features/study/components/SwipeButtonList";
+import { SwipeButtonList as Template } from "./SwipeButtonList";
 
 const meta = {
   title: "Study/SwipeButtonList",

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -11,8 +11,8 @@ import type { ConfigState } from "@/shared/config";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useStudyActions } from "@/features/study/hooks/useStudyActions";
-import { studyStore } from "@/features/study/state/studyStore";
+import { useStudyActions } from "./useStudyActions";
+import { studyStore } from "../state/studyStore";
 import { actAsync } from "@/test/act";
 
 const mocks = vi.hoisted(() => {
@@ -50,7 +50,7 @@ vi.mock("@/entities/deck", () => ({
   useDecks: () => ({ decksById: {} }),
 }));
 
-vi.mock("@/features/study/hooks/useStudyCards", () => ({
+vi.mock("./useStudyCards", () => ({
   useStudyCards: () => mocks.filteredCards,
 }));
 

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -12,11 +12,11 @@ import React from "react";
 
 import { selectCardsForDeck, useCards } from "@/entities/card";
 import { useDecks } from "@/entities/deck";
-import { useStudyCards } from "@/features/study/hooks/useStudyCards";
-import { buildStudySession, calculateNextIndex } from "@/features/study/model/session";
-import { createStudyCard } from "@/features/study/model/studyCard";
-import { buildStudyPatch, resolveSwipeAction } from "@/features/study/model/swipe";
-import { studyStore } from "@/features/study/state/studyStore";
+import { useStudyCards } from "./useStudyCards";
+import { buildStudySession, calculateNextIndex } from "../model/session";
+import { createStudyCard } from "../model/studyCard";
+import { buildStudyPatch, resolveSwipeAction } from "../model/swipe";
+import { studyStore } from "../state/studyStore";
 import { useConfig } from "@/shared/config";
 
 export interface StudyActions {

--- a/src/features/study/hooks/useStudyCards.spec.tsx
+++ b/src/features/study/hooks/useStudyCards.spec.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCard, createConfig, createDeck } from "@/test/factories";
 
-import { useStudyCards } from "@/features/study/hooks/useStudyCards";
+import { useStudyCards } from "./useStudyCards";
 
 describe("useStudyCards", () => {
   beforeEach(() => vi.restoreAllMocks());

--- a/src/features/study/hooks/useStudyCards.ts
+++ b/src/features/study/hooks/useStudyCards.ts
@@ -3,8 +3,8 @@ import { useEffect, useMemo, useState } from "react";
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
-import { filterCardsForDeck } from "@/features/study/model/cardSelection";
-import { createStudyCard } from "@/features/study/model/studyCard";
+import { filterCardsForDeck } from "../model/cardSelection";
+import { createStudyCard } from "../model/studyCard";
 import type { ConfigState } from "@/shared/config";
 
 const MAX_TIMEOUT_MS = 2_147_483_647;

--- a/src/features/study/hooks/useStudyControllerState.spec.tsx
+++ b/src/features/study/hooks/useStudyControllerState.spec.tsx
@@ -11,8 +11,8 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Controller, type ControllerProps } from "@/features/study/components/Controller";
-import { useStudyControllerState } from "@/features/study/hooks/useStudyControllerState";
+import { Controller, type ControllerProps } from "../components/Controller";
+import { useStudyControllerState } from "./useStudyControllerState";
 
 /**
  * Renders the test-only Controller Harness component with controlled state or providers.

--- a/src/features/study/hooks/useStudyControllerState.ts
+++ b/src/features/study/hooks/useStudyControllerState.ts
@@ -5,7 +5,7 @@
  */
 
 import * as React from "react";
-import type { ControllerProps } from "@/features/study/components/Controller";
+import type { ControllerProps } from "../components/Controller";
 
 export interface UseStudyControllerStateOptions extends ControllerProps {
   enabled?: boolean;

--- a/src/features/study/hooks/useStudyHydrated.spec.ts
+++ b/src/features/study/hooks/useStudyHydrated.spec.ts
@@ -7,8 +7,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useStudyHydrated } from "@/features/study/hooks/useStudyHydrated";
-import { studyStore } from "@/features/study/state/studyStore";
+import { useStudyHydrated } from "./useStudyHydrated";
+import { studyStore } from "../state/studyStore";
 
 const { getState, persist } = studyStore;
 

--- a/src/features/study/hooks/useStudyHydrated.ts
+++ b/src/features/study/hooks/useStudyHydrated.ts
@@ -6,7 +6,7 @@
 
 import { useSyncExternalStore } from "react";
 
-import { studyStore } from "@/features/study/state/studyStore";
+import { studyStore } from "../state/studyStore";
 
 const { persist } = studyStore;
 

--- a/src/features/study/hooks/useStudyStore.ts
+++ b/src/features/study/hooks/useStudyStore.ts
@@ -6,7 +6,7 @@
 
 import { useStore } from "zustand";
 
-import { type StudyState, studyStore } from "@/features/study/state/studyStore";
+import { type StudyState, studyStore } from "../state/studyStore";
 
 /**
  * Provides the study store values and operations needed by React components.

--- a/src/features/study/model/cardSelection.spec.ts
+++ b/src/features/study/model/cardSelection.spec.ts
@@ -1,11 +1,11 @@
 import type { Card } from "@/entities/card";
 import { createStudyProgress, type StudyProgress } from "@/entities/study-progress";
-import type { StudyCard } from "@/features/study/model/studyCard";
+import type { StudyCard } from "./studyCard";
 import type { StudyPreferences } from "@/shared/config";
 
 import { describe, expect, it } from "vitest";
 
-import { filterCardsForDeck } from "@/features/study/model/cardSelection";
+import { filterCardsForDeck } from "./cardSelection";
 import { createCard, createDeck } from "@/test/factories";
 
 describe("filterCardsForDeck", () => {

--- a/src/features/study/model/cardSelection.ts
+++ b/src/features/study/model/cardSelection.ts
@@ -1,6 +1,6 @@
 import type { Deck } from "@/entities/deck";
 import { compareStudyProgress, isStudyProgressEligible } from "@/entities/study-progress";
-import type { StudyCard } from "@/features/study/model/studyCard";
+import type { StudyCard } from "./studyCard";
 import type { StudyPreferences } from "@/shared/config";
 
 const isCardMatchingTags = (card: StudyCard["card"], deck: Pick<Deck, "selectedTags" | "tagAndFilter">) => {

--- a/src/features/study/model/session.spec.ts
+++ b/src/features/study/model/session.spec.ts
@@ -3,7 +3,7 @@ import type { StudyPreferences } from "@/shared/config";
 
 import { describe, expect, it } from "vitest";
 
-import { buildStudySession, calculateNextIndex } from "@/features/study/model/session";
+import { buildStudySession, calculateNextIndex } from "./session";
 
 describe("calculateNextIndex", () => {
   it("moves forward for non-prev actions", () => {

--- a/src/features/study/model/swipe.spec.ts
+++ b/src/features/study/model/swipe.spec.ts
@@ -3,8 +3,8 @@ import type { SwipeState } from "@/shared/config";
 import { describe, expect, it } from "vitest";
 
 import { createStudyProgress } from "@/entities/study-progress";
-import type { StudyCard } from "@/features/study/model/studyCard";
-import { buildStudyPatch, resolveSwipeAction } from "@/features/study/model/swipe";
+import type { StudyCard } from "./studyCard";
+import { buildStudyPatch, resolveSwipeAction } from "./swipe";
 import { createCard } from "@/test/factories";
 
 describe("resolveSwipeAction", () => {

--- a/src/features/study/model/swipe.ts
+++ b/src/features/study/model/swipe.ts
@@ -1,6 +1,6 @@
 import type { CardEdit } from "@/entities/card";
 import { recordStudyProgress, type StudyRating } from "@/entities/study-progress";
-import { createCardProgressEdit, type StudyCard } from "@/features/study/model/studyCard";
+import { createCardProgressEdit, type StudyCard } from "./studyCard";
 import type { SwipeAction, SwipeDirection, SwipeState } from "@/shared/config";
 
 export const resolveSwipeAction = (controls: SwipeState, direction: SwipeDirection): SwipeAction => {

--- a/src/features/study/state/studyStore.spec.ts
+++ b/src/features/study/state/studyStore.spec.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { STUDY_STORAGE_KEY, createStudyStore, selectStudySessionForRoute } from "@/features/study/state/studyStore";
+import { STUDY_STORAGE_KEY, createStudyStore, selectStudySessionForRoute } from "./studyStore";
 
 /**
  * Provides the create memory storage test helper used by this file.


### PR DESCRIPTION
## Summary

- classify each `features/*`, `entities/*`, and `pages/*` slice as its own boundaries element
- resolve TypeScript path aliases and reject `@/**` dependencies that stay inside the same slice
- migrate existing same-slice imports, re-exports, mocks, and dynamic imports to relative paths

## Root cause

The boundaries configuration classified source files only at the layer level, and ESLint did not resolve the TypeScript `@/` alias. As a result, same-slice alias dependencies could not be identified as internal relationships.

## Impact

Imports across slices and layers can continue to use `@/`. Internal implementation references in feature, entity, and page slices now consistently use relative paths and are enforced by ESLint.

## Validation

- `npm run lint:eslint`
- `mise run check` (includes full lint and 614 unit tests)
- temporary policy fixtures verified import, re-export, dynamic import, feature/entity self-import, and page self-import failures plus relative and cross-layer passes

Closes #701