### PR TITLE
refactor: move settings ownership to page

### DIFF
--- a/src/app/providers/auth/AuthLogout.spec.tsx
+++ b/src/app/providers/auth/AuthLogout.spec.tsx
@@ -56,7 +56,7 @@ vi.mock("@/shared/config", () => ({
   updateConfig: vi.fn(),
 }));
 vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
-vi.mock("@/features/settings/model/hooks/useConfigFormState", () => ({
+vi.mock("@/pages/settings/model/useConfigFormState", () => ({
   useConfigFormState: (options: Record<string, unknown>) => options,
 }));
 vi.mock("@/pages/settings/ui/SettingsView", () => ({

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,3 +1,0 @@
-export { ConfigForm, type ConfigFormFields, type ConfigFormProps } from "./ui/components/ConfigForm";
-export { useAccountOperations } from "./model/hooks/useAccountOperations";
-export { useConfigFormState } from "./model/hooks/useConfigFormState";

--- a/src/pages/settings/model/useAccountOperations.spec.tsx
+++ b/src/pages/settings/model/useAccountOperations.spec.tsx
@@ -8,7 +8,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import React, { type PropsWithChildren } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { useAccountOperations } from "@/features/settings/model/hooks/useAccountOperations";
+import { useAccountOperations } from "./useAccountOperations";
 import { actAsync } from "@/test/act";
 
 /**

--- a/src/pages/settings/model/useAccountOperations.ts
+++ b/src/pages/settings/model/useAccountOperations.ts
@@ -1,5 +1,5 @@
 /**
- * @file Provides the settings feature's Use Account Operations React hook.
+ * @file Provides the Settings page's Use Account Operations React hook.
  * The hook combines state and operations behind one interface so components do not need to
  * coordinate services themselves.
  */

--- a/src/pages/settings/model/useConfigFormState.spec.tsx
+++ b/src/pages/settings/model/useConfigFormState.spec.tsx
@@ -13,8 +13,8 @@ import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { expect, it, describe, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { ConfigForm } from "@/features/settings/ui/components/ConfigForm";
-import { useConfigFormState } from "@/features/settings/model/hooks/useConfigFormState";
+import { ConfigForm } from "../ui/ConfigForm";
+import { useConfigFormState } from "./useConfigFormState";
 
 /**
  * Renders the test-only Config Form Harness component with controlled state or providers.

--- a/src/pages/settings/model/useConfigFormState.ts
+++ b/src/pages/settings/model/useConfigFormState.ts
@@ -1,5 +1,5 @@
 /**
- * @file Provides the settings feature's Use Config Form State React hook.
+ * @file Provides the Settings page's Use Config Form State React hook.
  * The hook combines state and operations behind one interface so components do not need to
  * coordinate services themselves.
  */
@@ -9,7 +9,7 @@ import type { ConfigState } from "@/shared/config";
 import * as React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
-import type { ConfigFormProps } from "@/features/settings/ui/components/ConfigForm";
+import type { ConfigFormProps } from "../ui/ConfigForm";
 
 export interface UseConfigFormStateOptions {
   config: ConfigState;
@@ -25,7 +25,7 @@ export interface UseConfigFormStateOptions {
 
 /**
  * Provides the config form state values and operations needed by React components.
- * Callers receive one focused interface without coordinating the settings feature's stores and
+ * Callers receive one focused interface without coordinating the Settings page's stores and
  * services themselves.
  */
 export const useConfigFormState = ({

--- a/src/pages/settings/ui/ConfigForm.spec.tsx
+++ b/src/pages/settings/ui/ConfigForm.spec.tsx
@@ -12,7 +12,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { ConfigForm, type ConfigFormFields, type ConfigFormProps } from "@/features/settings/ui/components/ConfigForm";
+import { ConfigForm, type ConfigFormFields, type ConfigFormProps } from "./ConfigForm";
 import { createConfig } from "@/test/factories";
 
 /**

--- a/src/pages/settings/ui/ConfigForm.stories.tsx
+++ b/src/pages/settings/ui/ConfigForm.stories.tsx
@@ -6,8 +6,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ConfigForm as Template, type ConfigFormFields } from "@/features/settings/ui/components/ConfigForm";
 import * as fixture from "@/storybook/fixture";
+
+import { ConfigForm as Template, type ConfigFormFields } from "./ConfigForm";
 
 const fields: ConfigFormFields = {
   showHeader: { checked: fixture.config.default.appearance.showHeader, onChange: () => undefined },

--- a/src/pages/settings/ui/ConfigForm.tsx
+++ b/src/pages/settings/ui/ConfigForm.tsx
@@ -1,5 +1,5 @@
 /**
- * @file Defines the settings feature's Config Form presentation component.
+ * @file Defines the Settings page's Config Form presentation component.
  * The component renders props and reports user intent through callbacks while data access stays
  * outside the view.
  */
@@ -10,9 +10,10 @@ import type * as React from "react";
 import { useId } from "react";
 import { AiOutlineDown, AiOutlineEye, AiOutlinePlayCircle, AiOutlineTool, AiOutlineUser } from "react-icons/ai";
 
-import { SettingsRow, SettingsSection } from "@/features/settings/ui/components/SettingsSection";
 import { Button } from "@/shared/ui/button";
 import { Slider, Switch } from "@/shared/ui/forms";
+
+import { SettingsRow, SettingsSection } from "./SettingsSection";
 
 export interface ConfigFormFields {
   showHeader: React.ComponentProps<typeof Switch>;

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -18,7 +18,7 @@ vi.mock("@/shared/config", () => ({
   updateConfig: vi.fn(),
 }));
 vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
-vi.mock("@/features/settings/model/hooks/useAccountOperations", () => ({
+vi.mock("@/pages/settings/model/useAccountOperations", () => ({
   useAccountOperations: () => ({
     pending: false,
     error: null,
@@ -27,10 +27,10 @@ vi.mock("@/features/settings/model/hooks/useAccountOperations", () => ({
     retry: vi.fn(async () => undefined),
   }),
 }));
-vi.mock("@/features/settings/model/hooks/useConfigFormState", () => ({
+vi.mock("@/pages/settings/model/useConfigFormState", () => ({
   useConfigFormState: () => ({}),
 }));
-vi.mock("@/features/settings/ui/components/ConfigForm", () => ({ ConfigForm: () => null }));
+vi.mock("@/pages/settings/ui/ConfigForm", () => ({ ConfigForm: () => null }));
 
 import { SettingsPage } from "./SettingsPage";
 

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -3,11 +3,12 @@ import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { useAuthSession } from "@/entities/auth-session";
-import { useAccountOperations, useConfigFormState } from "@/features/settings";
 import { setDarkMode, updateConfig, useConfig } from "@/shared/config";
 import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 
+import { useAccountOperations } from "../model/useAccountOperations";
+import { useConfigFormState } from "../model/useConfigFormState";
 import { SettingsView } from "./SettingsView";
 
 interface SettingsPageProps {

--- a/src/pages/settings/ui/SettingsSection.spec.tsx
+++ b/src/pages/settings/ui/SettingsSection.spec.tsx
@@ -9,7 +9,7 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 
-import { SettingsRow, SettingsSection } from "@/features/settings/ui/components/SettingsSection";
+import { SettingsRow, SettingsSection } from "./SettingsSection";
 
 describe("settings presentation", () => {
   it("relates a settings section to its unique heading", () => {

--- a/src/pages/settings/ui/SettingsSection.tsx
+++ b/src/pages/settings/ui/SettingsSection.tsx
@@ -1,5 +1,5 @@
 /**
- * @file Defines the settings feature's Settings Section presentation component.
+ * @file Defines the Settings page's Settings Section presentation component.
  * The component renders props and reports user intent through callbacks while data access stays
  * outside the view.
  */

--- a/src/pages/settings/ui/SettingsView.spec.tsx
+++ b/src/pages/settings/ui/SettingsView.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import type { ConfigFormFields } from "@/features/settings";
+import type { ConfigFormFields } from "./ConfigForm";
 import { createConfig } from "@/test/factories";
 
 import { SettingsView } from "./SettingsView";

--- a/src/pages/settings/ui/SettingsView.stories.tsx
+++ b/src/pages/settings/ui/SettingsView.stories.tsx
@@ -1,10 +1,9 @@
-import type { ConfigFormFields } from "@/features/settings";
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
+import type { ConfigFormFields } from "./ConfigForm";
 import { SettingsView as View } from "./SettingsView";
 
 const fields: ConfigFormFields = {

--- a/src/pages/settings/ui/SettingsView.tsx
+++ b/src/pages/settings/ui/SettingsView.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 
-import { ConfigForm, type ConfigFormProps } from "@/features/settings";
+import { ConfigForm, type ConfigFormProps } from "./ConfigForm";
 
 export interface SettingsViewProps {
   configForm?: ConfigFormProps;

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -17,7 +17,6 @@ export default defineConfig([
       "./src/entities/study-progress/**",
       "./src/features/deck-editor/**",
       "./src/features/export/**",
-      "./src/features/settings/**",
     ],
     rules: {
       "fsd/insignificant-slice": "off",


### PR DESCRIPTION
## Summary

- move the Settings-only form state, account-operation feedback, and presentation components into the Settings page slice
- remove the unused `features/settings` public API
- remove the `fsd/insignificant-slice` exception for Settings

## Why

The Settings feature was consumed only by the Settings page, so keeping a separate feature slice added an insignificant boundary. Co-locating the route-specific responsibilities removes that boundary without adding dummy consumers or broad lint exceptions. The application-wide config contract and persistence remain in `shared/config`.

## Impact

This is an ownership-only refactor. Settings values, UI behavior, authentication behavior, persistence, and i18n are unchanged.

## Validation

- `CHOKIDAR_USEPOLLING=1 npm run lint:fsd`
- `npm run test:unit -- src/pages/settings src/app/providers/auth/AuthLogout.spec.tsx` (7 files, 27 tests)
- `CHOKIDAR_USEPOLLING=1 mise run check` (112 files, 614 tests)

Closes #706
