### PR TITLE
[#691] Encapsulate study identity cleanup behind lifecycle API

### DIFF
--- a/src/app/auth/logout.ts
+++ b/src/app/auth/logout.ts
@@ -1,13 +1,11 @@
 import { stopRemoteReads } from "@/app/providers/remote-read/remoteReadLifecycle";
 import { signOutCurrentUser, suspendAnonymousBootstrap } from "@/features/auth";
-import { clearStudyStore, studyStore, type StudyState } from "@/features/study";
-
-const { getState: getStudyState } = studyStore;
+import { createStudyIdentityCleanup, type StudyIdentityCleanup } from "@/features/study";
 
 interface LogoutCleanupProgress {
   remote: boolean;
   study: boolean;
-  studyStateAfterClear?: StudyState;
+  studyCleanup: StudyIdentityCleanup;
 }
 
 type LogoutCleanupStep = "remote" | "study";
@@ -43,12 +41,7 @@ const runLogout = async (
     };
 
     await run("remote", () => stopRemoteReads(confirmedUid));
-    await run("study", async () => {
-      if (progress.studyStateAfterClear && getStudyState() !== progress.studyStateAfterClear) return;
-      const cleanup = clearStudyStore();
-      progress.studyStateAfterClear = getStudyState();
-      await cleanup;
-    });
+    await run("study", progress.studyCleanup);
     if (errors.length > 0) {
       throw new LogoutCleanupError(errors[0], () => runLogout(confirmedUid, progress, false));
     }
@@ -58,4 +51,4 @@ const runLogout = async (
 };
 
 export const logout = (confirmedUid: string): Promise<void> =>
-  runLogout(confirmedUid, { remote: false, study: false }, true);
+  runLogout(confirmedUid, { remote: false, study: false, studyCleanup: createStudyIdentityCleanup() }, true);

--- a/src/app/providers/auth/AuthLogout.spec.tsx
+++ b/src/app/providers/auth/AuthLogout.spec.tsx
@@ -23,8 +23,8 @@ const mocks = vi.hoisted(() => ({
   dispatch: vi.fn(),
   startRemoteReads: vi.fn(),
   cleanupUid: vi.fn(),
-  clearStudyStore: vi.fn(),
-  actualClearStudyStore: undefined as undefined | (() => Promise<void>),
+  runStudyCleanup: vi.fn(),
+  actualCreateStudyIdentityCleanup: undefined as undefined | (() => () => Promise<void>),
   operations: [] as string[],
   navigate: vi.fn(),
 }));
@@ -47,8 +47,17 @@ vi.mock("@/app/providers/remote-read/remoteReadLifecycle", () => ({
 }));
 vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
-  mocks.actualClearStudyStore = actual.clearStudyStore;
-  return { ...actual, clearStudyStore: mocks.clearStudyStore };
+  mocks.actualCreateStudyIdentityCleanup = actual.createStudyIdentityCleanup;
+  return {
+    ...actual,
+    createStudyIdentityCleanup: () => {
+      if (!mocks.actualCreateStudyIdentityCleanup) {
+        throw new Error("Actual study cleanup was not initialized");
+      }
+      const cleanup = mocks.actualCreateStudyIdentityCleanup();
+      return () => mocks.runStudyCleanup(cleanup);
+    },
+  };
 });
 vi.mock("@/shared/config", () => ({
   useConfig: () => ({ appearance: { darkMode: false } }),
@@ -90,10 +99,7 @@ beforeEach(() => {
   mocks.auth.currentUser = null;
   mocks.publishUser = undefined;
   mocks.operations.length = 0;
-  mocks.clearStudyStore.mockImplementation(() => {
-    if (!mocks.actualClearStudyStore) throw new Error("Actual study cleanup was not initialized");
-    return mocks.actualClearStudyStore();
-  });
+  mocks.runStudyCleanup.mockImplementation((cleanup: () => Promise<void>) => cleanup());
   studyStore.setState({ sessionsByDeckId: {}, showBackText: false, autoPlay: false, lastSwipe: undefined });
   localStorage.clear();
 });
@@ -131,7 +137,7 @@ it("waits for logout cleanup before bootstrapping the next anonymous UID", async
   mocks.startRemoteReads.mockImplementation(async (uid: string) => {
     mocks.operations.push(`subscribe:${uid}`);
   });
-  mocks.clearStudyStore.mockImplementation(async () => {
+  mocks.runStudyCleanup.mockImplementation(async () => {
     mocks.operations.push("clear-study");
   });
   mocks.signOut.mockImplementation(async () => {
@@ -166,7 +172,7 @@ it("waits for logout cleanup before bootstrapping the next anonymous UID", async
   expect(mocks.operations).toContain("sign-out");
   expect(mocks.signInAnonymously).not.toHaveBeenCalled();
   expect(mocks.startRemoteReads).not.toHaveBeenCalledWith("uid-b");
-  expect(mocks.clearStudyStore).not.toHaveBeenCalled();
+  expect(mocks.runStudyCleanup).not.toHaveBeenCalled();
 
   await actAsync(async () => {
     resolveCleanup();
@@ -209,7 +215,7 @@ it("keeps post-sign-out cleanup failures visible and retries only unfinished cle
     .mockReturnValueOnce(firstCleanup)
     .mockRejectedValueOnce(retryCleanupError)
     .mockResolvedValueOnce(undefined);
-  mocks.clearStudyStore.mockResolvedValue(undefined);
+  mocks.runStudyCleanup.mockResolvedValue(undefined);
 
   const runtime = createTestRuntime();
   render(
@@ -226,19 +232,19 @@ it("keeps post-sign-out cleanup failures visible and retries only unfinished cle
   expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
   expect(mocks.signOut).toHaveBeenCalledOnce();
   expect(mocks.cleanupUid).toHaveBeenCalledOnce();
-  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+  expect(mocks.runStudyCleanup).toHaveBeenCalledOnce();
 
   fireEvent.click(screen.getByRole("button", { name: "Retry" }));
   await waitFor(() => expect(mocks.cleanupUid).toHaveBeenCalledTimes(2));
   expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
   expect(mocks.signOut).toHaveBeenCalledOnce();
-  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+  expect(mocks.runStudyCleanup).toHaveBeenCalledOnce();
 
   fireEvent.click(screen.getByRole("button", { name: "Retry" }));
   await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   expect(mocks.cleanupUid).toHaveBeenCalledTimes(3);
   expect(mocks.signOut).toHaveBeenCalledOnce();
-  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+  expect(mocks.runStudyCleanup).toHaveBeenCalledOnce();
 });
 
 it("hands cleanup feedback across auth after retrying a failed sign-out", async () => {
@@ -255,7 +261,7 @@ it("hands cleanup feedback across auth after retrying a failed sign-out", async 
   mocks.signOut.mockRejectedValueOnce(signOutError).mockImplementationOnce(async () => mocks.publishUser?.(null));
   mocks.signInAnonymously.mockReturnValue(anonymousBootstrap);
   mocks.cleanupUid.mockRejectedValueOnce(cleanupError).mockResolvedValueOnce(undefined);
-  mocks.clearStudyStore.mockResolvedValue(undefined);
+  mocks.runStudyCleanup.mockResolvedValue(undefined);
 
   const runtime = createTestRuntime();
   render(
@@ -282,7 +288,7 @@ it("hands cleanup feedback across auth after retrying a failed sign-out", async 
   await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   expect(mocks.signOut).toHaveBeenCalledTimes(2);
   expect(mocks.cleanupUid).toHaveBeenCalledTimes(2);
-  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+  expect(mocks.runStudyCleanup).toHaveBeenCalledOnce();
 });
 
 it("does not erase a new anonymous study when obsolete logout cleanup is retried", async () => {
@@ -330,5 +336,5 @@ it("does not erase a new anonymous study when obsolete logout cleanup is retried
   });
   expect(mocks.signOut).toHaveBeenCalledOnce();
   expect(mocks.cleanupUid).toHaveBeenCalledOnce();
-  expect(mocks.clearStudyStore).toHaveBeenCalledOnce();
+  expect(mocks.runStudyCleanup).toHaveBeenCalledTimes(2);
 });

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -15,9 +15,11 @@ export { useStudyControllerState } from "./hooks/useStudyControllerState";
 export { useStudySessions } from "./hooks/useStudySessions";
 export { useStudyStore } from "./hooks/useStudyStore";
 export {
-  clearStudyStore,
+  createStudyIdentityCleanup,
+  type StudyIdentityCleanup,
+} from "./lifecycle/studyIdentityCleanup";
+export {
   selectStudySessionForRoute,
   studyStore,
   type StudySession,
-  type StudyState,
 } from "./state/studyStore";

--- a/src/features/study/lifecycle/studyIdentityCleanup.spec.ts
+++ b/src/features/study/lifecycle/studyIdentityCleanup.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { STUDY_STORAGE_KEY, studyStore } from "../state/studyStore";
+import { createStudyIdentityCleanup } from "./studyIdentityCleanup";
+
+describe("createStudyIdentityCleanup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    studyStore.setState({
+      sessionsByDeckId: {},
+      showBackText: false,
+      autoPlay: false,
+      lastSwipe: undefined,
+    });
+  });
+
+  it("clears persisted sessions and transient UI state without removing unrelated storage", async () => {
+    localStorage.setItem("unrelated-preference", "preserve-me");
+    studyStore.getState().startStudy("deck", ["card"]);
+    studyStore.setState({
+      showBackText: true,
+      autoPlay: true,
+      lastSwipe: { direction: "cardSwipeLeft", eventId: 1 },
+    });
+
+    await createStudyIdentityCleanup()();
+
+    expect(studyStore.getState()).toMatchObject({
+      sessionsByDeckId: {},
+      showBackText: false,
+      autoPlay: false,
+      lastSwipe: undefined,
+    });
+    expect(localStorage.getItem(STUDY_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem("unrelated-preference")).toBe("preserve-me");
+  });
+
+  it("returns a storage cleanup failure to the caller and completes on retry", async () => {
+    studyStore.getState().startStudy("deck", ["card"]);
+    const cleanupError = new Error("storage cleanup failed");
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementationOnce(() => {
+      throw cleanupError;
+    });
+    const cleanup = createStudyIdentityCleanup();
+
+    await expect(cleanup()).rejects.toBe(cleanupError);
+    expect(studyStore.getState().sessionsByDeckId).toEqual({});
+
+    await expect(cleanup()).resolves.toBeUndefined();
+    expect(localStorage.getItem(STUDY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not remove study state created after a failed cleanup", async () => {
+    studyStore.getState().startStudy("old-deck", ["old-card"]);
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementationOnce(() => {
+      throw new Error("storage cleanup failed");
+    });
+    const cleanup = createStudyIdentityCleanup();
+    await expect(cleanup()).rejects.toThrow("storage cleanup failed");
+
+    studyStore.getState().startStudy("new-deck", ["new-card"]);
+    const persistedNewState = localStorage.getItem(STUDY_STORAGE_KEY);
+
+    await cleanup();
+
+    expect(studyStore.getState().sessionsByDeckId).toEqual({
+      "new-deck": expect.objectContaining({ deckId: "new-deck", cardOrderIds: ["new-card"] }),
+    });
+    expect(localStorage.getItem(STUDY_STORAGE_KEY)).toBe(persistedNewState);
+  });
+});

--- a/src/features/study/lifecycle/studyIdentityCleanup.ts
+++ b/src/features/study/lifecycle/studyIdentityCleanup.ts
@@ -1,0 +1,26 @@
+import { clearStudyStore, studyStore, type StudyState } from "../state/studyStore";
+
+export type StudyIdentityCleanup = () => Promise<void>;
+
+/**
+ * Creates a retryable cleanup operation for an identity transition.
+ * A retry becomes obsolete when study state changes after the initial reset, because that state
+ * belongs to the next identity and its persisted data must not be removed.
+ */
+export const createStudyIdentityCleanup = (): StudyIdentityCleanup => {
+  let stateAfterClear: StudyState | undefined;
+  let completed = false;
+
+  return async () => {
+    if (completed) return;
+    if (stateAfterClear && studyStore.getState() !== stateAfterClear) {
+      completed = true;
+      return;
+    }
+
+    const cleanup = clearStudyStore();
+    stateAfterClear = studyStore.getState();
+    await cleanup;
+    completed = true;
+  };
+};


### PR DESCRIPTION
## Summary

- add a retryable study identity cleanup operation to the public study lifecycle API
- keep store generation checks and persisted/transient state clearing inside the study feature
- update logout orchestration to depend only on the lifecycle operation
- add feature-level coverage for storage failures, safe retries, new-state protection, and unrelated storage preservation

## Root cause

Logout owned study store internals, including `StudyState` and object identity checks, so store implementation changes leaked into app orchestration.

## Impact

Identity teardown keeps the existing cleanup behavior while obsolete retries can no longer delete study state created for the next identity.

## Validation

- `mise run check`
- 113 unit test files passed (617 tests)

Closes #691