### PR TITLE
No issue: Define shared layer boundaries

### DIFF
--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Instructions
+
+- Treat `src/shared` as domain-agnostic shared code.
+- Do not place domain concepts, domain-specific terminology, or domain/business logic in `shared`.
+- Keep only generic, reusable technical code here.
+- If code requires domain knowledge, place it in the appropriate domain layer.


### PR DESCRIPTION
## Summary

- add `src/shared/AGENTS.md`
- define `src/shared` as domain-agnostic shared code
- prohibit domain concepts, domain-specific terminology, and domain/business logic in `shared`

## Why

Keep the `shared` layer generic and reusable, and prevent domain knowledge from leaking into it.

## Impact

Future changes under `src/shared` should contain only generic technical code. Domain-aware code should live in the appropriate domain layer.

## Checks

- Documentation-only change; no runtime checks required.