### PR TITLE
[No issue] refactor: centralize application layout

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ import testingLibrary from "eslint-plugin-testing-library";
 
 const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
-const sliceLayers = ["entities", "features", "pages"];
+const sliceLayers = ["entities", "features", "pages", "widgets"];
 const nonSliceLayers = ["app", "shared"];
 
 export default [

--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -95,24 +95,10 @@ describe("CardFormPage", () => {
     expect(mocks.navigate).toHaveBeenCalledWith(-1);
   });
 
-  it("renders the ready screen in the application shell and forwards header actions", async () => {
-    const view = render(<CardFormPage />);
-
-    await userEvent.click(screen.getByRole("button", { name: "tango" }));
-    await userEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    await userEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
-
-    view.unmount();
-    mocks.config = createConfig({ appearance: { darkMode: true } });
+  it("renders the ready screen in the application shell", () => {
     render(<CardFormPage />);
-    await userEvent.click(screen.getByRole("button", { name: "Switch to light mode" }));
-    expect(mocks.setDarkMode).toHaveBeenNthCalledWith(2, false);
+
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("returns to the previous page without saving when cancelled", async () => {

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -4,16 +4,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { type Card, useCards } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
 import { useCardFormState, useCardMutations } from "@/features/card";
-import { setDarkMode, useConfig } from "@/shared/config";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { CardFormView } from "./CardFormView";
 
 const CardFormContent = ({ card }: { card: Card }) => {
-  const config = useConfig();
   const navigate = useNavigate();
   const mutations = useCardMutations();
   const categoryOptions = CATEGORY.map((category) => ({ label: category, value: category }));
@@ -32,23 +30,14 @@ const CardFormContent = ({ card }: { card: Card }) => {
   });
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <CardFormView
         feedbackSlot={
           <RemoteMutationNotice pending={mutations.pending} error={mutations.error} onRetry={mutations.retry} />
         }
         cardForm={{ ...cardForm, onCancel: goBack }}
       />
-    </Layout>
+    </AppLayout>
   );
 };
 

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -180,18 +180,10 @@ describe("CardListPage", () => {
     expect(screen.getByText("Filters")).toBeVisible();
   });
 
-  it("renders the ready screen in the application shell and forwards header actions", async () => {
+  it("renders the ready screen in the application shell", () => {
     render(<CardListPage />);
 
-    await userEvent.click(screen.getByRole("button", { name: "tango" }));
-    await userEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    await userEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("navigates to Card edit and responds to top and settings shortcuts", async () => {

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -9,14 +9,14 @@ import { getCategory, isHighlightLanguage, type Deck, useDecks } from "@/entitie
 import { useCardMutations } from "@/features/card";
 import { useEditDeck } from "@/features/deck/edit";
 import { DeckStartForm, useDeckFilterState, useStudyCards } from "@/features/study";
-import { setDarkMode, useConfig } from "@/shared/config";
+import { useConfig } from "@/shared/config";
 import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { CardListView } from "./CardListView";
 
@@ -43,16 +43,7 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
   useKey("s", () => void navigate("/settings"));
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <CardListView
         cards={cards}
         filter={{
@@ -133,7 +124,7 @@ const CardListContent = (props: { deck: Deck; cards: Card[]; tags: string[]; con
           : {})}
         onShowCard={setShowCard}
       />
-    </Layout>
+    </AppLayout>
   );
 };
 

--- a/src/pages/card-view/ui/CardViewPage.spec.tsx
+++ b/src/pages/card-view/ui/CardViewPage.spec.tsx
@@ -70,18 +70,10 @@ describe("CardViewPage", () => {
     expect(screen.getByText(/answer =/)).toHaveTextContent("const answer = 42;");
   });
 
-  it("renders the ready screen in the application shell and forwards header actions", async () => {
+  it("renders the ready screen in the application shell", () => {
     render(<CardViewPage />);
 
-    await userEvent.click(screen.getByRole("button", { name: "tango" }));
-    await userEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    await userEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("shows recovery actions when the card is unavailable", async () => {

--- a/src/pages/card-view/ui/CardViewPage.tsx
+++ b/src/pages/card-view/ui/CardViewPage.tsx
@@ -3,30 +3,20 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { type Card, useCards } from "@/entities/card";
 import { getCategory, isHighlightLanguage, type Deck, useDecks } from "@/entities/deck";
-import { setDarkMode, useConfig } from "@/shared/config";
+import { useConfig } from "@/shared/config";
 import { combineRemoteReadStates } from "@/shared/lib/remote-read";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { CardViewView } from "./CardViewView";
 
 const CardViewContent = ({ card, deck }: { card: Card; deck: Deck }) => {
-  const navigate = useNavigate();
   const config = useConfig();
   const category = getCategory(deck.category, card.tags);
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <CardViewView
         backText={{
           category,
@@ -35,7 +25,7 @@ const CardViewContent = ({ card, deck }: { card: Card; deck: Deck }) => {
           text: card.backText,
         }}
       />
-    </Layout>
+    </AppLayout>
   );
 };
 

--- a/src/pages/deck-form/ui/DeckFormPage.spec.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.spec.tsx
@@ -72,19 +72,11 @@ describe("DeckFormPage", () => {
     vi.clearAllMocks();
   });
 
-  it("composes the route, application shell, and deck editor", async () => {
+  it("composes the route, application shell, and deck editor", () => {
     render(<DeckFormPage />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Deck name" })).toBeVisible();
-    await userEvent.click(screen.getByRole("button", { name: "tango" }));
-    await userEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    await userEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("owns navigation after saving", async () => {

--- a/src/pages/deck-form/ui/DeckFormPage.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.tsx
@@ -4,16 +4,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { CATEGORY, type Category, type Deck, useDecks } from "@/entities/deck";
 import { useEditDeck } from "@/features/deck/edit";
 import { useDeckEditorActions, useDeckFormState } from "@/features/deck-editor";
-import { setDarkMode, useConfig } from "@/shared/config";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckFormView } from "./DeckFormView";
 
 const DeckFormContent = ({ deck }: { deck: Deck }) => {
-  const config = useConfig();
   const navigate = useNavigate();
   const mutations = useEditDeck();
   const goToList = () => void navigate("/", { replace: true });
@@ -30,23 +28,14 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
   });
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <DeckFormView
         feedbackSlot={
           <RemoteMutationNotice pending={deckActions.pending} error={deckActions.error} onRetry={deckActions.retry} />
         }
         deckForm={deckForm}
       />
-    </Layout>
+    </AppLayout>
   );
 };
 

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -111,18 +111,10 @@ describe("DeckImportPage", () => {
     expect(mocks.downloadSampleCsv).toHaveBeenCalledOnce();
   });
 
-  it("renders the import screen in the application shell and forwards header actions", async () => {
+  it("renders the import screen in the application shell", () => {
     render(<DeckImportPage />);
 
-    await userEvent.click(screen.getByRole("button", { name: "tango" }));
-    await userEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    await userEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("navigates from top and settings keyboard shortcuts", () => {

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -4,8 +4,8 @@ import { useKey } from "react-use";
 
 import { createDeck } from "@/features/deck/create";
 import { downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/import";
-import { setDarkMode, useConfig } from "@/shared/config";
-import { Layout } from "@/shared/ui/layout";
+import { useConfig } from "@/shared/config";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckImportView } from "./DeckImportView";
 
@@ -17,16 +17,7 @@ export const DeckImportPage: React.FC = () => {
   useKey("s", () => void navigate("/settings"));
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <DeckImportView
         onChange={(file) => {
           void deckImport.selectFile(file).catch(() => undefined);
@@ -52,6 +43,6 @@ export const DeckImportPage: React.FC = () => {
         dark={config.appearance.darkMode}
         sampleText={SAMPLE_CSV_TEXT}
       />
-    </Layout>
+    </AppLayout>
   );
 };

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -200,18 +200,10 @@ describe("DeckListPage", () => {
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
   });
 
-  it("forwards header actions", () => {
+  it("renders the application shell", () => {
     render(<DeckListPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "tango" }));
-    fireEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    fireEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("removes only the deleted deck session after the remote delete succeeds", async () => {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -16,20 +16,18 @@ import {
   useStudyHydrated,
   useStudySessions,
 } from "@/features/study";
-import { setDarkMode, useConfig } from "@/shared/config";
 import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { buildDeckListSections } from "../selectors/buildDeckListSections";
 import { DeckListView } from "./DeckListView";
 
 export const DeckListPage: React.FC = () => {
   const navigate = useNavigate();
-  const config = useConfig();
   const cardRemote = useCards();
   const deckRemote = useDecks();
   const readState = combineRemoteReadStates(cardRemote, deckRemote);
@@ -65,16 +63,7 @@ export const DeckListPage: React.FC = () => {
       onRetry={readState.retry}
     >
       {hydrated ? (
-        <Layout
-          showHeader
-          headerProps={{
-            dark: config.appearance.darkMode,
-            onClickDarkMode: setDarkMode,
-            onClickLogo: () => void navigate("/"),
-            onClickImport: () => void navigate("/import"),
-            onClickSettings: () => void navigate("/settings"),
-          }}
-        >
+        <AppLayout showHeader>
           <RemoteMutationNotice
             pending={mutations.pending}
             error={mutations.error}
@@ -135,7 +124,7 @@ export const DeckListPage: React.FC = () => {
               },
             }}
           />
-        </Layout>
+        </AppLayout>
       ) : (
         <div role="status" className="py-10 text-center text-sm text-ink-muted">
           Loading study progress…

--- a/src/pages/deck-start/ui/DeckStartPage.spec.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.spec.tsx
@@ -82,15 +82,7 @@ describe("DeckStartPage", () => {
 
     expect(screen.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Start 1 card" })).toBeVisible();
-    fireEvent.click(screen.getByRole("button", { name: "tango" }));
-    fireEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    fireEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("starts from Enter only outside interactive controls", () => {

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -10,11 +10,11 @@ import { selectCardsForDeck, selectTagsForDeck, useCards } from "@/entities/card
 import { useDecks } from "@/entities/deck";
 import { useEditDeck } from "@/features/deck/edit";
 import { DeckStartForm, useDeckFilterState, useStudyActions, useStudyCards } from "@/features/study";
-import { setDarkMode, useConfig } from "@/shared/config";
+import { useConfig } from "@/shared/config";
 import { combineRemoteReadStates } from "@/shared/lib/remote-read";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckStartView } from "./DeckStartView";
 
@@ -36,16 +36,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: ConfigStat
   useKey("Enter", startFromEnter, {}, [startFromEnter]);
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <DeckStartView
         deckName={deck.name}
         maxNumberOfCardsToLearn={config.study.maxNumberOfCardsToLearn}
@@ -53,7 +44,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; config: ConfigStat
         onClickStart={studyActions.start}
         filterSlot={<DeckStartForm {...deckStartForm} />}
       />
-    </Layout>
+    </AppLayout>
   );
 };
 

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -277,18 +277,10 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
   });
 
-  it("forwards header actions from the ready study screen", () => {
+  it("renders the application shell for the ready study screen", () => {
     render(<DeckSwiperPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "tango" }));
-    fireEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    fireEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
-
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
   it("keeps pending study saves silent while disabling swipe controls", () => {

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -16,11 +16,11 @@ import {
   useStudyHydrated,
   useStudyStore,
 } from "@/features/study";
-import { setDarkMode, toggleShowHeader, toggleShowSwipeButtonList, useConfig } from "@/shared/config";
+import { toggleShowHeader, toggleShowSwipeButtonList, useConfig } from "@/shared/config";
 import { combineRemoteReadStates } from "@/shared/lib/remote-read";
-import { Layout } from "@/shared/ui/layout";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckSwiperView } from "./DeckSwiperView";
 
@@ -153,18 +153,7 @@ export const DeckSwiperPage: React.FC = () => {
   };
 
   return (
-    <Layout
-      fullscreen
-      scroll={showBackText}
-      showHeader={config.appearance.showHeader && !showBackText}
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout fullscreen scroll={showBackText} showHeader={config.appearance.showHeader && !showBackText}>
       <DeckSwiperView
         showController={config.study.cardInterval > 0}
         showBackText={showBackText}
@@ -209,6 +198,6 @@ export const DeckSwiperPage: React.FC = () => {
         swipeButtonList={swipeActions}
         swipeOverlay={swipeActions}
       />
-    </Layout>
+    </AppLayout>
   );
 };

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -45,19 +45,12 @@ describe("SettingsPage", () => {
     mocks.config = createConfig({ appearance: { darkMode: false } });
   });
 
-  it("owns the route shortcut and application header", () => {
+  it("owns the route shortcut and renders in the application shell", () => {
     render(<SettingsPage login={vi.fn()} logout={vi.fn()} />);
 
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     fireEvent.keyDown(window, { key: "t" });
-    fireEvent.click(screen.getByRole("button", { name: "tango" }));
-    fireEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    fireEvent.click(screen.getByRole("button", { name: "Import decks" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
 
-    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/import");
-    expect(mocks.navigate).toHaveBeenNthCalledWith(4, "/settings");
+    expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith("/");
   });
 });

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -6,9 +6,9 @@ import { useAuthSession } from "@/entities/auth-session";
 import { useSignIn } from "@/features/auth/sign-in";
 import { useSignOut } from "@/features/auth/sign-out";
 import { useConfigFormState } from "@/features/settings";
-import { setDarkMode, updateConfig, useConfig } from "@/shared/config";
-import { Layout } from "@/shared/ui/layout";
+import { updateConfig, useConfig } from "@/shared/config";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
+import { AppLayout } from "@/widgets/app-layout";
 
 import { SettingsView } from "./SettingsView";
 
@@ -53,17 +53,8 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
   useKey("t", () => void navigate("/"));
 
   return (
-    <Layout
-      showHeader
-      headerProps={{
-        dark: config.appearance.darkMode,
-        onClickDarkMode: setDarkMode,
-        onClickLogo: () => void navigate("/"),
-        onClickImport: () => void navigate("/import"),
-        onClickSettings: () => void navigate("/settings"),
-      }}
-    >
+    <AppLayout showHeader>
       <SettingsView configForm={configForm} />
-    </Layout>
+    </AppLayout>
   );
 };

--- a/src/widgets/app-layout/index.ts
+++ b/src/widgets/app-layout/index.ts
@@ -1,0 +1,1 @@
+export { AppLayout } from "./ui/AppLayout";

--- a/src/widgets/app-layout/ui/AppLayout.spec.tsx
+++ b/src/widgets/app-layout/ui/AppLayout.spec.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const mocks = vi.hoisted(() => ({
+  darkMode: false,
+  navigate: vi.fn(),
+  setDarkMode: vi.fn(),
+}));
+
+vi.mock("@/shared/config", () => ({
+  useConfig: () => ({ appearance: { darkMode: mocks.darkMode } }),
+  setDarkMode: mocks.setDarkMode,
+}));
+vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
+
+import { AppLayout } from "./AppLayout";
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.darkMode = false;
+  });
+
+  it("owns application header navigation and theme actions", () => {
+    const view = render(<AppLayout showHeader>Page content</AppLayout>);
+
+    expect(screen.getByText("Page content")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "tango" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
+    fireEvent.click(screen.getByRole("button", { name: "Import decks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
+    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
+    expect(mocks.navigate).toHaveBeenNthCalledWith(3, "/settings");
+    expect(mocks.setDarkMode).toHaveBeenCalledExactlyOnceWith(true);
+
+    mocks.darkMode = true;
+    view.rerender(<AppLayout showHeader>Page content</AppLayout>);
+    fireEvent.click(screen.getByRole("button", { name: "Switch to light mode" }));
+
+    expect(mocks.setDarkMode).toHaveBeenNthCalledWith(2, false);
+  });
+});

--- a/src/widgets/app-layout/ui/AppLayout.tsx
+++ b/src/widgets/app-layout/ui/AppLayout.tsx
@@ -1,0 +1,25 @@
+import type * as React from "react";
+import { useNavigate } from "react-router-dom";
+
+import { setDarkMode, useConfig } from "@/shared/config";
+import { Layout } from "@/shared/ui/layout";
+
+type AppLayoutProps = Omit<React.ComponentProps<typeof Layout>, "headerProps">;
+
+export const AppLayout: React.FC<AppLayoutProps> = (props) => {
+  const navigate = useNavigate();
+  const config = useConfig();
+
+  return (
+    <Layout
+      {...props}
+      headerProps={{
+        dark: config.appearance.darkMode,
+        onClickDarkMode: setDarkMode,
+        onClickLogo: () => void navigate("/"),
+        onClickImport: () => void navigate("/import"),
+        onClickSettings: () => void navigate("/settings"),
+      }}
+    />
+  );
+};


### PR DESCRIPTION
## Summary

- add an `AppLayout` widget that owns shared header navigation and theme behavior
- replace duplicated layout/header setup across nine pages
- consolidate repeated header-action tests into the widget test
- register the standard FSD `widgets` layer in the ESLint boundary configuration

## Why

Application header configuration was repeated in every page, so navigation or theme behavior changes required synchronized edits across production code and page tests.

## Impact

There is no intended user-facing behavior change. Header navigation, theme toggling, fullscreen behavior, and page-specific content remain unchanged.

## Validation

- `CHOKIDAR_USEPOLLING=1 mise run check`
- 113 test files passed
- 616 tests passed
