### PR TITLE
[#736] Move deck list logic into feature

### DIFF
--- a/src/features/deck/list/index.ts
+++ b/src/features/deck/list/index.ts
@@ -1,0 +1,6 @@
+export {
+  buildDeckListSections,
+  type DeckListItem,
+  type DeckListSections,
+  type DeckListStudyProgress,
+} from "./model/buildDeckListSections";

--- a/src/features/deck/list/model/buildDeckListSections.spec.ts
+++ b/src/features/deck/list/model/buildDeckListSections.spec.ts
@@ -1,15 +1,7 @@
-/**
- * @file Verifies the Deck List selector contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "puts active decks in recent
- * order and inactive decks in name order", "uses deck name as a stable tie breaker for equally
- * recent sessions".
- */
-
 import type { DeckId } from "@/entities/deck";
 
 import { describe, expect, it } from "vitest";
 
-import type { StudySession } from "@/features/study";
 import { createCard, createDeck } from "@/test/factories";
 
 import { buildDeckListSections } from "./buildDeckListSections";
@@ -27,7 +19,7 @@ describe("buildDeckListSections", () => {
       createCard({ id: "card-2", deckId: "other-z" }),
       createCard({ id: "card-3", deckId: "other-a" }),
     ];
-    const sessionsByDeckId: Partial<Record<DeckId, StudySession>> = {
+    const sessionsByDeckId = {
       "active-old": {
         deckId: "active-old",
         cardOrderIds: ["old-1", "old-2"],
@@ -62,7 +54,7 @@ describe("buildDeckListSections", () => {
 
   it("uses deck name as a stable tie breaker for equally recent sessions", () => {
     const decks = [createDeck({ id: "b", name: "Beta" }), createDeck({ id: "a", name: "Alpha" })];
-    const session = (deckId: DeckId): StudySession => ({
+    const session = (deckId: DeckId) => ({
       deckId,
       cardOrderIds: [`${deckId}-card`],
       currentIndex: 0,

--- a/src/features/deck/list/model/buildDeckListSections.ts
+++ b/src/features/deck/list/model/buildDeckListSections.ts
@@ -1,12 +1,11 @@
-/**
- * @file Builds the view model for the Deck List Page.
- * Keeping these calculations outside React makes their inputs, outputs, and edge cases easier to
- * understand and test.
- */
-
 import type { Card } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
-import type { StudySession } from "@/features/study";
+
+interface DeckListStudySession {
+  cardOrderIds: string[];
+  currentIndex: number;
+  lastStudiedAt: number;
+}
 
 export interface DeckListStudyProgress {
   currentIndex: number;
@@ -25,21 +24,12 @@ export interface DeckListSections {
   other: DeckListItem[];
 }
 
-/**
- * Orders two deck-list items alphabetically by deck name.
- * The named comparison keeps the inactive-deck section stable and easy to scan.
- */
 const compareNames = (left: DeckListItem, right: DeckListItem) => left.deck.name.localeCompare(right.deck.name);
 
-/**
- * Builds deck list sections from the supplied application values.
- * The returned value is ready for the next layer, so callers do not need to repeat assembly or
- * defaulting rules.
- */
 export const buildDeckListSections = (
   decks: Deck[],
   cards: Card[],
-  sessionsByDeckId: Partial<Record<DeckId, StudySession>>
+  sessionsByDeckId: Partial<Record<DeckId, DeckListStudySession>>
 ): DeckListSections => {
   const cardCounts = new Map<DeckId, number>();
   for (const card of cards) cardCounts.set(card.deckId, (cardCounts.get(card.deckId) ?? 0) + 1);

--- a/src/pages/deck-list/ui/DeckListCard.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.tsx
@@ -9,8 +9,8 @@ import * as React from "react";
 import { AiFillCaretRight, AiOutlineCloud } from "react-icons/ai";
 
 import type { Deck, DeckId } from "@/entities/deck";
+import type { DeckListStudyProgress } from "@/features/deck/list";
 
-import type { DeckListStudyProgress } from "../selectors/buildDeckListSections";
 import { DeckActionsMenu } from "./DeckActionsMenu";
 
 export interface DeckListCardActions {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -7,6 +7,7 @@ import type { Deck, DeckId } from "@/entities/deck";
 import { useDecks } from "@/entities/deck";
 import { createDeck } from "@/features/deck/create";
 import { useDeleteDeck } from "@/features/deck/delete";
+import { buildDeckListSections } from "@/features/deck/list";
 import { downloadDeckCsv } from "@/features/export";
 import { useSampleDeckBootstrap } from "@/features/import";
 import {
@@ -23,7 +24,6 @@ import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { AppLayout } from "@/widgets/app-layout";
 
-import { buildDeckListSections } from "../selectors/buildDeckListSections";
 import { DeckListView } from "./DeckListView";
 
 export const DeckListPage: React.FC = () => {

--- a/src/pages/deck-list/ui/DeckListView.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListView.spec.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { DeckId } from "@/entities/deck";
+import type { DeckListSections } from "@/features/deck/list";
 
 import * as React from "react";
 import { fireEvent, render, within, screen } from "@testing-library/react";
@@ -13,7 +14,6 @@ import { describe, expect, it } from "vitest";
 
 import { createDeck } from "@/test/factories";
 
-import type { DeckListSections } from "../selectors/buildDeckListSections";
 import { DeckListView } from "./DeckListView";
 
 const activeDeck = createDeck({ id: "active", name: "Active deck", category: "math" });

--- a/src/pages/deck-list/ui/DeckListView.stories.tsx
+++ b/src/pages/deck-list/ui/DeckListView.stories.tsx
@@ -7,10 +7,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { Deck } from "@/entities/deck";
+import type { DeckListItem, DeckListSections } from "@/features/deck/list";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
-import type { DeckListItem, DeckListSections } from "../selectors/buildDeckListSections";
 import { DeckListView as Template } from "./DeckListView";
 
 /**

--- a/src/pages/deck-list/ui/DeckListView.tsx
+++ b/src/pages/deck-list/ui/DeckListView.tsx
@@ -4,7 +4,8 @@
 
 import * as React from "react";
 
-import type { DeckListItem, DeckListSections } from "../selectors/buildDeckListSections";
+import type { DeckListItem, DeckListSections } from "@/features/deck/list";
+
 import { DeckListCard, type DeckListCardActions } from "./DeckListCard";
 
 export interface DeckListViewProps {


### PR DESCRIPTION
## Related issue

Fixes #736

## Summary

- move the deck list view-model builder and its tests from the page layer to `features/deck/list`
- expose only the builder and deck-list view-model types through the feature public API
- remove the feature-to-feature dependency on `features/study` by accepting a minimal structural session interface
- update the deck list page, views, tests, and stories to use the feature public API

## Testing

- `mise run check`
