### PR TITLE
No issue: refactor(study): remove unused StudySession export

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -6,14 +6,14 @@
 
 import type { Card } from "@/entities/card";
 import { cardRemoteReadStore } from "@/entities/card/model/remoteReadStore";
-import type { Deck, DeckId } from "@/entities/deck";
+import type { Deck } from "@/entities/deck";
 import { deckRemoteReadStore } from "@/entities/deck/model/remoteReadStore";
 
 import type { Decorator } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 
 import { AuthSessionProvider, createAuthSessionStore, type AuthSessionState } from "@/entities/auth-session";
-import type { StudySession } from "@/features/study/state/studyStore";
+import type { StudyState } from "@/features/study/state/studyStore";
 import { studyStore } from "@/features/study/state/studyStoreInstance";
 import { configStore } from "@/shared/config/configStoreInstance";
 import { parsePersistedConfig } from "@/shared/config/configSchema";
@@ -32,7 +32,7 @@ export interface PageStoryParameters {
   decks?: Deck[];
   cards?: Card[];
   config?: PartialConfigState;
-  sessionsByDeckId?: Partial<Record<DeckId, StudySession>>;
+  sessionsByDeckId?: StudyState["sessionsByDeckId"];
   showBackText?: boolean;
   autoPlay?: boolean;
 }
@@ -57,10 +57,8 @@ const cloneCard = (card: Card): Card => ({
   ...(card.nextSeeingAt === undefined ? {} : { nextSeeingAt: new Date(card.nextSeeingAt.getTime()) }),
 });
 
-const cloneSessions = (
-  sessionsByDeckId: Partial<Record<DeckId, StudySession>>
-): Partial<Record<DeckId, StudySession>> => {
-  const sessions: Partial<Record<DeckId, StudySession>> = {};
+const cloneSessions = (sessionsByDeckId: StudyState["sessionsByDeckId"]): StudyState["sessionsByDeckId"] => {
+  const sessions: StudyState["sessionsByDeckId"] = {};
   Object.entries(sessionsByDeckId).forEach(([deckId, session]) => {
     if (session != null) sessions[deckId] = { ...session, cardOrderIds: [...session.cardOrderIds] };
   });

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -14,8 +14,5 @@ export { useStudyCards } from "./hooks/useStudyCards";
 export { useStudyControllerState } from "./hooks/useStudyControllerState";
 export { useStudySessions } from "./hooks/useStudySessions";
 export { useStudyStore } from "./hooks/useStudyStore";
-export {
-  selectStudySessionForRoute,
-  type StudySession,
-} from "./state/studyStore";
+export { selectStudySessionForRoute } from "./state/studyStore";
 export { clearStudyStore } from "./state/studyStoreInstance";

--- a/src/features/study/state/studyStore.ts
+++ b/src/features/study/state/studyStore.ts
@@ -13,7 +13,7 @@ import { createStore } from "zustand/vanilla";
 
 const STUDY_STORAGE_KEY = "tango-study";
 
-export interface StudySession {
+interface StudySession {
   deckId: DeckId;
   cardOrderIds: CardId[];
   currentIndex: number;

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -13,14 +13,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Card, CardId } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
-import type { StudySession } from "@/features/study";
+import type { useStudySessions } from "@/features/study";
 import { createCard, createConfig, createDeck } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   config: {} as ConfigState,
   decksById: {} as Record<DeckId, Deck>,
   cardsById: {} as Record<CardId, Card>,
-  sessionsByDeckId: {} as Partial<Record<DeckId, StudySession>>,
+  sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
   hydrated: true,
   pending: false,
   syncStatus: "synced" as "cached" | "pending" | "synced",

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -15,7 +15,7 @@ import "@testing-library/jest-dom/vitest";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { StudySession } from "@/features/study";
+import type { useStudySessions } from "@/features/study";
 import { createConfig } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -38,7 +38,7 @@ const mocks = vi.hoisted(() => ({
     retry: vi.fn(),
   },
   studyState: {
-    sessionsByDeckId: {} as Partial<Record<DeckId, StudySession>>,
+    sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
     showBackText: false,
     autoPlay: false,
     lastSwipe: undefined as { direction: SwipeDirection; eventId: number } | undefined,


### PR DESCRIPTION
## Summary
Fixes failing `npm run lint` caused by `knip:production` flagging `StudySession` as an unused exported type from `src/features/study/state/studyStore.ts` and `src/features/study/index.ts`.

## Changes
- Unexported `StudySession` from `src/features/study/state/studyStore.ts` and removed it from `src/features/study/index.ts` public re-exports.
- Updated spec and storybook files to reference store types via `ReturnType<typeof useStudySessions>` and `StudyState["sessionsByDeckId"]`.

## Verification
- Verified `mise run check` passes cleanly in the isolated worktree.