### PR TITLE
refactor: centralize Deck validation schemas (#741)

### DIFF
--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -2,6 +2,14 @@ export { CATEGORY, getCategory, isHighlightLanguage } from "./model/category";
 export type { Category } from "./model/category";
 export { generateDeckId } from "./api/firestore";
 export { createDeck } from "./model/deck";
-export type { Deck, DeckEdit, DeckId } from "./model/deck";
+export { createDeckSchema, deleteDeckSchema, editDeckSchema } from "./model/schema";
+export type {
+  CreateDeckInput,
+  Deck,
+  DeckEdit,
+  DeckId,
+  DeleteDeckInput,
+  EditDeckInput,
+} from "./model/schema";
 export { useDecks } from "./hooks/useDecks";
 export { startDeckReads, stopDeckReads } from "./model/remoteReadStore";

--- a/src/entities/deck/model/deck.ts
+++ b/src/entities/deck/model/deck.ts
@@ -1,42 +1,10 @@
-import type { Category } from "./category";
+import type { Deck as DeckModel } from "./schema";
 
-export type DeckId = string;
+export type { Deck, DeckId } from "./schema";
 
-export interface Deck {
-  name: string;
-  url?: string;
-  isPublic: boolean;
-  id: DeckId;
-  uid: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  scoreMax: number | null;
-  scoreMin: number | null;
-  selectedTags: string[];
-  tagAndFilter: boolean;
-  category: Category;
-  convertToBr: boolean;
-}
+export type DeckRaw = Pick<DeckModel, "name">;
 
-export type DeckRaw = Pick<Deck, "name">;
-export type DeckEdit = Pick<Deck, "id"> &
-  Partial<
-    Pick<
-      Deck,
-      | "name"
-      | "url"
-      | "isPublic"
-      | "scoreMax"
-      | "scoreMin"
-      | "selectedTags"
-      | "tagAndFilter"
-      | "category"
-      | "convertToBr"
-    >
-  >;
-
-export const createDeck = (deck: DeckRaw, uid: string, generateId: () => string): Deck => ({
+export const createDeck = (deck: DeckRaw, uid: string, generateId: () => string): DeckModel => ({
   ...deck,
   uid,
   id: generateId(),

--- a/src/entities/deck/model/schema.spec.ts
+++ b/src/entities/deck/model/schema.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { createDeck as createDeckFixture } from "@/test/factories";
+
+import { createDeckSchema, deleteDeckSchema, editDeckSchema } from "./schema";
+
+describe("Deck operation schemas", () => {
+  const deck = createDeckFixture({ id: "deck", uid: "uid-a" });
+
+  describe("createDeckSchema", () => {
+    it("accepts a complete Deck owned by the authenticated user", () => {
+      expect(createDeckSchema.parse({ uid: "uid-a", deck })).toEqual({ uid: "uid-a", deck });
+    });
+
+    it.each([
+      ["authenticated uid", { uid: "", deck }, "confirmed user"],
+      ["Deck id", { uid: "uid-a", deck: { ...deck, id: "" } }, "Deck id"],
+      ["Deck uid", { uid: "uid-a", deck: { ...deck, uid: "" } }, "Deck owner"],
+      ["Deck name", { uid: "uid-a", deck: { ...deck, name: "" } }, "Deck name"],
+      ["owner relationship", { uid: "uid-b", deck }, "owner does not match"],
+    ])("rejects an invalid %s", (_case, input, message) => {
+      expect(() => createDeckSchema.parse(input)).toThrow(message);
+    });
+  });
+
+  describe("editDeckSchema", () => {
+    it("accepts a partial edit with a non-empty Deck id", () => {
+      expect(editDeckSchema.parse({ uid: "uid-a", deck: { id: "deck", name: "Renamed" } })).toEqual({
+        uid: "uid-a",
+        deck: { id: "deck", name: "Renamed" },
+      });
+    });
+
+    it.each([
+      ["authenticated uid", { uid: "", deck: { id: "deck" } }, "confirmed user"],
+      ["Deck id", { uid: "uid-a", deck: { id: "" } }, "Deck id"],
+      ["provided Deck name", { uid: "uid-a", deck: { id: "deck", name: "" } }, "Deck name"],
+    ])("rejects an invalid %s", (_case, input, message) => {
+      expect(() => editDeckSchema.parse(input)).toThrow(message);
+    });
+  });
+
+  describe("deleteDeckSchema", () => {
+    it("accepts a Deck identity owned by the authenticated user", () => {
+      expect(deleteDeckSchema.parse({ uid: "uid-a", deck })).toEqual({
+        uid: "uid-a",
+        deck: { id: "deck", uid: "uid-a" },
+      });
+    });
+
+    it.each([
+      ["authenticated uid", { uid: "", deck }, "confirmed user"],
+      ["Deck id", { uid: "uid-a", deck: { ...deck, id: "" } }, "Deck id"],
+      ["Deck uid", { uid: "uid-a", deck: { ...deck, uid: "" } }, "Deck owner"],
+      ["owner relationship", { uid: "uid-b", deck }, "owner does not match"],
+    ])("rejects an invalid %s", (_case, input, message) => {
+      expect(() => deleteDeckSchema.parse(input)).toThrow(message);
+    });
+  });
+});

--- a/src/entities/deck/model/schema.ts
+++ b/src/entities/deck/model/schema.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote Deck writes");
+const deckIdSchema = z.string().min(1, "Deck id is required");
+const deckUidSchema = z.string().min(1, "Deck owner is required");
+
+const editableDeckFieldsSchema = z.object({
+  name: z.string().min(1, "Deck name is required"),
+  url: z.string().optional(),
+  isPublic: z.boolean(),
+  scoreMax: z.number().nullable(),
+  scoreMin: z.number().nullable(),
+  selectedTags: z.array(z.string()),
+  tagAndFilter: z.boolean(),
+  category: z.string(),
+  convertToBr: z.boolean(),
+});
+
+const deckSchema = editableDeckFieldsSchema.extend({
+  id: deckIdSchema,
+  uid: deckUidSchema,
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  deletedAt: z.number().nullable(),
+});
+
+const deckEditSchema = editableDeckFieldsSchema.partial().extend({ id: deckIdSchema });
+const deckIdentitySchema = z.object({ id: deckIdSchema, uid: deckUidSchema });
+
+const validateDeckOwner = (input: { uid: string; deck: { uid: string } }, context: z.RefinementCtx): void => {
+  if (input.deck.uid !== input.uid) {
+    context.addIssue({
+      code: "custom",
+      message: "Deck owner does not match the authenticated user",
+      path: ["deck", "uid"],
+    });
+  }
+};
+
+export const createDeckSchema = z
+  .object({ uid: authenticatedUidSchema, deck: deckSchema })
+  .superRefine(validateDeckOwner);
+
+export const editDeckSchema = z.object({
+  uid: authenticatedUidSchema,
+  deck: deckEditSchema,
+});
+
+export const deleteDeckSchema = z
+  .object({ uid: authenticatedUidSchema, deck: deckIdentitySchema })
+  .superRefine(validateDeckOwner);
+
+export type Deck = z.infer<typeof deckSchema>;
+export type DeckId = z.infer<typeof deckIdSchema>;
+export type DeckEdit = z.infer<typeof deckEditSchema>;
+export type CreateDeckInput = z.infer<typeof createDeckSchema>;
+export type EditDeckInput = z.infer<typeof editDeckSchema>;
+export type DeleteDeckInput = z.infer<typeof deleteDeckSchema>;

--- a/src/features/deck/create/api/createDeck.ts
+++ b/src/features/deck/create/api/createDeck.ts
@@ -1,13 +1,8 @@
-import type { Deck } from "@/entities/deck";
+import { createDeckSchema, type CreateDeckInput } from "@/entities/deck";
 
 import { createDeckDocument } from "./firestore";
 
-const requireOwner = (uid: string, deck: Deck) => {
-  if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
-  if (deck.uid !== uid) throw new Error("Deck owner does not match the authenticated user");
-};
-
-export const createDeck = async (uid: string, deck: Deck): Promise<void> => {
-  requireOwner(uid, deck);
-  await createDeckDocument(deck);
+export const createDeck = async (uid: string, deck: CreateDeckInput["deck"]): Promise<void> => {
+  const input = createDeckSchema.parse({ uid, deck });
+  await createDeckDocument(input.deck);
 };

--- a/src/features/deck/delete/api/deleteDeck.ts
+++ b/src/features/deck/delete/api/deleteDeck.ts
@@ -1,9 +1,8 @@
-import type { Deck } from "@/entities/deck";
+import { deleteDeckSchema, type DeleteDeckInput } from "@/entities/deck";
 
 import { deleteDeckDocuments } from "./firestore";
 
-export const deleteDeck = async (uid: string, deck: Deck): Promise<void> => {
-  if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
-  if (deck.uid !== uid) throw new Error("Deck owner does not match the authenticated user");
-  await deleteDeckDocuments(uid, deck.id);
+export const deleteDeck = async (uid: string, deck: DeleteDeckInput["deck"]): Promise<void> => {
+  const input = deleteDeckSchema.parse({ uid, deck });
+  await deleteDeckDocuments(input.uid, input.deck.id);
 };

--- a/src/features/deck/edit/api/editDeck.ts
+++ b/src/features/deck/edit/api/editDeck.ts
@@ -1,8 +1,8 @@
-import type { DeckEdit } from "@/entities/deck";
+import { editDeckSchema, type EditDeckInput } from "@/entities/deck";
 
 import { updateDeckDocument } from "./firestore";
 
-export const editDeck = async (uid: string, deck: DeckEdit): Promise<void> => {
-  if (uid === "") throw new Error("A confirmed user is required for remote Deck writes");
-  await updateDeckDocument(deck);
+export const editDeck = async (uid: string, deck: EditDeckInput["deck"]): Promise<void> => {
+  const input = editDeckSchema.parse({ uid, deck });
+  await updateDeckDocument(input.deck);
 };


### PR DESCRIPTION
## Related issue

Fixes #741

## Summary

- Add create, edit, and delete Deck domain schemas under `entities/deck`.
- Share non-empty identity checks and owner matching refinement across operations.
- Derive Deck operation input types from the Zod schemas and expose them through the entity public API.
- Replace feature-local validation in Deck create, edit, and delete commands with the domain schemas.
- Add unit coverage for valid operations and representative identity, field, and ownership failures.

## Why

Deck write constraints were duplicated across feature commands, which made ownership and required-field behavior easier to drift. Keeping operation-specific rules in the Deck entity gives every feature one validation boundary without mixing in Firestore-specific document validation.

## Testing

- `npm run test:unit -- src/entities/deck/model/schema.spec.ts src/entities/deck/model/deck.spec.ts src/features/deck/create/api/createDeck.spec.ts src/features/deck/edit/api/editDeck.spec.ts src/features/deck/delete/api/deleteDeck.spec.ts`
- `mise run check` completed TypeScript, ESLint, Biome, FSD, formatting, sample formatting, and all 582 unit tests. Its final `lint:knip:production` step still reports the two pre-existing unused `StudySession` exports; the same failure reproduces on `origin/main`.