### PR TITLE
refactor(#747): Simplify useDeleteDeck

### DIFF
--- a/src/features/deck/delete/model/useDeleteDeck.ts
+++ b/src/features/deck/delete/model/useDeleteDeck.ts
@@ -1,42 +1,16 @@
 import type { Deck } from "@/entities/deck";
 
-import { useEffect, useRef } from "react";
-
 import { useAuthSession } from "@/entities/auth-session";
 import { useAsyncAction } from "@/shared/hooks";
 import { deleteDeck } from "../api/deleteDeck";
 
-interface UseDeleteDeckOptions {
-  onSuccess?: (deck: Deck) => void;
-}
-
-export const useDeleteDeck = ({ onSuccess }: UseDeleteDeckOptions = {}) => {
+export const useDeleteDeck = () => {
   const auth = useAuthSession();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const mutation = useAsyncAction<string>(uid);
-  const scope = useRef({ uid });
-  const onSuccessRef = useRef(onSuccess);
-
-  useEffect(() => {
-    onSuccessRef.current = onSuccess;
-  }, [onSuccess]);
-  useEffect(() => {
-    scope.current = { uid };
-    return () => {
-      scope.current = { uid };
-    };
-  }, [uid]);
-
-  const remove = (deck: Deck) => {
-    const operationScope = scope.current;
-    return mutation.run([deck.id], `remove:${deck.id}`, async () => {
-      await deleteDeck(uid, deck);
-      if (scope.current === operationScope) onSuccessRef.current?.(deck);
-    });
-  };
 
   return {
-    remove,
+    remove: (deck: Deck) => mutation.run([deck.id], `remove:${deck.id}`, () => deleteDeck(uid, deck)),
     pending: mutation.pending,
     isPending: mutation.isPending,
     error: mutation.error,

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -26,7 +26,6 @@ const mocks = vi.hoisted(() => ({
   syncStatus: "synced" as "cached" | "pending" | "synced",
   pendingDeckIds: new Set<DeckId>(),
   error: null as unknown,
-  onRemoveSuccess: undefined as ((deck: Deck) => void) | undefined,
   remove: vi.fn(async (_deck: Deck) => undefined),
   retry: vi.fn(),
   downloadDeckCsv: vi.fn(),
@@ -66,16 +65,13 @@ vi.mock("@/entities/deck", () => ({
   }),
 }));
 vi.mock("@/features/deck/delete", () => ({
-  useDeleteDeck: (options?: { onSuccess?: (deck: Deck) => void }) => {
-    mocks.onRemoveSuccess = options?.onSuccess;
-    return {
-      remove: (deck: Deck) => mocks.remove(deck).then(() => mocks.onRemoveSuccess?.(deck)),
-      pending: mocks.pending,
-      isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
-      error: mocks.error,
-      retry: mocks.retry,
-    };
-  },
+  useDeleteDeck: () => ({
+    remove: mocks.remove,
+    pending: mocks.pending,
+    isPending: (id: DeckId) => mocks.pendingDeckIds.has(id),
+    error: mocks.error,
+    retry: mocks.retry,
+  }),
 }));
 vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
 vi.mock("@/features/deck/import", () => ({ useSampleDeckBootstrap: vi.fn() }));
@@ -95,7 +91,6 @@ describe("DeckListPage", () => {
     mocks.syncStatus = "synced";
     mocks.pendingDeckIds = new Set();
     mocks.error = null;
-    mocks.onRemoveSuccess = undefined;
     mocks.config = createConfig({ darkMode: false });
     mocks.decksById = { [otherDeck.id]: otherDeck, [oldDeck.id]: oldDeck, [recentDeck.id]: recentDeck };
     mocks.cardsById = {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -33,13 +33,7 @@ export const DeckListPage: React.FC = () => {
   const readState = combineRemoteReadStates(cardRemote, deckRemote);
   const [deletionTarget, setDeletionTarget] = React.useState<{ deck: Deck; cardCount: number }>();
   const [successMessage, setSuccessMessage] = React.useState<string>();
-  const mutations = useDeleteDeck({
-    onSuccess: (deck) => {
-      removeStudySession(deck.id);
-      setDeletionTarget((target) => (target?.deck.id === deck.id ? undefined : target));
-      setSuccessMessage(`Deleted deck “${deck.name}”.`);
-    },
-  });
+  const mutations = useDeleteDeck();
   const [openMenuDeckId, setOpenMenuDeckId] = React.useState<DeckId>();
   const sessionsByDeckId = useStudySessions();
   const hydrated = useStudyHydrated();
@@ -93,7 +87,17 @@ export const DeckListPage: React.FC = () => {
                 </>
               }
               onCancel={() => setDeletionTarget(undefined)}
-              onConfirm={() => mutations.remove(deletionTarget.deck).catch(() => undefined)}
+              onConfirm={async () => {
+                const deck = deletionTarget.deck;
+                try {
+                  await mutations.remove(deck);
+                  removeStudySession(deck.id);
+                  setDeletionTarget(undefined);
+                  setSuccessMessage(`Deleted deck “${deck.name}”.`);
+                } catch {
+                  // The mutation exposes the error and retry action to the dialog and notice.
+                }
+              }}
             />
           ) : null}
           <DeckListView


### PR DESCRIPTION
## Related issue

Fixes #747

## Summary

- simplify `useDeleteDeck` to run the delete mutation and expose its state
- move study session cleanup, dialog closing, and success feedback to `DeckListPage`
- update the Deck List Page test mock for the caller-owned success flow

## Testing

- `mise run check`