### PR TITLE
No issue: restrict deck categories to major languages without hljs

### DIFF
--- a/src/entities/deck/model/category.spec.ts
+++ b/src/entities/deck/model/category.spec.ts
@@ -1,27 +1,31 @@
 import { describe, expect, it } from "vitest";
-// biome-ignore lint/correctness/noUnresolvedImports: highlight.js exposes this default through its ESM export map.
-import hljs from "highlight.js";
 
 import { CATEGORY, getCategory, isHighlightLanguage } from "./category";
 
 describe("category", () => {
-  it("uses Highlight.js languages and aliases as the source of truth", () => {
-    const languages = hljs.listLanguages();
-    const aliases = languages.flatMap((language) => hljs.getLanguage(language)?.aliases ?? []);
-
-    expect(CATEGORY).toEqual([...new Set(["raw", "math", ...languages, ...aliases])]);
-  });
-
-  it("keeps legacy selectable aliases available", () => {
+  it("defines supported categories including application categories and major languages", () => {
+    expect(CATEGORY).toContain("raw");
+    expect(CATEGORY).toContain("math");
+    expect(CATEGORY).toContain("python");
+    expect(CATEGORY).toContain("typescript");
+    expect(CATEGORY).toContain("javascript");
     expect(CATEGORY).toContain("golang");
     expect(CATEGORY).toContain("sh");
+  });
+
+  it("identifies code languages correctly", () => {
+    expect(isHighlightLanguage("ts")).toBe(true);
+    expect(isHighlightLanguage("python")).toBe(true);
+    expect(isHighlightLanguage("raw")).toBe(false);
+    expect(isHighlightLanguage("math")).toBe(false);
+    expect(isHighlightLanguage("unknown")).toBe(false);
   });
 
   it("uses the first supported tag as the effective category", () => {
     expect(getCategory("markdown", ["unknown", "math", "python"])).toBe("math");
   });
 
-  it("accepts Highlight.js language aliases without maintaining a local mapping", () => {
+  it("accepts language aliases for tag resolution", () => {
     expect(isHighlightLanguage("ts")).toBe(true);
     expect(getCategory("markdown", ["ts"])).toBe("ts");
   });

--- a/src/entities/deck/model/category.ts
+++ b/src/entities/deck/model/category.ts
@@ -1,26 +1,55 @@
 /**
  * @file Owns deck category values and the rule for resolving a card's effective category.
- * Highlight.js is the source of truth for supported code-language categories.
  */
-
-// biome-ignore lint/correctness/noUnresolvedImports: highlight.js exposes this default through its ESM export map.
-import hljs from "highlight.js";
 
 export type Category = string;
 
 const APPLICATION_CATEGORIES: Category[] = ["raw", "math"];
-const HIGHLIGHT_LANGUAGES = hljs.listLanguages();
-const HIGHLIGHT_ALIASES = HIGHLIGHT_LANGUAGES.flatMap((language) => hljs.getLanguage(language)?.aliases ?? []);
 
-export const CATEGORY: Category[] = [
-  ...new Set([...APPLICATION_CATEGORIES, ...HIGHLIGHT_LANGUAGES, ...HIGHLIGHT_ALIASES]),
+const MAJOR_LANGUAGES: Category[] = [
+  "c",
+  "cpp",
+  "csharp",
+  "cs",
+  "css",
+  "go",
+  "golang",
+  "html",
+  "java",
+  "javascript",
+  "js",
+  "jsx",
+  "json",
+  "kotlin",
+  "markdown",
+  "md",
+  "php",
+  "python",
+  "py",
+  "ruby",
+  "rb",
+  "rust",
+  "shell",
+  "sh",
+  "bash",
+  "sql",
+  "swift",
+  "typescript",
+  "ts",
+  "tsx",
+  "yaml",
+  "yml",
+  "haskell",
+  "hs",
 ];
 
-export const isHighlightLanguage = (category: Category): boolean => hljs.getLanguage(category) !== undefined;
+export const CATEGORY: Category[] = [...new Set([...APPLICATION_CATEGORIES, ...MAJOR_LANGUAGES])];
+
+export const isHighlightLanguage = (category: Category): boolean => MAJOR_LANGUAGES.includes(category);
 
 /**
  * Resolves the category used to render a card.
- * The first supported application category or Highlight.js language/alias overrides the deck default.
+ * The first supported application category or code language tag overrides the deck default.
  */
 export const getCategory = (category: Category, tags: string[]): Category => {
   const tagCategory = tags.find((tag) => APPLICATION_CATEGORIES.includes(tag) || isHighlightLanguage(tag));


### PR DESCRIPTION
## Summary

Restricts `entities/deck` category definitions (`CATEGORY` and `isHighlightLanguage`) to major programming languages and common aliases without depending on `highlight.js`'s full language listing.

## Changes

- Removed `import hljs from "highlight.js"` in `src/entities/deck/model/category.ts` and `src/entities/deck/model/category.spec.ts`.
- Defined an explicit list of major programming languages and common aliases.
- Updated `isHighlightLanguage` and `CATEGORY` to use the explicit major languages list.
- Updated unit tests in `category.spec.ts`.

## Verification

- `npm run test:unit` passed all unit tests (570 tests across 119 files).
- `mise run check` passed with zero errors.