### PR TITLE
[No issue] refactor: alias createDeck as prepareDeck in useDeckImport

### DIFF
--- a/src/features/deck/import/hooks/useDeckImport.ts
+++ b/src/features/deck/import/hooks/useDeckImport.ts
@@ -11,7 +11,7 @@ import type { RemoteSyncStatus } from "@/shared/api";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { createCard as prepareCard, selectCardsForDeck, useCards } from "@/entities/card";
-import { createDeck, generateDeckId } from "@/entities/deck";
+import { createDeck as prepareDeck, generateDeckId } from "@/entities/deck";
 import { useAuthSession } from "@/entities/auth-session";
 import type { DeckImportPreview, DeckImportResult, DeckImportRow } from "../model/deckImportTypes";
 import { parseCsv } from "../lib/cardCsv";
@@ -130,7 +130,7 @@ const prepareDeckImportAttempt = (
   );
   const createDeckPending = deck == null;
   if (deck == null) {
-    deck = createDeck({ name }, uid, generateDeckId);
+    deck = prepareDeck({ name }, uid, generateDeckId);
     if (preferredDeckId !== undefined) deck = { ...deck, id: preferredDeckId };
   }
 


### PR DESCRIPTION
## Description

This PR refactors the import alias in `useDeckImport` to import `createDeck` from `@/entities/deck` as `prepareDeck`.

### Changes

- Alias `createDeck` as `prepareDeck` in `useDeckImport.ts` when importing from `@/entities/deck`.
- Call `prepareDeck` for in-memory Deck entity preparation in `prepareDeckImportAttempt`.
- Aligns Deck entity preparation and persistence naming cleanly with Card handling (`prepareCard` / `createCard`).

## Verification

- Ran `mise run check` (all 119 unit test files passed, zero linter or formatting errors).