### PR TITLE
refactor(#745): Move study screen workflow into feature

### DIFF
--- a/src/app/auth/logout.spec.ts
+++ b/src/app/auth/logout.spec.ts
@@ -2,7 +2,8 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { logout } from "@/app/auth/logout";
-import { clearStudyStore, useStudyStore } from "@/features/study";
+import { clearStudyStore, useStudyActions, useStudySessions } from "@/features/study";
+import { createCard } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   signOutCurrentUser: vi.fn(),
@@ -22,13 +23,14 @@ vi.mock("@/app/providers/remote-read/remoteReadLifecycle", () => ({
 }));
 
 const startStudy = (deckId: string, cardIds: string[]) => {
-  const { result, unmount } = renderHook(() => useStudyStore((state) => state.startStudy));
-  act(() => result.current(deckId, cardIds));
+  const cards = cardIds.map((id) => createCard({ id, deckId }));
+  const { result, unmount } = renderHook(() => useStudyActions(deckId, { cardsById: {} }));
+  act(() => result.current.start(cards));
   unmount();
 };
 
 const getStudySessions = () => {
-  const { result, unmount } = renderHook(() => useStudyStore((state) => state.sessionsByDeckId));
+  const { result, unmount } = renderHook(useStudySessions);
   const sessions = result.current;
   unmount();
   return sessions;

--- a/src/app/providers/auth/AuthLogout.spec.tsx
+++ b/src/app/providers/auth/AuthLogout.spec.tsx
@@ -12,6 +12,8 @@ import React, { type ReactNode } from "react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
+import type { ConfigState } from "@/shared/config";
+import { createCard, createConfig } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   auth: { currentUser: null },
@@ -26,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   actualClearStudyStore: undefined as undefined | (() => Promise<void>),
   operations: [] as string[],
   navigate: vi.fn(),
+  config: null as ConfigState | null,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: mocks.auth }));
@@ -50,7 +53,10 @@ vi.mock("@/features/study", async (importOriginal) => {
   return { ...actual, clearStudyStore: mocks.clearStudyStore };
 });
 vi.mock("@/shared/config", () => ({
-  useConfig: () => ({ appearance: { darkMode: false } }),
+  useConfig: () => {
+    if (mocks.config == null) throw new Error("Mock config is not initialized");
+    return mocks.config;
+  },
   setDarkMode: vi.fn(),
   updateConfig: vi.fn(),
 }));
@@ -78,7 +84,7 @@ import { createAuthRuntime } from "@/app/providers/auth/authController";
 import { RemoteReadBootstrap } from "@/app/providers/remote-read";
 import { useAuthSession } from "@/entities/auth-session";
 import { SettingsPage } from "@/pages/settings";
-import { useStudyStore } from "@/features/study";
+import { useStudyActions, useStudySessions } from "@/features/study";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -87,6 +93,7 @@ afterEach(() => {
 beforeEach(async () => {
   vi.clearAllMocks();
   mocks.auth.currentUser = null;
+  mocks.config = createConfig();
   mocks.publishUser = undefined;
   mocks.operations.length = 0;
   mocks.clearStudyStore.mockImplementation(() => {
@@ -99,13 +106,14 @@ beforeEach(async () => {
 });
 
 const startStudy = (deckId: string, cardIds: string[]) => {
-  const { result, unmount } = renderHook(() => useStudyStore((state) => state.startStudy));
-  act(() => result.current(deckId, cardIds));
+  const cards = cardIds.map((id) => createCard({ id, deckId }));
+  const { result, unmount } = renderHook(() => useStudyActions(deckId, { cardsById: {} }));
+  act(() => result.current.start(cards));
   unmount();
 };
 
 const getStudySessions = () => {
-  const { result, unmount } = renderHook(() => useStudyStore((state) => state.sessionsByDeckId));
+  const { result, unmount } = renderHook(useStudySessions);
   const sessions = result.current;
   unmount();
   return sessions;

--- a/src/features/study/hooks/useStudyScreen.spec.tsx
+++ b/src/features/study/hooks/useStudyScreen.spec.tsx
@@ -1,0 +1,216 @@
+import type { Card, CardId } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import type { ConfigState, SwipeDirection } from "@/shared/config";
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createConfig } from "@/test/factories";
+
+const mocks = vi.hoisted(() => {
+  const actions = {
+    start: vi.fn(),
+    swipeUp: vi.fn(),
+    swipeDown: vi.fn(),
+    swipeLeft: vi.fn(),
+    swipeRight: vi.fn(),
+    updateIndex: vi.fn(),
+    toggleShowBackText: vi.fn(),
+    toggleAutoPlay: vi.fn(),
+    resetStudy: vi.fn(),
+  };
+  return {
+    actions,
+    config: null as ConfigState | null,
+    hydrated: true,
+    initializeStudySessionUi: vi.fn(),
+    touchStudySession: vi.fn(),
+    toggleShowHeader: vi.fn(),
+    toggleShowSwipeButtonList: vi.fn(),
+    state: {
+      sessionsByDeckId: {} as Record<
+        string,
+        { deckId: string; cardOrderIds: CardId[]; currentIndex: number; lastStudiedAt: number }
+      >,
+      showBackText: false,
+      autoPlay: false,
+      lastSwipe: undefined as { direction: SwipeDirection; eventId: number } | undefined,
+      clearLastSwipe: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/shared/config", () => ({
+  useConfig: () => {
+    if (mocks.config == null) throw new Error("Mock config is not initialized");
+    return mocks.config;
+  },
+  toggleShowHeader: mocks.toggleShowHeader,
+  toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
+}));
+
+vi.mock("../commands/studySessionCommands", () => ({
+  initializeStudySessionUi: mocks.initializeStudySessionUi,
+  touchStudySession: mocks.touchStudySession,
+}));
+
+vi.mock("./useEditStudyProgress", () => ({ useEditStudyProgress: () => ({ update: vi.fn() }) }));
+vi.mock("./useStudyActions", () => ({ useStudyActions: () => mocks.actions }));
+vi.mock("./useStudyControllerState", () => ({
+  useStudyControllerState: (options: unknown) => options,
+}));
+vi.mock("./useStudyHydrated", () => ({ useStudyHydrated: () => mocks.hydrated }));
+vi.mock("./useStudyStore", () => ({
+  useStudyStore: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+}));
+
+import { useStudyScreen } from "./useStudyScreen";
+
+const deck: Deck = {
+  id: "deck-id",
+  uid: "user-id",
+  name: "Deck",
+  isPublic: false,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  category: "raw",
+  convertToBr: false,
+  selectedTags: [],
+  tagAndFilter: false,
+  scoreMax: null,
+  scoreMin: null,
+};
+
+const card: Card = {
+  id: "card-id",
+  deckId: deck.id,
+  uid: "user-id",
+  frontText: "Front",
+  backText: "Back",
+  tags: ["typescript"],
+  uniqueKey: "unique-key",
+  score: 2,
+  numberOfSeen: 3,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+};
+
+const renderStudyScreen = (options?: { cardsById?: Record<CardId, Card>; readsReady?: boolean }) => {
+  const onUnavailable = vi.fn();
+  const cardsById = options?.cardsById ?? { [card.id]: card };
+  const readsReady = options?.readsReady ?? true;
+  return {
+    ...renderHook(() => useStudyScreen({ cardsById, deck, readsReady, onUnavailable })),
+    onUnavailable,
+  };
+};
+
+describe("useStudyScreen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.config = createConfig({
+      cardInterval: 1,
+      darkMode: true,
+      showHeader: true,
+      showSwipeButtonList: true,
+      showSwipeFeedback: true,
+    });
+    mocks.hydrated = true;
+    mocks.state.sessionsByDeckId = {
+      [deck.id]: {
+        deckId: deck.id,
+        cardOrderIds: [card.id],
+        currentIndex: 0,
+        lastStudiedAt: 0,
+      },
+    };
+    mocks.state.showBackText = false;
+    mocks.state.autoPlay = false;
+    mocks.state.lastSwipe = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds the active study view state and initializes its session", () => {
+    const { result } = renderStudyScreen();
+
+    expect(result.current).toMatchObject({
+      card,
+      category: "typescript",
+      backText: { category: "typescript", code: true, dark: true },
+      showBackText: false,
+      showController: true,
+      showHeader: true,
+      showSwipeButtonList: true,
+      swipeActions: {
+        onClickUp: mocks.actions.swipeUp,
+        onClickDown: mocks.actions.swipeDown,
+        onClickLeft: mocks.actions.swipeLeft,
+        onClickRight: mocks.actions.swipeRight,
+      },
+    });
+    expect(result.current.controller).toMatchObject({
+      index: 0,
+      numberOfCards: 1,
+      onChange: mocks.actions.updateIndex,
+      onToggleAutoPlay: mocks.actions.toggleAutoPlay,
+    });
+    expect(mocks.initializeStudySessionUi).toHaveBeenCalledWith(false);
+    expect(mocks.touchStudySession).toHaveBeenCalledWith(deck.id);
+  });
+
+  it("owns study shortcuts", () => {
+    renderStudyScreen();
+
+    for (const key of ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Enter", "h", "b", " "]) {
+      act(() => window.dispatchEvent(new KeyboardEvent("keydown", { key })));
+    }
+
+    expect(mocks.actions.swipeUp).toHaveBeenCalledOnce();
+    expect(mocks.actions.swipeDown).toHaveBeenCalledOnce();
+    expect(mocks.actions.swipeLeft).toHaveBeenCalledOnce();
+    expect(mocks.actions.swipeRight).toHaveBeenCalledOnce();
+    expect(mocks.actions.toggleShowBackText).toHaveBeenCalledOnce();
+    expect(mocks.toggleShowHeader).toHaveBeenCalledOnce();
+    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
+    expect(mocks.actions.toggleAutoPlay).toHaveBeenCalledOnce();
+  });
+
+  it("clears swipe feedback after its display interval", () => {
+    vi.useFakeTimers();
+    mocks.state.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
+    const { result } = renderStudyScreen();
+
+    expect(result.current.swipeFeedback).toBe("cardSwipeLeft");
+    act(() => vi.advanceTimersByTime(899));
+    expect(mocks.state.clearLastSwipe).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(mocks.state.clearLastSwipe).toHaveBeenCalledOnce();
+  });
+
+  it("waits for hydration and reads before rejecting an unavailable session", () => {
+    mocks.state.sessionsByDeckId = {};
+    mocks.hydrated = false;
+    const onUnavailable = vi.fn();
+    const view = renderHook(({ readsReady }) => useStudyScreen({ cardsById: {}, deck, readsReady, onUnavailable }), {
+      initialProps: { readsReady: false },
+    });
+
+    expect(mocks.actions.resetStudy).not.toHaveBeenCalled();
+    expect(onUnavailable).not.toHaveBeenCalled();
+
+    mocks.hydrated = true;
+    view.rerender({ readsReady: true });
+
+    expect(mocks.actions.resetStudy).toHaveBeenCalledOnce();
+    expect(onUnavailable).toHaveBeenCalledOnce();
+
+    view.rerender({ readsReady: true });
+    expect(mocks.actions.resetStudy).toHaveBeenCalledOnce();
+    expect(onUnavailable).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/study/hooks/useStudyScreen.ts
+++ b/src/features/study/hooks/useStudyScreen.ts
@@ -1,0 +1,121 @@
+import type { Card, CardId } from "@/entities/card";
+import { getCategory, isHighlightLanguage, type Deck, type DeckId } from "@/entities/deck";
+
+import * as React from "react";
+import { useKey } from "react-use";
+
+import { toggleShowHeader, toggleShowSwipeButtonList, useConfig } from "@/shared/config";
+
+import type { SwipeButtonListProps } from "../components/SwipeButtonList";
+import { initializeStudySessionUi, touchStudySession } from "../commands/studySessionCommands";
+import { selectStudySessionForRoute } from "../state/studyStore";
+import { useEditStudyProgress } from "./useEditStudyProgress";
+import { useStudyActions } from "./useStudyActions";
+import { useStudyControllerState } from "./useStudyControllerState";
+import { useStudyHydrated } from "./useStudyHydrated";
+import { useStudyStore } from "./useStudyStore";
+
+const SWIPE_FEEDBACK_DURATION_MS = 900;
+
+interface UseStudyScreenOptions {
+  cardsById: Partial<Record<CardId, Card>>;
+  deck: Deck;
+  readsReady: boolean;
+  onUnavailable: () => void;
+}
+
+export const useStudyScreen = ({ cardsById, deck, readsReady, onUnavailable }: UseStudyScreenOptions) => {
+  const deckId = deck.id;
+  const config = useConfig();
+  const session = useStudyStore(selectStudySessionForRoute(deckId));
+  const showBackText = useStudyStore((state) => state.showBackText);
+  const autoPlay = useStudyStore((state) => state.autoPlay);
+  const lastSwipe = useStudyStore((state) => state.lastSwipe);
+  const clearLastSwipe = useStudyStore((state) => state.clearLastSwipe);
+  const hydrated = useStudyHydrated();
+  const index = session?.currentIndex ?? -1;
+  const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
+  const card = cardId == null ? undefined : cardsById[cardId];
+  const cardMutation = useEditStudyProgress();
+  const actions = useStudyActions(deckId, {
+    cardsById,
+    cardMutation: { update: cardMutation.update },
+  });
+
+  useKey("ArrowUp", actions.swipeUp);
+  useKey("ArrowDown", actions.swipeDown);
+  useKey("ArrowLeft", actions.swipeLeft);
+  useKey("ArrowRight", actions.swipeRight);
+  useKey("Enter", actions.toggleShowBackText);
+  useKey("h", toggleShowHeader);
+  useKey("b", toggleShowSwipeButtonList);
+  useKey(" ", actions.toggleAutoPlay);
+
+  React.useEffect(() => {
+    if (!config.appearance.showSwipeFeedback) {
+      if (lastSwipe !== undefined) clearLastSwipe();
+      return;
+    }
+    if (lastSwipe === undefined) return;
+
+    const timeout = window.setTimeout(clearLastSwipe, SWIPE_FEEDBACK_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [clearLastSwipe, config.appearance.showSwipeFeedback, lastSwipe]);
+
+  const valid = session != null && index >= 0 && index < session.cardOrderIds.length && card != null;
+  const controller = useStudyControllerState({
+    autoPlay,
+    cardInterval: config.study.cardInterval,
+    enabled: card != null && config.study.cardInterval > 0,
+    index,
+    numberOfCards: session?.cardOrderIds.length ?? 0,
+    onChange: actions.updateIndex,
+    onToggleAutoPlay: actions.toggleAutoPlay,
+  });
+  const exitingDeck = React.useRef<DeckId>(undefined);
+
+  React.useEffect(() => {
+    if (!valid) return;
+    initializeStudySessionUi(config.study.defaultAutoPlay);
+    touchStudySession(deckId);
+  }, [config.study.defaultAutoPlay, deckId, valid]);
+
+  React.useEffect(() => {
+    if (valid) {
+      exitingDeck.current = undefined;
+      return;
+    }
+    if (!hydrated || !readsReady || exitingDeck.current === deckId) return;
+
+    exitingDeck.current = deckId;
+    actions.resetStudy();
+    onUnavailable();
+  }, [actions, deckId, hydrated, onUnavailable, readsReady, valid]);
+
+  const category = card == null ? undefined : getCategory(deck.category, card.tags);
+  const swipeActions: SwipeButtonListProps = {
+    disabled: false,
+    onClickUp: actions.swipeUp,
+    onClickDown: actions.swipeDown,
+    onClickLeft: actions.swipeLeft,
+    onClickRight: actions.swipeRight,
+  };
+
+  return {
+    actions,
+    backText: {
+      category,
+      code: category == null ? false : isHighlightLanguage(category),
+      dark: config.appearance.darkMode,
+    },
+    card,
+    category,
+    controller,
+    showBackText,
+    showController: config.study.cardInterval > 0,
+    showHeader: config.appearance.showHeader && !showBackText,
+    showSwipeButtonList: config.controls.showSwipeButtonList,
+    swipeActions,
+    swipeFeedback: config.appearance.showSwipeFeedback && lastSwipe !== undefined ? lastSwipe.direction : undefined,
+  };
+};

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -3,7 +3,6 @@ export { Controller, type ControllerProps } from "./components/Controller";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
 export {
   discardStudySessionsMissingDecks,
-  initializeStudySessionUi,
   removeStudySession,
   touchStudySession,
 } from "./commands/studySessionCommands";
@@ -11,9 +10,7 @@ export { useStudyHydrated } from "./hooks/useStudyHydrated";
 export { useDeckFilterState } from "./hooks/useDeckFilterState";
 export { useStudyActions } from "./hooks/useStudyActions";
 export { useStudyCards } from "./hooks/useStudyCards";
-export { useStudyControllerState } from "./hooks/useStudyControllerState";
+export { useStudyScreen } from "./hooks/useStudyScreen";
 export { useStudySessions } from "./hooks/useStudySessions";
-export { useStudyStore } from "./hooks/useStudyStore";
-export { selectStudySessionForRoute } from "./state/studyStore";
 export { clearStudyStore } from "./state/studyStoreInstance";
 export { useEditStudyProgress, type StudyProgressPatch } from "./hooks/useEditStudyProgress";

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -1,75 +1,71 @@
-/**
- * @file Verifies the "DeckSwiperPage with DeckSwiperView" contract with automated
- * examples.
- * The examples make the expected behavior concrete with cases such as "renders the active session
- * card and forwards study callbacks", "keeps pending study saves silent while disabling swipe
- * controls", "installs one back-navigation guard when StrictMode replays the effect".
- */
-
 import type { Card, CardId } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
-import type { ConfigState, SwipeDirection } from "@/shared/config";
+import type { ConfigState } from "@/shared/config";
 
-import { act, fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import React from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { useStudySessions } from "@/features/study";
 import { createConfig } from "@/test/factories";
 
-const mocks = vi.hoisted(() => ({
-  params: { id: "deck-id" as string | undefined },
-  state: null as { deck: Record<DeckId, Deck>; card: Record<CardId, Card>; config: ConfigState } | null,
-  navigate: vi.fn(),
-  toggleShowBackText: vi.fn(),
-  toggleAutoPlay: vi.fn(),
-  swipeUp: vi.fn(),
-  swipeDown: vi.fn(),
-  swipeLeft: vi.fn(),
-  swipeRight: vi.fn(),
-  updateIndex: vi.fn(),
-  resetStudy: vi.fn(),
-  cardMutation: {
-    update: vi.fn(),
-  },
-  studyState: {
-    sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
-    showBackText: false,
-    autoPlay: false,
-    lastSwipe: undefined as { direction: SwipeDirection; eventId: number } | undefined,
-    clearLastSwipe: vi.fn(),
-  },
-  initializeStudySessionUi: vi.fn(),
-  touchStudySession: vi.fn(),
-  hydrated: true,
-  cardReadStatus: "ready" as "loading" | "ready" | "error" | "blocked",
-  deckReadStatus: "ready" as "loading" | "ready" | "error" | "blocked",
-  cardReadRetry: vi.fn(),
-  deckReadRetry: vi.fn(),
-  toggleShowHeader: vi.fn(),
-  toggleShowSwipeButtonList: vi.fn(),
-  setDarkMode: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const actions = {
+    swipeUp: vi.fn(),
+    swipeDown: vi.fn(),
+    swipeLeft: vi.fn(),
+    swipeRight: vi.fn(),
+    toggleShowBackText: vi.fn(),
+  };
 
-vi.mock("@/shared/firebase", () => ({ auth: {} }));
+  return {
+    actions,
+    params: { id: "deck-id" as string | undefined },
+    navigate: vi.fn(),
+    cardReadStatus: "ready" as "loading" | "ready" | "error" | "blocked",
+    deckReadStatus: "ready" as "loading" | "ready" | "error" | "blocked",
+    cardReadRetry: vi.fn(),
+    deckReadRetry: vi.fn(),
+    state: null as { deck: Record<DeckId, Deck>; card: Record<CardId, Card>; config: ConfigState } | null,
+    study: null as null | {
+      actions: typeof actions;
+      backText: { category: string | undefined; code: boolean; dark: boolean };
+      card: Card | undefined;
+      category: string | undefined;
+      controller: {
+        autoPlay: boolean;
+        cardInterval: number;
+        index: number;
+        numberOfCards: number;
+        onChange: (index: number) => void;
+        onToggleAutoPlay: () => void;
+      };
+      showBackText: boolean;
+      showController: boolean;
+      showHeader: boolean;
+      showSwipeButtonList: boolean;
+      swipeActions: {
+        disabled: boolean;
+        onClickUp: () => void;
+        onClickDown: () => void;
+        onClickLeft: () => void;
+        onClickRight: () => void;
+      };
+      swipeFeedback: undefined;
+    },
+    useStudyScreen: vi.fn(),
+    onUnavailable: undefined as (() => void) | undefined,
+  };
+});
 
 vi.mock("@/shared/config", () => ({
   useConfig: () => {
     if (mocks.state == null) throw new Error("Mock state is not initialized");
     return mocks.state.config;
   },
-  toggleShowHeader: mocks.toggleShowHeader,
-  toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
-  setDarkMode: mocks.setDarkMode,
+  setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/entities/deck", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/entities/deck")>();
-  return {
-    ...actual,
-  };
-});
 vi.mock("@/features/deck/read", () => ({
   useDecks: () => ({
     status: mocks.deckReadStatus,
@@ -93,230 +89,123 @@ vi.mock("react-router-dom", () => ({
 
 vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
-  return {
-    ...actual,
-    initializeStudySessionUi: mocks.initializeStudySessionUi,
-    touchStudySession: mocks.touchStudySession,
-    useEditStudyProgress: () => mocks.cardMutation,
-    useStudyActions: () => ({
-      swipeUp: mocks.swipeUp,
-      swipeDown: mocks.swipeDown,
-      swipeLeft: mocks.swipeLeft,
-      swipeRight: mocks.swipeRight,
-      updateIndex: mocks.updateIndex,
-      toggleShowBackText: mocks.toggleShowBackText,
-      toggleAutoPlay: mocks.toggleAutoPlay,
-      resetStudy: mocks.resetStudy,
-    }),
-    useStudyHydrated: () => mocks.hydrated,
-    useStudyStore: (selector: (state: typeof mocks.studyState) => unknown) => selector(mocks.studyState),
-  };
+  return { ...actual, useStudyScreen: mocks.useStudyScreen };
 });
 
 import { DeckSwiperPage } from "./DeckSwiperPage";
 
-describe("DeckSwiperPage with DeckSwiperView", () => {
-  const deck: Deck = {
-    id: "deck-id",
-    uid: "user-id",
-    name: "Deck",
-    isPublic: false,
-    createdAt: 0,
-    updatedAt: 0,
-    deletedAt: null,
-    category: "raw",
-    convertToBr: false,
-    selectedTags: [],
-    tagAndFilter: false,
-    scoreMax: null,
-    scoreMin: null,
-  };
-  const card: Card = {
-    id: "card-id",
-    deckId: deck.id,
-    uid: "user-id",
-    frontText: "FRONT SLOT",
-    backText: "const answer = 42;",
-    tags: ["typescript"],
-    uniqueKey: "unique-key",
-    score: 2,
-    numberOfSeen: 3,
-    createdAt: 0,
-    updatedAt: 0,
-    deletedAt: null,
-    lastSeenAt: 1,
-  };
-  const legacyCard: Card = {
-    ...card,
-    id: "legacy-card-id",
-    frontText: "LEGACY FRONT",
-    uniqueKey: "legacy-key",
-  };
+const deck: Deck = {
+  id: "deck-id",
+  uid: "user-id",
+  name: "Deck",
+  isPublic: false,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  category: "raw",
+  convertToBr: false,
+  selectedTags: [],
+  tagAndFilter: false,
+  scoreMax: null,
+  scoreMin: null,
+};
 
-  const createState = (currentDeck: Deck = deck) => ({
-    deck: { [currentDeck.id]: currentDeck },
-    card: { [card.id]: card, [legacyCard.id]: legacyCard },
-    config: createConfig({
-      cardInterval: 1,
-      darkMode: false,
-      showHeader: true,
-      showSwipeButtonList: true,
-    }),
-  });
+const card: Card = {
+  id: "card-id",
+  deckId: deck.id,
+  uid: "user-id",
+  frontText: "FRONT SLOT",
+  backText: "const answer = 42;",
+  tags: ["typescript"],
+  uniqueKey: "unique-key",
+  score: 2,
+  numberOfSeen: 3,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  lastSeenAt: 1,
+};
 
+describe("DeckSwiperPage", () => {
   beforeEach(() => {
-    localStorage.clear();
     vi.clearAllMocks();
     mocks.params.id = deck.id;
-    mocks.state = createState();
-    mocks.hydrated = true;
     mocks.cardReadStatus = "ready";
     mocks.deckReadStatus = "ready";
-    mocks.studyState.sessionsByDeckId = {
-      [deck.id]: {
-        deckId: deck.id,
-        cardOrderIds: [card.id, legacyCard.id],
-        currentIndex: 0,
-        lastStudiedAt: 0,
-      },
+    mocks.state = {
+      deck: { [deck.id]: deck },
+      card: { [card.id]: card },
+      config: createConfig(),
     };
-    mocks.studyState.showBackText = false;
-    mocks.studyState.autoPlay = false;
-    mocks.studyState.lastSwipe = undefined;
-    mocks.studyState.clearLastSwipe.mockImplementation(() => {
-      mocks.studyState.lastSwipe = undefined;
-    });
-    mocks.initializeStudySessionUi.mockImplementation((defaultAutoPlay: boolean) => {
-      mocks.studyState.showBackText = false;
-      mocks.studyState.autoPlay = defaultAutoPlay;
-      mocks.studyState.lastSwipe = undefined;
-    });
-    mocks.touchStudySession.mockImplementation((deckId: DeckId) => {
-      const session = mocks.studyState.sessionsByDeckId[deckId];
-      if (session != null) {
-        mocks.studyState.sessionsByDeckId[deckId] = { ...session, lastStudiedAt: Date.now() };
-      }
+    mocks.study = {
+      actions: mocks.actions,
+      backText: { category: "typescript", code: true, dark: false },
+      card,
+      category: "typescript",
+      controller: {
+        autoPlay: false,
+        cardInterval: 1,
+        index: 0,
+        numberOfCards: 2,
+        onChange: vi.fn(),
+        onToggleAutoPlay: vi.fn(),
+      },
+      showBackText: false,
+      showController: true,
+      showHeader: true,
+      showSwipeButtonList: true,
+      swipeActions: {
+        disabled: false,
+        onClickUp: mocks.actions.swipeUp,
+        onClickDown: mocks.actions.swipeDown,
+        onClickLeft: mocks.actions.swipeLeft,
+        onClickRight: mocks.actions.swipeRight,
+      },
+      swipeFeedback: undefined,
+    };
+    mocks.onUnavailable = undefined;
+    mocks.useStudyScreen.mockImplementation((options: { onUnavailable: () => void }) => {
+      mocks.onUnavailable = options.onUnavailable;
+      if (mocks.study == null) throw new Error("Mock study state is not initialized");
+      return mocks.study;
     });
     window.history.replaceState(null, document.title, document.location.href);
-    mocks.resetStudy.mockImplementation(() => {
-      const { [deck.id]: _removed, ...sessionsByDeckId } = mocks.studyState.sessionsByDeckId;
-      mocks.studyState.sessionsByDeckId = sessionsByDeckId;
-    });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("renders the active session card and responds to study controls", () => {
+  it("composes the route shell from the study feature state", () => {
     render(<DeckSwiperPage />);
 
+    expect(mocks.useStudyScreen).toHaveBeenCalledWith({
+      cardsById: { [card.id]: card },
+      deck,
+      readsReady: true,
+      onUnavailable: expect.any(Function),
+    });
     expect(screen.getByText(card.frontText)).toBeVisible();
-    expect(screen.queryByText(legacyCard.frontText)).not.toBeInTheDocument();
     expect(screen.getByText(/3 times/)).toBeVisible();
+
     fireEvent.click(screen.getByText(card.frontText));
     fireEvent.change(screen.getByRole("slider"), { target: { value: 1 } });
-
-    expect(mocks.toggleShowBackText).toHaveBeenCalledOnce();
-    expect(mocks.updateIndex).toHaveBeenCalledWith(1);
-
-    mocks.toggleShowBackText.mockClear();
-    fireEvent.keyDown(window, { key: "ArrowUp" });
-    fireEvent.keyDown(window, { key: "ArrowDown" });
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-    fireEvent.keyDown(window, { key: "ArrowRight" });
-    fireEvent.keyDown(window, { key: "Enter" });
-    fireEvent.keyDown(window, { key: "h" });
-    fireEvent.keyDown(window, { key: "b" });
-    fireEvent.keyDown(window, { key: " " });
-
-    expect(mocks.swipeUp).toHaveBeenCalledOnce();
-    expect(mocks.swipeDown).toHaveBeenCalledOnce();
-    expect(mocks.swipeLeft).toHaveBeenCalledOnce();
-    expect(mocks.swipeRight).toHaveBeenCalledOnce();
-    expect(mocks.toggleShowBackText).toHaveBeenCalledOnce();
-    expect(mocks.toggleShowHeader).toHaveBeenCalledOnce();
-    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
-    expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
+    expect(mocks.actions.toggleShowBackText).toHaveBeenCalledOnce();
+    expect(mocks.study?.controller.onChange).toHaveBeenCalledWith(1);
   });
 
-  it("owns header visibility across front and back content", () => {
-    const view = render(<DeckSwiperPage />);
-
-    expect(screen.getByRole("button", { name: "tango" })).toBeInTheDocument();
-
-    mocks.studyState.showBackText = true;
-    view.rerender(<DeckSwiperPage />);
-
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-
-    mocks.studyState.showBackText = false;
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.config = createConfig({
-      ...mocks.state.config,
-      appearance: { ...mocks.state.config.appearance, showHeader: false },
-    });
-    view.rerender(<DeckSwiperPage />);
-
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-  });
-
-  it("renders the application shell for the ready study screen", () => {
+  it("maps the feature's unavailable intent to route navigation", () => {
     render(<DeckSwiperPage />);
 
-    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
+    act(() => mocks.onUnavailable?.());
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("shows the last swipe briefly only when feedback is enabled", () => {
-    vi.useFakeTimers();
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.config = createConfig({
-      ...mocks.state.config,
-      appearance: { ...mocks.state.config.appearance, showSwipeFeedback: true },
-    });
-    const view = render(<DeckSwiperPage />);
+  it("keeps loading and retry feedback at the route boundary", () => {
+    mocks.cardReadStatus = "loading";
+    if (mocks.study == null) throw new Error("Mock study state is not initialized");
+    mocks.study = { ...mocks.study, card: undefined };
+    render(<DeckSwiperPage />);
 
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
-    view.rerender(<DeckSwiperPage />);
-    expect(screen.getByText("Swiped left")).toHaveAttribute("role", "status");
-
-    act(() => vi.advanceTimersByTime(899));
-    expect(screen.getByText("Swiped left")).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(1));
-    view.rerender(<DeckSwiperPage />);
-    expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
-
-    mocks.state.config = createConfig({
-      ...mocks.state.config,
-      appearance: { ...mocks.state.config.appearance, showSwipeFeedback: false },
-    });
-    mocks.studyState.lastSwipe = { direction: "cardSwipeRight", eventId: 2 };
-    view.rerender(<DeckSwiperPage />);
-    expect(screen.queryByText("Swiped right")).not.toBeInTheDocument();
-  });
-
-  it("restarts swipe feedback timing for repeated identical swipes", () => {
-    vi.useFakeTimers();
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.config = createConfig({
-      ...mocks.state.config,
-      appearance: { ...mocks.state.config.appearance, showSwipeFeedback: true },
-    });
-    const view = render(<DeckSwiperPage />);
-
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
-    view.rerender(<DeckSwiperPage />);
-    act(() => vi.advanceTimersByTime(500));
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 2 };
-    view.rerender(<DeckSwiperPage />);
-
-    act(() => vi.advanceTimersByTime(899));
-    expect(screen.getByText("Swiped left")).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(1));
-    view.rerender(<DeckSwiperPage />);
-    expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Loading…" })).toBeInTheDocument();
+    expect(mocks.useStudyScreen).toHaveBeenCalledWith(expect.objectContaining({ readsReady: false }));
   });
 
   it("installs one back-navigation guard when StrictMode replays the effect", () => {
@@ -335,145 +224,5 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     mocks.navigate.mockClear();
     act(() => window.dispatchEvent(new PopStateEvent("popstate")));
     expect(mocks.navigate).not.toHaveBeenCalled();
-  });
-
-  it("updates the route session activity when the study screen opens", () => {
-    const session = mocks.studyState.sessionsByDeckId[deck.id];
-    if (session == null) throw new Error("Expected an active study session");
-    mocks.studyState.sessionsByDeckId[deck.id] = { ...session, lastStudiedAt: 100 };
-    mocks.studyState.showBackText = true;
-    mocks.studyState.autoPlay = true;
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
-    const now = vi.spyOn(Date, "now").mockReturnValue(9000);
-
-    render(<DeckSwiperPage />);
-
-    expect(mocks.initializeStudySessionUi).toHaveBeenCalledWith(false);
-    expect(mocks.touchStudySession).toHaveBeenCalledWith(deck.id);
-    expect(mocks.studyState.sessionsByDeckId[deck.id]?.lastStudiedAt).toBe(9000);
-    expect(mocks.studyState).toMatchObject({ showBackText: false, autoPlay: false, lastSwipe: undefined });
-    now.mockRestore();
-  });
-
-  it("renders Zustand back text and controlled auto-play", () => {
-    const view = render(<DeckSwiperPage />);
-    mocks.studyState.showBackText = true;
-    mocks.studyState.autoPlay = true;
-    view.rerender(<DeckSwiperPage />);
-
-    const code = screen.getByText(/answer =/);
-    expect(code).toHaveTextContent(card.backText);
-    expect(screen.getByTestId("pause")).toBeInTheDocument();
-    fireEvent.click(code);
-    fireEvent.click(screen.getByTestId("pause"));
-    const swipeLeftButton = screen.getAllByRole("button", { name: "Swipe left" })[0];
-    const swipeRightButton = screen.getAllByRole("button", { name: "Swipe right" })[0];
-    if (swipeLeftButton == null || swipeRightButton == null) throw new Error("Expected swipe controls");
-    fireEvent.click(swipeLeftButton);
-    fireEvent.click(swipeRightButton);
-
-    expect(mocks.toggleShowBackText).toHaveBeenCalledOnce();
-    expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
-    expect(mocks.swipeLeft).toHaveBeenCalledOnce();
-    expect(mocks.swipeRight).toHaveBeenCalledOnce();
-  });
-
-  it("waits for hydration, then rejects an old-shaped deck without a current session", async () => {
-    const legacyDeck = {
-      ...deck,
-      currentIndex: 0,
-      cardOrderIds: [card.id],
-    };
-    mocks.state = createState(legacyDeck);
-    delete mocks.studyState.sessionsByDeckId[deck.id];
-    mocks.hydrated = false;
-
-    const view = render(<DeckSwiperPage />);
-
-    expect(screen.getByRole("status")).toHaveTextContent("Study session unavailable.");
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-    expect(mocks.resetStudy).not.toHaveBeenCalled();
-    expect(mocks.navigate).not.toHaveBeenCalled();
-    expect(mocks.studyState.sessionsByDeckId[deck.id]).toBeUndefined();
-
-    mocks.hydrated = true;
-    view.rerender(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-    expect(mocks.studyState.sessionsByDeckId[deck.id]).toBeUndefined();
-  });
-
-  it("exits without removing a session that belongs to another deck", async () => {
-    delete mocks.studyState.sessionsByDeckId[deck.id];
-    mocks.studyState.sessionsByDeckId["other-deck"] = {
-      deckId: "other-deck",
-      cardOrderIds: [card.id],
-      currentIndex: 0,
-      lastStudiedAt: 0,
-    };
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-    expect(mocks.studyState.sessionsByDeckId["other-deck"]).toMatchObject({ deckId: "other-deck" });
-  });
-
-  it("resets and exits when no session or legacy candidate exists", async () => {
-    delete mocks.studyState.sessionsByDeckId[deck.id];
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-  });
-
-  it("resets and exits at a terminal session index", async () => {
-    const session = mocks.studyState.sessionsByDeckId[deck.id];
-    if (session == null) throw new Error("Expected an active study session");
-    mocks.studyState.sessionsByDeckId[deck.id] = { ...session, currentIndex: -1 };
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-  });
-
-  it("resets and exits when the session card is missing", async () => {
-    mocks.studyState.sessionsByDeckId[deck.id] = {
-      deckId: deck.id,
-      cardOrderIds: ["missing-card"],
-      currentIndex: 0,
-      lastStudiedAt: 0,
-    };
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-  });
-
-  it("keeps the study session while Card reads are still loading", () => {
-    mocks.cardReadStatus = "loading";
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.card = {};
-
-    render(<DeckSwiperPage />);
-
-    expect(screen.getByRole("heading", { name: "Loading…" })).toBeInTheDocument();
-    expect(mocks.resetStudy).not.toHaveBeenCalled();
-    expect(mocks.navigate).not.toHaveBeenCalledWith("/", { replace: true });
-    expect(mocks.studyState.sessionsByDeckId[deck.id]).toBeDefined();
   });
 });

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -1,24 +1,12 @@
-import { getCategory, isHighlightLanguage, type Deck, type DeckId } from "@/entities/deck";
+import type { Deck } from "@/entities/deck";
 
 import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useKey } from "react-use";
 
 import { useCards } from "@/features/card/read";
 import { BackText, CardOverlay, FrontText } from "@/features/card/view";
 import { useDecks } from "@/features/deck/read";
-import {
-  initializeStudySessionUi,
-  selectStudySessionForRoute,
-  type SwipeButtonListProps,
-  touchStudySession,
-  useEditStudyProgress,
-  useStudyActions,
-  useStudyControllerState,
-  useStudyHydrated,
-  useStudyStore,
-} from "@/features/study";
-import { toggleShowHeader, toggleShowSwipeButtonList, useConfig } from "@/shared/config";
+import { useStudyScreen } from "@/features/study";
 import { combineRemoteReadStates } from "@/shared/lib/remote-read";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
 import { AppLayout } from "@/widgets/app-layout";
@@ -26,7 +14,6 @@ import { AppLayout } from "@/widgets/app-layout";
 import { DeckSwiperView } from "./DeckSwiperView";
 
 const STUDY_HISTORY_GUARD = "tangoStudyDeckId";
-const SWIPE_FEEDBACK_DURATION_MS = 900;
 const isHistoryState = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value != null && !Array.isArray(value);
 
@@ -44,73 +31,12 @@ const DeckSwiperContent = ({
 }) => {
   const navigate = useNavigate();
   const deckId = deck.id;
-  const config = useConfig();
-  const session = useStudyStore(selectStudySessionForRoute(deckId));
-  const showBackText = useStudyStore((state) => state.showBackText);
-  const autoPlay = useStudyStore((state) => state.autoPlay);
-  const lastSwipe = useStudyStore((state) => state.lastSwipe);
-  const clearLastSwipe = useStudyStore((state) => state.clearLastSwipe);
-  const hydrated = useStudyHydrated();
-
-  const index = session?.currentIndex ?? -1;
-  const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
-  const card = cardId == null ? undefined : cardRemote.cardsById[cardId];
-  const cardMutation = useEditStudyProgress();
-  const studyActions = useStudyActions(deckId, {
+  const study = useStudyScreen({
     cardsById: cardRemote.cardsById,
-    cardMutation: {
-      update: cardMutation.update,
-    },
+    deck,
+    readsReady: readState.status === "ready",
+    onUnavailable: () => void navigate("/", { replace: true }),
   });
-  useKey("ArrowUp", studyActions.swipeUp);
-  useKey("ArrowDown", studyActions.swipeDown);
-  useKey("ArrowLeft", studyActions.swipeLeft);
-  useKey("ArrowRight", studyActions.swipeRight);
-  useKey("Enter", studyActions.toggleShowBackText);
-  useKey("h", toggleShowHeader);
-  useKey("b", toggleShowSwipeButtonList);
-  useKey(" ", studyActions.toggleAutoPlay);
-
-  React.useEffect(() => {
-    if (!config.appearance.showSwipeFeedback) {
-      if (lastSwipe !== undefined) clearLastSwipe();
-      return;
-    }
-    if (lastSwipe === undefined) return;
-
-    const timeout = window.setTimeout(clearLastSwipe, SWIPE_FEEDBACK_DURATION_MS);
-    return () => window.clearTimeout(timeout);
-  }, [clearLastSwipe, config.appearance.showSwipeFeedback, lastSwipe]);
-
-  const valid = session != null && index >= 0 && index < session.cardOrderIds.length && card != null;
-  const controller = useStudyControllerState({
-    autoPlay,
-    cardInterval: config.study.cardInterval,
-    enabled: card != null && config.study.cardInterval > 0,
-    index,
-    numberOfCards: session?.cardOrderIds.length ?? 0,
-    onChange: studyActions.updateIndex,
-    onToggleAutoPlay: studyActions.toggleAutoPlay,
-  });
-
-  const exitingDeck = React.useRef<DeckId>(undefined);
-  React.useEffect(() => {
-    if (!valid) return;
-    initializeStudySessionUi(config.study.defaultAutoPlay);
-    touchStudySession(deckId);
-  }, [config.study.defaultAutoPlay, deckId, valid]);
-
-  React.useEffect(() => {
-    if (valid) {
-      exitingDeck.current = undefined;
-      return;
-    }
-    if (!hydrated || readState.status !== "ready" || exitingDeck.current === deckId) return;
-
-    exitingDeck.current = deckId;
-    studyActions.resetStudy();
-    void navigate("/", { replace: true });
-  }, [deckId, hydrated, navigate, readState.status, studyActions, valid]);
 
   // Keep the active study session on the route when browser history moves backward.
   React.useEffect(() => {
@@ -128,7 +54,7 @@ const DeckSwiperContent = ({
     };
   }, [deckId, navigate]);
 
-  if (card == null) {
+  if (study.card == null) {
     return (
       <RemoteReadBoundary
         status={readState.status}
@@ -141,48 +67,37 @@ const DeckSwiperContent = ({
     );
   }
 
-  const category = getCategory(deck.category, card.tags);
-  const swipeActions: SwipeButtonListProps = {
-    disabled: false,
-    onClickUp: studyActions.swipeUp,
-    onClickDown: studyActions.swipeDown,
-    onClickLeft: studyActions.swipeLeft,
-    onClickRight: studyActions.swipeRight,
-  };
-
   return (
-    <AppLayout fullscreen scroll={showBackText} showHeader={config.appearance.showHeader && !showBackText}>
+    <AppLayout fullscreen scroll={study.showBackText} showHeader={study.showHeader}>
       <DeckSwiperView
-        showController={config.study.cardInterval > 0}
-        showBackText={showBackText}
-        showSwipeButtonList={config.controls.showSwipeButtonList}
-        {...(config.appearance.showSwipeFeedback && lastSwipe !== undefined
-          ? { swipeFeedback: lastSwipe.direction }
-          : {})}
+        showController={study.showController}
+        showBackText={study.showBackText}
+        showSwipeButtonList={study.showSwipeButtonList}
+        {...(study.swipeFeedback === undefined ? {} : { swipeFeedback: study.swipeFeedback })}
         frontTextSlot={
           <FrontText
-            category={category}
-            text={card.frontText}
-            onSwipeUp={studyActions.swipeUp}
-            onSwipeDown={studyActions.swipeDown}
-            onSwipeLeft={studyActions.swipeLeft}
-            onSwipeRight={studyActions.swipeRight}
-            onClick={studyActions.toggleShowBackText}
+            {...(study.category === undefined ? {} : { category: study.category })}
+            text={study.card.frontText}
+            onSwipeUp={study.actions.swipeUp}
+            onSwipeDown={study.actions.swipeDown}
+            onSwipeLeft={study.actions.swipeLeft}
+            onSwipeRight={study.actions.swipeRight}
+            onClick={study.actions.toggleShowBackText}
           />
         }
-        cardOverlaySlot={<CardOverlay card={card} />}
+        cardOverlaySlot={<CardOverlay card={study.card} />}
         backTextSlot={
           <BackText
-            category={category}
-            code={isHighlightLanguage(category)}
-            dark={config.appearance.darkMode}
-            text={card.backText}
-            onClick={studyActions.toggleShowBackText}
+            {...(study.backText.category === undefined ? {} : { category: study.backText.category })}
+            code={study.backText.code}
+            dark={study.backText.dark}
+            text={study.card.backText}
+            onClick={study.actions.toggleShowBackText}
           />
         }
-        controller={controller}
-        swipeButtonList={swipeActions}
-        swipeOverlay={swipeActions}
+        controller={study.controller}
+        swipeButtonList={study.swipeActions}
+        swipeOverlay={study.swipeActions}
       />
     </AppLayout>
   );


### PR DESCRIPTION
## Related issue
Fixes #745

## Summary

- Move study session selection, shortcuts, mutation and controller coordination, and feedback lifecycle into features/study.
- Keep DeckSwiperPage focused on route data, navigation, shell, and lower-layer composition.
- Add focused feature tests and reduce the public Study API surface.

## Testing

- mise run check