### PR TITLE
refactor: add StudyProgress ownership (#771)

### DIFF
--- a/src/entities/study-progress/model/schema.spec.ts
+++ b/src/entities/study-progress/model/schema.spec.ts
@@ -3,17 +3,30 @@ import { describe, expect, it } from "vitest";
 import { editStudyProgressSchema } from "./schema";
 
 describe("StudyProgress operation schemas", () => {
-  it("accepts progress fields for an identified Card", () => {
+  it("accepts edits owned by the authenticated user", () => {
     expect(
       editStudyProgressSchema.parse({
         uid: "uid-a",
-        progress: { cardId: "card", score: 2, frontText: "unexpected", deckId: "other-deck" },
+        progress: { uid: "uid-a", cardId: "card", score: 2, frontText: "unexpected", deckId: "other-deck" },
       })
-    ).toEqual({ uid: "uid-a", progress: { cardId: "card", score: 2 } });
+    ).toEqual({ uid: "uid-a", progress: { uid: "uid-a", cardId: "card", score: 2 } });
   });
 
-  it("rejects missing user and Card identities", () => {
-    expect(() => editStudyProgressSchema.parse({ uid: "", progress: { cardId: "card" } })).toThrow("confirmed user");
-    expect(() => editStudyProgressSchema.parse({ uid: "uid-a", progress: { cardId: "" } })).toThrow("Card id");
+  it("rejects edits owned by another user", () => {
+    expect(() => editStudyProgressSchema.parse({ uid: "uid-a", progress: { uid: "uid-b", cardId: "card" } })).toThrow(
+      "owner does not match"
+    );
+  });
+
+  it("rejects missing user, owner, and Card identities", () => {
+    expect(() => editStudyProgressSchema.parse({ uid: "", progress: { uid: "uid-a", cardId: "card" } })).toThrow(
+      "confirmed user"
+    );
+    expect(() => editStudyProgressSchema.parse({ uid: "uid-a", progress: { uid: "", cardId: "card" } })).toThrow(
+      "StudyProgress owner"
+    );
+    expect(() => editStudyProgressSchema.parse({ uid: "uid-a", progress: { uid: "uid-a", cardId: "" } })).toThrow(
+      "Card id"
+    );
   });
 });

--- a/src/entities/study-progress/model/schema.ts
+++ b/src/entities/study-progress/model/schema.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
 const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote StudyProgress writes");
+const studyProgressUidSchema = z.string().min(1, "StudyProgress owner is required");
 
 const studyProgressEditSchema = z.object({
+  uid: studyProgressUidSchema,
   cardId: z.string().min(1, "Card id is required"),
   score: z.number().optional(),
   numberOfSeen: z.number().optional(),
@@ -11,9 +13,24 @@ const studyProgressEditSchema = z.object({
   interval: z.number().optional(),
 });
 
-export const editStudyProgressSchema = z.object({
-  uid: authenticatedUidSchema,
-  progress: studyProgressEditSchema,
-});
+const validateStudyProgressOwner = (
+  input: { uid: string; progress: { uid: string } },
+  context: z.RefinementCtx
+): void => {
+  if (input.progress.uid !== input.uid) {
+    context.addIssue({
+      code: "custom",
+      message: "StudyProgress owner does not match the authenticated user",
+      path: ["progress", "uid"],
+    });
+  }
+};
+
+export const editStudyProgressSchema = z
+  .object({
+    uid: authenticatedUidSchema,
+    progress: studyProgressEditSchema,
+  })
+  .superRefine(validateStudyProgressOwner);
 
 export type EditStudyProgressInput = z.infer<typeof editStudyProgressSchema>;

--- a/src/entities/study-progress/model/studyProgress.spec.ts
+++ b/src/entities/study-progress/model/studyProgress.spec.ts
@@ -11,17 +11,24 @@ import {
   type StudyRating,
 } from "../index";
 
-const initialStudyProgress = (cardId: string): StudyProgress => ({ cardId, score: 0, numberOfSeen: 0 });
+const initialStudyProgress = (cardId: string): StudyProgress => ({
+  uid: "uid-a",
+  cardId,
+  score: 0,
+  numberOfSeen: 0,
+});
 
 describe("createStudyProgressFromCard", () => {
   it("allows editing selected progress fields while retaining the card id", () => {
     const edit: StudyProgressEdit = {
+      uid: "uid-a",
       cardId: "card-id",
       score: 3,
       lastSeenAt: 1_786_512_000_000,
     };
 
     expect(edit).toEqual({
+      uid: "uid-a",
       cardId: "card-id",
       score: 3,
       lastSeenAt: 1_786_512_000_000,
@@ -31,6 +38,7 @@ describe("createStudyProgressFromCard", () => {
   it("restores progress from a Card without copying Card content", () => {
     const card = {
       id: "card-id",
+      uid: "uid-a",
       score: 3,
       numberOfSeen: 4,
       lastSeenAt: 1_786_512_000_000,
@@ -41,6 +49,7 @@ describe("createStudyProgressFromCard", () => {
     const progress = createStudyProgressFromCard(card);
 
     expect(progress).toEqual({
+      uid: "uid-a",
       cardId: "card-id",
       score: 3,
       numberOfSeen: 4,
@@ -65,6 +74,7 @@ describe("recordStudyProgress", () => {
     const progress = { ...initialStudyProgress("card-id"), score, numberOfSeen: 2 };
 
     expect(recordStudyProgress(progress, rating, 1_786_512_000_000)).toEqual({
+      uid: "uid-a",
       cardId: "card-id",
       score: expectedScore,
       numberOfSeen: 3,

--- a/src/entities/study-progress/model/studyProgress.ts
+++ b/src/entities/study-progress/model/studyProgress.ts
@@ -1,6 +1,7 @@
 import type { CardId } from "@/entities/card/@x/study-progress";
 
 export interface StudyProgress {
+  readonly uid: string;
   cardId: CardId;
   score: number;
   numberOfSeen: number;
@@ -9,7 +10,7 @@ export interface StudyProgress {
   interval?: number;
 }
 
-export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
+export type StudyProgressEdit = Partial<Omit<StudyProgress, "uid">> & Pick<StudyProgress, "uid" | "cardId">;
 
 export type StudyRating = "mastered" | "not-mastered" | "unrated";
 
@@ -21,6 +22,7 @@ export interface StudyProgressFilter {
 
 interface CardProgressFields {
   id: CardId;
+  uid: string;
   score: number;
   numberOfSeen: number;
   lastSeenAt?: number;
@@ -28,14 +30,15 @@ interface CardProgressFields {
   interval?: number;
 }
 
-const createStudyProgress = (cardId: CardId): StudyProgress => ({
+const createStudyProgress = (uid: string, cardId: CardId): StudyProgress => ({
+  uid,
   cardId,
   score: 0,
   numberOfSeen: 0,
 });
 
 export const createStudyProgressFromCard = (card: CardProgressFields): StudyProgress => {
-  const progress = createStudyProgress(card.id);
+  const progress = createStudyProgress(card.uid, card.id);
   progress.score = card.score;
   progress.numberOfSeen = card.numberOfSeen;
   if (card.lastSeenAt !== undefined) progress.lastSeenAt = card.lastSeenAt;
@@ -55,6 +58,7 @@ export const recordStudyProgress = (
   rating: StudyRating,
   studiedAt: number
 ): StudyProgressEdit => ({
+  uid: progress.uid,
   cardId: progress.cardId,
   score: calculateScore(progress.score, rating),
   numberOfSeen: progress.numberOfSeen + 1,

--- a/src/features/study/api/editStudyProgress.spec.ts
+++ b/src/features/study/api/editStudyProgress.spec.ts
@@ -25,11 +25,11 @@ describe("editStudyProgress", () => {
 
   it("writes only StudyProgress fields when runtime input contains Card fields", async () => {
     const untrustedInput = {
+      uid: "uid-a",
       cardId: "card",
       score: 2,
       frontText: "unexpected",
       deckId: "other-deck",
-      uid: "other-user",
       deletedAt: 1,
     } as unknown as Parameters<typeof editStudyProgress>[1];
 
@@ -37,5 +37,13 @@ describe("editStudyProgress", () => {
 
     expect(mocks.doc).toHaveBeenCalledWith("db", "card", "card");
     expect(mocks.updateDoc).toHaveBeenCalledWith("card-reference", { score: 2, updatedAt: 100 });
+  });
+
+  it("rejects writes for progress owned by another user", async () => {
+    await expect(editStudyProgress("uid-a", { uid: "uid-b", cardId: "card", score: 2 })).rejects.toThrow(
+      "owner does not match"
+    );
+
+    expect(mocks.updateDoc).not.toHaveBeenCalled();
   });
 });

--- a/src/features/study/api/editStudyProgress.ts
+++ b/src/features/study/api/editStudyProgress.ts
@@ -6,7 +6,7 @@ import { getDb, getTimestamp, omitUndefined } from "@/shared/firestore";
 
 export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });
-  const { cardId, ...fields } = input.progress;
+  const { cardId, uid: _ownerUid, ...fields } = input.progress;
   const document = omitUndefined({ ...fields, updatedAt: getTimestamp() });
   await updateDoc(doc(getDb(), "card", cardId), document);
 };

--- a/src/features/study/hooks/useEditStudyProgress.ts
+++ b/src/features/study/hooks/useEditStudyProgress.ts
@@ -4,7 +4,7 @@ import type { StudyProgressEdit } from "@/entities/study-progress";
 import { useAuthSession } from "@/entities/auth-session";
 import { editStudyProgress } from "../api/editStudyProgress";
 
-export type StudyProgressPatch = Omit<StudyProgressEdit, "cardId">;
+export type StudyProgressPatch = Omit<StudyProgressEdit, "cardId" | "uid">;
 
 export const useEditStudyProgress = () => {
   const auth = useAuthSession();
@@ -14,6 +14,6 @@ export const useEditStudyProgress = () => {
   return {
     update,
     updateBy: (card: Card, buildPatch: (card: Card) => StudyProgressPatch) =>
-      update({ ...buildPatch(card), cardId: card.id }),
+      update({ ...buildPatch(card), uid: card.uid, cardId: card.id }),
   };
 };

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -176,6 +176,7 @@ describe("useStudyActions", () => {
     });
 
     const patch = {
+      uid: card1.uid,
       cardId: card1.id,
       score: 1,
       numberOfSeen: 1,

--- a/src/features/study/model/cardSelection.spec.ts
+++ b/src/features/study/model/cardSelection.spec.ts
@@ -14,7 +14,7 @@ describe("filterCardsForDeck", () => {
     const content = createCard({ id: "c1", tags: [], ...card });
     return {
       card: content,
-      progress: { score: 0, numberOfSeen: 0, ...progress, cardId: content.id },
+      progress: { uid: content.uid, score: 0, numberOfSeen: 0, ...progress, cardId: content.id },
     };
   };
 

--- a/src/features/study/model/studyCard.ts
+++ b/src/features/study/model/studyCard.ts
@@ -1,7 +1,7 @@
 import type { Card } from "@/entities/card";
 import { createStudyProgressFromCard, type StudyProgress } from "@/entities/study-progress";
 
-type StudyCardContent = Omit<Card, keyof Omit<StudyProgress, "cardId">>;
+type StudyCardContent = Omit<Card, keyof Omit<StudyProgress, "cardId" | "uid">>;
 
 export interface StudyCard<TCard extends StudyCardContent = StudyCardContent> {
   card: TCard;
@@ -12,6 +12,7 @@ export const createStudyCard = <TCard extends Card>(card: TCard): StudyCard<TCar
   card,
   progress: createStudyProgressFromCard({
     id: card.id,
+    uid: card.uid,
     score: card.score,
     numberOfSeen: card.numberOfSeen,
     ...(card.lastSeenAt === undefined ? {} : { lastSeenAt: card.lastSeenAt }),

--- a/src/features/study/model/swipe.spec.ts
+++ b/src/features/study/model/swipe.spec.ts
@@ -25,12 +25,13 @@ describe("buildStudyPatch", () => {
   const now = new Date(1999, 10, 1).getTime();
   const card: StudyCard = {
     card: createCard({ id: "c1", deckId: "d1" }),
-    progress: { cardId: "c1", score: 0, numberOfSeen: 2 },
+    progress: { uid: "uid", cardId: "c1", score: 0, numberOfSeen: 2 },
   };
 
   it("builds a patch with incremented numberOfSeen and computed score", () => {
     const patch = buildStudyPatch(card, "GoToNextCardMastered", now);
     expect(patch).toEqual({
+      uid: "uid",
       cardId: "c1",
       score: 1,
       numberOfSeen: 3,


### PR DESCRIPTION
## Summary

- add the owning `uid` to the `StudyProgress` domain entity and preserve it when mapping from existing Card documents
- validate that the authenticated user matches the StudyProgress owner before edits
- keep ownership immutable in edit patches and exclude `uid` from Firestore updates
- add domain and API coverage for matching, mismatched, and empty owner identities

## Why

`editStudyProgressSchema` previously validated only that an authenticated UID was present because `StudyProgress` had no owner identity. This made the domain layer unable to enforce that users only edit their own progress.

## Impact

Study progress behavior and the existing Firestore card document format are unchanged. Existing card document `uid` values now supply the StudyProgress owner, while writes continue to update only mutable progress fields.

## Validation

- `npm run lint:fsd`
- `mise run check` (115 test files, 553 tests)

Closes #771