### PR TITLE
refactor: simplify preferences persistence (#794)

### DIFF
--- a/src/app/providers/preferences-persistence/preferencesPersistence.spec.ts
+++ b/src/app/providers/preferences-persistence/preferencesPersistence.spec.ts
@@ -5,7 +5,6 @@ import { defaultPreferences, preferencesStore } from "@/entities/preferences";
 import { startPreferencesPersistence } from "./preferencesPersistence";
 
 const PREFERENCES_STORAGE_KEY = "tango-config";
-const PREFERENCES_STORAGE_VERSION = 3;
 
 const createMemoryStorage = (initial: Record<string, string> = {}) => {
   const values = new Map(Object.entries(initial));
@@ -21,6 +20,27 @@ describe("preferences persistence", () => {
   });
 
   it("hydrates the store and persists subsequent changes", () => {
+    const persistedPreferences = {
+      ...defaultPreferences,
+      appearance: { ...defaultPreferences.appearance, darkMode: true },
+    };
+    const storage = createMemoryStorage({
+      [PREFERENCES_STORAGE_KEY]: JSON.stringify(persistedPreferences),
+    });
+    const stop = startPreferencesPersistence(storage);
+
+    expect(preferencesStore.getState().preferences.appearance.darkMode).toBe(true);
+
+    preferencesStore.getState().updatePreferences({ appearance: { showHeader: false } });
+    expect(JSON.parse(storage.getItem(PREFERENCES_STORAGE_KEY) ?? "{}")).toEqual({
+      ...defaultPreferences,
+      appearance: { ...defaultPreferences.appearance, darkMode: true, showHeader: false },
+    });
+
+    stop();
+  });
+
+  it("does not restore legacy persistence envelopes", () => {
     const storage = createMemoryStorage({
       [PREFERENCES_STORAGE_KEY]: JSON.stringify({
         state: {
@@ -29,62 +49,19 @@ describe("preferences persistence", () => {
             appearance: { ...defaultPreferences.appearance, darkMode: true },
           },
         },
-        version: PREFERENCES_STORAGE_VERSION,
+        version: 3,
       }),
     });
     const stop = startPreferencesPersistence(storage);
 
-    expect(preferencesStore.getState().preferences.appearance.darkMode).toBe(true);
-
-    preferencesStore.getState().updatePreferences({ appearance: { showHeader: false } });
-    expect(JSON.parse(storage.getItem(PREFERENCES_STORAGE_KEY) ?? "{}")).toEqual({
-      state: {
-        preferences: {
-          ...defaultPreferences,
-          appearance: { ...defaultPreferences.appearance, darkMode: true, showHeader: false },
-        },
-      },
-      version: PREFERENCES_STORAGE_VERSION,
-    });
+    expect(preferencesStore.getState().preferences).toEqual(defaultPreferences);
 
     stop();
   });
 
-  it("migrates the previous persisted config envelope and flat settings", () => {
-    const persisted = {
-      state: {
-        config: {
-          cardInterval: 15,
-          cardSwipeLeft: "GoBack",
-          darkMode: "yes",
-          selectedTags: ["typescript"],
-          showHeader: false,
-          showScoreSlider: true,
-          removedSetting: true,
-          githubAccessToken: "legacy-secret",
-        },
-      },
-      version: 2,
-    };
-
-    const storage = createMemoryStorage({ [PREFERENCES_STORAGE_KEY]: JSON.stringify(persisted) });
-    const stop = startPreferencesPersistence(storage);
-
-    expect(preferencesStore.getState().preferences).toEqual({
-      ...defaultPreferences,
-      appearance: { ...defaultPreferences.appearance, showHeader: false },
-      study: { ...defaultPreferences.study, cardInterval: 15, selectedTags: ["typescript"] },
-      controls: { ...defaultPreferences.controls, cardSwipeLeft: "GoBack", showScoreSlider: true },
-    });
-
-    stop();
-  });
-
-  it("uses current defaults for invalid persisted data", () => {
+  it("keeps current defaults for malformed persisted data", () => {
     preferencesStore.getState().updatePreferences({ appearance: { darkMode: true } });
-    const storage = createMemoryStorage({
-      [PREFERENCES_STORAGE_KEY]: JSON.stringify({ state: { config: "invalid" }, version: 1 }),
-    });
+    const storage = createMemoryStorage({ [PREFERENCES_STORAGE_KEY]: "invalid json" });
 
     const stop = startPreferencesPersistence(storage);
 

--- a/src/app/providers/preferences-persistence/preferencesPersistence.ts
+++ b/src/app/providers/preferences-persistence/preferencesPersistence.ts
@@ -1,44 +1,27 @@
-import { defaultPreferences, preferencesSchema, preferencesStore, type Preferences } from "@/entities/preferences";
+import { defaultPreferences, preferencesSchema, preferencesStore } from "@/entities/preferences";
 
 const PREFERENCES_STORAGE_KEY = "tango-config";
-const PREFERENCES_STORAGE_VERSION = 3;
 
-const getRecord = (value: unknown): Record<string, unknown> =>
-  typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-
-const unwrapPersistedPreferences = (input: unknown): unknown => {
-  const envelope = getRecord(input);
-  const state = getRecord(envelope.state);
-  return state.preferences ?? state.config ?? envelope.preferences ?? envelope.config ?? input;
+const parsePersistedPreferences = (value: string) => {
+  try {
+    return preferencesSchema.safeParse(JSON.parse(value));
+  } catch {
+    return undefined;
+  }
 };
-
-const parsePersistedPreferences = (input: unknown): Preferences => {
-  const rawPreferences = getRecord(unwrapPersistedPreferences(input));
-  const nested = ["appearance", "study", "controls"].some((section) => section in rawPreferences);
-
-  return preferencesSchema.parse(
-    nested ? rawPreferences : { appearance: rawPreferences, study: rawPreferences, controls: rawPreferences }
-  );
-};
-
-const serializePreferences = (preferences: Preferences): string =>
-  JSON.stringify({ state: { preferences }, version: PREFERENCES_STORAGE_VERSION });
 
 export const startPreferencesPersistence = (
   storage: Pick<Storage, "getItem" | "setItem"> = localStorage
 ): (() => void) => {
   const persistedValue = storage.getItem(PREFERENCES_STORAGE_KEY);
   if (persistedValue != null) {
-    try {
-      preferencesStore.getState().updatePreferences(parsePersistedPreferences(JSON.parse(persistedValue)));
-    } catch {
-      preferencesStore.getState().updatePreferences(defaultPreferences);
-    }
+    const result = parsePersistedPreferences(persistedValue);
+    preferencesStore.getState().updatePreferences(result?.success ? result.data : defaultPreferences);
   }
 
   return preferencesStore.subscribe((state, previousState) => {
     if (state.preferences !== previousState.preferences) {
-      storage.setItem(PREFERENCES_STORAGE_KEY, serializePreferences(state.preferences));
+      storage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(state.preferences));
     }
   });
 };


### PR DESCRIPTION
## Summary

- store the current `Preferences` object directly in localStorage
- validate persisted JSON with the current preferences schema before hydration
- remove legacy envelope, version, and flat-config compatibility logic
- keep defaults when persisted JSON is malformed or does not match the current shape
- update persistence tests for the simplified format

## Why

Preferences persistence had accumulated format-guessing and migration behavior for several historical storage shapes. Legacy compatibility is no longer required, so persistence can be limited to the current schema and remain owned by the app-level provider.

## Impact

Existing legacy persistence envelopes are intentionally ignored and users with those values will start from current defaults. Current-format preferences continue to hydrate and persist normally.

## Validation

- `mise run check`
- 108 unit test files passed (511 tests)
- format, TypeScript, ESLint, Biome, FSD, Knip, Dockerfile, and sample checks passed

Closes #794