### PR TITLE
[No issue] Add knip --fix --allow-remove-files to lint:fix

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -7,8 +7,8 @@ const config: KnipConfig = {
     "!src/**/*.{spec,test}.{ts,tsx}!",
     "!src/**/*.stories.{ts,tsx}!",
   ],
+  ignoreDependencies: ["@feature-sliced/steiger-plugin", "tailwindcss"],
   includeEntryExports: true,
-  treatConfigHintsAsErrors: true,
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:biome": "biome lint --error-on-warnings .",
     "lint:eslint": "eslint --max-warnings=0 'src/**/*.{ts,tsx}'",
     "lint:fsd": "steiger ./src",
-    "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && biome lint --write . && npm run fmt:markdown",
+    "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && biome lint --write . && knip --fix --allow-remove-files && npm run fmt:markdown",
     "lint:knip": "knip --strict",
     "lint:markdown": "markdownlint-cli2",
     "lint:tsc": "tsc",


### PR DESCRIPTION
Added `knip --fix --allow-remove-files` to the `lint:fix` npm script and updated `knip.ts` to ignore devDependencies used in top-level config files.