### PR TITLE
#799 Move anonymous auth bootstrap state into Auth state

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -67,7 +67,7 @@ describe("App", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
     expect(screen.queryByText("Deck list")).toBeNull();
 
-    mocks.authState = { status: "authenticating", attemptId: "attempt-a" };
+    mocks.authState = { status: "authenticating", attemptId: Symbol("attempt-a") };
     view.rerender(<App />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();

--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -67,7 +67,7 @@ describe("App", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
     expect(screen.queryByText("Deck list")).toBeNull();
 
-    mocks.authState = { status: "authenticating" };
+    mocks.authState = { status: "authenticating", attemptId: "attempt-a" };
     view.rerender(<App />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();

--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -1,7 +1,7 @@
 /**
  * @file Verifies the "App" contract with automated examples.
  * The examples make the expected behavior concrete with cases such as "updates only the theme when
- * the setting changes", "shows startup feedback for initializing and signed-out authentication",
+ * the setting changes", "shows startup feedback while authentication is in progress",
  * "shows startup errors and reloads on request".
  */
 
@@ -54,7 +54,7 @@ describe("App", () => {
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it("shows startup feedback for initializing and signed-out authentication", () => {
+  it("shows startup feedback while authentication is in progress", () => {
     mocks.authState = { status: "initializing" };
     const view = render(<App />);
 
@@ -62,6 +62,12 @@ describe("App", () => {
     expect(screen.queryByText("Deck list")).toBeNull();
 
     mocks.authState = { status: "signedOut" };
+    view.rerender(<App />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.queryByText("Deck list")).toBeNull();
+
+    mocks.authState = { status: "authenticating" };
     view.rerender(<App />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -25,7 +25,11 @@ const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
 
-  if (authState.status === "initializing" || authState.status === "signedOut") {
+  if (
+    authState.status === "initializing" ||
+    authState.status === "signedOut" ||
+    authState.status === "authenticating"
+  ) {
     return (
       <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
     );

--- a/src/app/providers/auth/authLifecycle.spec.ts
+++ b/src/app/providers/auth/authLifecycle.spec.ts
@@ -90,6 +90,7 @@ describe("authLifecycle", () => {
     expect(getAuthSession()).toEqual({ status: "signedOut" });
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledOnce());
+    expect(getAuthSession()).toEqual({ status: "authenticating" });
   });
 
   it("waits for Study cleanup before anonymous sign-in", async () => {
@@ -138,6 +139,39 @@ describe("authLifecycle", () => {
     publishUser(null);
 
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not restart anonymous sign-in for duplicate signed-out events", async () => {
+    const signInAnonymously = vi.fn(() => new Promise<UserCredential>(() => undefined));
+    const { getAuthSession, publishUser } = await createHarness(signInAnonymously);
+
+    publishUser(null);
+    await vi.waitFor(() => expect(getAuthSession()).toEqual({ status: "authenticating" }));
+    publishUser(null);
+    await Promise.resolve();
+
+    expect(signInAnonymously).toHaveBeenCalledOnce();
+    expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
+    expect(getAuthSession()).toEqual({ status: "authenticating" });
+  });
+
+  it("starts anonymous sign-in once when duplicate cleanups finish", async () => {
+    let finishCleanup: () => void = () => undefined;
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const signInAnonymously = vi.fn(() => new Promise<UserCredential>(() => undefined));
+    const { getAuthSession, publishUser } = await createHarness(signInAnonymously);
+    singletonMocks.clearStudyStore.mockReturnValue(cleanup);
+
+    publishUser(null);
+    publishUser(null);
+    expect(singletonMocks.clearStudyStore).toHaveBeenCalledTimes(2);
+
+    finishCleanup();
+    await vi.waitFor(() => expect(getAuthSession()).toEqual({ status: "authenticating" }));
+
+    expect(signInAnonymously).toHaveBeenCalledOnce();
   });
 
   it("publishes Study cleanup failures before anonymous bootstrap", async () => {

--- a/src/app/providers/auth/authLifecycle.spec.ts
+++ b/src/app/providers/auth/authLifecycle.spec.ts
@@ -90,7 +90,7 @@ describe("authLifecycle", () => {
     expect(getAuthSession()).toEqual({ status: "signedOut" });
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledOnce());
-    expect(getAuthSession()).toEqual({ status: "authenticating" });
+    expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
   });
 
   it("waits for Study cleanup before anonymous sign-in", async () => {
@@ -146,13 +146,15 @@ describe("authLifecycle", () => {
     const { getAuthSession, publishUser } = await createHarness(signInAnonymously);
 
     publishUser(null);
-    await vi.waitFor(() => expect(getAuthSession()).toEqual({ status: "authenticating" }));
+    await vi.waitFor(() =>
+      expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) })
+    );
     publishUser(null);
     await Promise.resolve();
 
     expect(signInAnonymously).toHaveBeenCalledOnce();
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
-    expect(getAuthSession()).toEqual({ status: "authenticating" });
+    expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
   });
 
   it("starts anonymous sign-in once when duplicate cleanups finish", async () => {
@@ -169,7 +171,9 @@ describe("authLifecycle", () => {
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledTimes(2);
 
     finishCleanup();
-    await vi.waitFor(() => expect(getAuthSession()).toEqual({ status: "authenticating" }));
+    await vi.waitFor(() =>
+      expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) })
+    );
 
     expect(signInAnonymously).toHaveBeenCalledOnce();
   });
@@ -210,5 +214,35 @@ describe("authLifecycle", () => {
     await signInAttempt.catch(() => undefined);
 
     expect(getAuthSession()).toMatchObject({ status: "authenticated", uid: "uid-a" });
+  });
+
+  it("ignores a stale failure after a later anonymous attempt starts", async () => {
+    let rejectFirstSignIn: (error: unknown) => void = () => undefined;
+    const firstSignIn = new Promise<UserCredential>((_resolve, reject) => {
+      rejectFirstSignIn = reject;
+    });
+    const secondSignIn = new Promise<UserCredential>(() => undefined);
+    const signInAnonymously = vi
+      .fn()
+      .mockImplementationOnce(() => firstSignIn)
+      .mockImplementationOnce(() => secondSignIn);
+    const { getAuthSession, publishUser } = await createHarness(signInAnonymously);
+
+    publishUser(null);
+    await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledOnce());
+    const firstAttempt = getAuthSession();
+    expect(firstAttempt).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
+
+    publishUser(createUser("uid-a"));
+    publishUser(null);
+    await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledTimes(2));
+    const secondAttempt = getAuthSession();
+    expect(secondAttempt).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
+    expect(secondAttempt).not.toEqual(firstAttempt);
+
+    rejectFirstSignIn(new Error("late failure"));
+    await firstSignIn.catch(() => undefined);
+
+    expect(getAuthSession()).toEqual(secondAttempt);
   });
 });

--- a/src/app/providers/auth/authLifecycle.spec.ts
+++ b/src/app/providers/auth/authLifecycle.spec.ts
@@ -90,7 +90,7 @@ describe("authLifecycle", () => {
     expect(getAuthSession()).toEqual({ status: "signedOut" });
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledOnce());
-    expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
+    expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) });
   });
 
   it("waits for Study cleanup before anonymous sign-in", async () => {
@@ -147,14 +147,14 @@ describe("authLifecycle", () => {
 
     publishUser(null);
     await vi.waitFor(() =>
-      expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) })
+      expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) })
     );
     publishUser(null);
     await Promise.resolve();
 
     expect(signInAnonymously).toHaveBeenCalledOnce();
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
-    expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
+    expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) });
   });
 
   it("starts anonymous sign-in once when duplicate cleanups finish", async () => {
@@ -172,7 +172,7 @@ describe("authLifecycle", () => {
 
     finishCleanup();
     await vi.waitFor(() =>
-      expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(String) })
+      expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) })
     );
 
     expect(signInAnonymously).toHaveBeenCalledOnce();
@@ -231,13 +231,13 @@ describe("authLifecycle", () => {
     publishUser(null);
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledOnce());
     const firstAttempt = getAuthSession();
-    expect(firstAttempt).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
+    expect(firstAttempt).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) });
 
     publishUser(createUser("uid-a"));
     publishUser(null);
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledTimes(2));
     const secondAttempt = getAuthSession();
-    expect(secondAttempt).toMatchObject({ status: "authenticating", attemptId: expect.any(String) });
+    expect(secondAttempt).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) });
     expect(secondAttempt).not.toEqual(firstAttempt);
 
     rejectFirstSignIn(new Error("late failure"));

--- a/src/app/providers/auth/authLifecycle.ts
+++ b/src/app/providers/auth/authLifecycle.ts
@@ -14,9 +14,13 @@ const authSessionFromUser = (user: User) => ({
 const startAnonymousBootstrap = () => {
   if (getAuthSession().status !== "signedOut") return;
 
-  replaceAuthSession({ status: "authenticating" });
+  const attemptId = crypto.randomUUID();
+  replaceAuthSession({ status: "authenticating", attemptId });
   void signInAnonymously(auth).catch((error) => {
-    if (getAuthSession().status === "authenticating") replaceAuthSession({ status: "error", error });
+    const currentSession = getAuthSession();
+    if (currentSession.status === "authenticating" && currentSession.attemptId === attemptId) {
+      replaceAuthSession({ status: "error", error });
+    }
   });
 };
 

--- a/src/app/providers/auth/authLifecycle.ts
+++ b/src/app/providers/auth/authLifecycle.ts
@@ -1,10 +1,8 @@
-import { onIdTokenChanged, signInAnonymously, type User, type UserCredential } from "firebase/auth";
+import { onIdTokenChanged, signInAnonymously, type User } from "firebase/auth";
 
 import { getAuthSession, replaceAuthSession } from "@/entities/auth";
 import { clearStudyStore } from "@/features/study";
 import { auth } from "@/shared/firebase";
-
-let anonymousSignIn: Promise<UserCredential> | undefined;
 
 const authSessionFromUser = (user: User) => ({
   status: "authenticated" as const,
@@ -14,25 +12,22 @@ const authSessionFromUser = (user: User) => ({
 });
 
 const startAnonymousBootstrap = () => {
-  if (anonymousSignIn || getAuthSession().status !== "signedOut") return;
+  if (getAuthSession().status !== "signedOut") return;
 
-  const pendingSignIn = signInAnonymously(auth);
-  anonymousSignIn = pendingSignIn;
-  void pendingSignIn.catch((error) => {
-    if (anonymousSignIn !== pendingSignIn) return;
-
-    anonymousSignIn = undefined;
-    if (getAuthSession().status === "signedOut") replaceAuthSession({ status: "error", error });
+  replaceAuthSession({ status: "authenticating" });
+  void signInAnonymously(auth).catch((error) => {
+    if (getAuthSession().status === "authenticating") replaceAuthSession({ status: "error", error });
   });
 };
 
 export const startAuthSession = () =>
   onIdTokenChanged(auth, (user) => {
     if (user) {
-      anonymousSignIn = undefined;
       replaceAuthSession(authSessionFromUser(user));
       return;
     }
+
+    if (getAuthSession().status === "authenticating") return;
 
     replaceAuthSession({ status: "signedOut" });
     void clearStudyStore()

--- a/src/app/providers/auth/authLifecycle.ts
+++ b/src/app/providers/auth/authLifecycle.ts
@@ -14,7 +14,7 @@ const authSessionFromUser = (user: User) => ({
 const startAnonymousBootstrap = () => {
   if (getAuthSession().status !== "signedOut") return;
 
-  const attemptId = crypto.randomUUID();
+  const attemptId = Symbol("anonymous-auth-attempt");
   replaceAuthSession({ status: "authenticating", attemptId });
   void signInAnonymously(auth).catch((error) => {
     const currentSession = getAuthSession();

--- a/src/entities/auth/model/store.spec.ts
+++ b/src/entities/auth/model/store.spec.ts
@@ -27,8 +27,8 @@ describe("authSessionStore", () => {
   });
 
   it("represents anonymous authentication without an SDK credential", () => {
-    replaceAuthSession({ status: "authenticating" });
+    replaceAuthSession({ status: "authenticating", attemptId: "attempt-a" });
 
-    expect(getAuthSession()).toEqual({ status: "authenticating" });
+    expect(getAuthSession()).toEqual({ status: "authenticating", attemptId: "attempt-a" });
   });
 });

--- a/src/entities/auth/model/store.spec.ts
+++ b/src/entities/auth/model/store.spec.ts
@@ -27,8 +27,9 @@ describe("authSessionStore", () => {
   });
 
   it("represents anonymous authentication without an SDK credential", () => {
-    replaceAuthSession({ status: "authenticating", attemptId: "attempt-a" });
+    const attemptId = Symbol("attempt-a");
+    replaceAuthSession({ status: "authenticating", attemptId });
 
-    expect(getAuthSession()).toEqual({ status: "authenticating", attemptId: "attempt-a" });
+    expect(getAuthSession()).toEqual({ status: "authenticating", attemptId });
   });
 });

--- a/src/entities/auth/model/store.spec.ts
+++ b/src/entities/auth/model/store.spec.ts
@@ -25,4 +25,10 @@ describe("authSessionStore", () => {
       displayName: null,
     });
   });
+
+  it("represents anonymous authentication without an SDK credential", () => {
+    replaceAuthSession({ status: "authenticating" });
+
+    expect(getAuthSession()).toEqual({ status: "authenticating" });
+  });
 });

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -8,7 +8,7 @@ type AuthenticatedSession = {
 
 export type AuthSessionState =
   | { status: "initializing" }
-  | { status: "authenticating"; attemptId: string }
+  | { status: "authenticating"; attemptId: symbol }
   | ({ status: "authenticated" } & AuthenticatedSession)
   | { status: "signedOut" }
   | { status: "error"; error: unknown };

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -8,6 +8,7 @@ type AuthenticatedSession = {
 
 export type AuthSessionState =
   | { status: "initializing" }
+  | { status: "authenticating" }
   | ({ status: "authenticated" } & AuthenticatedSession)
   | { status: "signedOut" }
   | { status: "error"; error: unknown };

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -8,7 +8,7 @@ type AuthenticatedSession = {
 
 export type AuthSessionState =
   | { status: "initializing" }
-  | { status: "authenticating" }
+  | { status: "authenticating"; attemptId: string }
   | ({ status: "authenticated" } & AuthenticatedSession)
   | { status: "signedOut" }
   | { status: "error"; error: unknown };


### PR DESCRIPTION
## Summary

- add an explicit `authenticating` state with an attempt token for anonymous bootstrap progress
- replace the module-global sign-in Promise guard with Zustand state transitions
- keep duplicate and stale Firebase events from restarting bootstrap or overwriting a later authentication attempt
- render startup feedback while anonymous authentication is in progress

## Why

The authentication lifecycle was split between the Auth entity store and a module-global Promise in `authLifecycle.ts`. Keeping the in-flight state and attempt identity in `AuthSessionState` makes the store the single source of truth without exposing Firebase SDK types.

## User impact

Startup behavior remains the same, while duplicate anonymous sign-ins and stale failures are guarded by explicit Auth state transitions.

## Validation

- `mise run check`
- `mise run e2e` (21 tests)
- focused auth lifecycle, Auth store, and App tests (21 tests)

Closes #799