### PR TITLE
#802 Refactor study state updates with Immer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^12.17.0",
         "github-markdown-css": "^5.9.0",
         "highlight.js": "^11.11.1",
+        "immer": "^11.1.16",
         "katex": "^0.16.47",
         "lodash": "^4.18.1",
         "papaparse": "^5.5.4",
@@ -14671,10 +14672,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "devOptional": true,
+      "version": "11.1.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
+      "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -22191,6 +22191,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/steiger/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/steiger/node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "firebase": "^12.17.0",
     "github-markdown-css": "^5.9.0",
     "highlight.js": "^11.11.1",
+    "immer": "^11.1.16",
     "katex": "^0.16.47",
     "lodash": "^4.18.1",
     "papaparse": "^5.5.4",

--- a/src/features/study/state/studyStore.ts
+++ b/src/features/study/state/studyStore.ts
@@ -9,6 +9,7 @@ import type { DeckId } from "@/entities/deck";
 import type { SwipeDirection } from "@/entities/preferences";
 
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
 const STUDY_STORAGE_KEY = "tango-study";
@@ -126,34 +127,26 @@ const migratePersistedStudyState = (persistedState: unknown, version: number): P
 export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOptions = {}) => {
   const persistStorage = createJSONStorage<PersistedStudyState>(() => storage ?? localStorage);
   return createStore<StudyState>()(
-    persist<StudyState, [], [], PersistedStudyState>(
-      (set) => ({
+    persist(
+      immer<StudyState>((set) => ({
         sessionsByDeckId: {},
         showBackText: false,
         autoPlay: false,
         lastSwipe: undefined,
         startStudy: (deckId, cardOrderIds) =>
-          set((state) => ({
-            sessionsByDeckId: {
-              ...state.sessionsByDeckId,
-              [deckId]: {
-                deckId,
-                cardOrderIds: [...cardOrderIds],
-                currentIndex: 0,
-                lastStudiedAt: Date.now(),
-              },
-            },
-          })),
+          set((state) => {
+            state.sessionsByDeckId[deckId] = {
+              deckId,
+              cardOrderIds: [...cardOrderIds],
+              currentIndex: 0,
+              lastStudiedAt: Date.now(),
+            };
+          }),
         touchStudy: (deckId) =>
           set((state) => {
             const session = state.sessionsByDeckId[deckId];
-            if (session == null) return state;
-            return {
-              sessionsByDeckId: {
-                ...state.sessionsByDeckId,
-                [deckId]: { ...session, lastStudiedAt: Date.now() },
-              },
-            };
+            if (session == null) return;
+            session.lastStudiedAt = Date.now();
           }),
         setCurrentIndex: (deckId, currentIndex) =>
           set((state) => {
@@ -164,19 +157,14 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
               currentIndex < 0 ||
               currentIndex >= session.cardOrderIds.length
             ) {
-              return state;
+              return;
             }
-            return {
-              sessionsByDeckId: {
-                ...state.sessionsByDeckId,
-                [deckId]: { ...session, currentIndex, lastStudiedAt: Date.now() },
-              },
-            };
+            session.currentIndex = currentIndex;
+            session.lastStudiedAt = Date.now();
           }),
         removeStudy: (deckId) =>
           set((state) => {
-            const { [deckId]: _removed, ...sessionsByDeckId } = state.sessionsByDeckId;
-            return { sessionsByDeckId };
+            delete state.sessionsByDeckId[deckId];
           }),
         initializeStudyUi: (defaultAutoPlay) =>
           set({
@@ -195,7 +183,7 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
           })),
         clearLastSwipe: () => set({ lastSwipe: undefined }),
         hideBackText: () => set({ showBackText: false }),
-      }),
+      })),
       {
         name: STUDY_STORAGE_KEY,
         version: 3,


### PR DESCRIPTION
## Summary

- add `immer` as a direct application dependency
- apply Zustand's Immer middleware to `studyStore`
- simplify `startStudy`, `touchStudy`, `setCurrentIndex`, and `removeStudy` with draft mutations

## Why

Nested immutable updates in `sessionsByDeckId` required repeated object spreads, which obscured the state transitions themselves. Immer keeps immutable behavior while making those transitions direct and easier to read. Validation, persistence, and migration behavior remain unchanged.

## Impact

Study session behavior is unchanged. The store implementation is smaller and future nested updates are easier to maintain.

## Validation

- `mise run check`
- 106 unit test files passed (513 tests)
- lint, formatting, TypeScript, FSD, Knip, Markdown, Dockerfile, and sample checks passed

Closes #802