### PR TITLE
entities の model ファイル責務を明確化

### DIFF
--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -2,15 +2,43 @@
 
 - Treat `src/entities` as the FSD Entities layer and each `src/entities/<entity>` directory as an Entity slice.
 - Keep Entity domain code in `model/` and expose the slice through `index.ts`.
-- `model/` implementation files are limited to the following roles:
-  - `schema.ts`: Zod schemas, validation, refinements, and schema-level defaults.
-  - `types.ts`: shared Entity types and interfaces; prefer deriving types from Zod schemas.
-  - `defaults.ts`: Entity default values, initial values, and pure default factories.
-  - `rules.ts`: pure domain rules, calculations, relationships, selections, and transformations.
-  - `store.ts`: global Entity store and synchronous state mutations.
-  - `hooks.ts`: thin React hooks for reading or selecting Entity state.
+
+## `schema.ts`
+
+- Define Zod schemas, validation, refinements, and schema-level defaults.
+- Keep schema definitions pure.
+
+## `types.ts`
+
+- Define shared Entity types and interfaces.
+- Prefer deriving types from Zod schemas.
+
+## `defaults.ts`
+
+- Define Entity default values, initial values, and pure default factories.
+- Keep defaults independent from stores and external systems.
+
+## `rules.ts`
+
+- Define pure domain rules, calculations, relationships, selections, and transformations.
+- Do not access stores, React, browser APIs, or external systems.
+
+## `store.ts`
+
+- Define the global Entity store and synchronous state mutations.
+- Do not perform external access, subscriptions, or asynchronous workflows.
+
+## `hooks.ts`
+
+- Define thin React hooks for reading or selecting Entity state.
+- Do not place business logic or external access here.
+
+## `index.ts`
+
+- Define the slice Public API using re-exports only.
+
+## Restrictions
+
 - Colocate tests as `*.spec.ts` or `*.spec.tsx` next to the file they cover.
 - Do not create additional implementation files such as `category.ts`, `relations.ts`, `logic.ts`, `utils.ts`, `helpers.ts`, or `constants.ts`; place the code in the appropriate role above.
-- Keep domain models, schemas, defaults, rules, and selectors pure. Global Entity stores and thin selector hooks are allowed as explicit exceptions.
 - Do not place UI, use cases, external access, subscriptions, or asynchronous workflows in `entities`.
-- `index.ts` is the slice Public API and should contain re-exports only.

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -40,5 +40,5 @@
 ## Restrictions
 
 - Colocate tests as `*.spec.ts` or `*.spec.tsx` next to the file they cover.
-- Do not create additional implementation files such as `category.ts`, `relations.ts`, `logic.ts`, `utils.ts`, `helpers.ts`, or `constants.ts`; place the code in the appropriate role above.
+- Do not create implementation files outside the roles defined above.
 - Do not place UI, use cases, external access, subscriptions, or asynchronous workflows in `entities`.

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -1,6 +1,16 @@
 # Entities Instructions
 
-- Treat `src/entities` as the domain layer.
-- Keep domain models, schemas, business rules, and domain logic pure.
-- Global Entity stores and thin selector hooks are allowed as an exception.
-- Do not place any other responsibilities in `entities`, including UI, use cases, external access, subscriptions, or asynchronous workflows.
+- Treat `src/entities` as the FSD Entities layer and each `src/entities/<entity>` directory as an Entity slice.
+- Keep Entity domain code in `model/` and expose the slice through `index.ts`.
+- `model/` implementation files are limited to the following roles:
+  - `schema.ts`: Zod schemas, validation, refinements, and schema-level defaults.
+  - `types.ts`: shared Entity types and interfaces; prefer deriving types from Zod schemas.
+  - `defaults.ts`: Entity default values, initial values, and pure default factories.
+  - `rules.ts`: pure domain rules, calculations, relationships, selections, and transformations.
+  - `store.ts`: global Entity store and synchronous state mutations.
+  - `hooks.ts`: thin React hooks for reading or selecting Entity state.
+- Colocate tests as `*.spec.ts` or `*.spec.tsx` next to the file they cover.
+- Do not create additional implementation files such as `category.ts`, `relations.ts`, `logic.ts`, `utils.ts`, `helpers.ts`, or `constants.ts`; place the code in the appropriate role above.
+- Keep domain models, schemas, defaults, rules, and selectors pure. Global Entity stores and thin selector hooks are allowed as explicit exceptions.
+- Do not place UI, use cases, external access, subscriptions, or asynchronous workflows in `entities`.
+- `index.ts` is the slice Public API and should contain re-exports only.

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -3,32 +3,32 @@
 - Treat `src/entities` as the FSD Entities layer and each `src/entities/<entity>` directory as an Entity slice.
 - Keep Entity domain code in `model/` and expose the slice through `index.ts`.
 
-## `schema.ts`
+## `model/schema.ts`
 
 - Define Zod schemas, validation, refinements, and schema-level defaults.
 - Keep schema definitions pure.
 
-## `types.ts`
+## `model/types.ts`
 
 - Define shared Entity types and interfaces.
 - Prefer deriving types from Zod schemas.
 
-## `defaults.ts`
+## `model/defaults.ts`
 
 - Define Entity default values, initial values, and pure default factories.
 - Keep defaults independent from stores and external systems.
 
-## `rules.ts`
+## `model/rules.ts`
 
 - Define pure domain rules, calculations, relationships, selections, and transformations.
 - Do not access stores, React, browser APIs, or external systems.
 
-## `store.ts`
+## `model/store.ts`
 
 - Define the global Entity store and synchronous state mutations.
 - Do not perform external access, subscriptions, or asynchronous workflows.
 
-## `hooks.ts`
+## `model/hooks.ts`
 
 - Define thin React hooks for reading or selecting Entity state.
 - Do not place business logic or external access here.


### PR DESCRIPTION
## 概要

`src/entities/AGENTS.md` に、FSDの Entities layer / Entity slice を前提とした `model/` 内の標準ファイルと責務を明記します。

## 変更内容

`model/` の実装ファイルを以下の6役割に限定します。

- `schema.ts`: Zod schema / validation / schema-level defaults
- `types.ts`: Entityの共有 type / interface
- `defaults.ts`: Entityのdefault値・初期値・pure factory
- `rules.ts`: pureなdomain rules / calculations / relationships / selections / transformations
- `store.ts`: global Entity store / synchronous mutations
- `hooks.ts`: storeを読むthin React hooks

あわせて、`category.ts`、`relations.ts`、`logic.ts`、`utils.ts` など役割外の実装ファイルを新設せず、上記いずれかへ配置する方針を明記します。

`index.ts` はsliceのPublic APIとしてre-exportのみに限定します。

## 目的

Entityごと・概念ごとに任意のファイル名が増えることを防ぎ、`entities` 配下でコードの配置先と責務を一意に判断しやすくします。

## 確認

ドキュメントのみの変更のため、テストは実行していません。