### PR TITLE
#802 Simplify preference updates with Immer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^12.17.0",
         "github-markdown-css": "^5.9.0",
         "highlight.js": "^11.11.1",
+        "immer": "^10.2.0",
         "katex": "^0.16.47",
         "lodash": "^4.18.1",
         "papaparse": "^5.5.4",
@@ -14674,7 +14675,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "firebase": "^12.17.0",
     "github-markdown-css": "^5.9.0",
     "highlight.js": "^11.11.1",
+    "immer": "^10.2.0",
     "katex": "^0.16.47",
     "lodash": "^4.18.1",
     "papaparse": "^5.5.4",

--- a/src/entities/preferences/model/store.ts
+++ b/src/entities/preferences/model/store.ts
@@ -25,11 +25,12 @@ const createPreferencesStore = () =>
         preferences: defaultPreferences,
         updatePreferences: (preferencesInput) =>
           set((state) => {
+            const { selectedTags, ...study } = preferencesInput.study ?? {};
             Object.assign(state.preferences.appearance, preferencesInput.appearance);
-            Object.assign(state.preferences.study, preferencesInput.study);
+            Object.assign(state.preferences.study, study);
             Object.assign(state.preferences.controls, preferencesInput.controls);
-            if (preferencesInput.study?.selectedTags != null) {
-              state.preferences.study.selectedTags = [...preferencesInput.study.selectedTags];
+            if (selectedTags != null) {
+              state.preferences.study.selectedTags = [...selectedTags];
             }
             state.preferences = preferencesSchema.parse(state.preferences);
           }),

--- a/src/entities/preferences/model/store.ts
+++ b/src/entities/preferences/model/store.ts
@@ -1,4 +1,5 @@
 import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
 import { defaultPreferences, type Preferences } from "./preferences";
@@ -19,26 +20,20 @@ interface PersistedPreferencesState {
 
 const createPreferencesStore = () =>
   createStore<PreferencesStoreState>()(
-    persist<PreferencesStoreState, [], [], PersistedPreferencesState>(
-      (set) => ({
+    persist<PreferencesStoreState, [], [["zustand/immer", never]], PersistedPreferencesState>(
+      immer((set) => ({
         preferences: defaultPreferences,
         updatePreferences: (preferencesInput) =>
           set((state) => {
-            const merged = {
-              appearance: { ...state.preferences.appearance, ...preferencesInput.appearance },
-              study: {
-                ...state.preferences.study,
-                ...preferencesInput.study,
-                selectedTags:
-                  preferencesInput.study?.selectedTags == null
-                    ? state.preferences.study.selectedTags
-                    : [...preferencesInput.study.selectedTags],
-              },
-              controls: { ...state.preferences.controls, ...preferencesInput.controls },
-            };
-            return { preferences: preferencesSchema.parse(merged) };
+            Object.assign(state.preferences.appearance, preferencesInput.appearance);
+            Object.assign(state.preferences.study, preferencesInput.study);
+            Object.assign(state.preferences.controls, preferencesInput.controls);
+            if (preferencesInput.study?.selectedTags != null) {
+              state.preferences.study.selectedTags = [...preferencesInput.study.selectedTags];
+            }
+            state.preferences = preferencesSchema.parse(state.preferences);
           }),
-      }),
+      })),
       {
         name: "tango-config",
         merge: (persistedState, currentState) => {


### PR DESCRIPTION
## Summary

- add Immer as a direct dependency
- apply Zustand's Immer middleware only to `preferencesStore`
- replace nested immutable-update spreads with draft mutations while preserving `selectedTags` isolation

## Why

`updatePreferences` rebuilt every nested preference group with repeated spreads. This made a focused partial update harder to read and maintain. Immer keeps the update local to the affected draft while the existing schema validation and persisted state shape remain unchanged.

## Impact

Preference updates are simpler internally. Validation, persistence, hydration, public helpers, and the stored `tango-config` format retain their existing behavior.

## Validation

- `mise run check`
- 106 unit-test files passed (513 tests)

Closes #802