### PR TITLE
Rename signedOut auth state to unauthenticated

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -61,7 +61,7 @@ describe("App", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
     expect(screen.queryByText("Deck list")).toBeNull();
 
-    mocks.authState = { status: "signedOut" };
+    mocks.authState = { status: "unauthenticated" };
     view.rerender(<App />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location
 
   if (
     authState.status === "initializing" ||
-    authState.status === "signedOut" ||
+    authState.status === "unauthenticated" ||
     authState.status === "authenticating"
   ) {
     return (

--- a/src/app/providers/auth/authLifecycle.spec.ts
+++ b/src/app/providers/auth/authLifecycle.spec.ts
@@ -87,7 +87,7 @@ describe("authLifecycle", () => {
 
     publishUser(null);
 
-    expect(getAuthSession()).toEqual({ status: "signedOut" });
+    expect(getAuthSession()).toEqual({ status: "unauthenticated" });
     expect(singletonMocks.clearStudyStore).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledOnce());
     expect(getAuthSession()).toMatchObject({ status: "authenticating", attemptId: expect.any(Symbol) });
@@ -142,7 +142,7 @@ describe("authLifecycle", () => {
     await vi.waitFor(() => expect(signInAnonymously).toHaveBeenCalledTimes(2));
   });
 
-  it("does not restart anonymous sign-in for duplicate signed-out events", async () => {
+  it("does not restart anonymous sign-in for duplicate unauthenticated events", async () => {
     const signInAnonymously = vi.fn(() => new Promise<UserCredential>(() => undefined));
     const { getAuthSession, publishUser } = await createHarness(signInAnonymously);
 

--- a/src/app/providers/auth/authLifecycle.ts
+++ b/src/app/providers/auth/authLifecycle.ts
@@ -12,7 +12,7 @@ const authSessionFromUser = (user: User) => ({
 });
 
 const startAnonymousBootstrap = () => {
-  if (getAuthSession().status !== "signedOut") return;
+  if (getAuthSession().status !== "unauthenticated") return;
 
   const attemptId = Symbol("anonymous-auth-attempt");
   replaceAuthSession({ status: "authenticating", attemptId });
@@ -33,10 +33,10 @@ export const startAuthSession = () =>
 
     if (getAuthSession().status === "authenticating") return;
 
-    replaceAuthSession({ status: "signedOut" });
+    replaceAuthSession({ status: "unauthenticated" });
     void clearStudyStore()
       .then(startAnonymousBootstrap)
       .catch((error) => {
-        if (getAuthSession().status === "signedOut") replaceAuthSession({ status: "error", error });
+        if (getAuthSession().status === "unauthenticated") replaceAuthSession({ status: "error", error });
       });
   });

--- a/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
@@ -30,7 +30,9 @@ import { replaceAuthSession } from "@/entities/auth";
 const createHarness = (children?: ReactNode) => {
   const publishUser = (uid: string | null) =>
     replaceAuthSession(
-      uid == null ? { status: "signedOut" } : { status: "authenticated", uid, isAnonymous: true, displayName: null }
+      uid == null
+        ? { status: "unauthenticated" }
+        : { status: "authenticated", uid, isAnonymous: true, displayName: null }
     );
   render(
     <React.StrictMode>

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -6,11 +6,46 @@ type AuthenticatedSession = {
   displayName: string | null;
 };
 
+/**
+ * Authentication lifecycle exposed to the rest of the application.
+ *
+ * A typical anonymous startup follows:
+ * `initializing` -> `unauthenticated` -> `authenticating` -> `authenticated`.
+ *
+ * `authenticated` represents any Firebase user. Use `isAnonymous` to distinguish
+ * an anonymous user from a linked account.
+ */
 export type AuthSessionState =
+  /** Waiting for Firebase to publish the initial authentication snapshot. */
   | { status: "initializing" }
+  /**
+   * Firebase currently has no user.
+   *
+   * This is a transient state in Tango. Study state is cleared before anonymous
+   * authentication starts, after which the session moves to `authenticating`.
+   */
+  | { status: "unauthenticated" }
+  /**
+   * Anonymous authentication has started and Tango is waiting for Firebase to
+   * publish the resulting user.
+   *
+   * `attemptId` identifies the in-flight attempt so that a late failure from an
+   * older attempt cannot overwrite a newer authentication attempt.
+   */
   | { status: "authenticating"; attemptId: symbol }
+  /**
+   * Firebase has an active user.
+   *
+   * Both anonymous and linked users use this state. `isAnonymous` indicates
+   * which kind of authenticated user is active.
+   */
   | ({ status: "authenticated" } & AuthenticatedSession)
-  | { status: "signedOut" }
+  /**
+   * Authentication startup failed.
+   *
+   * This currently covers failures while clearing Study state before anonymous
+   * bootstrap or while starting anonymous authentication.
+   */
   | { status: "error"; error: unknown };
 
 const initialAuthSession: AuthSessionState = { status: "initializing" };

--- a/src/features/card/delete/model/useDeleteCard.spec.tsx
+++ b/src/features/card/delete/model/useDeleteCard.spec.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({ uid: "uid-a", deleteCard: vi.fn() }));
 vi.mock("@/entities/auth", () => ({
   useAuthSession: () =>
     mocks.uid === ""
-      ? { status: "signedOut" }
+      ? { status: "unauthenticated" }
       : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
 }));
 vi.mock("../api/deleteCard", () => ({ deleteCard: mocks.deleteCard }));

--- a/src/features/card/edit/model/useEditCard.spec.tsx
+++ b/src/features/card/edit/model/useEditCard.spec.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({ uid: "uid-a", editCard: vi.fn() }));
 vi.mock("@/entities/auth", () => ({
   useAuthSession: () =>
     mocks.uid === ""
-      ? { status: "signedOut" }
+      ? { status: "unauthenticated" }
       : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
 }));
 vi.mock("../api/editCard", () => ({ editCard: mocks.editCard }));

--- a/src/features/card/read/hooks/useCardReadState.spec.tsx
+++ b/src/features/card/read/hooks/useCardReadState.spec.tsx
@@ -30,7 +30,7 @@ import { useCardReadState } from "../index";
 const authenticatedWrapper = ({ children }: PropsWithChildren) => (
   <RemoteReadScopeProvider uid="uid-a">{children}</RemoteReadScopeProvider>
 );
-const signedOutWrapper = ({ children }: PropsWithChildren) => (
+const unauthenticatedWrapper = ({ children }: PropsWithChildren) => (
   <RemoteReadScopeProvider uid={null}>{children}</RemoteReadScopeProvider>
 );
 
@@ -72,10 +72,10 @@ describe("Card remote hooks", () => {
     expect(result.current.syncStatus).toBeUndefined();
   });
 
-  it("reports idle immediately when the App scope is signed out", () => {
+  it("reports idle immediately when the App scope is unauthenticated", () => {
     mocks.state = { uid: "uid-a", status: "ready", syncStatus: "synced", itemsById: {} };
 
-    const { result } = renderHook(useCardReadState, { wrapper: signedOutWrapper });
+    const { result } = renderHook(useCardReadState, { wrapper: unauthenticatedWrapper });
 
     expect(result.current.status).toBe("idle");
   });


### PR DESCRIPTION
## Summary

- rename the Auth session state `signedOut` to `unauthenticated`
- update the application auth lifecycle and startup rendering to use the new state name
- update affected tests and test helpers
- document every `AuthSessionState` variant and the typical anonymous-auth transition in `store.ts`

## Why

`signedOut` sounds like a stable state reached after an explicit sign-out action, but in Tango the state means that Firebase currently has no user. It is transient: Tango clears Study state and immediately starts anonymous authentication.

`unauthenticated` describes that condition more accurately. Anonymous Firebase users remain `authenticated` with `isAnonymous: true`.

## Behavior

The intended flow is unchanged:

`initializing` -> `unauthenticated` -> `authenticating` -> `authenticated`

This is a naming/documentation change only; authentication behavior is not intentionally changed.
