### PR TITLE
fix(#805): Prevent stale Card rendering after logout

### DIFF
--- a/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
@@ -15,7 +15,16 @@ vi.mock("@/features/card/read", () => ({
   startCardReads: mocks.startCards,
   stopCardReads: mocks.stopCards,
 }));
-vi.mock("@/entities/card", () => ({ clearCards: mocks.clearCards }));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...actual,
+    clearCards: () => {
+      mocks.clearCards();
+      actual.clearCards();
+    },
+  };
+});
 vi.mock("@/entities/deck", () => ({ clearDecks: mocks.clearDecks }));
 vi.mock("./deck", () => ({
   subscribeDecks: vi.fn((uid: string, onReady: () => void) => {
@@ -26,6 +35,19 @@ vi.mock("./deck", () => ({
 
 import { RemoteReadProvider } from "@/app/providers/remote-read";
 import { replaceAuthSession } from "@/entities/auth";
+import { replaceCards, useCards } from "@/entities/card";
+import { createCard } from "@/test/factories";
+
+const CardConsumer = () => {
+  const cards = useCards();
+  return (
+    <>
+      {cards.map((card) => (
+        <div key={card.id}>{card.frontText}</div>
+      ))}
+    </>
+  );
+};
 
 const createHarness = (children?: ReactNode) => {
   const publishUser = (uid: string | null) =>
@@ -43,6 +65,7 @@ const createHarness = (children?: ReactNode) => {
 describe("RemoteReadProvider integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    replaceCards([]);
     replaceAuthSession({ status: "initializing" });
     Object.keys(mocks.deckReadyByUid).forEach((uid) => {
       delete mocks.deckReadyByUid[uid];
@@ -97,5 +120,20 @@ describe("RemoteReadProvider integration", () => {
 
     await waitFor(() => expect(mocks.stopCards).toHaveBeenCalledWith("uid-a"));
     expect(mocks.clearCards).toHaveBeenCalled();
+  });
+
+  it("hides the previous user's Card while logout clears the read scope", async () => {
+    const card = createCard({ id: "card-a", uid: "uid-a", frontText: "Previous user Card" });
+    const { publishUser } = createHarness(<CardConsumer />);
+    act(() => publishUser("uid-a"));
+    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
+    act(() => mocks.deckReadyByUid["uid-a"]?.());
+    act(() => replaceCards([card]));
+    expect(screen.getByText(card.frontText)).toBeTruthy();
+
+    act(() => publishUser(null));
+
+    expect(screen.queryByText(card.frontText)).toBeNull();
+    await waitFor(() => expect(mocks.stopCards).toHaveBeenCalledWith("uid-a"));
   });
 });

--- a/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
@@ -38,8 +38,9 @@ import { replaceAuthSession } from "@/entities/auth";
 import { replaceCards, useCards } from "@/entities/card";
 import { createCard } from "@/test/factories";
 
-const CardConsumer = () => {
+const CardConsumer = ({ onRender }: { onRender?: (frontTexts: string[]) => void }) => {
   const cards = useCards();
+  onRender?.(cards.map(({ frontText }) => frontText));
   return (
     <>
       {cards.map((card) => (
@@ -124,10 +125,11 @@ describe("RemoteReadProvider integration", () => {
 
   it("hides the previous user's Card while logout clears the read scope", async () => {
     const card = createCard({ id: "card-a", uid: "uid-a", frontText: "Previous user Card" });
+    const renderedCards: string[][] = [];
     const { publishUser } = createHarness(
       <>
         <div>scope content</div>
-        <CardConsumer />
+        <CardConsumer onRender={(frontTexts) => renderedCards.push(frontTexts)} />
       </>
     );
     act(() => publishUser("uid-a"));
@@ -136,9 +138,11 @@ describe("RemoteReadProvider integration", () => {
     act(() => readyA?.());
     act(() => replaceCards([card]));
     expect(screen.getByText(card.frontText)).toBeTruthy();
+    renderedCards.length = 0;
 
     act(() => publishUser(null));
 
+    expect(renderedCards.flat()).not.toContain(card.frontText);
     expect(screen.queryByText(card.frontText)).toBeNull();
     expect(screen.getByText("scope content")).toBeTruthy();
     act(() => readyA?.());

--- a/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
@@ -124,16 +124,31 @@ describe("RemoteReadProvider integration", () => {
 
   it("hides the previous user's Card while logout clears the read scope", async () => {
     const card = createCard({ id: "card-a", uid: "uid-a", frontText: "Previous user Card" });
-    const { publishUser } = createHarness(<CardConsumer />);
+    const { publishUser } = createHarness(
+      <>
+        <div>scope content</div>
+        <CardConsumer />
+      </>
+    );
     act(() => publishUser("uid-a"));
     await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
-    act(() => mocks.deckReadyByUid["uid-a"]?.());
+    const readyA = mocks.deckReadyByUid["uid-a"];
+    act(() => readyA?.());
     act(() => replaceCards([card]));
     expect(screen.getByText(card.frontText)).toBeTruthy();
 
     act(() => publishUser(null));
 
     expect(screen.queryByText(card.frontText)).toBeNull();
+    expect(screen.getByText("scope content")).toBeTruthy();
+    act(() => readyA?.());
+    expect(screen.getByText("scope content")).toBeTruthy();
     await waitFor(() => expect(mocks.stopCards).toHaveBeenCalledWith("uid-a"));
+
+    act(() => publishUser("uid-a"));
+    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText("scope content")).toBeNull();
+    act(() => mocks.deckReadyByUid["uid-a"]?.());
+    expect(screen.getByText("scope content")).toBeTruthy();
   });
 });

--- a/src/app/providers/remote-read/RemoteReadProvider.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.tsx
@@ -10,16 +10,18 @@ import { subscribeDecks } from "./deck";
 export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
   const authSession = useAuthSession();
   const uid = authSession.status === "authenticated" ? authSession.uid : null;
-  const [deckReadyUid, setDeckReadyUid] = useState<string | null>(null);
+  const [readReadyUid, setReadReadyUid] = useState<string | null>();
 
   useEffect(() => {
     if (uid == null) {
       clearCards();
       clearDecks();
+      // Expose the signed-out scope only after stale entity data has been cleared.
+      queueMicrotask(() => setReadReadyUid(null));
       return;
     }
     startCardReads(uid);
-    const unsubscribeDecks = subscribeDecks(uid, () => setDeckReadyUid(uid), console.error);
+    const unsubscribeDecks = subscribeDecks(uid, () => setReadReadyUid(uid), console.error);
     return () => {
       stopCardReads(uid);
       unsubscribeDecks();
@@ -28,7 +30,7 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
     };
   }, [uid]);
 
-  if (uid != null && deckReadyUid !== uid) return null;
+  if (readReadyUid !== uid) return null;
 
   return <RemoteReadScopeProvider uid={uid}>{children}</RemoteReadScopeProvider>;
 };

--- a/src/app/providers/remote-read/RemoteReadProvider.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useEffect, useState } from "react";
+import { type PropsWithChildren, useLayoutEffect, useMemo, useState } from "react";
 
 import { useAuthSession } from "@/entities/auth";
 import { clearCards } from "@/entities/card";
@@ -10,27 +10,34 @@ import { subscribeDecks } from "./deck";
 export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
   const authSession = useAuthSession();
   const uid = authSession.status === "authenticated" ? authSession.uid : null;
-  const [readReadyUid, setReadReadyUid] = useState<string | null>();
+  const subscriptionToken = useMemo(() => Symbol(uid ?? "signed-out"), [uid]);
+  const [deckReadyToken, setDeckReadyToken] = useState<symbol>();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (uid == null) {
       clearCards();
       clearDecks();
-      // Expose the signed-out scope only after stale entity data has been cleared.
-      queueMicrotask(() => setReadReadyUid(null));
       return;
     }
+    let active = true;
     startCardReads(uid);
-    const unsubscribeDecks = subscribeDecks(uid, () => setReadReadyUid(uid), console.error);
+    const unsubscribeDecks = subscribeDecks(
+      uid,
+      () => {
+        if (active) setDeckReadyToken(subscriptionToken);
+      },
+      console.error
+    );
     return () => {
+      active = false;
       stopCardReads(uid);
       unsubscribeDecks();
       clearCards();
       clearDecks();
     };
-  }, [uid]);
+  }, [subscriptionToken, uid]);
 
-  if (readReadyUid !== uid) return null;
+  if (uid != null && deckReadyToken !== subscriptionToken) return null;
 
   return <RemoteReadScopeProvider uid={uid}>{children}</RemoteReadScopeProvider>;
 };

--- a/src/app/providers/remote-read/RemoteReadProvider.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
+import { type PropsWithChildren, useEffect, useState } from "react";
 
 import { useAuthSession } from "@/entities/auth";
 import { clearCards } from "@/entities/card";
@@ -10,8 +10,7 @@ import { subscribeDecks } from "./deck";
 export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
   const authSession = useAuthSession();
   const uid = authSession.status === "authenticated" ? authSession.uid : null;
-  const subscriptionToken = useMemo(() => Symbol(uid ?? "signed-out"), [uid]);
-  const [readReadyToken, setReadReadyToken] = useState<symbol>();
+  const [readReadyUid, setReadReadyUid] = useState<string | null>();
 
   useEffect(() => {
     clearCards();
@@ -19,7 +18,7 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
     if (uid == null) {
       // The signed-out scope becomes renderable only after its entity stores are empty.
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setReadReadyToken(subscriptionToken);
+      setReadReadyUid(null);
       return;
     }
     let active = true;
@@ -27,7 +26,7 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
     const unsubscribeDecks = subscribeDecks(
       uid,
       () => {
-        if (active) setReadReadyToken(subscriptionToken);
+        if (active) setReadReadyUid(uid);
       },
       console.error
     );
@@ -38,9 +37,9 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
       clearCards();
       clearDecks();
     };
-  }, [subscriptionToken, uid]);
+  }, [uid]);
 
-  if (readReadyToken !== subscriptionToken) return null;
+  if (readReadyUid !== uid) return null;
 
   return <RemoteReadScopeProvider uid={uid}>{children}</RemoteReadScopeProvider>;
 };

--- a/src/app/providers/remote-read/RemoteReadProvider.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useLayoutEffect, useMemo, useState } from "react";
+import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
 
 import { useAuthSession } from "@/entities/auth";
 import { clearCards } from "@/entities/card";
@@ -11,12 +11,15 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
   const authSession = useAuthSession();
   const uid = authSession.status === "authenticated" ? authSession.uid : null;
   const subscriptionToken = useMemo(() => Symbol(uid ?? "signed-out"), [uid]);
-  const [deckReadyToken, setDeckReadyToken] = useState<symbol>();
+  const [readReadyToken, setReadReadyToken] = useState<symbol>();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
+    clearCards();
+    clearDecks();
     if (uid == null) {
-      clearCards();
-      clearDecks();
+      // The signed-out scope becomes renderable only after its entity stores are empty.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setReadReadyToken(subscriptionToken);
       return;
     }
     let active = true;
@@ -24,7 +27,7 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
     const unsubscribeDecks = subscribeDecks(
       uid,
       () => {
-        if (active) setDeckReadyToken(subscriptionToken);
+        if (active) setReadReadyToken(subscriptionToken);
       },
       console.error
     );
@@ -37,7 +40,7 @@ export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
     };
   }, [subscriptionToken, uid]);
 
-  if (uid != null && deckReadyToken !== subscriptionToken) return null;
+  if (readReadyToken !== subscriptionToken) return null;
 
   return <RemoteReadScopeProvider uid={uid}>{children}</RemoteReadScopeProvider>;
 };


### PR DESCRIPTION
## Related issue

Related to #805
Follow-up to #813

## Summary

- Keep remote-read children hidden while logout clears stale entity data.
- Re-expose the signed-out scope only after Card and Deck stores are cleared.
- Add an integration test that prevents the previous user Card from rendering after logout.

## Testing

- mise run check