### PR TITLE
#826 Move remote read transitions to the app lifecycle

### DIFF
--- a/src/app/providers/AppProviders.tsx
+++ b/src/app/providers/AppProviders.tsx
@@ -2,9 +2,18 @@ import { useEffect, type PropsWithChildren } from "react";
 
 import { RemoteReadProvider } from "@/app/providers/remote-read";
 import { startAuthSession } from "./auth/lifecycle";
+import { startRemoteReadSession } from "./remote-read/lifecycle";
 
 export const AppProviders = ({ children }: PropsWithChildren) => {
-  useEffect(startAuthSession, []);
+  useEffect(() => {
+    const stopRemoteReadSession = startRemoteReadSession();
+    const stopAuthSession = startAuthSession();
+
+    return () => {
+      stopAuthSession();
+      stopRemoteReadSession();
+    };
+  }, []);
 
   return <RemoteReadProvider>{children}</RemoteReadProvider>;
 };

--- a/src/app/providers/auth/AuthLogout.spec.tsx
+++ b/src/app/providers/auth/AuthLogout.spec.tsx
@@ -44,9 +44,8 @@ vi.mock("@/app/providers/remote-read/card", () => ({
   startCardSynchronization: () => vi.fn(),
 }));
 vi.mock("@/app/providers/remote-read/deck", () => ({
-  subscribeDecks: (uid: string, onReady?: () => void) => {
+  subscribeDecks: (uid: string) => {
     void mocks.startRemoteReads(uid);
-    onReady?.();
     return () => void mocks.cleanupUid(uid);
   },
 }));

--- a/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.spec.tsx
@@ -1,164 +1,63 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
-import React, { type ReactNode } from "react";
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  startCards: vi.fn(),
-  stopCardsByUid: {} as Record<string, ReturnType<typeof vi.fn>>,
-  stopDecks: vi.fn(),
-  clearCards: vi.fn(),
-  clearDecks: vi.fn(),
-  deckReadyByUid: {} as Record<string, () => void>,
-}));
-
-vi.mock("./card", () => ({
-  startCardSynchronization: mocks.startCards.mockImplementation((uid: string) => {
-    const stop = vi.fn();
-    mocks.stopCardsByUid[uid] = stop;
-    return stop;
-  }),
-}));
-vi.mock("@/entities/card", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/entities/card")>();
-  return {
-    ...actual,
-    clearCards: () => {
-      mocks.clearCards();
-      actual.clearCards();
-    },
-  };
-});
-vi.mock("@/entities/deck", () => ({ clearDecks: mocks.clearDecks }));
-vi.mock("./deck", () => ({
-  subscribeDecks: vi.fn((uid: string, onReady: () => void) => {
-    mocks.deckReadyByUid[uid] = onReady;
-    return mocks.stopDecks;
-  }),
-}));
+vi.mock("@/shared/firebase", () => ({ db: "db" }));
+vi.mock("./card", () => ({ startCardSynchronization: () => vi.fn() }));
+vi.mock("./deck", () => ({ subscribeDecks: () => vi.fn() }));
 
 import { RemoteReadProvider } from "@/app/providers/remote-read";
 import { replaceAuthSession } from "@/entities/auth";
-import { replaceCards, useCards } from "@/entities/card";
+import { clearCards, replaceCards, useCards } from "@/entities/card";
 import { createCard } from "@/test/factories";
+import { startRemoteReadSession } from "./lifecycle";
+
+const authenticate = (uid: string) =>
+  replaceAuthSession({ status: "authenticated", uid, isAnonymous: true, displayName: null });
 
 const CardConsumer = ({ onRender }: { onRender?: (frontTexts: string[]) => void }) => {
   const cards = useCards();
-  onRender?.(cards.map(({ frontText }) => frontText));
-  return (
-    <>
-      {cards.map((card) => (
-        <div key={card.id}>{card.frontText}</div>
-      ))}
-    </>
-  );
+  const frontTexts = cards.map(({ frontText }) => frontText);
+  onRender?.(frontTexts);
+  return frontTexts.map((frontText) => <div key={frontText}>{frontText}</div>);
 };
 
-const createHarness = (children?: ReactNode) => {
-  const publishUser = (uid: string | null) =>
-    replaceAuthSession(
-      uid == null
-        ? { status: "unauthenticated" }
-        : { status: "authenticated", uid, isAnonymous: true, displayName: null }
-    );
-  render(
-    <React.StrictMode>
-      <RemoteReadProvider>{children}</RemoteReadProvider>
-    </React.StrictMode>
-  );
-  return { publishUser };
-};
-
-describe("RemoteReadProvider integration", () => {
+describe("RemoteReadProvider", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    replaceCards([]);
     replaceAuthSession({ status: "initializing" });
-    Object.keys(mocks.deckReadyByUid).forEach((uid) => {
-      delete mocks.deckReadyByUid[uid];
-    });
-    Object.keys(mocks.stopCardsByUid).forEach((uid) => {
-      delete mocks.stopCardsByUid[uid];
-    });
+    clearCards();
   });
 
-  it("renders children after the current UID's first Deck snapshot", async () => {
-    const { publishUser } = createHarness(<div>content</div>);
+  it("renders without waiting for a remote snapshot", () => {
+    authenticate("uid-a");
 
-    act(() => publishUser("uid-a"));
-
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
-    expect(screen.queryByText("content")).toBeNull();
-    act(() => mocks.deckReadyByUid["uid-a"]?.());
-    expect(screen.getByText("content")).toBeTruthy();
-  });
-
-  it("ignores readiness from a previous UID", async () => {
-    const { publishUser } = createHarness(<div>content</div>);
-    act(() => publishUser("uid-a"));
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
-    const readyA = mocks.deckReadyByUid["uid-a"];
-    act(() => publishUser("uid-b"));
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-b"));
-
-    act(() => readyA?.());
-    expect(screen.queryByText("content")).toBeNull();
-    act(() => mocks.deckReadyByUid["uid-b"]?.());
-    expect(screen.getByText("content")).toBeTruthy();
-  });
-
-  it("stops the previous UID before starting its replacement", async () => {
-    const { publishUser } = createHarness();
-    act(() => publishUser("uid-a"));
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
-    act(() => publishUser("uid-b"));
-
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-b"));
-    expect(mocks.stopCardsByUid["uid-a"]).toHaveBeenCalledOnce();
-    expect(mocks.stopDecks).toHaveBeenCalledOnce();
-    expect(mocks.clearCards).toHaveBeenCalled();
-    expect(mocks.clearDecks).toHaveBeenCalled();
-  });
-
-  it("stops Card synchronization after logout", async () => {
-    const { publishUser } = createHarness();
-    act(() => publishUser("uid-a"));
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
-
-    act(() => publishUser(null));
-
-    await waitFor(() => expect(mocks.stopCardsByUid["uid-a"]).toHaveBeenCalledOnce());
-  });
-
-  it("does not render the previous user's Card during logout cleanup", async () => {
-    const card = createCard({ id: "card-a", uid: "uid-a", frontText: "Previous user Card" });
-    const renderedCards: string[][] = [];
-    const { publishUser } = createHarness(
-      <>
-        <div>scope content</div>
-        <CardConsumer onRender={(frontTexts) => renderedCards.push(frontTexts)} />
-      </>
+    render(
+      <RemoteReadProvider>
+        <div>content</div>
+      </RemoteReadProvider>
     );
-    act(() => publishUser("uid-a"));
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledWith("uid-a"));
-    const readyA = mocks.deckReadyByUid["uid-a"];
-    act(() => readyA?.());
+
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+
+  it("does not render the previous UID's Cards after a session transition", () => {
+    const stopRemoteReadSession = startRemoteReadSession();
+    authenticate("uid-a");
+    const renderedCards: string[][] = [];
+    const card = createCard({ id: "card-a", uid: "uid-a", frontText: "Previous user Card" });
+    const { unmount } = render(
+      <RemoteReadProvider>
+        <CardConsumer onRender={(frontTexts) => renderedCards.push(frontTexts)} />
+      </RemoteReadProvider>
+    );
     act(() => replaceCards([card]));
     expect(screen.getByText(card.frontText)).toBeTruthy();
     renderedCards.length = 0;
 
-    act(() => publishUser(null));
+    act(() => authenticate("uid-b"));
 
-    expect(renderedCards.flat()).not.toContain(card.frontText);
     expect(screen.queryByText(card.frontText)).toBeNull();
-    expect(screen.getByText("scope content")).toBeTruthy();
-    act(() => readyA?.());
-    expect(screen.getByText("scope content")).toBeTruthy();
-    await waitFor(() => expect(mocks.stopCardsByUid["uid-a"]).toHaveBeenCalledOnce());
-
-    act(() => publishUser("uid-a"));
-    await waitFor(() => expect(mocks.startCards).toHaveBeenCalledTimes(2));
-    expect(screen.queryByText("scope content")).toBeNull();
-    act(() => mocks.deckReadyByUid["uid-a"]?.());
-    expect(screen.getByText("scope content")).toBeTruthy();
+    expect(renderedCards.flat()).not.toContain(card.frontText);
+    unmount();
+    stopRemoteReadSession();
   });
 });

--- a/src/app/providers/remote-read/RemoteReadProvider.tsx
+++ b/src/app/providers/remote-read/RemoteReadProvider.tsx
@@ -1,44 +1,11 @@
-import { type PropsWithChildren, useEffect, useState } from "react";
+import type { PropsWithChildren } from "react";
 
 import { useAuthSession } from "@/entities/auth";
-import { clearCards } from "@/entities/card";
-import { clearDecks } from "@/entities/deck";
 import { RemoteReadScopeProvider } from "@/shared/lib/remote-read";
-import { startCardSynchronization } from "./card";
-import { subscribeDecks } from "./deck";
 
 export const RemoteReadProvider = ({ children }: PropsWithChildren) => {
   const authSession = useAuthSession();
   const uid = authSession.status === "authenticated" ? authSession.uid : null;
-  const [readReadyUid, setReadReadyUid] = useState<string | null>();
-
-  useEffect(() => {
-    clearCards();
-    clearDecks();
-    if (uid == null) {
-      // The signed-out scope becomes renderable only after its entity stores are empty.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setReadReadyUid(null);
-      return;
-    }
-    let active = true;
-    const stopCards = startCardSynchronization(uid);
-    const unsubscribeDecks = subscribeDecks(
-      uid,
-      () => {
-        if (active) setReadReadyUid(uid);
-      },
-      console.error
-    );
-    return () => {
-      active = false;
-      stopCards();
-      unsubscribeDecks();
-      clearDecks();
-    };
-  }, [uid]);
-
-  if (readReadyUid !== uid) return null;
 
   return <RemoteReadScopeProvider uid={uid}>{children}</RemoteReadScopeProvider>;
 };

--- a/src/app/providers/remote-read/card.spec.tsx
+++ b/src/app/providers/remote-read/card.spec.tsx
@@ -180,7 +180,7 @@ describe("Card app synchronization", () => {
     stop();
   });
 
-  it("unsubscribes, clears Cards, and ignores late callbacks when stopped", () => {
+  it("unsubscribes and ignores late callbacks when stopped", () => {
     const { result } = renderCardState();
     const stop = startCardSynchronization("uid-a");
     const previousListener = mocks.listeners[0];
@@ -190,8 +190,7 @@ describe("Card app synchronization", () => {
     act(stop);
 
     expect(previousListener?.unsubscribe).toHaveBeenCalledOnce();
-    expect(result.current.cards).toEqual([]);
     act(() => previousListener?.next(snapshot([cardDocument("late")])));
-    expect(result.current.cards).toEqual([]);
+    expect(result.current.cards).toEqual([expect.objectContaining({ id: "old" })]);
   });
 });

--- a/src/app/providers/remote-read/card.ts
+++ b/src/app/providers/remote-read/card.ts
@@ -3,7 +3,7 @@ import type { Card, CardId } from "@/entities/card";
 import { collection, onSnapshot, query, where } from "firebase/firestore";
 import { z } from "zod";
 
-import { clearCards, replaceCards } from "@/entities/card";
+import { replaceCards } from "@/entities/card";
 import { resetCardRead, setCardReadError, setCardReadLoading, setCardReadReady } from "@/features/card/read";
 import type { RemoteSyncStatus } from "@/shared/api";
 import { db } from "@/shared/firebase";
@@ -132,6 +132,5 @@ export const startCardSynchronization = (uid: string): (() => void) => {
     unsubscribe?.();
     unsubscribe = undefined;
     resetCardRead(uid);
-    clearCards();
   };
 };

--- a/src/app/providers/remote-read/deck.spec.ts
+++ b/src/app/providers/remote-read/deck.spec.ts
@@ -52,8 +52,7 @@ describe("Deck app synchronization", () => {
 
   it("subscribes by UID and replaces the store with active Decks", () => {
     const { result } = renderHook(useDecks);
-    const onReady = vi.fn();
-    const unsubscribe = subscribeDecks("uid-a", onReady, vi.fn());
+    const unsubscribe = subscribeDecks("uid-a", vi.fn());
 
     expect(mocks.collection).toHaveBeenCalledWith("db", "deck");
     expect(mocks.where).toHaveBeenCalledWith("uid", "==", "uid-a");
@@ -64,21 +63,29 @@ describe("Deck app synchronization", () => {
     );
 
     expect(result.current).toEqual([expect.objectContaining({ id: "active", url: "https://example.com" })]);
-    expect(onReady).toHaveBeenCalledOnce();
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("reports invalid Firestore documents", () => {
-    const onReady = vi.fn();
     const onError = vi.fn();
-    subscribeDecks("uid-a", onReady, onError);
+    subscribeDecks("uid-a", onError);
 
     act(() => getSnapshotHandler()({ docs: [deckDocument("invalid", { selectedTags: [42] })] }));
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ name: "FirestoreDocumentValidationError", documentId: "invalid" })
     );
-    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it("ignores snapshots after the session is no longer current", () => {
+    const { result } = renderHook(useDecks);
+    let current = true;
+    subscribeDecks("uid-a", vi.fn(), () => current);
+    current = false;
+
+    act(() => getSnapshotHandler()({ docs: [deckDocument("late")] }));
+
+    expect(result.current).toEqual([]);
   });
 });

--- a/src/app/providers/remote-read/deck.spec.ts
+++ b/src/app/providers/remote-read/deck.spec.ts
@@ -52,7 +52,8 @@ describe("Deck app synchronization", () => {
 
   it("subscribes by UID and replaces the store with active Decks", () => {
     const { result } = renderHook(useDecks);
-    const unsubscribe = subscribeDecks("uid-a", vi.fn());
+    const onSnapshot = vi.fn();
+    const unsubscribe = subscribeDecks("uid-a", onSnapshot, vi.fn());
 
     expect(mocks.collection).toHaveBeenCalledWith("db", "deck");
     expect(mocks.where).toHaveBeenCalledWith("uid", "==", "uid-a");
@@ -63,13 +64,14 @@ describe("Deck app synchronization", () => {
     );
 
     expect(result.current).toEqual([expect.objectContaining({ id: "active", url: "https://example.com" })]);
+    expect(onSnapshot).toHaveBeenCalledWith([expect.objectContaining({ id: "active" })]);
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("reports invalid Firestore documents", () => {
     const onError = vi.fn();
-    subscribeDecks("uid-a", onError);
+    subscribeDecks("uid-a", vi.fn(), onError);
 
     act(() => getSnapshotHandler()({ docs: [deckDocument("invalid", { selectedTags: [42] })] }));
 
@@ -81,11 +83,13 @@ describe("Deck app synchronization", () => {
   it("ignores snapshots after the session is no longer current", () => {
     const { result } = renderHook(useDecks);
     let current = true;
-    subscribeDecks("uid-a", vi.fn(), () => current);
+    const onSnapshot = vi.fn();
+    subscribeDecks("uid-a", onSnapshot, vi.fn(), () => current);
     current = false;
 
     act(() => getSnapshotHandler()({ docs: [deckDocument("late")] }));
 
     expect(result.current).toEqual([]);
+    expect(onSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/src/app/providers/remote-read/deck.ts
+++ b/src/app/providers/remote-read/deck.ts
@@ -31,16 +31,20 @@ const convertDeckDtoToDeck = (id: DeckId, value: unknown): Deck => {
   return deck;
 };
 
-export const subscribeDecks = (uid: string, onReady: () => void, onError: (error: Error) => void): (() => void) =>
+export const subscribeDecks = (
+  uid: string,
+  onError: (error: Error) => void,
+  isCurrent: () => boolean = () => true
+): (() => void) =>
   onSnapshot(
     query(collection(db, "deck"), where("uid", "==", uid)),
     (snapshot) => {
+      if (!isCurrent()) return;
       try {
         const decks = snapshot.docs
           .map((document) => convertDeckDtoToDeck(document.id, document.data()))
           .filter((deck) => deck.deletedAt === null);
         replaceDecks(decks);
-        onReady();
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }

--- a/src/app/providers/remote-read/deck.ts
+++ b/src/app/providers/remote-read/deck.ts
@@ -33,6 +33,7 @@ const convertDeckDtoToDeck = (id: DeckId, value: unknown): Deck => {
 
 export const subscribeDecks = (
   uid: string,
+  onDecks: (decks: Deck[]) => void,
   onError: (error: Error) => void,
   isCurrent: () => boolean = () => true
 ): (() => void) =>
@@ -45,6 +46,7 @@ export const subscribeDecks = (
           .map((document) => convertDeckDtoToDeck(document.id, document.data()))
           .filter((deck) => deck.deletedAt === null);
         replaceDecks(decks);
+        onDecks(decks);
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }

--- a/src/app/providers/remote-read/lifecycle.spec.ts
+++ b/src/app/providers/remote-read/lifecycle.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   operations: [] as string[],
   currentDeckSessionByUid: {} as Record<string, () => boolean>,
+  publishDecksByUid: {} as Record<string, (decks: { id: string }[]) => void>,
 }));
 
 vi.mock("@/entities/card", () => ({
@@ -11,6 +12,13 @@ vi.mock("@/entities/card", () => ({
 vi.mock("@/entities/deck", () => ({
   clearDecks: () => mocks.operations.push("clear-decks"),
 }));
+vi.mock("@/features/study", () => ({
+  reconcileStudySessionsWithDecks: (deckIds: string[]) => {
+    const label = deckIds.join(",");
+    mocks.operations.push(`reconcile-study:${label}`);
+    return () => mocks.operations.push(`cancel-study:${label}`);
+  },
+}));
 vi.mock("./card", () => ({
   startCardSynchronization: (uid: string) => {
     mocks.operations.push(`start-cards:${uid}`);
@@ -18,9 +26,17 @@ vi.mock("./card", () => ({
   },
 }));
 vi.mock("./deck", () => ({
-  subscribeDecks: (uid: string, _onError: (error: Error) => void, isCurrent: () => boolean) => {
+  subscribeDecks: (
+    uid: string,
+    onSnapshot: (decks: { id: string }[]) => void,
+    _onError: (error: Error) => void,
+    isCurrent: () => boolean
+  ) => {
     mocks.operations.push(`start-decks:${uid}`);
     mocks.currentDeckSessionByUid[uid] = isCurrent;
+    mocks.publishDecksByUid[uid] = (decks) => {
+      if (isCurrent()) onSnapshot(decks);
+    };
     return () => mocks.operations.push(`stop-decks:${uid}`);
   },
 }));
@@ -37,6 +53,9 @@ describe("remote read session lifecycle", () => {
     mocks.operations.length = 0;
     Object.keys(mocks.currentDeckSessionByUid).forEach((uid) => {
       delete mocks.currentDeckSessionByUid[uid];
+    });
+    Object.keys(mocks.publishDecksByUid).forEach((uid) => {
+      delete mocks.publishDecksByUid[uid];
     });
     replaceAuthSession({ status: "initializing" });
   });
@@ -86,6 +105,23 @@ describe("remote read session lifecycle", () => {
 
     expect(mocks.operations).toEqual(["stop-cards:uid-a", "stop-decks:uid-a", "clear-cards", "clear-decks"]);
 
+    stop();
+  });
+
+  it("reconciles Study sessions only after a current Deck snapshot", () => {
+    const stop = startRemoteReadSession();
+    authenticate("uid-a");
+    expect(mocks.operations).not.toContain("reconcile-study:deck-a");
+
+    mocks.publishDecksByUid["uid-a"]?.([{ id: "deck-a" }]);
+    expect(mocks.operations).toContain("reconcile-study:deck-a");
+
+    authenticate("uid-b");
+    mocks.operations.length = 0;
+    mocks.publishDecksByUid["uid-a"]?.([{ id: "late-deck" }]);
+    mocks.publishDecksByUid["uid-b"]?.([{ id: "deck-b" }]);
+
+    expect(mocks.operations).toEqual(["reconcile-study:deck-b"]);
     stop();
   });
 

--- a/src/app/providers/remote-read/lifecycle.spec.ts
+++ b/src/app/providers/remote-read/lifecycle.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  operations: [] as string[],
+  currentDeckSessionByUid: {} as Record<string, () => boolean>,
+}));
+
+vi.mock("@/entities/card", () => ({
+  clearCards: () => mocks.operations.push("clear-cards"),
+}));
+vi.mock("@/entities/deck", () => ({
+  clearDecks: () => mocks.operations.push("clear-decks"),
+}));
+vi.mock("./card", () => ({
+  startCardSynchronization: (uid: string) => {
+    mocks.operations.push(`start-cards:${uid}`);
+    return () => mocks.operations.push(`stop-cards:${uid}`);
+  },
+}));
+vi.mock("./deck", () => ({
+  subscribeDecks: (uid: string, _onError: (error: Error) => void, isCurrent: () => boolean) => {
+    mocks.operations.push(`start-decks:${uid}`);
+    mocks.currentDeckSessionByUid[uid] = isCurrent;
+    return () => mocks.operations.push(`stop-decks:${uid}`);
+  },
+}));
+
+import { replaceAuthSession } from "@/entities/auth";
+import { startRemoteReadSession } from "./lifecycle";
+
+const authenticate = (uid: string) =>
+  replaceAuthSession({ status: "authenticated", uid, isAnonymous: true, displayName: null });
+
+describe("remote read session lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.operations.length = 0;
+    Object.keys(mocks.currentDeckSessionByUid).forEach((uid) => {
+      delete mocks.currentDeckSessionByUid[uid];
+    });
+    replaceAuthSession({ status: "initializing" });
+  });
+
+  it("clears entity data on startup and starts listeners for an authenticated UID", () => {
+    const stop = startRemoteReadSession();
+
+    expect(mocks.operations).toEqual(["clear-cards", "clear-decks"]);
+    authenticate("uid-a");
+    expect(mocks.operations.slice(-4)).toEqual([
+      "clear-cards",
+      "clear-decks",
+      "start-cards:uid-a",
+      "start-decks:uid-a",
+    ]);
+
+    stop();
+  });
+
+  it("stops and clears the previous UID before starting the next UID", () => {
+    const stop = startRemoteReadSession();
+    authenticate("uid-a");
+    mocks.operations.length = 0;
+
+    authenticate("uid-b");
+
+    expect(mocks.operations).toEqual([
+      "stop-cards:uid-a",
+      "stop-decks:uid-a",
+      "clear-cards",
+      "clear-decks",
+      "start-cards:uid-b",
+      "start-decks:uid-b",
+    ]);
+    expect(mocks.currentDeckSessionByUid["uid-a"]?.()).toBe(false);
+    expect(mocks.currentDeckSessionByUid["uid-b"]?.()).toBe(true);
+
+    stop();
+  });
+
+  it("stops and clears listeners on logout without starting replacements", () => {
+    const stop = startRemoteReadSession();
+    authenticate("uid-a");
+    mocks.operations.length = 0;
+
+    replaceAuthSession({ status: "unauthenticated" });
+
+    expect(mocks.operations).toEqual(["stop-cards:uid-a", "stop-decks:uid-a", "clear-cards", "clear-decks"]);
+
+    stop();
+  });
+
+  it("does not restart listeners when authenticated metadata changes for the same UID", () => {
+    const stop = startRemoteReadSession();
+    authenticate("uid-a");
+    mocks.operations.length = 0;
+
+    replaceAuthSession({ status: "authenticated", uid: "uid-a", isAnonymous: false, displayName: "Ada" });
+
+    expect(mocks.operations).toEqual([]);
+    stop();
+  });
+});

--- a/src/app/providers/remote-read/lifecycle.ts
+++ b/src/app/providers/remote-read/lifecycle.ts
@@ -1,10 +1,11 @@
 import { getAuthSession, subscribeAuthSession } from "@/entities/auth";
 import { clearCards } from "@/entities/card";
 import { clearDecks } from "@/entities/deck";
+import { reconcileStudySessionsWithDecks } from "@/features/study";
 import { startCardSynchronization } from "./card";
 import { subscribeDecks } from "./deck";
 
-const emptyCleanup = () => undefined;
+const emptyCleanup = (): void => undefined;
 
 export const startRemoteReadSession = (): (() => void) => {
   let currentUid: string | null | undefined;
@@ -24,12 +25,22 @@ export const startRemoteReadSession = (): (() => void) => {
     if (nextUid == null) return;
 
     let active = true;
+    let cancelStudyReconciliation = emptyCleanup;
     const stopCards = startCardSynchronization(nextUid);
-    const stopDecks = subscribeDecks(nextUid, console.error, () => active);
+    const stopDecks = subscribeDecks(
+      nextUid,
+      (decks) => {
+        cancelStudyReconciliation();
+        cancelStudyReconciliation = reconcileStudySessionsWithDecks(decks.map(({ id }) => id));
+      },
+      console.error,
+      () => active
+    );
     cleanupCurrent = () => {
       active = false;
       stopCards();
       stopDecks();
+      cancelStudyReconciliation();
     };
   };
 

--- a/src/app/providers/remote-read/lifecycle.ts
+++ b/src/app/providers/remote-read/lifecycle.ts
@@ -1,0 +1,47 @@
+import { getAuthSession, subscribeAuthSession } from "@/entities/auth";
+import { clearCards } from "@/entities/card";
+import { clearDecks } from "@/entities/deck";
+import { startCardSynchronization } from "./card";
+import { subscribeDecks } from "./deck";
+
+const emptyCleanup = () => undefined;
+
+export const startRemoteReadSession = (): (() => void) => {
+  let currentUid: string | null | undefined;
+  let cleanupCurrent = emptyCleanup;
+
+  const transition = () => {
+    const authSession = getAuthSession();
+    const nextUid = authSession.status === "authenticated" ? authSession.uid : null;
+    if (nextUid === currentUid) return;
+
+    cleanupCurrent();
+    cleanupCurrent = emptyCleanup;
+    clearCards();
+    clearDecks();
+    currentUid = nextUid;
+
+    if (nextUid == null) return;
+
+    let active = true;
+    const stopCards = startCardSynchronization(nextUid);
+    const stopDecks = subscribeDecks(nextUid, console.error, () => active);
+    cleanupCurrent = () => {
+      active = false;
+      stopCards();
+      stopDecks();
+    };
+  };
+
+  const unsubscribeAuthSession = subscribeAuthSession(transition);
+  transition();
+
+  return () => {
+    unsubscribeAuthSession();
+    cleanupCurrent();
+    cleanupCurrent = emptyCleanup;
+    clearCards();
+    clearDecks();
+    currentUid = null;
+  };
+};

--- a/src/entities/auth/index.ts
+++ b/src/entities/auth/index.ts
@@ -1,2 +1,2 @@
 export { useAuthSession } from "./model/hooks";
-export { getAuthSession, replaceAuthSession } from "./model/store";
+export { getAuthSession, replaceAuthSession, subscribeAuthSession } from "./model/store";

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -7,6 +7,8 @@ export const authSessionStore = createStore<AuthSessionState>()(() => initialAut
 
 export const getAuthSession = (): AuthSessionState => authSessionStore.getState();
 
+export const subscribeAuthSession = (listener: () => void): (() => void) => authSessionStore.subscribe(listener);
+
 export const replaceAuthSession = (session: AuthSessionState): void => {
   authSessionStore.setState(session, true);
 };

--- a/src/features/study/commands/studySessionCommands.spec.ts
+++ b/src/features/study/commands/studySessionCommands.spec.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { studyStore } from "../state/studyStoreInstance";
 import {
-  discardStudySessionsMissingDecks,
   initializeStudySessionUi,
+  reconcileStudySessionsWithDecks,
   removeStudySession,
   touchStudySession,
 } from "./studySessionCommands";
@@ -51,10 +51,28 @@ describe("study session commands", () => {
   });
 
   it("discards sessions whose decks are unavailable", () => {
-    discardStudySessionsMissingDecks(["second"]);
+    reconcileStudySessionsWithDecks(["second"]);
 
     expect(studyStore.getState().sessionsByDeckId).toEqual({
       second: { deckId: "second", cardOrderIds: ["card-2"], currentIndex: 0, lastStudiedAt: 200 },
     });
+  });
+
+  it("waits for hydration before discarding sessions", () => {
+    let finishHydration: () => void = () => undefined;
+    const unsubscribe = vi.fn();
+    vi.spyOn(studyStore.persist, "hasHydrated").mockReturnValue(false);
+    vi.spyOn(studyStore.persist, "onFinishHydration").mockImplementation((listener) => {
+      finishHydration = () => listener(studyStore.getState());
+      return unsubscribe;
+    });
+
+    const cancel = reconcileStudySessionsWithDecks(["second"]);
+    expect(studyStore.getState().sessionsByDeckId).toHaveProperty("first");
+
+    finishHydration();
+    expect(studyStore.getState().sessionsByDeckId).not.toHaveProperty("first");
+    cancel();
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/study/commands/studySessionCommands.ts
+++ b/src/features/study/commands/studySessionCommands.ts
@@ -14,10 +14,20 @@ export const touchStudySession = (deckId: DeckId) => {
   studyStore.getState().touchStudy(deckId);
 };
 
-export const discardStudySessionsMissingDecks = (deckIds: Iterable<DeckId>) => {
+const discardStudySessionsMissingDecks = (deckIds: Iterable<DeckId>) => {
   const availableDeckIds = new Set(deckIds);
   const state = studyStore.getState();
   for (const deckId of Object.keys(state.sessionsByDeckId)) {
     if (!availableDeckIds.has(deckId)) state.removeStudy(deckId);
   }
+};
+
+export const reconcileStudySessionsWithDecks = (deckIds: Iterable<DeckId>): (() => void) => {
+  const currentDeckIds = [...deckIds];
+  const reconcile = () => discardStudySessionsMissingDecks(currentDeckIds);
+  if (studyStore.persist.hasHydrated()) {
+    reconcile();
+    return () => undefined;
+  }
+  return studyStore.persist.onFinishHydration(reconcile);
 };

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -2,8 +2,8 @@ export { DeckStartForm } from "./components/DeckStartForm";
 export { Controller, type ControllerProps } from "./components/Controller";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
 export {
-  discardStudySessionsMissingDecks,
   initializeStudySessionUi,
+  reconcileStudySessionsWithDecks,
   removeStudySession,
   touchStudySession,
 } from "./commands/studySessionCommands";

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -25,7 +25,6 @@ const mocks = vi.hoisted(() => ({
   syncStatus: "synced" as "cached" | "pending" | "synced",
   remove: vi.fn(async (_deck: Deck) => undefined),
   downloadDeckCsv: vi.fn(),
-  discardStudySessionsMissingDecks: vi.fn<(deckIds: Iterable<DeckId>) => void>(),
   removeStudySession: vi.fn<(deckId: DeckId) => void>(),
   touchStudySession: vi.fn<(deckId: DeckId) => void>(),
   navigate: vi.fn(),
@@ -37,7 +36,6 @@ vi.mock("@/entities/preferences", () => ({
   setDarkMode: mocks.setDarkMode,
 }));
 vi.mock("@/features/study", () => ({
-  discardStudySessionsMissingDecks: mocks.discardStudySessionsMissingDecks,
   removeStudySession: mocks.removeStudySession,
   touchStudySession: mocks.touchStudySession,
   useStudyHydrated: () => mocks.hydrated,
@@ -103,12 +101,6 @@ describe("DeckListPage", () => {
     });
     mocks.removeStudySession.mockImplementation((deckId) => {
       delete mocks.sessionsByDeckId[deckId];
-    });
-    mocks.discardStudySessionsMissingDecks.mockImplementation((deckIds) => {
-      const availableDeckIds = new Set(deckIds);
-      for (const deckId of Object.keys(mocks.sessionsByDeckId)) {
-        if (!availableDeckIds.has(deckId)) delete mocks.sessionsByDeckId[deckId];
-      }
     });
   });
 
@@ -225,21 +217,6 @@ describe("DeckListPage", () => {
     mocks.hydrated = true;
     view.rerender(<DeckListPage />);
     expect(screen.getByRole("region", { name: "Studying" })).toBeInTheDocument();
-  });
-
-  it("prunes sessions for decks that no longer exist", async () => {
-    mocks.sessionsByDeckId.missing = {
-      deckId: "missing",
-      cardOrderIds: ["card"],
-      currentIndex: 0,
-      lastStudiedAt: 3000,
-    };
-
-    render(<DeckListPage />);
-
-    await waitFor(() => expect(mocks.sessionsByDeckId.missing).toBeUndefined());
-    expect(mocks.discardStudySessionsMissingDecks).toHaveBeenCalled();
-    expect(mocks.sessionsByDeckId[recentDeck.id]).toBeDefined();
   });
 
   it("lets the user repeat the original Deck deletion after failure", async () => {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -12,13 +12,7 @@ import { useDeleteDeck } from "@/features/deck/delete";
 import { buildDeckListSections } from "@/features/deck/list";
 import { downloadDeckCsv } from "@/features/deck/export";
 import { useSampleDeckBootstrap } from "@/features/deck/import";
-import {
-  discardStudySessionsMissingDecks,
-  removeStudySession,
-  touchStudySession,
-  useStudyHydrated,
-  useStudySessions,
-} from "@/features/study";
+import { removeStudySession, touchStudySession, useStudyHydrated, useStudySessions } from "@/features/study";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
 import { RemoteReadBoundary } from "@/shared/ui/remote-read-boundary";
@@ -51,11 +45,6 @@ export const DeckListPage: React.FC = () => {
   });
   useKey("s", () => void navigate("/settings"));
   useKey("i", () => void navigate("/import"));
-
-  React.useEffect(() => {
-    if (!hydrated) return;
-    discardStudySessionsMissingDecks(decks.map((deck) => deck.id));
-  }, [decks, hydrated]);
 
   return (
     <RemoteReadBoundary

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -36,7 +36,7 @@ describe("Query realtime subscriptions", () => {
   it("delivers initial, update, and delete snapshots without a cursor", async () => {
     const uid = "uid";
     const errors: Error[] = [];
-    const stopDecks = subscribeDecks(uid, (error) => errors.push(error));
+    const stopDecks = subscribeDecks(uid, vi.fn(), (error) => errors.push(error));
     const stopCards = startCardSynchronization(uid);
 
     try {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -36,7 +36,7 @@ describe("Query realtime subscriptions", () => {
   it("delivers initial, update, and delete snapshots without a cursor", async () => {
     const uid = "uid";
     const errors: Error[] = [];
-    const stopDecks = subscribeDecks(uid, vi.fn(), (error) => errors.push(error));
+    const stopDecks = subscribeDecks(uid, (error) => errors.push(error));
     const stopCards = startCardSynchronization(uid);
 
     try {


### PR DESCRIPTION
## Summary

- move remote-read UID transitions into a single app-level lifecycle
- reduce `RemoteReadProvider` to providing the current UID scope without readiness render state
- stop listeners, clear Card/Deck entities, and start replacement listeners in a deterministic order
- guard Deck snapshots from stale sessions and keep Card cleanup owned by the session lifecycle
- reconcile persisted Study sessions only after the current UID's first Deck snapshot and Study hydration
- add direct lifecycle coverage for startup, switch, logout, teardown safety, same-UID metadata updates, and snapshot-gated reconciliation

## Root cause

`RemoteReadProvider` owned the remote-read session state machine through render gating, effect cleanup, and a Deck readiness callback. This coupled logout and UID-switch correctness to React effect timing and local state.

Moving the lifecycle initially exposed `DeckListPage` before the first Deck snapshot. Its render effect interpreted the temporarily empty Deck store as authoritative and deleted valid persisted Study sessions. Reconciliation now runs from the app lifecycle only after a current Deck snapshot is available.

## Impact

Remote-read transitions now run imperatively from application startup. Previous listeners are stopped and previous entity data is cleared before a new UID begins synchronization, while the React tree no longer carries remote-read readiness state. Study progress remains intact during startup and is reconciled only against authoritative Deck data.

## Validation

- `mise run check`
- 106 unit test files passed (518 tests)
- `mise run e2e` (21 tests passed)
- TypeScript, ESLint, Biome, FSD, Knip, Docker lint, formatting, and sample checks passed

Closes #826