### PR TITLE
[No issue] Deduplicate shared text controls

### DIFF
--- a/src/shared/ui/forms/Input.tsx
+++ b/src/shared/ui/forms/Input.tsx
@@ -1,70 +1,9 @@
-/**
- * @file Defines the reusable Input component in the shared form library.
- * Feature screens compose this building block through props instead of duplicating presentation
- * and interaction rules.
- */
+import type { ComponentProps } from "react";
 
-import type * as React from "react";
-import cx from "classnames";
+import { textControlClassName } from "./textControlStyles";
 
-/**
- * Renders the Input user interface.
- * Renders the shared text input styling while forwarding its value, state, accessibility
- * attributes, and change handler.
- */
-export const Input: React.FC<{
-  id?: string;
-  className?: string;
-  name?: string;
-  type?: string;
-  value?: string;
-  defaultValue?: string;
-  disabled?: boolean;
-  readOnly?: boolean;
-  required?: boolean;
-  "aria-invalid"?: React.AriaAttributes["aria-invalid"];
-  "aria-describedby"?: React.AriaAttributes["aria-describedby"];
-  placeholder?: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
-  ref?: React.Ref<HTMLInputElement>;
-}> = ({
-  id,
-  className,
-  name,
-  type,
-  value,
-  defaultValue,
-  disabled,
-  readOnly,
-  required,
-  "aria-invalid": ariaInvalid,
-  "aria-describedby": ariaDescribedBy,
-  placeholder,
-  onChange,
-  onBlur,
-  ref,
-}) => {
-  return (
-    <input
-      ref={ref}
-      id={id}
-      type={type}
-      name={name}
-      defaultValue={defaultValue}
-      value={value}
-      disabled={disabled}
-      readOnly={readOnly}
-      required={required}
-      aria-invalid={ariaInvalid}
-      aria-describedby={ariaDescribedBy}
-      placeholder={placeholder}
-      onChange={onChange}
-      onBlur={onBlur}
-      className={cx(
-        "min-h-touch w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
-        className
-      )}
-    />
-  );
-};
+type InputProps = Omit<ComponentProps<"input">, "children">;
+
+export const Input = ({ className, ...props }: InputProps) => (
+  <input {...props} className={textControlClassName("text", className)} />
+);

--- a/src/shared/ui/forms/Select.tsx
+++ b/src/shared/ui/forms/Select.tsx
@@ -1,69 +1,25 @@
-/**
- * @file Defines the reusable Select component in the shared form library.
- * Feature screens compose this building block through props instead of duplicating presentation
- * and interaction rules.
- */
+import type { ComponentProps } from "react";
 
-import cx from "classnames";
-import type * as React from "react";
+import { textControlClassName } from "./textControlStyles";
 
 export interface Option {
   label: string;
   value: string;
 }
 
-/**
- * Renders the Select user interface.
- * Builds a select control from the supplied options and reports the chosen value through its
- * change handler.
- */
-export const Select: React.FC<{
+type SelectProps = Omit<ComponentProps<"select">, "children"> & {
   options?: Option[];
   empty?: boolean;
-  className?: string;
-  name?: string;
-  value?: string;
-  defaultValue?: string;
-  disabled?: boolean;
-  required?: boolean;
-  onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-  onBlur?: (e: React.FocusEvent<HTMLSelectElement>) => void;
-  ref?: React.Ref<HTMLSelectElement>;
-}> = ({
-  options: originalOptions,
-  empty,
-  className,
-  name,
-  value,
-  defaultValue,
-  disabled,
-  required,
-  onChange,
-  onBlur,
-  ref,
-}) => {
-  let options = originalOptions;
-  if (empty) {
-    options = [{ label: "", value: "" }, ...(originalOptions ?? [])];
-  }
+};
+
+export const Select = ({ options = [], empty, className, ...props }: SelectProps) => {
+  const renderedOptions = empty ? [{ label: "", value: "" }, ...options] : options;
+
   return (
-    <select
-      ref={ref}
-      name={name}
-      value={value}
-      defaultValue={defaultValue}
-      disabled={disabled}
-      required={required}
-      onChange={onChange}
-      onBlur={onBlur}
-      className={cx(
-        "block min-h-touch w-full appearance-none rounded-control border border-border bg-surface px-4 py-2 pr-8 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted",
-        className
-      )}
-    >
-      {options?.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
+    <select {...props} className={textControlClassName("select", className)}>
+      {renderedOptions.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
         </option>
       ))}
     </select>

--- a/src/shared/ui/forms/Textarea.tsx
+++ b/src/shared/ui/forms/Textarea.tsx
@@ -1,70 +1,9 @@
-/**
- * @file Defines the reusable Textarea component in the shared form library.
- * Feature screens compose this building block through props instead of duplicating presentation
- * and interaction rules.
- */
+import type { ComponentProps } from "react";
 
-import type * as React from "react";
-import cx from "classnames";
+import { textControlClassName } from "./textControlStyles";
 
-/**
- * Renders the Textarea user interface.
- * Renders the shared multiline input styling while forwarding its value, row count, validation
- * state, and change handler.
- */
-export const Textarea: React.FC<{
-  id?: string;
-  className?: string;
-  rows?: number;
-  name?: string;
-  value?: string;
-  defaultValue?: string;
-  disabled?: boolean;
-  readOnly?: boolean;
-  required?: boolean;
-  "aria-invalid"?: React.AriaAttributes["aria-invalid"];
-  "aria-describedby"?: React.AriaAttributes["aria-describedby"];
-  placeholder?: string;
-  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
-  ref?: React.Ref<HTMLTextAreaElement>;
-}> = ({
-  id,
-  className,
-  rows,
-  name,
-  value,
-  defaultValue,
-  disabled,
-  readOnly,
-  required,
-  "aria-invalid": ariaInvalid,
-  "aria-describedby": ariaDescribedBy,
-  placeholder,
-  onChange,
-  onBlur,
-  ref,
-}) => {
-  return (
-    <textarea
-      ref={ref}
-      id={id}
-      name={name}
-      value={value}
-      defaultValue={defaultValue}
-      disabled={disabled}
-      readOnly={readOnly}
-      required={required}
-      aria-invalid={ariaInvalid}
-      aria-describedby={ariaDescribedBy}
-      placeholder={placeholder}
-      onChange={onChange}
-      onBlur={onBlur}
-      rows={rows}
-      className={cx(
-        "min-h-touch w-full appearance-none rounded-control border border-border bg-surface px-3 py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm placeholder:text-ink-muted hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted read-only:bg-surface-muted",
-        className
-      )}
-    />
-  );
-};
+type TextareaProps = Omit<ComponentProps<"textarea">, "children">;
+
+export const Textarea = ({ className, ...props }: TextareaProps) => (
+  <textarea {...props} className={textControlClassName("text", className)} />
+);

--- a/src/shared/ui/forms/textControlStyles.ts
+++ b/src/shared/ui/forms/textControlStyles.ts
@@ -1,0 +1,14 @@
+import cx from "classnames";
+
+type TextControlKind = "select" | "text";
+
+const baseClassName =
+  "min-h-touch w-full appearance-none rounded-control border border-border bg-surface py-2 leading-tight text-ink shadow-surface transition-colors duration-fast ease-calm hover:border-ink-muted focus-visible:border-focus invalid:border-danger disabled:cursor-not-allowed disabled:bg-surface-muted disabled:text-ink-muted";
+
+const kindClassNames: Record<TextControlKind, string> = {
+  select: "block px-4 pr-8",
+  text: "px-3 placeholder:text-ink-muted read-only:bg-surface-muted",
+};
+
+export const textControlClassName = (kind: TextControlKind, className?: string) =>
+  cx(baseClassName, kindClassNames[kind], className);


### PR DESCRIPTION
## Related issue

None

## Summary

- Centralize the shared visual classes for input, textarea, and select controls.
- Forward native element props instead of maintaining duplicate prop and attribute lists.
- Preserve the existing select option API and empty-option behavior.

## Testing

- `mise run check`