### PR TITLE
entities の Firestore アクセス方針を明確化

### DIFF
--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -26,9 +26,9 @@
 ## `model/store.ts`
 
 - Define the global Entity store and synchronous state mutations.
-- Zustand may be used here as an explicit Entity-layer exception.
+- Treat Zustand as an explicit Entity-layer exception.
 - Do not perform external access, subscriptions, or asynchronous workflows.
-- As an explicit exception, persistence middleware may access storage, hydrate state, and manage persistence subscriptions.
+- Treat persistence middleware as an explicit exception for storage access, state hydration, and persistence subscriptions.
 
 ## `model/hooks.ts`
 
@@ -38,7 +38,7 @@
 ## `api/`
 
 - Define Entity-specific Firestore access and persistence implementations.
-- `api/` may access Firestore resources related to this Entity.
+- Keep Firestore access in `api/` to resources related to this Entity.
 - Collection names, document IDs, Entity CRUD, and Entity-specific query or parsing primitives belong here.
 - Firestore SDK access is allowed here, not in `model/`.
 

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -25,8 +25,7 @@
 
 ## `model/store.ts`
 
-- Define the global Entity store and synchronous state mutations.
-- Treat Zustand as an explicit Entity-layer exception.
+- Define the global Entity store with Zustand and synchronous state mutations.
 - Do not perform external access, subscriptions, or asynchronous workflows.
 - Treat persistence middleware as an explicit exception for storage access, state hydration, and persistence subscriptions.
 

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -26,6 +26,7 @@
 ## `model/store.ts`
 
 - Define the global Entity store and synchronous state mutations.
+- Zustand may be used here as an explicit Entity-layer exception.
 - Do not perform external access, subscriptions, or asynchronous workflows.
 - As an explicit exception, persistence middleware may access storage, hydrate state, and manage persistence subscriptions.
 
@@ -36,10 +37,10 @@
 
 ## `api/`
 
-- Own Entity-specific external access and persistence implementations.
+- Define Entity-specific Firestore access and persistence implementations.
+- `api/` may access Firestore resources related to this Entity.
 - Collection names, document IDs, Entity CRUD, and Entity-specific query or parsing primitives belong here.
-- Firebase, Firestore, and other external SDKs may be accessed only from `api/`, not `model/`.
-- Keep runtime subscription lifecycle, feature workflows, and use-case orchestration outside `entities`.
+- Firestore SDK access is allowed here, not in `model/`.
 
 ## `@x/`
 
@@ -54,5 +55,5 @@
 
 - Colocate tests as `*.spec.ts` or `*.spec.tsx` next to the file they cover.
 - Do not create implementation files outside the roles defined above.
-- Do not place UI, use cases, subscription lifecycle, or feature workflow state in `entities`.
-- Keep generic external-system helpers in `shared` and Entity-specific persistence in the owning Entity `api/`.
+- Do not place UI in `entities`.
+- Keep generic external-system helpers in `shared` and Entity-related Firestore access in `api/`.

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -56,4 +56,3 @@
 - Colocate tests as `*.spec.ts` or `*.spec.tsx` next to the file they cover.
 - Do not create implementation files outside the roles defined above.
 - Do not place UI in `entities`.
-- Keep generic external-system helpers in `shared` and Entity-related Firestore access in `api/`.


### PR DESCRIPTION
## 概要

`src/entities/AGENTS.md` の `api/` と `model/store.ts` の責務を見直しました。

## 変更内容

- `model/store.ts` で Zustand の利用を明示的な例外として許可
- `api/` で、この Entity に関連する Firestore リソースへのアクセスを明示的に許可
- `api/` の外部アクセス対象を Firestore として明確化
- `entities` から runtime subscription lifecycle / feature workflow / use case を排除する制約を削除
- UI は引き続き `entities` に置かない方針を維持

## 意図

Entity ごとの Firestore API を `entities/<entity>/api/` に集約できるようにしつつ、関連する Firestore リソースも必要に応じて扱えるようにします。

現時点で `entities` に許可する実装上の例外を、Zustand の store と Firestore の API として明確にします。

## 確認

ドキュメント変更のみのため、テスト実行は省略しています。