### PR TITLE
test(#825): Cover authenticated remote read startup

### DIFF
--- a/src/app/providers/remote-read/lifecycle.spec.ts
+++ b/src/app/providers/remote-read/lifecycle.spec.ts
@@ -69,6 +69,14 @@ describe("remote read session lifecycle", () => {
     expect(mocks.operations).toEqual(["clear Cards", "clear Decks"]);
   });
 
+  it("clears entity data before starting listeners for the current authenticated session", () => {
+    mocks.session = authenticated("uid-a");
+
+    startRemoteReadSessionLifecycle();
+
+    expect(mocks.operations).toEqual(["clear Cards", "clear Decks", "start Cards uid-a", "start Decks uid-a"]);
+  });
+
   it("stops and clears the previous session before starting the replacement", () => {
     startRemoteReadSessionLifecycle();
     publish(authenticated("uid-a"));


### PR DESCRIPTION
## Related issue

Fixes #825

## Summary

- Verify that an already-authenticated App startup clears Card and Deck entity data before starting the current user's listeners.
- Complete the observable lifecycle coverage for the remote-read orchestration introduced by the completed child issues.

## Testing

- `mise run check`
