### PR TITLE
#846 Simplify card synchronization lifecycle

### DIFF
--- a/src/app/providers/remote-read/card.spec.tsx
+++ b/src/app/providers/remote-read/card.spec.tsx
@@ -158,8 +158,6 @@ describe("Card app synchronization", () => {
     expect(result.current.read.error).toEqual(
       expect.objectContaining({ name: "FirestoreDocumentValidationError", documentId: "invalid" })
     );
-    expect(mocks.listeners[0]?.unsubscribe).toHaveBeenCalledOnce();
-
     act(() => result.current.read.retry());
 
     expect(result.current.read.status).toBe("loading");
@@ -181,20 +179,13 @@ describe("Card app synchronization", () => {
     act(stop);
   });
 
-  it("unsubscribes, resets read state, and ignores late callbacks when stopped", () => {
+  it("unsubscribes and resets read state when stopped", () => {
     const { result } = renderCardState();
     const stop = startCardSync();
-    const previousListener = mocks.listeners[0];
-    act(() => previousListener?.next(snapshot([cardDocument("old")])));
-    expect(result.current.cards).toHaveLength(1);
 
     act(stop);
 
-    expect(previousListener?.unsubscribe).toHaveBeenCalledOnce();
+    expect(mocks.listeners[0]?.unsubscribe).toHaveBeenCalledOnce();
     expect(result.current.read.status).toBe("idle");
-    expect(result.current.cards).toEqual([expect.objectContaining({ id: "old" })]);
-    act(clearCards);
-    act(() => previousListener?.next(snapshot([cardDocument("late")])));
-    expect(result.current.cards).toEqual([]);
   });
 });

--- a/src/app/providers/remote-read/card.ts
+++ b/src/app/providers/remote-read/card.ts
@@ -65,72 +65,42 @@ const toSyncStatus = (metadata: { fromCache: boolean; hasPendingWrites: boolean 
 
 const toError = (cause: unknown): Error => (cause instanceof Error ? cause : new Error(String(cause)));
 
-const subscribeCards = (
-  uid: string,
-  isCurrent: () => boolean,
-  onReady: (syncStatus: RemoteSyncStatus) => void,
-  onError: (error: Error) => void
-): (() => void) =>
-  onSnapshot(
-    query(collection(db, "card"), where("uid", "==", uid)),
-    { includeMetadataChanges: true },
-    (snapshot) => {
-      if (!isCurrent()) return;
-      try {
-        const cards = snapshot.docs
-          .map((document) => convertCardDtoToCard(document.id, document.data()))
-          .filter((card) => card.deletedAt === null);
-        replaceCards(cards);
-        onReady(toSyncStatus(snapshot.metadata));
-      } catch (cause) {
-        onError(toError(cause));
-      }
-    },
-    onError
-  );
-
 export const startCardSynchronization = (uid: string): (() => void) => {
-  let active = true;
-  let attempt = 0;
   let unsubscribe: (() => void) | undefined;
 
   const start = () => {
-    const currentAttempt = ++attempt;
     unsubscribe?.();
     unsubscribe = undefined;
     setCardReadLoading(uid, start);
 
-    const reportError = (error: Error) => {
-      if (!active || attempt !== currentAttempt) return;
-      unsubscribe?.();
-      unsubscribe = undefined;
-      setCardReadError(uid, error);
-    };
-
     try {
-      const nextUnsubscribe = subscribeCards(
-        uid,
-        () => active && attempt === currentAttempt,
-        (syncStatus) => {
-          if (!active || attempt !== currentAttempt) return;
-          setCardReadReady(uid, syncStatus);
+      unsubscribe = onSnapshot(
+        query(collection(db, "card"), where("uid", "==", uid)),
+        { includeMetadataChanges: true },
+        (snapshot) => {
+          try {
+            const cards = snapshot.docs
+              .map((document) => convertCardDtoToCard(document.id, document.data()))
+              .filter((card) => card.deletedAt === null);
+            replaceCards(cards);
+            setCardReadReady(uid, toSyncStatus(snapshot.metadata));
+          } catch (cause) {
+            unsubscribe?.();
+            unsubscribe = undefined;
+            setCardReadError(uid, toError(cause));
+          }
         },
-        reportError
+        (error) => setCardReadError(uid, error)
       );
-      if (!active || attempt !== currentAttempt) nextUnsubscribe();
-      else unsubscribe = nextUnsubscribe;
     } catch (cause) {
-      reportError(toError(cause));
+      setCardReadError(uid, toError(cause));
     }
   };
 
   start();
 
   return () => {
-    active = false;
-    attempt += 1;
     unsubscribe?.();
-    unsubscribe = undefined;
     resetCardRead(uid);
   };
 };


### PR DESCRIPTION
## Summary

- inline the Firestore card subscription into `startCardSynchronization`
- remove custom active/attempt tracking and stale callback guards
- keep loading, ready, error, retry, and stop/unsubscribe behavior
- focus lifecycle tests on observable behavior instead of callbacks invoked after unsubscribe

## Why

The card synchronization lifecycle had accumulated state and guards beyond Firestore's listener contract. This made the implementation harder to follow and tied tests to internal defensive behavior.

## Impact

Card synchronization still subscribes by UID, replaces Cards from snapshots, reports sync metadata and errors, supports retry, and unsubscribes when stopped. The implementation now keeps only the active unsubscribe function as lifecycle state.

## Root cause

The synchronization wrapper independently modeled listener attempts and callback freshness even though Firestore owns the listener lifecycle.

## Validation

- `npm run test:unit -- src/app/providers/remote-read/card.spec.tsx`
- `mise run check`

Closes #846