### PR TITLE
refactor: simplify deck synchronization lifecycle (#848)

### DIFF
--- a/src/app/providers/remote-read/deck.spec.ts
+++ b/src/app/providers/remote-read/deck.spec.ts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   query: vi.fn((...parts: unknown[]) => parts),
   where: vi.fn((...parts: unknown[]) => parts),
   unsubscribe: vi.fn(),
-  reconcileStudySessions: vi.fn(),
 }));
 
 vi.mock("firebase/firestore", () => ({
@@ -19,9 +18,6 @@ vi.mock("firebase/firestore", () => ({
   where: mocks.where,
 }));
 vi.mock("@/shared/firebase", () => ({ db: "db" }));
-vi.mock("@/features/study", () => ({
-  reconcileStudySessionsWithDecks: mocks.reconcileStudySessions,
-}));
 
 import { subscribeDecks } from "./deck";
 
@@ -68,7 +64,6 @@ describe("Deck app synchronization", () => {
     );
 
     expect(result.current).toEqual([expect.objectContaining({ id: "active", url: "https://example.com" })]);
-    expect(mocks.reconcileStudySessions).toHaveBeenCalledWith(["active"]);
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
@@ -82,7 +77,6 @@ describe("Deck app synchronization", () => {
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ name: "FirestoreDocumentValidationError", documentId: "invalid" })
     );
-    expect(mocks.reconcileStudySessions).not.toHaveBeenCalled();
   });
 
   it("reports Firestore subscription errors", () => {

--- a/src/app/providers/remote-read/deck.spec.ts
+++ b/src/app/providers/remote-read/deck.spec.ts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   query: vi.fn((...parts: unknown[]) => parts),
   where: vi.fn((...parts: unknown[]) => parts),
   unsubscribe: vi.fn(),
-  reconciliationCleanups: [] as ReturnType<typeof vi.fn>[],
   reconcileStudySessions: vi.fn(),
 }));
 
@@ -47,18 +46,13 @@ const deckDocument = (id: string, overrides: Record<string, unknown> = {}) => ({
 
 const getSnapshotHandler = () =>
   mocks.onSnapshot.mock.calls[0]?.[1] as (snapshot: { docs: ReturnType<typeof deckDocument>[] }) => void;
+const getErrorHandler = () => mocks.onSnapshot.mock.calls[0]?.[2] as (error: Error) => void;
 
 describe("Deck app synchronization", () => {
   beforeEach(() => {
     clearDecks();
     vi.clearAllMocks();
     mocks.onSnapshot.mockReturnValue(mocks.unsubscribe);
-    mocks.reconciliationCleanups.length = 0;
-    mocks.reconcileStudySessions.mockImplementation(() => {
-      const cleanup = vi.fn();
-      mocks.reconciliationCleanups.push(cleanup);
-      return cleanup;
-    });
   });
 
   it("subscribes by UID and replaces the store with active Decks", () => {
@@ -77,7 +71,6 @@ describe("Deck app synchronization", () => {
     expect(mocks.reconcileStudySessions).toHaveBeenCalledWith(["active"]);
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
-    expect(mocks.reconciliationCleanups[0]).toHaveBeenCalledOnce();
   });
 
   it("reports invalid Firestore documents", () => {
@@ -92,32 +85,13 @@ describe("Deck app synchronization", () => {
     expect(mocks.reconcileStudySessions).not.toHaveBeenCalled();
   });
 
-  it("keeps only the latest snapshot's pending Study reconciliation", () => {
-    const unsubscribe = subscribeDecks("uid-a", vi.fn());
-    const snapshotHandler = getSnapshotHandler();
-    act(() => snapshotHandler({ docs: [deckDocument("first")] }));
-
-    act(() => snapshotHandler({ docs: [deckDocument("second")] }));
-
-    expect(mocks.reconciliationCleanups[0]).toHaveBeenCalledOnce();
-    expect(mocks.reconcileStudySessions).toHaveBeenLastCalledWith(["second"]);
-    unsubscribe();
-    expect(mocks.reconciliationCleanups[1]).toHaveBeenCalledOnce();
-  });
-
-  it("ignores snapshots and errors after unsubscribe", () => {
-    const { result } = renderHook(useDecks);
+  it("reports Firestore subscription errors", () => {
     const onError = vi.fn();
-    const unsubscribe = subscribeDecks("uid-a", onError);
-    const snapshotHandler = getSnapshotHandler();
-    const errorHandler = mocks.onSnapshot.mock.calls[0]?.[2] as (error: Error) => void;
+    subscribeDecks("uid-a", onError);
+    const error = new Error("subscription failed");
 
-    unsubscribe();
-    act(() => snapshotHandler({ docs: [deckDocument("late")] }));
-    errorHandler(new Error("late"));
+    getErrorHandler()(error);
 
-    expect(result.current).toEqual([]);
-    expect(onError).not.toHaveBeenCalled();
-    expect(mocks.reconcileStudySessions).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(error);
   });
 });

--- a/src/app/providers/remote-read/deck.ts
+++ b/src/app/providers/remote-read/deck.ts
@@ -4,7 +4,6 @@ import { collection, onSnapshot, query, where } from "firebase/firestore";
 import { z } from "zod";
 
 import { replaceDecks } from "@/entities/deck";
-import { reconcileStudySessionsWithDecks } from "@/features/study";
 import { db } from "@/shared/firebase";
 import { parseFirestoreDocument } from "@/shared/firestore";
 
@@ -41,7 +40,6 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
           .map((document) => convertDeckDtoToDeck(document.id, document.data()))
           .filter((deck) => deck.deletedAt === null);
         replaceDecks(decks);
-        reconcileStudySessionsWithDecks(decks.map((deck) => deck.id));
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }

--- a/src/app/providers/remote-read/deck.ts
+++ b/src/app/providers/remote-read/deck.ts
@@ -32,32 +32,19 @@ const convertDeckDtoToDeck = (id: DeckId, value: unknown): Deck => {
   return deck;
 };
 
-export const subscribeDecks = (uid: string, onError: (error: Error) => void): (() => void) => {
-  let active = true;
-  let cancelStudyReconciliation: (() => void) | undefined;
-  const unsubscribe = onSnapshot(
+export const subscribeDecks = (uid: string, onError: (error: Error) => void): (() => void) =>
+  onSnapshot(
     query(collection(db, "deck"), where("uid", "==", uid)),
     (snapshot) => {
-      if (!active) return;
       try {
         const decks = snapshot.docs
           .map((document) => convertDeckDtoToDeck(document.id, document.data()))
           .filter((deck) => deck.deletedAt === null);
         replaceDecks(decks);
-        cancelStudyReconciliation?.();
-        cancelStudyReconciliation = reconcileStudySessionsWithDecks(decks.map((deck) => deck.id));
+        reconcileStudySessionsWithDecks(decks.map((deck) => deck.id));
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }
     },
-    (error) => {
-      if (active) onError(error);
-    }
+    onError
   );
-
-  return () => {
-    active = false;
-    unsubscribe();
-    cancelStudyReconciliation?.();
-  };
-};

--- a/src/features/study/commands/studySessionCommands.spec.ts
+++ b/src/features/study/commands/studySessionCommands.spec.ts
@@ -1,12 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { studyStore } from "../state/studyStoreInstance";
-import {
-  initializeStudySessionUi,
-  reconcileStudySessionsWithDecks,
-  removeStudySession,
-  touchStudySession,
-} from "./studySessionCommands";
+import { initializeStudySessionUi, removeStudySession, touchStudySession } from "./studySessionCommands";
 
 describe("study session commands", () => {
   beforeEach(() => {
@@ -48,34 +43,5 @@ describe("study session commands", () => {
       autoPlay: true,
       lastSwipe: undefined,
     });
-  });
-
-  it("discards sessions whose decks are unavailable", () => {
-    vi.spyOn(studyStore.persist, "hasHydrated").mockReturnValue(true);
-
-    reconcileStudySessionsWithDecks(["second"]);
-
-    expect(studyStore.getState().sessionsByDeckId).toEqual({
-      second: { deckId: "second", cardOrderIds: ["card-2"], currentIndex: 0, lastStudiedAt: 200 },
-    });
-  });
-
-  it("waits for hydration before discarding sessions", () => {
-    let finishHydration: () => void = () => undefined;
-    const unsubscribe = vi.fn();
-    vi.spyOn(studyStore.persist, "hasHydrated").mockReturnValue(false);
-    vi.spyOn(studyStore.persist, "onFinishHydration").mockImplementation((listener) => {
-      finishHydration = () => listener(studyStore.getState());
-      return unsubscribe;
-    });
-
-    const cancel = reconcileStudySessionsWithDecks(["second"]);
-    expect(studyStore.getState().sessionsByDeckId).toHaveProperty("first");
-
-    finishHydration();
-
-    expect(studyStore.getState().sessionsByDeckId).not.toHaveProperty("first");
-    cancel?.();
-    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/study/commands/studySessionCommands.ts
+++ b/src/features/study/commands/studySessionCommands.ts
@@ -13,21 +13,3 @@ export const removeStudySession = (deckId: DeckId) => {
 export const touchStudySession = (deckId: DeckId) => {
   studyStore.getState().touchStudy(deckId);
 };
-
-const discardStudySessionsMissingDecks = (deckIds: Iterable<DeckId>) => {
-  const availableDeckIds = new Set(deckIds);
-  const state = studyStore.getState();
-  for (const deckId of Object.keys(state.sessionsByDeckId)) {
-    if (!availableDeckIds.has(deckId)) state.removeStudy(deckId);
-  }
-};
-
-export const reconcileStudySessionsWithDecks = (deckIds: Iterable<DeckId>): (() => void) | undefined => {
-  const currentDeckIds = [...deckIds];
-  const reconcile = () => discardStudySessionsMissingDecks(currentDeckIds);
-  if (studyStore.persist.hasHydrated()) {
-    reconcile();
-    return;
-  }
-  return studyStore.persist.onFinishHydration(reconcile);
-};

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -1,12 +1,7 @@
 export { DeckStartForm } from "./components/DeckStartForm";
 export { Controller, type ControllerProps } from "./components/Controller";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
-export {
-  initializeStudySessionUi,
-  reconcileStudySessionsWithDecks,
-  removeStudySession,
-  touchStudySession,
-} from "./commands/studySessionCommands";
+export { initializeStudySessionUi, removeStudySession, touchStudySession } from "./commands/studySessionCommands";
 export { useStudyHydrated } from "./hooks/useStudyHydrated";
 export { useDeckFilterState } from "./hooks/useDeckFilterState";
 export { useStudyActions } from "./hooks/useStudyActions";


### PR DESCRIPTION
## Summary

- delegate Deck listener lifecycle and error forwarding directly to Firestore
- remove Study session reconciliation from Deck synchronization and delete its unused hydration lifecycle
- replace implementation-dependent post-unsubscribe callback tests with observable subscription error coverage

## Why

`subscribeDecks` duplicated Firestore listener lifecycle guarantees with an `active` flag and coupled each snapshot to cleanup of persisted Study data. That maintenance behavior introduced hydration checks, snapshot-to-snapshot cancellation, and unsubscribe cleanup into the Deck synchronization path.

Normal Deck deletion already removes the related Study session, while Deck list and study route behavior are driven by existing Decks. The subscription can therefore focus on parsing active Deck documents, replacing the Deck store, and reporting errors.

## Impact

Deck filtering, store replacement, validation error handling, Firestore error handling, and unsubscribe behavior remain covered. Deck synchronization no longer owns stale persisted Study session cleanup.

## Validation

- `mise run check` (99 test files, 509 tests)

Closes #848