### PR TITLE
refactor: move Firestore subscriptions to provider (#870)

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -18,34 +18,16 @@ const mocks = vi.hoisted(() => ({
   authState: { status: "initializing" } as AuthSessionState,
   startAuthSession: vi.fn(),
   stopAuthSession: vi.fn(),
-  subscribeCards: vi.fn(),
-  subscribeDecks: vi.fn(),
-  resetCardRead: vi.fn(),
-  setCardReadError: vi.fn(),
-  setCardReadLoading: vi.fn(),
-  setCardReadReady: vi.fn(),
-  operations: [] as string[],
 }));
 
 vi.mock("@/app/providers/auth/lifecycle", () => ({ startAuthSession: mocks.startAuthSession }));
-vi.mock("@/entities/card", () => ({
-  clearCards: () => mocks.operations.push("clear Cards"),
-  subscribeCards: mocks.subscribeCards,
-}));
-vi.mock("@/entities/deck", () => ({
-  clearDecks: () => mocks.operations.push("clear Decks"),
-  subscribeDecks: mocks.subscribeDecks,
+vi.mock("@/app/providers/firestore-subscriptions", () => ({
+  FirestoreSubscriptionsProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => ({ appearance: { darkMode: mocks.darkMode } }),
 }));
 vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authState }));
-vi.mock("@/features/card/read", () => ({
-  resetCardRead: mocks.resetCardRead,
-  setCardReadError: mocks.setCardReadError,
-  setCardReadLoading: mocks.setCardReadLoading,
-  setCardReadReady: mocks.setCardReadReady,
-}));
 vi.mock("@/features/sign-in", () => ({ loginGoogle: vi.fn() }));
 vi.mock("@/features/sign-out", () => ({ signOutCurrentUser: vi.fn() }));
 vi.mock("@/pages/card-form", () => ({ CardFormPage: () => null }));
@@ -64,15 +46,6 @@ describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.startAuthSession.mockReturnValue(mocks.stopAuthSession);
-    mocks.subscribeCards.mockImplementation((uid: string) => {
-      mocks.operations.push(`start Cards ${uid}`);
-      return () => mocks.operations.push(`stop Cards ${uid}`);
-    });
-    mocks.subscribeDecks.mockImplementation((uid: string) => {
-      mocks.operations.push(`start Decks ${uid}`);
-      return () => mocks.operations.push(`stop Decks ${uid}`);
-    });
-    mocks.operations.length = 0;
     mocks.darkMode = false;
     mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
     document.documentElement.classList.remove("dark");
@@ -87,81 +60,6 @@ describe("App", () => {
     view.unmount();
 
     expect(mocks.stopAuthSession).toHaveBeenCalledOnce();
-  });
-
-  it("starts and stops remote reads for the authenticated UID", () => {
-    const view = render(<App />);
-
-    expect(mocks.operations).toEqual(["start Cards test-user", "start Decks test-user"]);
-
-    view.unmount();
-
-    expect(mocks.operations).toEqual([
-      "start Cards test-user",
-      "start Decks test-user",
-      "stop Cards test-user",
-      "stop Decks test-user",
-      "clear Cards",
-      "clear Decks",
-    ]);
-  });
-
-  it("updates the Card read state from subscription events", () => {
-    render(<App />);
-    const onError = mocks.subscribeCards.mock.calls[0]?.[1] as (error: Error) => void;
-    const onData = mocks.subscribeCards.mock.calls[0]?.[2] as (metadata: {
-      fromCache: boolean;
-      hasPendingWrites: boolean;
-    }) => void;
-    const error = new Error("Card subscription failed");
-
-    expect(mocks.setCardReadLoading).toHaveBeenCalledWith("test-user");
-    onData({ fromCache: true, hasPendingWrites: false });
-    onData({ fromCache: false, hasPendingWrites: true });
-    onData({ fromCache: false, hasPendingWrites: false });
-    onError(error);
-
-    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(1, "test-user", false);
-    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(2, "test-user", false);
-    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(3, "test-user", true);
-    expect(mocks.setCardReadError).toHaveBeenCalledWith("test-user", error);
-  });
-
-  it("replaces remote reads when the authenticated UID changes", () => {
-    const view = render(<App />);
-    mocks.operations.length = 0;
-
-    mocks.authState = { status: "authenticated", uid: "next-user", isAnonymous: false, displayName: "Ada" };
-    view.rerender(<App />);
-
-    expect(mocks.operations).toEqual([
-      "stop Cards test-user",
-      "stop Decks test-user",
-      "clear Cards",
-      "clear Decks",
-      "start Cards next-user",
-      "start Decks next-user",
-    ]);
-  });
-
-  it("keeps remote reads when authentication metadata changes for the same UID", () => {
-    const view = render(<App />);
-    mocks.operations.length = 0;
-
-    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: false, displayName: "Ada" };
-    view.rerender(<App />);
-
-    expect(mocks.operations).toEqual([]);
-  });
-
-  it("stops remote reads and clears data on logout", () => {
-    const view = render(<App />);
-    mocks.operations.length = 0;
-
-    mocks.authState = { status: "unauthenticated" };
-    view.rerender(<App />);
-
-    expect(mocks.operations).toEqual(["stop Cards test-user", "stop Decks test-user", "clear Cards", "clear Decks"]);
   });
 
   it("updates only the theme when the setting changes", () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,12 +8,10 @@ import React from "react";
 import { BrowserRouter } from "react-router-dom";
 
 import { startAuthSession } from "@/app/providers/auth/lifecycle";
+import { FirestoreSubscriptionsProvider } from "@/app/providers/firestore-subscriptions";
 import { AppRoutes } from "@/app/routes";
 import { useAuthSession } from "@/entities/auth";
-import { clearCards, subscribeCards } from "@/entities/card";
-import { clearDecks, subscribeDecks } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
-import { resetCardRead, setCardReadError, setCardReadLoading, setCardReadReady } from "@/features/card/read";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 
 /**
@@ -24,33 +22,11 @@ import { RouteFeedback } from "@/shared/ui/route-feedback";
 const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location.reload() }) => {
   const { darkMode } = usePreferences().appearance;
   const authState = useAuthSession();
-  const authenticatedUid = authState.status === "authenticated" ? authState.uid : null;
 
   React.useEffect(() => {
     const stopAuthSession = startAuthSession();
     return stopAuthSession;
   }, []);
-
-  React.useEffect(() => {
-    if (authenticatedUid != null) setCardReadLoading(authenticatedUid);
-    const stopCards =
-      authenticatedUid == null
-        ? undefined
-        : subscribeCards(
-            authenticatedUid,
-            (error) => setCardReadError(authenticatedUid, error),
-            (metadata) => setCardReadReady(authenticatedUid, !metadata.fromCache && !metadata.hasPendingWrites)
-          );
-    const stopDecks = authenticatedUid == null ? undefined : subscribeDecks(authenticatedUid, console.error);
-
-    return () => {
-      stopCards?.();
-      stopDecks?.();
-      resetCardRead(authenticatedUid ?? undefined);
-      clearCards();
-      clearDecks();
-    };
-  }, [authenticatedUid]);
 
   React.useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
@@ -62,25 +38,31 @@ const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location
     authState.status === "authenticating"
   ) {
     return (
-      <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
+      <FirestoreSubscriptionsProvider>
+        <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
+      </FirestoreSubscriptionsProvider>
     );
   }
 
   if (authState.status === "error") {
     return (
-      <RouteFeedback
-        title="Unable to start Tango"
-        description="Authentication could not be initialized."
-        tone="error"
-        primaryAction={{ label: "Reload", onClick: reload }}
-      />
+      <FirestoreSubscriptionsProvider>
+        <RouteFeedback
+          title="Unable to start Tango"
+          description="Authentication could not be initialized."
+          tone="error"
+          primaryAction={{ label: "Reload", onClick: reload }}
+        />
+      </FirestoreSubscriptionsProvider>
     );
   }
 
   return (
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
+    <FirestoreSubscriptionsProvider>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </FirestoreSubscriptionsProvider>
   );
 };
 

--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { useAuthSession } from "@/entities/auth";
+
+type AuthSessionState = ReturnType<typeof useAuthSession>;
+
+const mocks = vi.hoisted(() => ({
+  authState: { status: "initializing" } as AuthSessionState,
+  subscribeCards: vi.fn(),
+  subscribeDecks: vi.fn(),
+  setCardReadError: vi.fn(),
+  setCardReadLoading: vi.fn(),
+  setCardReadReady: vi.fn(),
+  operations: [] as string[],
+}));
+
+vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authState }));
+vi.mock("@/entities/card", () => ({
+  clearCards: () => mocks.operations.push("clear Cards"),
+  subscribeCards: mocks.subscribeCards,
+}));
+vi.mock("@/entities/deck", () => ({
+  clearDecks: () => mocks.operations.push("clear Decks"),
+  subscribeDecks: mocks.subscribeDecks,
+}));
+vi.mock("@/features/card/read", () => ({
+  resetCardRead: (uid?: string) => mocks.operations.push(`reset Card read ${uid ?? "all"}`),
+  setCardReadError: mocks.setCardReadError,
+  setCardReadLoading: mocks.setCardReadLoading,
+  setCardReadReady: mocks.setCardReadReady,
+}));
+
+import { FirestoreSubscriptionsProvider } from ".";
+
+describe("FirestoreSubscriptionsProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.subscribeCards.mockImplementation((uid: string) => {
+      mocks.operations.push(`start Cards ${uid}`);
+      return () => mocks.operations.push(`stop Cards ${uid}`);
+    });
+    mocks.subscribeDecks.mockImplementation((uid: string) => {
+      mocks.operations.push(`start Decks ${uid}`);
+      return () => mocks.operations.push(`stop Decks ${uid}`);
+    });
+    mocks.operations.length = 0;
+    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
+  });
+
+  it("starts subscriptions for the authenticated UID and cleans them up on unmount", () => {
+    const view = render(<FirestoreSubscriptionsProvider>content</FirestoreSubscriptionsProvider>);
+
+    expect(mocks.operations).toEqual(["start Cards test-user", "start Decks test-user"]);
+    expect(screen.getByText("content")).toBeDefined();
+
+    view.unmount();
+
+    expect(mocks.operations).toEqual([
+      "start Cards test-user",
+      "start Decks test-user",
+      "stop Cards test-user",
+      "stop Decks test-user",
+      "reset Card read test-user",
+      "clear Cards",
+      "clear Decks",
+    ]);
+  });
+
+  it("updates the Card read state from subscription events", () => {
+    render(<FirestoreSubscriptionsProvider />);
+    const onError = mocks.subscribeCards.mock.calls[0]?.[1] as (error: Error) => void;
+    const onData = mocks.subscribeCards.mock.calls[0]?.[2] as (metadata: {
+      fromCache: boolean;
+      hasPendingWrites: boolean;
+    }) => void;
+    const error = new Error("Card subscription failed");
+
+    expect(mocks.setCardReadLoading).toHaveBeenCalledWith("test-user");
+    onData({ fromCache: true, hasPendingWrites: false });
+    onData({ fromCache: false, hasPendingWrites: true });
+    onData({ fromCache: false, hasPendingWrites: false });
+    onError(error);
+
+    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(1, "test-user", false);
+    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(2, "test-user", false);
+    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(3, "test-user", true);
+    expect(mocks.setCardReadError).toHaveBeenCalledWith("test-user", error);
+  });
+
+  it("replaces subscriptions when the authenticated UID changes", () => {
+    const view = render(<FirestoreSubscriptionsProvider />);
+    mocks.operations.length = 0;
+
+    mocks.authState = { status: "authenticated", uid: "next-user", isAnonymous: false, displayName: "Ada" };
+    view.rerender(<FirestoreSubscriptionsProvider />);
+
+    expect(mocks.operations).toEqual([
+      "stop Cards test-user",
+      "stop Decks test-user",
+      "reset Card read test-user",
+      "clear Cards",
+      "clear Decks",
+      "start Cards next-user",
+      "start Decks next-user",
+    ]);
+    expect(mocks.setCardReadLoading).toHaveBeenLastCalledWith("next-user");
+  });
+
+  it("keeps subscriptions when authentication metadata changes for the same UID", () => {
+    const view = render(<FirestoreSubscriptionsProvider />);
+    mocks.operations.length = 0;
+
+    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: false, displayName: "Ada" };
+    view.rerender(<FirestoreSubscriptionsProvider />);
+
+    expect(mocks.operations).toEqual([]);
+    expect(mocks.subscribeCards).toHaveBeenCalledOnce();
+    expect(mocks.subscribeDecks).toHaveBeenCalledOnce();
+  });
+
+  it("stops subscriptions and clears related state on logout", () => {
+    const view = render(<FirestoreSubscriptionsProvider />);
+    mocks.operations.length = 0;
+
+    mocks.authState = { status: "unauthenticated" };
+    view.rerender(<FirestoreSubscriptionsProvider />);
+
+    expect(mocks.operations).toEqual([
+      "stop Cards test-user",
+      "stop Decks test-user",
+      "reset Card read test-user",
+      "clear Cards",
+      "clear Decks",
+    ]);
+  });
+});

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { useAuthSession } from "@/entities/auth";
+import { clearCards, subscribeCards } from "@/entities/card";
+import { clearDecks, subscribeDecks } from "@/entities/deck";
+import { resetCardRead, setCardReadError, setCardReadLoading, setCardReadReady } from "@/features/card/read";
+
+export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const authState = useAuthSession();
+  const authenticatedUid = authState.status === "authenticated" ? authState.uid : null;
+
+  React.useEffect(() => {
+    if (authenticatedUid != null) setCardReadLoading(authenticatedUid);
+    const stopCards =
+      authenticatedUid == null
+        ? undefined
+        : subscribeCards(
+            authenticatedUid,
+            (error) => setCardReadError(authenticatedUid, error),
+            (metadata) => setCardReadReady(authenticatedUid, !metadata.fromCache && !metadata.hasPendingWrites)
+          );
+    const stopDecks = authenticatedUid == null ? undefined : subscribeDecks(authenticatedUid, console.error);
+
+    return () => {
+      stopCards?.();
+      stopDecks?.();
+      resetCardRead(authenticatedUid ?? undefined);
+      clearCards();
+      clearDecks();
+    };
+  }, [authenticatedUid]);
+
+  return children;
+};


### PR DESCRIPTION
## Summary

- move Card and Deck Firestore subscription lifecycle orchestration into `FirestoreSubscriptionsProvider`
- keep Firestore queries, snapshots, document conversion, and entity store updates in the Card and Deck entity APIs
- move lifecycle coverage from `App` tests to provider-focused tests

## Why

`App.tsx` owned authentication UI, routing, and the detailed Card and Deck subscription lifecycle. This made the application shell responsible for starting subscriptions, translating Card subscription metadata, and cleaning up feature and entity state.

The provider now owns when subscriptions start and stop while the entity APIs continue to own how Firestore data is queried and stored.

## Impact

Authenticated UID changes unsubscribe the previous Card and Deck listeners, clean their related state, and subscribe with the new UID. Logout and unmount perform the same cleanup. Authentication metadata changes for the same UID do not restart subscriptions.

Closes #870

## Validation

- `mise run check`
- 489 unit tests passed
