### PR TITLE
refactor(auth): move auth lifecycle and feedback to AuthProvider (#877)

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -1,33 +1,26 @@
 /**
  * @file Verifies the "App" contract with automated examples.
  * The examples make the expected behavior concrete with cases such as "updates only the theme when
- * the setting changes", "shows startup feedback while authentication is in progress",
- * "shows startup errors and reloads on request".
+ * the setting changes" and "renders normal routes".
  */
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { useAuthSession } from "@/entities/auth";
-
-type AuthSessionState = ReturnType<typeof useAuthSession>;
-
 const mocks = vi.hoisted(() => ({
   darkMode: false,
-  authState: { status: "initializing" } as AuthSessionState,
-  startAuthSession: vi.fn(),
-  stopAuthSession: vi.fn(),
 }));
 
-vi.mock("@/app/providers/auth/lifecycle", () => ({ startAuthSession: mocks.startAuthSession }));
+vi.mock("@/app/providers/auth", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 vi.mock("@/app/providers/firestore-subscriptions", () => ({
   FirestoreSubscriptionsProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => ({ appearance: { darkMode: mocks.darkMode } }),
 }));
-vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authState }));
 vi.mock("@/features/sign-in", () => ({ loginGoogle: vi.fn() }));
 vi.mock("@/features/sign-out", () => ({ signOutCurrentUser: vi.fn() }));
 vi.mock("@/pages/card-form", () => ({ CardFormPage: () => null }));
@@ -45,21 +38,9 @@ import App from "./App";
 describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.startAuthSession.mockReturnValue(mocks.stopAuthSession);
     mocks.darkMode = false;
-    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
     document.documentElement.classList.remove("dark");
     window.history.replaceState({}, "", "/");
-  });
-
-  it("starts and stops the authentication lifecycle", () => {
-    const view = render(<App />);
-
-    expect(mocks.startAuthSession).toHaveBeenCalledOnce();
-
-    view.unmount();
-
-    expect(mocks.stopAuthSession).toHaveBeenCalledOnce();
   });
 
   it("updates only the theme when the setting changes", () => {
@@ -72,43 +53,13 @@ describe("App", () => {
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it("shows startup feedback while authentication is in progress", () => {
-    mocks.authState = { status: "initializing" };
-    const view = render(<App />);
-
-    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
-    expect(screen.queryByText("Deck list")).toBeNull();
-
-    mocks.authState = { status: "unauthenticated" };
-    view.rerender(<App />);
-
-    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
-    expect(screen.queryByText("Deck list")).toBeNull();
-
-    mocks.authState = { status: "authenticating", attemptId: Symbol("attempt-a") };
-    view.rerender(<App />);
-
-    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
-    expect(screen.queryByText("Deck list")).toBeNull();
-  });
-
-  it("shows startup errors and reloads on request", () => {
-    const reload = vi.fn();
-    mocks.authState = { status: "error", error: new Error("auth failed") };
-    render(<App reload={reload} />);
-
-    expect(screen.getByRole("heading", { level: 1, name: "Unable to start Tango" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
-    expect(reload).toHaveBeenCalledOnce();
-  });
-
-  it("renders normal routes after authentication", () => {
+  it("renders normal routes", () => {
     render(<App />);
 
     expect(screen.getByText("Deck list")).toBeInTheDocument();
   });
 
-  it("recovers from authenticated unknown routes", () => {
+  it("recovers from unknown routes", () => {
     window.history.replaceState({}, "", "/unknown");
     render(<App />);
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,62 +7,31 @@
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
 
-import { startAuthSession } from "@/app/providers/auth/lifecycle";
+import { AuthProvider } from "@/app/providers/auth";
 import { FirestoreSubscriptionsProvider } from "@/app/providers/firestore-subscriptions";
 import { AppRoutes } from "@/app/routes";
-import { useAuthSession } from "@/entities/auth";
 import { usePreferences } from "@/entities/preferences";
-import { RouteFeedback } from "@/shared/ui/route-feedback";
 
 /**
  * Renders the App user interface.
  * Reads authentication and display settings, installs the application routes, and offers reload
  * when startup fails.
  */
-const App: React.FC<{ reload?: () => void }> = ({ reload = () => window.location.reload() }) => {
+const App: React.FC<{ reload?: () => void }> = ({ reload }) => {
   const { darkMode } = usePreferences().appearance;
-  const authState = useAuthSession();
-
-  React.useEffect(() => {
-    const stopAuthSession = startAuthSession();
-    return stopAuthSession;
-  }, []);
 
   React.useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
 
-  if (
-    authState.status === "initializing" ||
-    authState.status === "unauthenticated" ||
-    authState.status === "authenticating"
-  ) {
-    return (
-      <FirestoreSubscriptionsProvider>
-        <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
-      </FirestoreSubscriptionsProvider>
-    );
-  }
-
-  if (authState.status === "error") {
-    return (
-      <FirestoreSubscriptionsProvider>
-        <RouteFeedback
-          title="Unable to start Tango"
-          description="Authentication could not be initialized."
-          tone="error"
-          primaryAction={{ label: "Reload", onClick: reload }}
-        />
-      </FirestoreSubscriptionsProvider>
-    );
-  }
-
   return (
-    <FirestoreSubscriptionsProvider>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
-    </FirestoreSubscriptionsProvider>
+    <AuthProvider reload={reload}>
+      <FirestoreSubscriptionsProvider>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+      </FirestoreSubscriptionsProvider>
+    </AuthProvider>
   );
 };
 

--- a/src/app/providers/auth/index.spec.tsx
+++ b/src/app/providers/auth/index.spec.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { useAuthSession } from "@/entities/auth";
+
+type AuthSessionState = ReturnType<typeof useAuthSession>;
+
+const mocks = vi.hoisted(() => ({
+  authState: { status: "initializing" } as AuthSessionState,
+  startAuthSession: vi.fn(),
+  stopAuthSession: vi.fn(),
+}));
+
+vi.mock("@/app/providers/auth/lifecycle", () => ({
+  startAuthSession: mocks.startAuthSession,
+}));
+vi.mock("@/entities/auth", () => ({
+  useAuthSession: () => mocks.authState,
+}));
+
+import { AuthProvider } from "./index";
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.startAuthSession.mockReturnValue(mocks.stopAuthSession);
+    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
+  });
+
+  it("starts and stops the authentication lifecycle", () => {
+    const view = render(
+      <AuthProvider>
+        <div>Content</div>
+      </AuthProvider>
+    );
+
+    expect(mocks.startAuthSession).toHaveBeenCalledOnce();
+
+    view.unmount();
+
+    expect(mocks.stopAuthSession).toHaveBeenCalledOnce();
+  });
+
+  it("shows startup feedback while authentication is in progress", () => {
+    mocks.authState = { status: "initializing" };
+    const view = render(
+      <AuthProvider>
+        <div>Content</div>
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.queryByText("Content")).toBeNull();
+
+    mocks.authState = { status: "unauthenticated" };
+    view.rerender(
+      <AuthProvider>
+        <div>Content</div>
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.queryByText("Content")).toBeNull();
+
+    mocks.authState = { status: "authenticating", attemptId: Symbol("attempt-a") };
+    view.rerender(
+      <AuthProvider>
+        <div>Content</div>
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
+    expect(screen.queryByText("Content")).toBeNull();
+  });
+
+  it("shows startup errors and reloads on request", () => {
+    const reload = vi.fn();
+    mocks.authState = { status: "error", error: new Error("auth failed") };
+    render(
+      <AuthProvider reload={reload}>
+        <div>Content</div>
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Unable to start Tango" })).toBeInTheDocument();
+    expect(screen.queryByText("Content")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("renders children when authenticated", () => {
+    render(
+      <AuthProvider>
+        <div>Content</div>
+      </AuthProvider>
+    );
+
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+});

--- a/src/app/providers/auth/index.tsx
+++ b/src/app/providers/auth/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import { startAuthSession } from "@/app/providers/auth/lifecycle";
+import { useAuthSession } from "@/entities/auth";
+import { RouteFeedback } from "@/shared/ui/route-feedback";
+
+export interface AuthProviderProps {
+  children: React.ReactNode;
+  reload?: (() => void) | undefined;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children, reload = () => window.location.reload() }) => {
+  const authState = useAuthSession();
+
+  React.useEffect(() => {
+    const stopAuthSession = startAuthSession();
+    return stopAuthSession;
+  }, []);
+
+  if (
+    authState.status === "initializing" ||
+    authState.status === "unauthenticated" ||
+    authState.status === "authenticating"
+  ) {
+    return (
+      <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
+    );
+  }
+
+  if (authState.status === "error") {
+    return (
+      <RouteFeedback
+        title="Unable to start Tango"
+        description="Authentication could not be initialized."
+        tone="error"
+        primaryAction={{ label: "Reload", onClick: reload }}
+      />
+    );
+  }
+
+  return children;
+};


### PR DESCRIPTION
## Summary
Move authentication lifecycle initialization, state observation, and startup/error feedback from `App.tsx` into `AuthProvider` under `src/app/providers/auth`.

## Changes
- Created `AuthProvider` in `src/app/providers/auth/index.tsx` to handle `startAuthSession()`, `useAuthSession()`, and display startup feedback (`RouteFeedback`) during `initializing` / `unauthenticated` / `authenticating` and error feedback on `error`.
- Simplified `App.tsx` to wrap children in `AuthProvider`.
- Moved auth-specific unit tests from `App.spec.tsx` to `src/app/providers/auth/index.spec.tsx`.

Closes #877