### PR TITLE
refactor: limit FirestoreSubscriptionsProvider to subscription lifecycle (#878)

### DIFF
--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -70,21 +70,16 @@ describe("FirestoreSubscriptionsProvider", () => {
   it("updates the Card read state from subscription events", () => {
     render(<FirestoreSubscriptionsProvider />);
     const onError = mocks.subscribeCards.mock.calls[0]?.[1] as (error: Error) => void;
-    const onData = mocks.subscribeCards.mock.calls[0]?.[2] as (metadata: {
-      fromCache: boolean;
-      hasPendingWrites: boolean;
-    }) => void;
+    const onData = mocks.subscribeCards.mock.calls[0]?.[2] as (event: { serverConfirmed: boolean }) => void;
     const error = new Error("Card subscription failed");
 
     expect(mocks.setCardReadLoading).toHaveBeenCalledWith("test-user");
-    onData({ fromCache: true, hasPendingWrites: false });
-    onData({ fromCache: false, hasPendingWrites: true });
-    onData({ fromCache: false, hasPendingWrites: false });
+    onData({ serverConfirmed: false });
+    onData({ serverConfirmed: true });
     onError(error);
 
     expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(1, "test-user", false);
-    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(2, "test-user", false);
-    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(3, "test-user", true);
+    expect(mocks.setCardReadReady).toHaveBeenNthCalledWith(2, "test-user", true);
     expect(mocks.setCardReadError).toHaveBeenCalledWith("test-user", error);
   });
 

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { useAuthSession } from "@/entities/auth";
+import type { CardSubscriptionEvent } from "@/entities/card";
 import { clearCards, subscribeCards } from "@/entities/card";
 import { clearDecks, subscribeDecks } from "@/entities/deck";
 import { resetCardRead, setCardReadError, setCardReadLoading, setCardReadReady } from "@/features/card/read";
@@ -17,7 +18,7 @@ export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> =
         : subscribeCards(
             authenticatedUid,
             (error) => setCardReadError(authenticatedUid, error),
-            (metadata) => setCardReadReady(authenticatedUid, !metadata.fromCache && !metadata.hasPendingWrites)
+            ({ serverConfirmed }: CardSubscriptionEvent) => setCardReadReady(authenticatedUid, serverConfirmed)
           );
     const stopDecks = authenticatedUid == null ? undefined : subscribeDecks(authenticatedUid, console.error);
 

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { useAuthSession } from "@/entities/auth";
-import type { CardSubscriptionEvent } from "@/entities/card";
 import { clearCards, subscribeCards } from "@/entities/card";
 import { clearDecks, subscribeDecks } from "@/entities/deck";
 import { resetCardRead, setCardReadError, setCardReadLoading, setCardReadReady } from "@/features/card/read";
@@ -18,7 +17,7 @@ export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> =
         : subscribeCards(
             authenticatedUid,
             (error) => setCardReadError(authenticatedUid, error),
-            ({ serverConfirmed }: CardSubscriptionEvent) => setCardReadReady(authenticatedUid, serverConfirmed)
+            ({ serverConfirmed }) => setCardReadReady(authenticatedUid, serverConfirmed)
           );
     const stopDecks = authenticatedUid == null ? undefined : subscribeDecks(authenticatedUid, console.error);
 

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -7,7 +7,6 @@ import type {
   DeleteCardInput,
   EditCardInput,
 } from "../model/types";
-import type { SnapshotMetadata } from "firebase/firestore";
 
 import { collection, doc, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
 import { z } from "zod";
@@ -18,6 +17,10 @@ import { createCardSchema, deleteCardSchema, editCardSchema } from "../model/sch
 import { replaceCards } from "../model/store";
 
 const CARD_COLLECTION = "card";
+
+export interface CardSubscriptionEvent {
+  serverConfirmed: boolean;
+}
 
 const cardDtoSchema = z.object({
   id: z.string().optional(),
@@ -70,7 +73,7 @@ const convertCardDtoToCard = (id: CardId, value: unknown): Card => {
 export const subscribeCards = (
   uid: string,
   onError: (error: Error) => void,
-  onData: (metadata: SnapshotMetadata) => void = () => undefined
+  onData: (event: CardSubscriptionEvent) => void = () => undefined
 ): (() => void) =>
   onSnapshot(
     query(collection(db, CARD_COLLECTION), where("uid", "==", uid)),
@@ -81,7 +84,8 @@ export const subscribeCards = (
           .map((document) => convertCardDtoToCard(document.id, document.data()))
           .filter((card) => card.deletedAt === null);
         replaceCards(cards);
-        onData(snapshot.metadata);
+        const serverConfirmed = !snapshot.metadata.fromCache && !snapshot.metadata.hasPendingWrites;
+        onData({ serverConfirmed });
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }

--- a/src/entities/card/api/subscription.spec.tsx
+++ b/src/entities/card/api/subscription.spec.tsx
@@ -111,13 +111,42 @@ describe("Card Firestore subscription", () => {
         endLine: 9,
       }),
     ]);
-    expect(onData).toHaveBeenCalledWith(metadata);
+    expect(onData).toHaveBeenCalledWith({ serverConfirmed: true });
 
     act(() => mocks.next?.({ metadata, docs: [cardDocument("replacement", { frontText: "Current" })] }));
     expect(result.current).toEqual([expect.objectContaining({ id: "replacement", frontText: "Current" })]);
 
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("evaluates serverConfirmed from Firestore snapshot metadata", () => {
+    const onData = vi.fn();
+    subscribeCards("uid-a", vi.fn(), onData);
+
+    act(() =>
+      mocks.next?.({
+        metadata: { fromCache: true, hasPendingWrites: false },
+        docs: [],
+      })
+    );
+    expect(onData).toHaveBeenNthCalledWith(1, { serverConfirmed: false });
+
+    act(() =>
+      mocks.next?.({
+        metadata: { fromCache: false, hasPendingWrites: true },
+        docs: [],
+      })
+    );
+    expect(onData).toHaveBeenNthCalledWith(2, { serverConfirmed: false });
+
+    act(() =>
+      mocks.next?.({
+        metadata: { fromCache: false, hasPendingWrites: false },
+        docs: [],
+      })
+    );
+    expect(onData).toHaveBeenNthCalledWith(3, { serverConfirmed: true });
   });
 
   it("reports invalid Firestore documents", () => {

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,5 @@
 export { createCard, deleteCard, editCard, generateCardId, subscribeCards } from "./api/firestore";
+export type { CardSubscriptionEvent } from "./api/firestore";
 export { useCard, useCards } from "./model/hooks";
 /** @public */
 export { clearCards, replaceCards } from "./model/store";

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,5 +1,4 @@
 export { createCard, deleteCard, editCard, generateCardId, subscribeCards } from "./api/firestore";
-export type { CardSubscriptionEvent } from "./api/firestore";
 export { useCard, useCards } from "./model/hooks";
 /** @public */
 export { clearCards, replaceCards } from "./model/store";


### PR DESCRIPTION
## Summary
Delegates Firestore `SnapshotMetadata` interpretation (`fromCache` / `hasPendingWrites`) to `entities/card/api`, limiting `FirestoreSubscriptionsProvider` strictly to subscription lifecycle orchestration.

## Changes
- Move `SnapshotMetadata` evaluation inside `subscribeCards` in `entities/card/api/firestore.ts`, passing `{ serverConfirmed: boolean }` (`CardSubscriptionEvent`) to callbacks.
- Add unit tests for `fromCache` and `hasPendingWrites` combinations in `src/entities/card/api/subscription.spec.tsx`.
- Update `FirestoreSubscriptionsProvider` to use `serverConfirmed` directly from `CardSubscriptionEvent`.
- Decouple `FirestoreSubscriptionsProvider` unit tests from internal Firestore metadata structure.

Closes #878