### PR TITLE
refactor(app): remove unnecessary reload prop from App (#891)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,10 +14,9 @@ import { usePreferences } from "@/entities/preferences";
 
 /**
  * Renders the App user interface.
- * Reads authentication and display settings, installs the application routes, and offers reload
- * when startup fails.
+ * Reads display settings and installs the application routes.
  */
-const App: React.FC<{ reload?: () => void }> = ({ reload }) => {
+const App: React.FC = () => {
   const { darkMode } = usePreferences().appearance;
 
   React.useEffect(() => {
@@ -25,7 +24,7 @@ const App: React.FC<{ reload?: () => void }> = ({ reload }) => {
   }, [darkMode]);
 
   return (
-    <AuthProvider reload={reload}>
+    <AuthProvider>
       <FirestoreSubscriptionsProvider>
         <BrowserRouter>
           <AppRoutes />


### PR DESCRIPTION
## Summary
Remove the unnecessary `reload` prop from `App` component as `AuthProvider` already handles reloading by default.

Closes #891

## Changes
- Removed the `reload` prop from `App`.
- Render `AuthProvider` without passing `reload` from `App`.
- Updated `App.tsx` comments to reflect current responsibilities.

## Verification
- All automated checks passed (`mise run check`).