### PR TITLE
refactor: simplify usePreferencesFormState (#897)

### DIFF
--- a/src/features/settings/model/hooks/usePreferencesFormState.ts
+++ b/src/features/settings/model/hooks/usePreferencesFormState.ts
@@ -14,13 +14,13 @@ import type { PreferencesFormProps } from "../../ui/components/PreferencesForm";
 export interface UsePreferencesFormStateOptions {
   preferences: Preferences;
   onSubmit?: (preferences: Preferences) => void;
-  isLoggedIn?: boolean;
-  identity?: PreferencesFormProps["identity"];
-  onLogin?: () => void;
-  onLogout?: () => void;
-  accountPending?: boolean;
-  accountFeedback?: React.ReactNode;
-  version?: string;
+}
+
+export interface UsePreferencesFormStateReturn {
+  preferences: Preferences;
+  fields: PreferencesFormProps["fields"];
+  maxNumberOfCardsToLearn: number;
+  cardInterval: number;
 }
 
 /**
@@ -31,14 +31,7 @@ export interface UsePreferencesFormStateOptions {
 export const usePreferencesFormState = ({
   preferences,
   onSubmit,
-  isLoggedIn,
-  identity,
-  onLogin,
-  onLogout,
-  accountPending,
-  accountFeedback,
-  version,
-}: UsePreferencesFormStateOptions): PreferencesFormProps => {
+}: UsePreferencesFormStateOptions): UsePreferencesFormStateReturn => {
   const { control, handleSubmit, register, setValue, subscribe } = useForm<Preferences>({
     defaultValues: preferences,
   });
@@ -56,35 +49,30 @@ export const usePreferencesFormState = ({
     setValue("appearance.darkMode", preferences.appearance.darkMode);
   }, [preferences.appearance.darkMode, setValue]);
 
+  const fields: PreferencesFormProps["fields"] = {
+    showHeader: register("appearance.showHeader"),
+    showSwipeButtonList: register("controls.showSwipeButtonList"),
+    showSwipeFeedback: register("appearance.showSwipeFeedback"),
+    darkMode: register("appearance.darkMode"),
+    shuffled: register("study.shuffled"),
+    useCardInterval: register("study.useCardInterval"),
+    maxNumberOfCardsToLearn: {
+      ...register("study.maxNumberOfCardsToLearn", { valueAsNumber: true }),
+      min: 0,
+      max: 100,
+    },
+    defaultAutoPlay: register("study.defaultAutoPlay"),
+    cardInterval: {
+      ...register("study.cardInterval", { valueAsNumber: true }),
+      min: 0,
+      max: 60,
+    },
+  };
+
   return {
     preferences,
-    ...(isLoggedIn !== undefined ? { isLoggedIn } : {}),
-    ...(identity !== undefined ? { identity } : {}),
-    ...(onLogin !== undefined ? { onLogin } : {}),
-    ...(onLogout !== undefined ? { onLogout } : {}),
-    ...(accountPending !== undefined ? { accountPending } : {}),
-    ...(accountFeedback !== undefined ? { accountFeedback } : {}),
-    ...(version !== undefined ? { version } : {}),
     maxNumberOfCardsToLearn,
     cardInterval,
-    fields: {
-      showHeader: register("appearance.showHeader"),
-      showSwipeButtonList: register("controls.showSwipeButtonList"),
-      showSwipeFeedback: register("appearance.showSwipeFeedback"),
-      darkMode: register("appearance.darkMode"),
-      shuffled: register("study.shuffled"),
-      useCardInterval: register("study.useCardInterval"),
-      maxNumberOfCardsToLearn: {
-        ...register("study.maxNumberOfCardsToLearn", { valueAsNumber: true }),
-        min: 0,
-        max: 100,
-      },
-      defaultAutoPlay: register("study.defaultAutoPlay"),
-      cardInterval: {
-        ...register("study.cardInterval", { valueAsNumber: true }),
-        min: 0,
-        max: 60,
-      },
-    },
+    fields,
   };
 };

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -31,30 +31,34 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
   const signOut = useSignOut(linkedUser ? logout : undefined);
   const account = linkedUser ? { ...signOut, kind: "logout" as const } : { ...signIn, kind: "login" as const };
   const retryAccountOperation = account.kind === "logout" ? signOut.signOut : signIn.signIn;
-  const preferencesForm = usePreferencesFormState({
+  const preferencesFormState = usePreferencesFormState({
     preferences,
-    identity,
-    version: __APP_VERSION__,
-    isLoggedIn: linkedUser != null,
-    onLogin: () => void signIn.signIn().catch(() => undefined),
-    ...(linkedUser ? { onLogout: () => void signOut.signOut().catch(() => undefined) } : {}),
-    accountPending: account.pending,
-    accountFeedback: (
-      <RemoteMutationNotice
-        pending={account.pending}
-        error={account.error}
-        onRetry={() => void retryAccountOperation().catch(() => undefined)}
-        pendingLabel={account.kind === "logout" ? "Signing out…" : "Signing in…"}
-        errorLabel={account.kind === "logout" ? "Unable to sign out." : "Unable to sign in."}
-      />
-    ),
     onSubmit: updatePreferences,
   });
   useKey("t", () => void navigate("/"));
 
   return (
     <AppLayout showHeader>
-      <SettingsView preferencesForm={preferencesForm} />
+      <SettingsView
+        preferencesForm={{
+          ...preferencesFormState,
+          identity,
+          version: __APP_VERSION__,
+          isLoggedIn: linkedUser != null,
+          onLogin: () => void signIn.signIn().catch(() => undefined),
+          ...(linkedUser ? { onLogout: () => void signOut.signOut().catch(() => undefined) } : {}),
+          accountPending: account.pending,
+          accountFeedback: (
+            <RemoteMutationNotice
+              pending={account.pending}
+              error={account.error}
+              onRetry={() => void retryAccountOperation().catch(() => undefined)}
+              pendingLabel={account.kind === "logout" ? "Signing out…" : "Signing in…"}
+              errorLabel={account.kind === "logout" ? "Unable to sign out." : "Unable to sign in."}
+            />
+          ),
+        }}
+      />
     </AppLayout>
   );
 };


### PR DESCRIPTION
## Summary
Refactor `usePreferencesFormState` to simplify form state management and clarify responsibilities.

## Changes Made
- Separated field registration (`fields`) into a local variable before the `return` statement in `usePreferencesFormState`.
- Removed pass-through account/version props (`isLoggedIn`, `identity`, `onLogin`, `onLogout`, `accountPending`, `accountFeedback`, `version`) from `usePreferencesFormState`.
- Updated `SettingsPage.tsx` to pass account and version props directly into `PreferencesForm` composition.

Closes #897