### PR TITLE
refactor: move StudyProgress Firestore write to entities/study-progress/api (#898)

### DIFF
--- a/src/entities/study-progress/api/firestore.spec.ts
+++ b/src/entities/study-progress/api/firestore.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/firebase", () => ({ db: {} }));
+
+import { editStudyProgress } from "./firestore";
+
+describe("StudyProgress Firestore persistence", () => {
+  it("rejects edit requests without a confirmed user identity", async () => {
+    await expect(editStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
+  });
+
+  it("rejects edit requests without a card ID", async () => {
+    await expect(editStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
+  });
+});

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -1,9 +1,10 @@
-import { editStudyProgressSchema, type EditStudyProgressInput } from "@/entities/study-progress";
+import type { EditStudyProgressInput } from "../model/types";
 
 import { doc, updateDoc } from "firebase/firestore";
 
 import { db } from "@/shared/firebase";
 import { getTimestamp, omitUndefined } from "@/shared/firestore";
+import { editStudyProgressSchema } from "../model/schema";
 
 export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,3 +1,4 @@
+export { editStudyProgress } from "./api/firestore";
 export {
   compareStudyProgress,
   createStudyProgressFromCard,
@@ -5,5 +6,4 @@ export {
   isStudyProgressEligible,
   recordStudyProgress,
 } from "./model/rules";
-export { editStudyProgressSchema } from "./model/schema";
-export type { EditStudyProgressInput, StudyProgress, StudyProgressEdit, StudyRating } from "./model/types";
+export type { StudyProgress, StudyProgressEdit, StudyRating } from "./model/types";

--- a/src/entities/study-progress/model/rules.spec.ts
+++ b/src/entities/study-progress/model/rules.spec.ts
@@ -6,10 +6,8 @@ import {
   getNextStudyAvailabilityAt,
   isStudyProgressEligible,
   recordStudyProgress,
-  type StudyProgress,
-  type StudyProgressEdit,
-  type StudyRating,
-} from "../index";
+} from "./rules";
+import type { StudyProgress, StudyProgressEdit, StudyRating } from "./types";
 
 const initialStudyProgress = (cardId: string): StudyProgress => ({ cardId, score: 0, numberOfSeen: 0 });
 

--- a/src/features/study/hooks/useEditStudyProgress.ts
+++ b/src/features/study/hooks/useEditStudyProgress.ts
@@ -1,8 +1,7 @@
 import type { Card } from "@/entities/card";
-import type { StudyProgressEdit } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 
 import { useAuthSession } from "@/entities/auth";
-import { editStudyProgress } from "../api/editStudyProgress";
 
 export type StudyProgressPatch = Omit<StudyProgressEdit, "cardId">;
 

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -11,6 +11,8 @@ import type { Preferences } from "@/entities/preferences";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+
 import { useStudyActions } from "./useStudyActions";
 import { studyStore } from "../state/studyStoreInstance";
 import { actAsync } from "@/test/act";

--- a/src/features/study/hooks/useStudyCards.spec.tsx
+++ b/src/features/study/hooks/useStudyCards.spec.tsx
@@ -1,6 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+
 import { createCard, createPreferences, createDeck } from "@/test/factories";
 
 import { useStudyCards } from "./useStudyCards";

--- a/src/features/study/model/cardSelection.spec.ts
+++ b/src/features/study/model/cardSelection.spec.ts
@@ -3,7 +3,9 @@ import type { StudyProgress } from "@/entities/study-progress";
 import type { StudyCard } from "./studyCard";
 import type { StudyPreferences } from "@/entities/preferences";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { filterCardsForDeck } from "./cardSelection";
 import { createCard, createDeck } from "@/test/factories";

--- a/src/features/study/model/swipe.spec.ts
+++ b/src/features/study/model/swipe.spec.ts
@@ -1,6 +1,8 @@
 import type { SwipeState } from "@/entities/preferences";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import type { StudyCard } from "./studyCard";
 import { buildStudyPatch, resolveSwipeAction } from "./swipe";

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -17,7 +17,7 @@ import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { collection, deleteDoc, getDocs, getFirestore, doc, getDoc, query, where } from "firebase/firestore";
 import { upsertImportedCards } from "@/features/deck-import/api/upsertImportedCards";
-import { editStudyProgress } from "@/features/study/api/editStudyProgress";
+import { editStudyProgress } from "@/entities/study-progress";
 import { getTimestamp } from "@/shared/firestore";
 import * as UUID from "uuid";
 import { createCard, createDeck } from "@/test/factories";


### PR DESCRIPTION
## Summary

Relocates the StudyProgress Firestore write implementation from `src/features/study/api/editStudyProgress.ts` to `src/entities/study-progress/api/firestore.ts` as specified in #898.

- Moves StudyProgress write logic to `src/entities/study-progress/api/firestore.ts`.
- Re-exports `editStudyProgress` from `src/entities/study-progress`.
- Updates `useEditStudyProgress` to import from `@/entities/study-progress`.
- Adds unit tests in `src/entities/study-progress/api/firestore.spec.ts`.
- Adds default fallback values for Firebase initialization in `src/shared/firebase/index.ts`.
- Removes direct Firestore persistence implementation from `src/features/study/api`.

## Related Issue

Closes #898