### PR TITLE
refactor: separate lastSwipe from persisted studyStore (#900)

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -83,7 +83,6 @@ export const preparePageStory = async (parameters: PageStoryParameters): Promise
     sessionsByDeckId: cloneSessions(parameters.sessionsByDeckId ?? {}),
     showBackText: parameters.showBackText ?? false,
     autoPlay: parameters.autoPlay ?? false,
-    lastSwipe: undefined,
   });
   replaceDecks(decks);
   replaceCards(cards);

--- a/src/features/study/commands/studySessionCommands.spec.ts
+++ b/src/features/study/commands/studySessionCommands.spec.ts
@@ -33,7 +33,6 @@ describe("study session commands", () => {
     studyStore.setState({
       showBackText: true,
       autoPlay: false,
-      lastSwipe: { direction: "cardSwipeLeft", eventId: 1 },
     });
 
     initializeStudySessionUi(true);
@@ -41,7 +40,6 @@ describe("study session commands", () => {
     expect(studyStore.getState()).toMatchObject({
       showBackText: false,
       autoPlay: true,
-      lastSwipe: undefined,
     });
   });
 });

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -116,7 +116,6 @@ describe("useStudyActions", () => {
       sessionsByDeckId: {},
       showBackText: false,
       autoPlay: false,
-      lastSwipe: undefined,
     });
   });
 
@@ -125,7 +124,7 @@ describe("useStudyActions", () => {
   });
 
   it("starts from filtered Query cards before notifying its owner", () => {
-    studyStore.setState({ showBackText: true, lastSwipe: { direction: "cardSwipeLeft", eventId: 1 } });
+    studyStore.setState({ showBackText: true });
     const onStarted = vi.fn(() => {
       expect(studyStore.getState()).toMatchObject({
         sessionsByDeckId: {
@@ -138,7 +137,6 @@ describe("useStudyActions", () => {
         },
         showBackText: false,
         autoPlay: true,
-        lastSwipe: undefined,
       });
     });
     const { result } = renderHook(() => useStudyActions(deck.id, { cardsById: getCardsById(), onStarted }));
@@ -163,14 +161,14 @@ describe("useStudyActions", () => {
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
     expect(studyStore.getState().sessionsByDeckId["deck-2"]?.deckId).toBe("deck-2");
     expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
-    expect(studyStore.getState().lastSwipe).toBeUndefined();
   });
 
-  it("writes a card patch and advances the Zustand session", async () => {
+  it("writes a card patch, notifies onSwipe, and advances the Zustand session", async () => {
+    const onSwipe = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     studyStore.setState({ showBackText: true });
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onSwipe })
     );
 
     await actAsync(async () => {
@@ -184,6 +182,7 @@ describe("useStudyActions", () => {
       lastSeenAt: 946684800000,
     };
     expect(mocks.cardUpdate).toHaveBeenCalledWith(patch);
+    expect(onSwipe).toHaveBeenCalledWith("cardSwipeRight");
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: {
         [deck.id]: {
@@ -193,7 +192,6 @@ describe("useStudyActions", () => {
           lastStudiedAt: 946684800000,
         },
       },
-      lastSwipe: { direction: "cardSwipeRight" },
       showBackText: false,
     });
   });
@@ -213,7 +211,6 @@ describe("useStudyActions", () => {
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: { [deck.id]: { currentIndex: 0 } },
       showBackText: true,
-      lastSwipe: undefined,
     });
   });
 
@@ -300,12 +297,13 @@ describe("useStudyActions", () => {
   });
 
   it("removes only the route session for GoBack without a card write", async () => {
+    const onSwipe = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     studyStore.getState().setCurrentIndex(deck.id, 1);
     studyStore.setState({ showBackText: true });
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onSwipe })
     );
 
     await actAsync(async () => {
@@ -313,9 +311,9 @@ describe("useStudyActions", () => {
     });
 
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
+    expect(onSwipe).toHaveBeenCalledWith("cardSwipeLeft");
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: { "deck-2": { deckId: "deck-2" } },
-      lastSwipe: { direction: "cardSwipeLeft" },
       showBackText: true,
     });
     expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -35,8 +35,9 @@ interface StudyCardMutation {
 
 interface UseStudyActionsOptions {
   cardsById: Partial<Record<CardId, Card>>;
-  cardMutation?: StudyCardMutation;
-  onStarted?: () => void;
+  cardMutation?: StudyCardMutation | undefined;
+  onStarted?: (() => void) | undefined;
+  onSwipe?: ((direction: SwipeDirection) => void) | undefined;
 }
 
 interface StudySwipeDependencies {
@@ -45,6 +46,7 @@ interface StudySwipeDependencies {
   preferences: Preferences;
   cardsById: Partial<Record<CardId, Card>>;
   update: (progress: StudyProgressEdit) => Promise<void>;
+  onSwipe?: ((direction: SwipeDirection) => void) | undefined;
 }
 
 const applyOptimisticUpdate = (deckId: DeckId, nextIndex: number) => {
@@ -63,7 +65,7 @@ const revertOptimisticUpdate = (
   mutationTokenRef: { current: symbol | undefined },
   mutationToken: symbol,
   optimisticSession: Session,
-  previous: { session: Session; showBackText: boolean; lastSwipe: StudyState["lastSwipe"] }
+  previous: { session: Session; showBackText: boolean }
 ) => {
   const current = studyStore.getState();
   const currentSession = current.sessionsByDeckId[deckId];
@@ -74,7 +76,6 @@ const revertOptimisticUpdate = (
     studyStore.setState((state) => ({
       sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
       showBackText: previous.showBackText,
-      lastSwipe: previous.lastSwipe,
     }));
   }
 };
@@ -85,7 +86,7 @@ const revertOptimisticUpdate = (
  */
 const runStudySwipe = async (
   direction: SwipeDirection,
-  { mutationTokenRef, deckId, preferences, cardsById, update }: StudySwipeDependencies
+  { mutationTokenRef, deckId, preferences, cardsById, update, onSwipe }: StudySwipeDependencies
 ): Promise<void> => {
   if (mutationTokenRef.current !== undefined) return;
   const state = studyStore.getState();
@@ -96,7 +97,7 @@ const runStudySwipe = async (
   if (swipeAction === "DoNothing") return;
 
   if (swipeAction === "GoBack") {
-    state.setLastSwipe(direction);
+    onSwipe?.(direction);
     state.removeStudy(deckId);
     return;
   }
@@ -108,10 +109,9 @@ const runStudySwipe = async (
   const previous = {
     session: { ...session },
     showBackText: state.showBackText,
-    lastSwipe: state.lastSwipe,
   };
 
-  state.setLastSwipe(direction);
+  onSwipe?.(direction);
   if (preferences.appearance.hideBodyWhenCardChanged) {
     state.hideBackText();
   }
@@ -137,7 +137,7 @@ const runStudySwipe = async (
  */
 export const useStudyActions = (
   deckId: DeckId,
-  { cardMutation, cardsById, onStarted }: UseStudyActionsOptions
+  { cardMutation, cardsById, onStarted, onSwipe }: UseStudyActionsOptions
 ): StudyActions => {
   const preferences = usePreferences();
   const mutationTokenRef = React.useRef<symbol | undefined>(undefined);
@@ -167,6 +167,7 @@ export const useStudyActions = (
       preferences,
       cardsById,
       update: cardMutation.update,
+      onSwipe,
     });
   };
 

--- a/src/features/study/state/studyStore.spec.ts
+++ b/src/features/study/state/studyStore.spec.ts
@@ -121,18 +121,15 @@ describe("study store", () => {
   it("initializes and toggles transient study UI state", () => {
     const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
     store.getState().toggleShowBackText();
-    store.getState().setLastSwipe("cardSwipeLeft");
 
     store.getState().initializeStudyUi(true);
-    expect(store.getState()).toMatchObject({ showBackText: false, autoPlay: true, lastSwipe: undefined });
+    expect(store.getState()).toMatchObject({ showBackText: false, autoPlay: true });
 
     store.getState().toggleShowBackText();
     store.getState().toggleAutoPlay();
-    store.getState().setLastSwipe("cardSwipeRight");
     expect(store.getState()).toMatchObject({
       showBackText: true,
       autoPlay: false,
-      lastSwipe: { direction: "cardSwipeRight" },
     });
 
     store.getState().hideBackText();
@@ -164,7 +161,6 @@ describe("study store", () => {
       },
       showBackText: false,
       autoPlay: false,
-      lastSwipe: undefined,
     });
     expect(restored.getState()).not.toHaveProperty("session");
   });

--- a/src/features/study/state/studyStore.ts
+++ b/src/features/study/state/studyStore.ts
@@ -6,7 +6,6 @@
 
 import type { CardId } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
-import type { SwipeDirection } from "@/entities/preferences";
 
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
@@ -20,11 +19,6 @@ interface StudySession {
   lastStudiedAt: number;
 }
 
-interface StudySwipeFeedback {
-  direction: SwipeDirection;
-  eventId: number;
-}
-
 interface PersistedStudyState {
   sessionsByDeckId: Partial<Record<DeckId, StudySession>>;
 }
@@ -32,7 +26,6 @@ interface PersistedStudyState {
 export interface StudyState extends PersistedStudyState {
   showBackText: boolean;
   autoPlay: boolean;
-  lastSwipe?: StudySwipeFeedback | undefined;
   startStudy: (deckId: DeckId, cardOrderIds: CardId[]) => void;
   touchStudy: (deckId: DeckId) => void;
   setCurrentIndex: (deckId: DeckId, currentIndex: number) => void;
@@ -40,8 +33,6 @@ export interface StudyState extends PersistedStudyState {
   initializeStudyUi: (defaultAutoPlay: boolean) => void;
   toggleShowBackText: () => void;
   toggleAutoPlay: () => void;
-  setLastSwipe: (lastSwipe: SwipeDirection) => void;
-  clearLastSwipe: () => void;
   hideBackText: () => void;
 }
 
@@ -131,7 +122,6 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
         sessionsByDeckId: {},
         showBackText: false,
         autoPlay: false,
-        lastSwipe: undefined,
         startStudy: (deckId, cardOrderIds) =>
           set((state) => ({
             sessionsByDeckId: {
@@ -182,18 +172,9 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
           set({
             showBackText: false,
             autoPlay: defaultAutoPlay,
-            lastSwipe: undefined,
           }),
         toggleShowBackText: () => set((state) => ({ showBackText: !state.showBackText })),
         toggleAutoPlay: () => set((state) => ({ autoPlay: !state.autoPlay })),
-        setLastSwipe: (direction) =>
-          set((state) => ({
-            lastSwipe: {
-              direction,
-              eventId: (state.lastSwipe?.eventId ?? 0) + 1,
-            },
-          })),
-        clearLastSwipe: () => set({ lastSwipe: undefined }),
         hideBackText: () => set({ showBackText: false }),
       }),
       {

--- a/src/features/study/state/studyStoreInstance.ts
+++ b/src/features/study/state/studyStoreInstance.ts
@@ -11,7 +11,6 @@ export const clearStudyStore = async (): Promise<void> => {
     sessionsByDeckId: {},
     showBackText: false,
     autoPlay: false,
-    lastSwipe: undefined,
   });
   await studyStore.persist.clearStorage();
 };

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -37,8 +37,6 @@ const mocks = vi.hoisted(() => ({
     sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
     showBackText: false,
     autoPlay: false,
-    lastSwipe: undefined as { direction: SwipeDirection; eventId: number } | undefined,
-    clearLastSwipe: vi.fn(),
   },
   initializeStudySessionUi: vi.fn(),
   touchStudySession: vi.fn(),
@@ -83,11 +81,23 @@ vi.mock("@/features/study", async (importOriginal) => {
     initializeStudySessionUi: mocks.initializeStudySessionUi,
     touchStudySession: mocks.touchStudySession,
     useEditStudyProgress: () => mocks.cardMutation,
-    useStudyActions: () => ({
-      swipeUp: mocks.swipeUp,
-      swipeDown: mocks.swipeDown,
-      swipeLeft: mocks.swipeLeft,
-      swipeRight: mocks.swipeRight,
+    useStudyActions: (_deckId: DeckId, options?: { onSwipe?: (direction: SwipeDirection) => void }) => ({
+      swipeUp: () => {
+        options?.onSwipe?.("cardSwipeUp");
+        mocks.swipeUp();
+      },
+      swipeDown: () => {
+        options?.onSwipe?.("cardSwipeDown");
+        mocks.swipeDown();
+      },
+      swipeLeft: () => {
+        options?.onSwipe?.("cardSwipeLeft");
+        mocks.swipeLeft();
+      },
+      swipeRight: () => {
+        options?.onSwipe?.("cardSwipeRight");
+        mocks.swipeRight();
+      },
       updateIndex: mocks.updateIndex,
       toggleShowBackText: mocks.toggleShowBackText,
       toggleAutoPlay: mocks.toggleAutoPlay,
@@ -165,14 +175,9 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     };
     mocks.studyState.showBackText = false;
     mocks.studyState.autoPlay = false;
-    mocks.studyState.lastSwipe = undefined;
-    mocks.studyState.clearLastSwipe.mockImplementation(() => {
-      mocks.studyState.lastSwipe = undefined;
-    });
     mocks.initializeStudySessionUi.mockImplementation((defaultAutoPlay: boolean) => {
       mocks.studyState.showBackText = false;
       mocks.studyState.autoPlay = defaultAutoPlay;
-      mocks.studyState.lastSwipe = undefined;
     });
     mocks.touchStudySession.mockImplementation((deckId: DeckId) => {
       const session = mocks.studyState.sessionsByDeckId[deckId];
@@ -257,25 +262,22 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
       ...mocks.state.preferences,
       appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: true },
     });
-    const view = render(<DeckSwiperPage />);
+    render(<DeckSwiperPage />);
 
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
-    view.rerender(<DeckSwiperPage />);
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
     expect(screen.getByText("Swiped left")).toHaveAttribute("role", "status");
 
     act(() => vi.advanceTimersByTime(899));
     expect(screen.getByText("Swiped left")).toBeInTheDocument();
 
     act(() => vi.advanceTimersByTime(1));
-    view.rerender(<DeckSwiperPage />);
     expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
 
     mocks.state.preferences = createPreferences({
       ...mocks.state.preferences,
       appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: false },
     });
-    mocks.studyState.lastSwipe = { direction: "cardSwipeRight", eventId: 2 };
-    view.rerender(<DeckSwiperPage />);
+    fireEvent.keyDown(window, { key: "ArrowRight" });
     expect(screen.queryByText("Swiped right")).not.toBeInTheDocument();
   });
 
@@ -286,19 +288,16 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
       ...mocks.state.preferences,
       appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: true },
     });
-    const view = render(<DeckSwiperPage />);
+    render(<DeckSwiperPage />);
 
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
-    view.rerender(<DeckSwiperPage />);
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
     act(() => vi.advanceTimersByTime(500));
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 2 };
-    view.rerender(<DeckSwiperPage />);
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
 
     act(() => vi.advanceTimersByTime(899));
     expect(screen.getByText("Swiped left")).toBeInTheDocument();
 
     act(() => vi.advanceTimersByTime(1));
-    view.rerender(<DeckSwiperPage />);
     expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
   });
 
@@ -326,7 +325,6 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     mocks.studyState.sessionsByDeckId[deck.id] = { ...session, lastStudiedAt: 100 };
     mocks.studyState.showBackText = true;
     mocks.studyState.autoPlay = true;
-    mocks.studyState.lastSwipe = { direction: "cardSwipeLeft", eventId: 1 };
     const now = vi.spyOn(Date, "now").mockReturnValue(9000);
 
     render(<DeckSwiperPage />);
@@ -334,7 +332,7 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     expect(mocks.initializeStudySessionUi).toHaveBeenCalledWith(false);
     expect(mocks.touchStudySession).toHaveBeenCalledWith(deck.id);
     expect(mocks.studyState.sessionsByDeckId[deck.id]?.lastStudiedAt).toBe(9000);
-    expect(mocks.studyState).toMatchObject({ showBackText: false, autoPlay: false, lastSwipe: undefined });
+    expect(mocks.studyState).toMatchObject({ showBackText: false, autoPlay: false });
     now.mockRestore();
   });
 

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -17,7 +17,12 @@ import {
   useStudyHydrated,
   useStudyStore,
 } from "@/features/study";
-import { toggleShowHeader, toggleShowSwipeButtonList, usePreferences } from "@/entities/preferences";
+import {
+  toggleShowHeader,
+  toggleShowSwipeButtonList,
+  usePreferences,
+  type SwipeDirection,
+} from "@/entities/preferences";
 import { toRemoteById } from "@/shared/api";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
@@ -37,9 +42,24 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   const session = useStudyStore(selectStudySessionForRoute(deckId));
   const showBackText = useStudyStore((state) => state.showBackText);
   const autoPlay = useStudyStore((state) => state.autoPlay);
-  const lastSwipe = useStudyStore((state) => state.lastSwipe);
-  const clearLastSwipe = useStudyStore((state) => state.clearLastSwipe);
+  const [lastSwipe, setLastSwipe] = React.useState<{ direction: SwipeDirection; eventId: number } | undefined>(
+    undefined
+  );
   const hydrated = useStudyHydrated();
+
+  const handleSwipe = React.useCallback(
+    (direction: SwipeDirection) => {
+      if (!preferences.appearance.showSwipeFeedback) return;
+      setLastSwipe((prev) => ({
+        direction,
+        eventId: (prev?.eventId ?? 0) + 1,
+      }));
+    },
+    [preferences.appearance.showSwipeFeedback]
+  );
+  const clearLastSwipe = React.useCallback(() => {
+    setLastSwipe(undefined);
+  }, []);
 
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
@@ -50,6 +70,7 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
     cardMutation: {
       update: cardMutation.update,
     },
+    onSwipe: handleSwipe,
   });
   useKey("ArrowUp", studyActions.swipeUp);
   useKey("ArrowDown", studyActions.swipeDown);
@@ -61,15 +82,11 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   useKey(" ", studyActions.toggleAutoPlay);
 
   React.useEffect(() => {
-    if (!preferences.appearance.showSwipeFeedback) {
-      if (lastSwipe !== undefined) clearLastSwipe();
-      return;
-    }
     if (lastSwipe === undefined) return;
 
     const timeout = window.setTimeout(clearLastSwipe, SWIPE_FEEDBACK_DURATION_MS);
     return () => window.clearTimeout(timeout);
-  }, [clearLastSwipe, preferences.appearance.showSwipeFeedback, lastSwipe]);
+  }, [clearLastSwipe, lastSwipe]);
 
   const valid = session != null && index >= 0 && index < session.cardOrderIds.length && card != null;
   const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;


### PR DESCRIPTION
## Summary

Closes #900

Decouple `lastSwipe` swipe feedback state from the persisted `studyStore` and own it as ephemeral state within the Study workflow (`DeckSwiperContent` and `useStudyActions`).

## Changes

- Removed `lastSwipe`, `setLastSwipe`, and `clearLastSwipe` from `studyStore` state interface and store implementation.
- Added optional `onSwipe` callback to `useStudyActions`.
- Managed ephemeral `lastSwipe` feedback state in `DeckSwiperContent` (`DeckSwiperPage.tsx`) using `React.useState`.
- Removed `lastSwipe` from `clearStudyStore` and test fixtures.
- Updated unit tests in `studyStore.spec.ts`, `useStudyActions.spec.tsx`, `studySessionCommands.spec.ts`, and `DeckSwiperPage.spec.tsx`.

## Verification

- `mise run check` passed clean (formatting, linting, type-checking, build, 96 unit test files / 474 tests).