### PR TITLE
feat: verify remote Deck state before Sample Deck bootstrap (#879)

### DIFF
--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -26,6 +26,8 @@ const mocks = vi.hoisted(() => ({
   editCard: vi.fn(),
   createDeck: vi.fn(),
   bulkUpsert: vi.fn(),
+  fetchDecks: vi.fn<(uid: string) => Promise<Deck[]>>(),
+  fetchCards: vi.fn<(uid: string) => Promise<Card[]>>(),
 }));
 
 vi.mock("@/entities/auth", () => ({
@@ -40,6 +42,7 @@ vi.mock("@/entities/card", async (importOriginal) => {
   return {
     ...actual,
     filterCardsByDeckId: (cards: Card[], id: DeckId) => cards.filter((card) => card.deckId === id),
+    fetchCards: (uid: string) => mocks.fetchCards(uid),
   };
 });
 vi.mock("../api/upsertImportedCards", async (importOriginal) => {
@@ -54,6 +57,7 @@ vi.mock("@/entities/deck", async (importOriginal) => {
   return {
     ...actual,
     generateDeckId: mocks.generateDeckId,
+    fetchDecks: (uid: string) => mocks.fetchDecks(uid),
   };
 });
 vi.mock("../lib/cardCsv", async (importOriginal) => {
@@ -78,6 +82,8 @@ describe("useDeckImport", () => {
     mocks.uid = "uid-a";
     mocks.decks = [];
     mocks.cards = [];
+    mocks.fetchDecks.mockImplementation(async () => mocks.decks);
+    mocks.fetchCards.mockImplementation(async () => mocks.cards);
     mocks.parseCsv.mockImplementation(async (content: string) => {
       const { parseCsv } = await vi.importActual<typeof import("../lib/cardCsv")>("../lib/cardCsv");
       return parseCsv(content);
@@ -189,14 +195,14 @@ describe("useDeckImport", () => {
     expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
   });
 
-  it("reuses the same sample Deck for the active user", async () => {
+  it("does not add a sample Deck when the user already has a Deck", async () => {
     mocks.decks = [createDeck({ id: "sample-v1-uid-a", name: "Renamed sample" })];
     const { result } = renderHook(useTestDeckImport);
 
     await actAsync(async () => result.current.addSample());
 
     expect(mocks.createDeck).not.toHaveBeenCalled();
-    expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
   });
 
   it("treats a non-2xx URL response as an error", async () => {

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -26,6 +26,8 @@ export interface DeckImportOptions {
   decks: Deck[];
   editCard: (uid: string, card: CardEdit) => Promise<unknown>;
   generateCardId: () => string;
+  fetchDecks?: (uid: string) => Promise<Deck[]>;
+  fetchCards?: (uid: string) => Promise<Card[]>;
 }
 
 interface DeckImportState {
@@ -145,6 +147,8 @@ export const useDeckImport = ({
   decks,
   editCard,
   generateCardId,
+  fetchDecks: fetchDecksOption,
+  fetchCards: fetchCardsOption,
 }: DeckImportOptions) => {
   const auth = useAuthSession();
   const cardsByDeckId = useCallback((deckId: DeckId) => filterCardsByDeckId(cards, deckId), [cards]);
@@ -179,10 +183,10 @@ export const useDeckImport = ({
       createDeck: (deck) => createDeck(uid, deck),
       generateCardId,
       bulkUpsert: (cards, createdIds) => upsertImportedCards(uid, cards, createdIds, { createCard, editCard }),
-      fetchDecks,
-      fetchCards,
+      fetchDecks: fetchDecksOption ?? fetchDecks,
+      fetchCards: fetchCardsOption ?? fetchCards,
     };
-  }, [cardsByDeckId, createCard, createDeck, decks, editCard, generateCardId, uid]);
+  }, [cardsByDeckId, createCard, createDeck, decks, editCard, fetchCardsOption, fetchDecksOption, generateCardId, uid]);
   const updateState = (update: Partial<Omit<DeckImportState, "uid">>) => {
     setState((current) => ({
       ...(current.uid === uid ? current : initialDeckImportState(uid)),

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -13,28 +13,46 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   auth: { status: "authenticated", uid: "uid-a" } as { status: "authenticated"; uid: string } | { status: "loading" },
-  remote: {
-    decks: [] as Deck[],
-  },
-  addSample: vi.fn<() => Promise<unknown>>(),
+  fetchDecks: vi.fn<(uid: string) => Promise<Deck[]>>(),
+  createDeck: vi.fn<(uid: string, deck: DeckCreateInput) => Promise<unknown>>(),
+  bulkUpsert: vi.fn(),
 }));
 
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.auth }));
-vi.mock("./useDeckImport", () => ({
-  useDeckImport: () => ({ addSample: mocks.addSample }),
-}));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...actual,
+    fetchCards: vi.fn(async () => []),
+  };
+});
+vi.mock("@/entities/deck", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/deck")>();
+  return {
+    ...actual,
+    fetchDecks: (uid: string) => mocks.fetchDecks(uid),
+  };
+});
+vi.mock("../api/upsertImportedCards", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/upsertImportedCards")>();
+  return {
+    ...actual,
+    upsertImportedCards: (_uid: string, cards: unknown[]) => mocks.bulkUpsert(cards),
+  };
+});
 
 import { useSampleDeckBootstrap } from "./useSampleDeckBootstrap";
 
-const createDeck = vi.fn<(uid: string, deck: DeckCreateInput) => Promise<unknown>>();
-const useTestSampleDeckBootstrap = () =>
+const useTestSampleDeckBootstrap = (localDecks: Deck[] = []) =>
   useSampleDeckBootstrap({
     cards: [],
     createCard: vi.fn(),
-    createDeck,
-    decks: mocks.remote.decks,
+    createDeck: mocks.createDeck,
+    decks: localDecks,
     editCard: vi.fn(),
     generateCardId: vi.fn(() => "card-id"),
+    fetchDecks: mocks.fetchDecks,
   });
 
 /**
@@ -47,32 +65,53 @@ describe("sample Deck bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.auth = { status: "authenticated", uid: crypto.randomUUID() };
-    mocks.remote = { decks: [] };
-    mocks.addSample.mockResolvedValue(undefined);
+    mocks.fetchDecks.mockResolvedValue([]);
+    mocks.createDeck.mockResolvedValue(undefined);
+    mocks.bulkUpsert.mockResolvedValue(undefined);
   });
 
-  it("adds the sample once for an empty user under StrictMode", async () => {
-    renderHook(useTestSampleDeckBootstrap, { wrapper: strictMode });
+  it("adds the sample once for a server-confirmed empty user under StrictMode", async () => {
+    renderHook(() => useTestSampleDeckBootstrap([]), { wrapper: strictMode });
 
-    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.createDeck).toHaveBeenCalledOnce());
+    expect(mocks.fetchDecks).toHaveBeenCalled();
   });
 
-  it("does not add the sample when the user already has a Deck", () => {
-    mocks.remote.decks = [{ id: "existing" } as Deck];
+  it("does not add the sample when remote Decks exist during the initial empty cache loading window", async () => {
+    mocks.fetchDecks.mockResolvedValue([{ id: "existing-remote-deck" } as Deck]);
 
-    renderHook(useTestSampleDeckBootstrap);
+    renderHook(() => useTestSampleDeckBootstrap([]));
 
-    expect(mocks.addSample).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.fetchDecks).toHaveBeenCalled());
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger remote read when the local store already has a Deck", () => {
+    renderHook(() => useTestSampleDeckBootstrap([{ id: "local-deck" } as Deck]));
+
+    expect(mocks.fetchDecks).not.toHaveBeenCalled();
+    expect(mocks.createDeck).not.toHaveBeenCalled();
   });
 
   it("deduplicates concurrent starts for one user", async () => {
-    let finish: () => void = () => undefined;
-    mocks.addSample.mockImplementation(() => new Promise<void>((resolve) => (finish = resolve)));
+    let finish!: (decks: Deck[]) => void;
+    mocks.fetchDecks.mockImplementation(() => new Promise((resolve) => (finish = resolve)));
 
-    renderHook(useTestSampleDeckBootstrap);
-    renderHook(useTestSampleDeckBootstrap);
+    renderHook(() => useTestSampleDeckBootstrap([]));
+    renderHook(() => useTestSampleDeckBootstrap([]));
 
-    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
-    finish();
+    await waitFor(() => expect(mocks.fetchDecks).toHaveBeenCalled());
+    finish([]);
+    await waitFor(() => expect(mocks.createDeck).toHaveBeenCalledOnce());
+  });
+
+  it("does not add the sample when remote Deck read fails", async () => {
+    mocks.fetchDecks.mockRejectedValue(new Error("Network error"));
+
+    renderHook(() => useTestSampleDeckBootstrap([]));
+
+    await waitFor(() => expect(mocks.fetchDecks).toHaveBeenCalled());
+    expect(mocks.createDeck).not.toHaveBeenCalled();
   });
 });

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -29,8 +29,8 @@ export interface DeckImportDependencies {
   createDeck: (deck: DeckCreateInput) => Promise<unknown>;
   generateCardId: () => string;
   bulkUpsert: (cards: CardCreateInput[], createdIds: CardId[]) => Promise<unknown>;
-  fetchDecks?: (uid: string) => Promise<Deck[]>;
-  fetchCards?: (uid: string) => Promise<Card[]>;
+  fetchDecks?: ((uid: string) => Promise<Deck[]>) | undefined;
+  fetchCards?: ((uid: string) => Promise<Card[]>) | undefined;
 }
 
 type DeckImportPreparationDependencies = Pick<
@@ -107,22 +107,64 @@ export const partialResultFrom = (error: unknown): DeckImportResult | undefined 
   return result as DeckImportResult;
 };
 
+interface ResolvedImportData {
+  activeDecks: Deck[];
+  getCardsByDeckId: (deckId: DeckId) => Card[];
+}
+
+const resolveActiveImportData = async (
+  uid: string,
+  requestKind: DeckImportRequest["kind"],
+  defaults: { decks: Deck[]; cardsByDeckId: (id: DeckId) => Card[] },
+  fetchers: {
+    fetchDecks?: ((uid: string) => Promise<Deck[]>) | undefined;
+    fetchCards?: ((uid: string) => Promise<Card[]>) | undefined;
+  }
+): Promise<ResolvedImportData> => {
+  if (fetchers.fetchDecks == null && fetchers.fetchCards == null) {
+    return { activeDecks: defaults.decks, getCardsByDeckId: defaults.cardsByDeckId };
+  }
+  try {
+    const [remoteDecks, remoteCards] = await Promise.all([
+      fetchers.fetchDecks != null ? fetchers.fetchDecks(uid) : Promise.resolve(defaults.decks),
+      fetchers.fetchCards != null ? fetchers.fetchCards(uid) : Promise.resolve([]),
+    ]);
+    return {
+      activeDecks: fetchers.fetchDecks != null ? remoteDecks : defaults.decks,
+      getCardsByDeckId:
+        fetchers.fetchCards != null
+          ? (deckId: DeckId) => remoteCards.filter((card) => card.deckId === deckId)
+          : defaults.cardsByDeckId,
+    };
+  } catch (cause) {
+    if (requestKind === "sample") {
+      throw cause;
+    }
+    return { activeDecks: defaults.decks, getCardsByDeckId: defaults.cardsByDeckId };
+  }
+};
+
 export const executeDeckImport = async (
   request: DeckImportRequest,
   { uid, decks, cardsByDeckId, createDeck, generateCardId, bulkUpsert, fetchDecks, fetchCards }: DeckImportDependencies
 ): Promise<DeckImportResult> => {
   if (uid === "") throw new Error("A confirmed user is required for imports");
 
-  let activeDecks = decks;
-  let getCardsByDeckId = cardsByDeckId;
-  if (fetchDecks != null && fetchCards != null) {
-    try {
-      const [remoteDecks, remoteCards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
-      activeDecks = remoteDecks;
-      getCardsByDeckId = (deckId: DeckId) => remoteCards.filter((card) => card.deckId === deckId);
-    } catch {
-      // Fall back to passed dependencies if remote fetch fails
-    }
+  const { activeDecks, getCardsByDeckId } = await resolveActiveImportData(
+    uid,
+    request.kind,
+    { decks, cardsByDeckId },
+    { fetchDecks, fetchCards }
+  );
+
+  if (request.kind === "sample" && activeDecks.length > 0) {
+    return {
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      deckId: "",
+    };
   }
 
   let attempt = request.attempt;


### PR DESCRIPTION
## Summary

This PR ensures that Sample Deck bootstrap performs an explicit remote Deck check before automatically creating a Sample Deck, preventing a temporarily empty local store during initial loading from triggering Sample Deck creation when remote Decks already exist for the user.

## Changes

- Updated `executeDeckImport` to explicitly read remote Decks via `fetchDecks(uid)` during sample Deck import.
- Added a check in `executeDeckImport` so that if any remote Deck exists for the user (`activeDecks.length > 0`), Sample Deck creation is bypassed.
- Refactored remote import data resolution into a helper `resolveActiveImportData` to keep cognitive complexity low.
- Updated `useDeckImport` and `DeckImportOptions` to accept optional `fetchDecks` and `fetchCards` handlers.
- Extended unit tests in `useSampleDeckBootstrap.spec.tsx` and `useDeckImport.spec.tsx` to cover the loading window where the local store is empty before the first subscription snapshot arrives.

Closes #879