### PR TITLE
refactor: separate showBackText from persisted studyStore (#901)

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -30,7 +30,6 @@ export interface PageStoryParameters {
   cards?: Card[];
   preferences?: PartialPreferences;
   sessionsByDeckId?: StudyState["sessionsByDeckId"];
-  showBackText?: boolean;
   autoPlay?: boolean;
 }
 
@@ -81,7 +80,6 @@ export const preparePageStory = async (parameters: PageStoryParameters): Promise
   });
   studyStore.setState({
     sessionsByDeckId: cloneSessions(parameters.sessionsByDeckId ?? {}),
-    showBackText: parameters.showBackText ?? false,
     autoPlay: parameters.autoPlay ?? false,
   });
   replaceDecks(decks);

--- a/src/features/study/commands/studySessionCommands.spec.ts
+++ b/src/features/study/commands/studySessionCommands.spec.ts
@@ -31,14 +31,12 @@ describe("study session commands", () => {
 
   it("initializes transient study controls", () => {
     studyStore.setState({
-      showBackText: true,
       autoPlay: false,
     });
 
     initializeStudySessionUi(true);
 
     expect(studyStore.getState()).toMatchObject({
-      showBackText: false,
       autoPlay: true,
     });
   });

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -114,7 +114,6 @@ describe("useStudyActions", () => {
     mocks.state = createState();
     studyStore.setState({
       sessionsByDeckId: {},
-      showBackText: false,
       autoPlay: false,
     });
   });
@@ -124,7 +123,7 @@ describe("useStudyActions", () => {
   });
 
   it("starts from filtered Query cards before notifying its owner", () => {
-    studyStore.setState({ showBackText: true });
+    const onHideBackText = vi.fn();
     const onStarted = vi.fn(() => {
       expect(studyStore.getState()).toMatchObject({
         sessionsByDeckId: {
@@ -135,16 +134,18 @@ describe("useStudyActions", () => {
             lastStudiedAt: 946684800000,
           },
         },
-        showBackText: false,
         autoPlay: true,
       });
     });
-    const { result } = renderHook(() => useStudyActions(deck.id, { cardsById: getCardsById(), onStarted }));
+    const { result } = renderHook(() =>
+      useStudyActions(deck.id, { cardsById: getCardsById(), onStarted, onHideBackText })
+    );
 
     act(() => {
       result.current.start([card1]);
     });
 
+    expect(onHideBackText).toHaveBeenCalledOnce();
     expect(onStarted).toHaveBeenCalledOnce();
   });
 
@@ -163,12 +164,17 @@ describe("useStudyActions", () => {
     expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
   });
 
-  it("writes a card patch, notifies onSwipe, and advances the Zustand session", async () => {
+  it("writes a card patch, notifies onSwipe and onHideBackText, and advances the Zustand session", async () => {
     const onSwipe = vi.fn();
+    const onHideBackText = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
-    studyStore.setState({ showBackText: true });
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onSwipe })
+      useStudyActions(deck.id, {
+        cardsById: getCardsById(),
+        cardMutation: mocks.cardMutations,
+        onSwipe,
+        onHideBackText,
+      })
     );
 
     await actAsync(async () => {
@@ -183,6 +189,7 @@ describe("useStudyActions", () => {
     };
     expect(mocks.cardUpdate).toHaveBeenCalledWith(patch);
     expect(onSwipe).toHaveBeenCalledWith("cardSwipeRight");
+    expect(onHideBackText).toHaveBeenCalledOnce();
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: {
         [deck.id]: {
@@ -192,16 +199,20 @@ describe("useStudyActions", () => {
           lastStudiedAt: 946684800000,
         },
       },
-      showBackText: false,
     });
   });
 
-  it("rolls the optimistic study index back when the Card write fails", async () => {
+  it("rolls the optimistic study index back and restores back text when the Card write fails", async () => {
+    const onRestoreBackText = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
-    studyStore.setState({ showBackText: true });
     mocks.cardUpdate.mockRejectedValueOnce(new Error("write failed"));
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, {
+        cardsById: getCardsById(),
+        cardMutation: mocks.cardMutations,
+        showBackText: true,
+        onRestoreBackText,
+      })
     );
 
     await actAsync(async () => {
@@ -210,8 +221,8 @@ describe("useStudyActions", () => {
 
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: { [deck.id]: { currentIndex: 0 } },
-      showBackText: true,
     });
+    expect(onRestoreBackText).toHaveBeenCalledWith(true);
   });
 
   it("does not roll back a newer same-index session update", async () => {
@@ -266,23 +277,27 @@ describe("useStudyActions", () => {
   });
 
   it("keeps back text visible when the long-lived preferences allows it", async () => {
+    const onHideBackText = vi.fn();
     mocks.state = createState(createPreferences({ appearance: { hideBodyWhenCardChanged: false } }));
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
-    studyStore.setState({ showBackText: true });
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, {
+        cardsById: getCardsById(),
+        cardMutation: mocks.cardMutations,
+        showBackText: true,
+        onHideBackText,
+      })
     );
 
     await actAsync(async () => {
       await result.current.swipeRight();
     });
 
-    expect(studyStore.getState().showBackText).toBe(true);
+    expect(onHideBackText).not.toHaveBeenCalled();
   });
 
   it("leaves all study and card state unchanged for DoNothing", async () => {
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
-    studyStore.setState({ showBackText: true });
     const before = studyStore.getState();
     const { result } = renderHook(() =>
       useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
@@ -301,7 +316,6 @@ describe("useStudyActions", () => {
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     studyStore.getState().setCurrentIndex(deck.id, 1);
-    studyStore.setState({ showBackText: true });
     const { result } = renderHook(() =>
       useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onSwipe })
     );
@@ -314,16 +328,15 @@ describe("useStudyActions", () => {
     expect(onSwipe).toHaveBeenCalledWith("cardSwipeLeft");
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: { "deck-2": { deckId: "deck-2" } },
-      showBackText: true,
     });
     expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
   });
 
-  it("updates the session index and hides back text", () => {
+  it("updates the session index and notifies onHideBackText", () => {
+    const onHideBackText = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
-    studyStore.setState({ showBackText: true });
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onHideBackText })
     );
 
     act(() => {
@@ -331,7 +344,18 @@ describe("useStudyActions", () => {
     });
 
     expect(studyStore.getState().sessionsByDeckId[deck.id]?.currentIndex).toBe(1);
-    expect(studyStore.getState().showBackText).toBe(false);
+    expect(onHideBackText).toHaveBeenCalledOnce();
+  });
+
+  it("calls onToggleBackText when toggleShowBackText is invoked", () => {
+    const onToggleBackText = vi.fn();
+    const { result } = renderHook(() => useStudyActions(deck.id, { cardsById: getCardsById(), onToggleBackText }));
+
+    act(() => {
+      result.current.toggleShowBackText();
+    });
+
+    expect(onToggleBackText).toHaveBeenCalledOnce();
   });
 
   it("finishes only the route session after the final card", async () => {

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -38,6 +38,10 @@ interface UseStudyActionsOptions {
   cardMutation?: StudyCardMutation | undefined;
   onStarted?: (() => void) | undefined;
   onSwipe?: ((direction: SwipeDirection) => void) | undefined;
+  showBackText?: boolean | undefined;
+  onHideBackText?: (() => void) | undefined;
+  onToggleBackText?: (() => void) | undefined;
+  onRestoreBackText?: ((showBackText: boolean) => void) | undefined;
 }
 
 interface StudySwipeDependencies {
@@ -47,6 +51,9 @@ interface StudySwipeDependencies {
   cardsById: Partial<Record<CardId, Card>>;
   update: (progress: StudyProgressEdit) => Promise<void>;
   onSwipe?: ((direction: SwipeDirection) => void) | undefined;
+  showBackText?: boolean | undefined;
+  onHideBackText?: (() => void) | undefined;
+  onRestoreBackText?: ((showBackText: boolean) => void) | undefined;
 }
 
 const applyOptimisticUpdate = (deckId: DeckId, nextIndex: number) => {
@@ -65,7 +72,8 @@ const revertOptimisticUpdate = (
   mutationTokenRef: { current: symbol | undefined },
   mutationToken: symbol,
   optimisticSession: Session,
-  previous: { session: Session; showBackText: boolean }
+  previous: { session: Session; showBackText: boolean },
+  onRestoreBackText?: ((showBackText: boolean) => void) | undefined
 ) => {
   const current = studyStore.getState();
   const currentSession = current.sessionsByDeckId[deckId];
@@ -75,8 +83,8 @@ const revertOptimisticUpdate = (
   if (changeStillCurrent) {
     studyStore.setState((state) => ({
       sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
-      showBackText: previous.showBackText,
     }));
+    onRestoreBackText?.(previous.showBackText);
   }
 };
 
@@ -86,7 +94,17 @@ const revertOptimisticUpdate = (
  */
 const runStudySwipe = async (
   direction: SwipeDirection,
-  { mutationTokenRef, deckId, preferences, cardsById, update, onSwipe }: StudySwipeDependencies
+  {
+    mutationTokenRef,
+    deckId,
+    preferences,
+    cardsById,
+    update,
+    onSwipe,
+    showBackText,
+    onHideBackText,
+    onRestoreBackText,
+  }: StudySwipeDependencies
 ): Promise<void> => {
   if (mutationTokenRef.current !== undefined) return;
   const state = studyStore.getState();
@@ -108,12 +126,12 @@ const runStudySwipe = async (
 
   const previous = {
     session: { ...session },
-    showBackText: state.showBackText,
+    showBackText: showBackText ?? false,
   };
 
   onSwipe?.(direction);
   if (preferences.appearance.hideBodyWhenCardChanged) {
-    state.hideBackText();
+    onHideBackText?.();
   }
 
   const patch = buildStudyPatch(createStudyCard(card), swipeAction, Date.now());
@@ -124,7 +142,15 @@ const runStudySwipe = async (
   try {
     await update(patch);
   } catch {
-    revertOptimisticUpdate(deckId, nextIndex, mutationTokenRef, mutationToken, optimisticSession, previous);
+    revertOptimisticUpdate(
+      deckId,
+      nextIndex,
+      mutationTokenRef,
+      mutationToken,
+      optimisticSession,
+      previous,
+      onRestoreBackText
+    );
   } finally {
     if (mutationTokenRef.current === mutationToken) mutationTokenRef.current = undefined;
   }
@@ -137,7 +163,16 @@ const runStudySwipe = async (
  */
 export const useStudyActions = (
   deckId: DeckId,
-  { cardMutation, cardsById, onStarted, onSwipe }: UseStudyActionsOptions
+  {
+    cardMutation,
+    cardsById,
+    onStarted,
+    onSwipe,
+    showBackText,
+    onHideBackText,
+    onToggleBackText,
+    onRestoreBackText,
+  }: UseStudyActionsOptions
 ): StudyActions => {
   const preferences = usePreferences();
   const mutationTokenRef = React.useRef<symbol | undefined>(undefined);
@@ -151,6 +186,7 @@ export const useStudyActions = (
     const state = studyStore.getState();
     state.startStudy(deckId, cardOrderIds);
     state.initializeStudyUi(preferences.study.defaultAutoPlay);
+    onHideBackText?.();
     onStarted?.();
   };
 
@@ -168,6 +204,9 @@ export const useStudyActions = (
       cardsById,
       update: cardMutation.update,
       onSwipe,
+      showBackText,
+      onHideBackText,
+      onRestoreBackText,
     });
   };
 
@@ -180,10 +219,10 @@ export const useStudyActions = (
     updateIndex: (currentIndex: number) => {
       const state = studyStore.getState();
       if (state.sessionsByDeckId[deckId] == null) return;
-      state.hideBackText();
+      onHideBackText?.();
       state.setCurrentIndex(deckId, currentIndex);
     },
-    toggleShowBackText: () => studyStore.getState().toggleShowBackText(),
+    toggleShowBackText: () => onToggleBackText?.(),
     toggleAutoPlay: () => studyStore.getState().toggleAutoPlay(),
     resetStudy: () => studyStore.getState().removeStudy(deckId),
   };

--- a/src/features/study/state/studyStore.spec.ts
+++ b/src/features/study/state/studyStore.spec.ts
@@ -120,20 +120,12 @@ describe("study store", () => {
 
   it("initializes and toggles transient study UI state", () => {
     const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
-    store.getState().toggleShowBackText();
 
     store.getState().initializeStudyUi(true);
-    expect(store.getState()).toMatchObject({ showBackText: false, autoPlay: true });
+    expect(store.getState()).toMatchObject({ autoPlay: true });
 
-    store.getState().toggleShowBackText();
     store.getState().toggleAutoPlay();
-    expect(store.getState()).toMatchObject({
-      showBackText: true,
-      autoPlay: false,
-    });
-
-    store.getState().hideBackText();
-    expect(store.getState().showBackText).toBe(false);
+    expect(store.getState()).toMatchObject({ autoPlay: false });
   });
 
   it("persists exactly the session map in a v3 envelope", async () => {
@@ -142,7 +134,6 @@ describe("study store", () => {
     const storage = createMemoryStorage();
     const store = createStudyStore({ storage, skipHydration: true });
     store.getState().startStudy("deck-1", ["card-1"]);
-    store.getState().toggleShowBackText();
 
     expect(JSON.parse(storage.getItem(STUDY_STORAGE_KEY) ?? "{}")).toEqual({
       state: {
@@ -159,7 +150,6 @@ describe("study store", () => {
       sessionsByDeckId: {
         "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
       },
-      showBackText: false,
       autoPlay: false,
     });
     expect(restored.getState()).not.toHaveProperty("session");
@@ -178,7 +168,6 @@ describe("study store", () => {
           },
           broken: { deckId: "broken", cardOrderIds: [], currentIndex: 0, lastStudiedAt: 2000 },
         },
-        showBackText: true,
         unknownRootMetadata: "drop",
       },
       3
@@ -191,7 +180,6 @@ describe("study store", () => {
       "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 1000 },
     });
     expect(store.getState()).not.toHaveProperty("unknownRootMetadata");
-    expect(store.getState().showBackText).toBe(false);
   });
 
   it.each([1, 2])("migrates a valid v%s session into the v3 map", async (version) => {

--- a/src/features/study/state/studyStore.ts
+++ b/src/features/study/state/studyStore.ts
@@ -24,16 +24,13 @@ interface PersistedStudyState {
 }
 
 export interface StudyState extends PersistedStudyState {
-  showBackText: boolean;
   autoPlay: boolean;
   startStudy: (deckId: DeckId, cardOrderIds: CardId[]) => void;
   touchStudy: (deckId: DeckId) => void;
   setCurrentIndex: (deckId: DeckId, currentIndex: number) => void;
   removeStudy: (deckId: DeckId) => void;
   initializeStudyUi: (defaultAutoPlay: boolean) => void;
-  toggleShowBackText: () => void;
   toggleAutoPlay: () => void;
-  hideBackText: () => void;
 }
 
 interface CreateStudyStoreOptions {
@@ -120,7 +117,6 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
     persist<StudyState, [], [], PersistedStudyState>(
       (set) => ({
         sessionsByDeckId: {},
-        showBackText: false,
         autoPlay: false,
         startStudy: (deckId, cardOrderIds) =>
           set((state) => ({
@@ -170,12 +166,9 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
           }),
         initializeStudyUi: (defaultAutoPlay) =>
           set({
-            showBackText: false,
             autoPlay: defaultAutoPlay,
           }),
-        toggleShowBackText: () => set((state) => ({ showBackText: !state.showBackText })),
         toggleAutoPlay: () => set((state) => ({ autoPlay: !state.autoPlay })),
-        hideBackText: () => set({ showBackText: false }),
       }),
       {
         name: STUDY_STORAGE_KEY,

--- a/src/features/study/state/studyStoreInstance.ts
+++ b/src/features/study/state/studyStoreInstance.ts
@@ -9,7 +9,6 @@ export const studyStore = createStudyStore();
 export const clearStudyStore = async (): Promise<void> => {
   studyStore.setState({
     sessionsByDeckId: {},
-    showBackText: false,
     autoPlay: false,
   });
   await studyStore.persist.clearStorage();

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -35,7 +35,6 @@ const mocks = vi.hoisted(() => ({
   },
   studyState: {
     sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
-    showBackText: false,
     autoPlay: false,
   },
   initializeStudySessionUi: vi.fn(),
@@ -81,7 +80,13 @@ vi.mock("@/features/study", async (importOriginal) => {
     initializeStudySessionUi: mocks.initializeStudySessionUi,
     touchStudySession: mocks.touchStudySession,
     useEditStudyProgress: () => mocks.cardMutation,
-    useStudyActions: (_deckId: DeckId, options?: { onSwipe?: (direction: SwipeDirection) => void }) => ({
+    useStudyActions: (
+      _deckId: DeckId,
+      options?: {
+        onSwipe?: (direction: SwipeDirection) => void;
+        onToggleBackText?: () => void;
+      }
+    ) => ({
       swipeUp: () => {
         options?.onSwipe?.("cardSwipeUp");
         mocks.swipeUp();
@@ -99,7 +104,10 @@ vi.mock("@/features/study", async (importOriginal) => {
         mocks.swipeRight();
       },
       updateIndex: mocks.updateIndex,
-      toggleShowBackText: mocks.toggleShowBackText,
+      toggleShowBackText: () => {
+        options?.onToggleBackText?.();
+        mocks.toggleShowBackText();
+      },
       toggleAutoPlay: mocks.toggleAutoPlay,
       resetStudy: mocks.resetStudy,
     }),
@@ -173,10 +181,8 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
         lastStudiedAt: 0,
       },
     };
-    mocks.studyState.showBackText = false;
     mocks.studyState.autoPlay = false;
     mocks.initializeStudySessionUi.mockImplementation((defaultAutoPlay: boolean) => {
-      mocks.studyState.showBackText = false;
       mocks.studyState.autoPlay = defaultAutoPlay;
     });
     mocks.touchStudySession.mockImplementation((deckId: DeckId) => {
@@ -229,22 +235,11 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
   });
 
   it("owns header visibility across front and back content", () => {
-    const view = render(<DeckSwiperPage />);
+    render(<DeckSwiperPage />);
 
     expect(screen.getByRole("button", { name: "tango" })).toBeInTheDocument();
 
-    mocks.studyState.showBackText = true;
-    view.rerender(<DeckSwiperPage />);
-
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-
-    mocks.studyState.showBackText = false;
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.preferences = createPreferences({
-      ...mocks.state.preferences,
-      appearance: { ...mocks.state.preferences.appearance, showHeader: false },
-    });
-    view.rerender(<DeckSwiperPage />);
+    fireEvent.click(screen.getByText(card.frontText));
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
   });
@@ -323,7 +318,6 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     const session = mocks.studyState.sessionsByDeckId[deck.id];
     if (session == null) throw new Error("Expected an active study session");
     mocks.studyState.sessionsByDeckId[deck.id] = { ...session, lastStudiedAt: 100 };
-    mocks.studyState.showBackText = true;
     mocks.studyState.autoPlay = true;
     const now = vi.spyOn(Date, "now").mockReturnValue(9000);
 
@@ -332,15 +326,15 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     expect(mocks.initializeStudySessionUi).toHaveBeenCalledWith(false);
     expect(mocks.touchStudySession).toHaveBeenCalledWith(deck.id);
     expect(mocks.studyState.sessionsByDeckId[deck.id]?.lastStudiedAt).toBe(9000);
-    expect(mocks.studyState).toMatchObject({ showBackText: false, autoPlay: false });
+    expect(mocks.studyState).toMatchObject({ autoPlay: false });
     now.mockRestore();
   });
 
-  it("renders Zustand back text and controlled auto-play", () => {
-    const view = render(<DeckSwiperPage />);
-    mocks.studyState.showBackText = true;
+  it("renders back text and controlled auto-play", () => {
     mocks.studyState.autoPlay = true;
-    view.rerender(<DeckSwiperPage />);
+    render(<DeckSwiperPage />);
+
+    fireEvent.click(screen.getByText(card.frontText));
 
     const code = screen.getByText(/answer =/);
     expect(code).toHaveTextContent(card.backText);
@@ -353,7 +347,7 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     fireEvent.click(swipeLeftButton);
     fireEvent.click(swipeRightButton);
 
-    expect(mocks.toggleShowBackText).toHaveBeenCalledOnce();
+    expect(mocks.toggleShowBackText).toHaveBeenCalled();
     expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
     expect(mocks.swipeLeft).toHaveBeenCalledOnce();
     expect(mocks.swipeRight).toHaveBeenCalledOnce();

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -331,8 +331,9 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
   });
 
   it("renders back text and controlled auto-play", () => {
+    const view = render(<DeckSwiperPage />);
     mocks.studyState.autoPlay = true;
-    render(<DeckSwiperPage />);
+    view.rerender(<DeckSwiperPage />);
 
     fireEvent.click(screen.getByText(card.frontText));
 

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -40,12 +40,22 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   const preferences = usePreferences();
   const allCards = useCards();
   const session = useStudyStore(selectStudySessionForRoute(deckId));
-  const showBackText = useStudyStore((state) => state.showBackText);
+  const [showBackText, setShowBackText] = React.useState(false);
   const autoPlay = useStudyStore((state) => state.autoPlay);
   const [lastSwipe, setLastSwipe] = React.useState<{ direction: SwipeDirection; eventId: number } | undefined>(
     undefined
   );
   const hydrated = useStudyHydrated();
+
+  const handleHideBackText = React.useCallback(() => {
+    setShowBackText(false);
+  }, []);
+  const handleToggleBackText = React.useCallback(() => {
+    setShowBackText((prev) => !prev);
+  }, []);
+  const handleRestoreBackText = React.useCallback((show: boolean) => {
+    setShowBackText(show);
+  }, []);
 
   const handleSwipe = React.useCallback(
     (direction: SwipeDirection) => {
@@ -71,6 +81,10 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
       update: cardMutation.update,
     },
     onSwipe: handleSwipe,
+    showBackText,
+    onHideBackText: handleHideBackText,
+    onToggleBackText: handleToggleBackText,
+    onRestoreBackText: handleRestoreBackText,
   });
   useKey("ArrowUp", studyActions.swipeUp);
   useKey("ArrowDown", studyActions.swipeDown);
@@ -106,6 +120,7 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   React.useEffect(() => {
     if (!valid) return;
     initializeStudySessionUi(preferences.study.defaultAutoPlay);
+    setShowBackText(false);
     touchStudySession(deckId);
   }, [preferences.study.defaultAutoPlay, deckId, valid]);
 

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -120,7 +120,6 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   React.useEffect(() => {
     if (!valid) return;
     initializeStudySessionUi(preferences.study.defaultAutoPlay);
-    setShowBackText(false);
     touchStudySession(deckId);
   }, [preferences.study.defaultAutoPlay, deckId, valid]);
 
@@ -219,5 +218,5 @@ export const DeckSwiperPage: React.FC = () => {
     return <RouteFeedback title="Study session unavailable." tone="not-found" />;
   }
 
-  return <DeckSwiperContent cardsById={cardsById} deck={deck} />;
+  return <DeckSwiperContent key={deck.id} cardsById={cardsById} deck={deck} />;
 };


### PR DESCRIPTION
## Summary

Separates `showBackText` and its associated actions (`toggleShowBackText`, `hideBackText`) from the persisted `studyStore` so card back text visibility is owned by local UI state in `DeckSwiperContent` rather than session persistence.

Closes #901

## Changes

- **`src/features/study/state/studyStore.ts`**: Removed `showBackText`, `toggleShowBackText`, and `hideBackText` from `StudyState` and `createStudyStore`.
- **`src/features/study/state/studyStoreInstance.ts`**: Removed `showBackText` from `clearStudyStore`.
- **`src/features/study/hooks/useStudyActions.ts`**: Added `showBackText`, `onHideBackText`, `onToggleBackText`, and `onRestoreBackText` options/callbacks to manage card back text visibility without store mutations.
- **`src/pages/deck-swiper/ui/DeckSwiperPage.tsx`**: Managed `showBackText` using `React.useState(false)` in `DeckSwiperContent` and passed visibility callbacks to `useStudyActions`.
- **`src/features/study/state/studyStore.spec.ts`**, **`src/features/study/hooks/useStudyActions.spec.tsx`**, **`src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx`**: Updated tests to reflect local state management and updated callbacks.

## Verification

- `mise run check` passed clean (all 512 tests across 48 test files passed; formatting, tsc, eslint, biome, knip clean).