### PR TITLE
feat: verify remote Deck state before Sample Deck bootstrap (#879)

### DIFF
--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -26,6 +26,7 @@ export interface DeckImportOptions {
   decks: Deck[];
   editCard: (uid: string, card: CardEdit) => Promise<unknown>;
   generateCardId: () => string;
+  fetchDecks?: (uid: string) => Promise<Deck[]>;
 }
 
 interface DeckImportState {
@@ -145,6 +146,7 @@ export const useDeckImport = ({
   decks,
   editCard,
   generateCardId,
+  fetchDecks: fetchDecksOption,
 }: DeckImportOptions) => {
   const auth = useAuthSession();
   const cardsByDeckId = useCallback((deckId: DeckId) => filterCardsByDeckId(cards, deckId), [cards]);
@@ -179,10 +181,10 @@ export const useDeckImport = ({
       createDeck: (deck) => createDeck(uid, deck),
       generateCardId,
       bulkUpsert: (cards, createdIds) => upsertImportedCards(uid, cards, createdIds, { createCard, editCard }),
-      fetchDecks,
+      fetchDecks: fetchDecksOption ?? fetchDecks,
       fetchCards,
     };
-  }, [cardsByDeckId, createCard, createDeck, decks, editCard, generateCardId, uid]);
+  }, [cardsByDeckId, createCard, createDeck, decks, editCard, fetchDecksOption, generateCardId, uid]);
   const updateState = (update: Partial<Omit<DeckImportState, "uid">>) => {
     setState((current) => ({
       ...(current.uid === uid ? current : initialDeckImportState(uid)),

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -1,10 +1,3 @@
-/**
- * @file Verifies the "sample Deck bootstrap" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "adds the sample once for a
- * server-confirmed empty user under StrictMode", "waits for the server before treating an empty cache
- * as an empty user", "does not add the sample when the user already has a Deck".
- */
-
 import type { Deck, DeckCreateInput } from "@/entities/deck";
 
 import { renderHook, waitFor } from "@testing-library/react";
@@ -17,9 +10,11 @@ const mocks = vi.hoisted(() => ({
     decks: [] as Deck[],
   },
   addSample: vi.fn<() => Promise<unknown>>(),
+  fetchDecks: vi.fn<(uid: string) => Promise<Deck[]>>(),
 }));
 
 vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.auth }));
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("./useDeckImport", () => ({
   useDeckImport: () => ({ addSample: mocks.addSample }),
 }));
@@ -35,6 +30,7 @@ const useTestSampleDeckBootstrap = () =>
     decks: mocks.remote.decks,
     editCard: vi.fn(),
     generateCardId: vi.fn(() => "card-id"),
+    fetchDecks: mocks.fetchDecks,
   });
 
 /**
@@ -49,30 +45,63 @@ describe("sample Deck bootstrap", () => {
     mocks.auth = { status: "authenticated", uid: crypto.randomUUID() };
     mocks.remote = { decks: [] };
     mocks.addSample.mockResolvedValue(undefined);
+    mocks.fetchDecks.mockResolvedValue([]);
   });
 
-  it("adds the sample once for an empty user under StrictMode", async () => {
+  it("adds the sample once for a remote-confirmed empty user under StrictMode", async () => {
     renderHook(useTestSampleDeckBootstrap, { wrapper: strictMode });
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+    expect(mocks.fetchDecks).toHaveBeenCalledWith(mocks.auth.status === "authenticated" ? mocks.auth.uid : "");
   });
 
-  it("does not add the sample when the user already has a Deck", () => {
+  it("does not add the sample when the user already has a Deck in local cache", () => {
     mocks.remote.decks = [{ id: "existing" } as Deck];
 
     renderHook(useTestSampleDeckBootstrap);
 
+    expect(mocks.fetchDecks).not.toHaveBeenCalled();
+    expect(mocks.addSample).not.toHaveBeenCalled();
+  });
+
+  it("does not add the sample when the user has remote Decks during the loading window", async () => {
+    mocks.remote.decks = [];
+    mocks.fetchDecks.mockResolvedValue([{ id: "remote-deck" } as Deck]);
+
+    renderHook(useTestSampleDeckBootstrap);
+
+    await waitFor(() =>
+      expect(mocks.fetchDecks).toHaveBeenCalledWith(mocks.auth.status === "authenticated" ? mocks.auth.uid : "")
+    );
+    expect(mocks.addSample).not.toHaveBeenCalled();
+  });
+
+  it("does not add the sample if remote deck fetch fails", async () => {
+    mocks.remote.decks = [];
+    mocks.fetchDecks.mockRejectedValue(new Error("Network error"));
+
+    renderHook(useTestSampleDeckBootstrap);
+
+    await waitFor(() =>
+      expect(mocks.fetchDecks).toHaveBeenCalledWith(mocks.auth.status === "authenticated" ? mocks.auth.uid : "")
+    );
     expect(mocks.addSample).not.toHaveBeenCalled();
   });
 
   it("deduplicates concurrent starts for one user", async () => {
     let finish: () => void = () => undefined;
-    mocks.addSample.mockImplementation(() => new Promise<void>((resolve) => (finish = resolve)));
+    mocks.fetchDecks.mockImplementation(
+      () =>
+        new Promise<Deck[]>((resolve) => {
+          finish = () => resolve([]);
+        })
+    );
 
     renderHook(useTestSampleDeckBootstrap);
     renderHook(useTestSampleDeckBootstrap);
 
-    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+    expect(mocks.fetchDecks).toHaveBeenCalledOnce();
     finish();
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
   });
 });

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -1,16 +1,13 @@
-/**
- * @file Provides the import feature's Use Sample Deck Bootstrap React hook.
- * The hook combines state and operations behind one interface so components do not need to
- * coordinate services themselves.
- */
-
 import { useEffect } from "react";
 
 import { useAuthSession } from "@/entities/auth";
+import type { Deck } from "@/entities/deck";
+import { fetchDecks } from "@/entities/deck";
 import { useDeckImport } from "./useDeckImport";
 import type { DeckImportOptions } from "./useDeckImport";
 
 type AddSample = () => Promise<unknown>;
+type FetchDecks = (uid: string) => Promise<Deck[]>;
 
 /**
  * Creates and configures a sample deck bootstrap controller.
@@ -22,12 +19,18 @@ const createSampleDeckBootstrapController = () => {
   const pendingByUid = new Map<string, Promise<unknown>>();
 
   return {
-    start: (uid: string, addSample: AddSample) => {
+    start: (uid: string, addSample: AddSample, fetchDecksFn: FetchDecks) => {
       if (completedUids.has(uid)) return;
       const pending = pendingByUid.get(uid);
       if (pending != null) return pending;
 
-      const operation = Promise.resolve().then(addSample);
+      const operation = (async () => {
+        const remoteDecks = await fetchDecksFn(uid);
+        if (remoteDecks.length === 0) {
+          await addSample();
+        }
+      })();
+
       pendingByUid.set(uid, operation);
       void operation.then(
         () => {
@@ -52,11 +55,12 @@ export const useSampleDeckBootstrap = (options: DeckImportOptions) => {
   const auth = useAuthSession();
   const deckImport = useDeckImport(options);
   const uid = auth.status === "authenticated" ? auth.uid : "";
+  const fetchDecksFn = options.fetchDecks ?? fetchDecks;
 
   useEffect(() => {
     if (uid === "" || options.decks.length > 0) {
       return;
     }
-    void sampleDeckBootstrapController.start(uid, deckImport.addSample)?.catch(() => undefined);
-  }, [deckImport.addSample, options.decks.length, uid]);
+    void sampleDeckBootstrapController.start(uid, deckImport.addSample, fetchDecksFn)?.catch(() => undefined);
+  }, [deckImport.addSample, fetchDecksFn, options.decks.length, uid]);
 };


### PR DESCRIPTION
## Summary

This PR ensures that automatic Sample Deck bootstrap explicitly checks remote Deck state in Firestore when the local Deck store is empty before triggering Sample Deck creation. This prevents a temporarily empty local store during initial subscription loading from accidentally creating a Sample Deck for existing users.

## Changes

- Updated `useSampleDeckBootstrap` to explicitly fetch remote Decks for the authenticated user when the local Deck store is empty.
- If remote Decks exist for the user, bootstrap completes without creating a Sample Deck.
- If remote Deck state confirms no Decks exist, `addSample()` is called.
- If remote Deck fetching fails, Sample Deck creation is bypassed to prevent unconfirmed state creation.
- Updated `useDeckImport` and `DeckImportOptions` to accept an optional `fetchDecks` handler.
- Expanded unit tests in `useSampleDeckBootstrap.spec.tsx` to cover the loading window, remote Deck verification, network failures, and StrictMode deduplication.

Closes #879