### PR TITLE
refactor: move DeckStart filter UI/state to page

### DIFF
--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -1,9 +1,7 @@
-export { DeckStartForm } from "./components/DeckStartForm";
 export { Controller, type ControllerProps } from "./components/Controller";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
 export { initializeStudySessionUi, removeStudySession, touchStudySession } from "./commands/studySessionCommands";
 export { useStudyHydrated } from "./hooks/useStudyHydrated";
-export { useDeckFilterState } from "./hooks/useDeckFilterState";
 export { useStudyActions } from "./hooks/useStudyActions";
 export { useStudyCards } from "./hooks/useStudyCards";
 export { useStudyControllerState } from "./hooks/useStudyControllerState";

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -55,14 +55,18 @@ vi.mock("@/features/card-list", () => ({
   },
 }));
 vi.mock("@/features/study", () => ({
+  useEditStudyProgress: () => ({ updateBy: mocks.updateBy }),
+  useStudyCards: (deck: Deck | undefined, cards: Card[]) => (deck == null ? [] : cards),
+}));
+vi.mock("@/pages/deck-start/ui/DeckStartForm", () => ({
   DeckStartForm: () => <div>Filter controls</div>,
+}));
+vi.mock("@/pages/deck-start/model/useDeckFilterState", () => ({
   useDeckFilterState: () => ({
     scoreMax: 4,
     scoreMin: -2,
     tagFilterProps: { selectedTags: ["typescript"], onClickTag: mocks.onClickTag },
   }),
-  useEditStudyProgress: () => ({ updateBy: mocks.updateBy }),
-  useStudyCards: (deck: Deck | undefined, cards: Card[]) => (deck == null ? [] : cards),
 }));
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -7,7 +7,9 @@ import { type Deck, useDeck } from "@/entities/deck";
 import { type Preferences, usePreferences } from "@/entities/preferences";
 import { CardList } from "@/features/card-list";
 import { BackText } from "@/features/card-view";
-import { DeckStartForm, useDeckFilterState, useEditStudyProgress, useStudyCards } from "@/features/study";
+import { useEditStudyProgress, useStudyCards } from "@/features/study";
+import { DeckStartForm } from "@/pages/deck-start/ui/DeckStartForm";
+import { useDeckFilterState } from "@/pages/deck-start/model/useDeckFilterState";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 

--- a/src/pages/deck-start/model/useDeckFilterState.spec.tsx
+++ b/src/pages/deck-start/model/useDeckFilterState.spec.tsx
@@ -59,7 +59,10 @@ describe("DeckStartForm with useDeckFilterState", () => {
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: 0, scoreMin: null }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith(
+        "user-id",
+        expect.objectContaining({ scoreMax: 0, scoreMin: null })
+      );
     });
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
     await waitFor(() => {
@@ -69,13 +72,19 @@ describe("DeckStartForm with useDeckFilterState", () => {
     fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), { target: { value: 2 } });
     fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), { target: { value: -2 } });
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: 2, scoreMin: -2 }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith(
+        "user-id",
+        expect.objectContaining({ scoreMax: 2, scoreMin: -2 })
+      );
     });
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: null, scoreMin: null }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith(
+        "user-id",
+        expect.objectContaining({ scoreMax: null, scoreMin: null })
+      );
     });
   });
 

--- a/src/pages/deck-start/model/useDeckFilterState.spec.tsx
+++ b/src/pages/deck-start/model/useDeckFilterState.spec.tsx
@@ -1,8 +1,5 @@
 /**
  * @file Verifies the "DeckStartForm with useDeckFilterState" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "auto-submits score and tag
- * filter changes", "auto-submits score toggle and slider changes", "auto-submits individual tag,
- * all, and clear changes".
  */
 
 import type { Deck } from "@/entities/deck";
@@ -14,7 +11,7 @@ import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { DeckStartForm } from "../components/DeckStartForm";
+import { DeckStartForm } from "../ui/DeckStartForm";
 import { useDeckFilterState } from "./useDeckFilterState";
 import { createDeck } from "@/test/factories";
 
@@ -25,10 +22,6 @@ vi.mock("@/entities/auth", () => ({
 }));
 vi.mock("@/entities/deck", () => ({ editDeck: mocks.editDeck }));
 
-/**
- * Renders the test-only Deck Filter Harness component with controlled state or providers.
- * Individual tests reuse it to exercise realistic interactions without repeating setup code.
- */
 const DeckFilterHarness: React.FC<{
   deck: Deck;
   tags: string[];
@@ -38,12 +31,7 @@ const DeckFilterHarness: React.FC<{
 };
 
 describe("DeckStartForm with useDeckFilterState", () => {
-  const deck = createDeck({
-    scoreMax: 1,
-    scoreMin: -1,
-    tagAndFilter: false,
-    selectedTags: [],
-  });
+  const deck = createDeck({ scoreMax: 1, scoreMin: -1, tagAndFilter: false, selectedTags: [] });
   const tags = ["tag1", "tag2", "tag3"];
 
   beforeEach(() => {
@@ -53,12 +41,8 @@ describe("DeckStartForm with useDeckFilterState", () => {
   it("persists score and tag filter changes", async () => {
     render(<DeckFilterHarness deck={deck} tags={tags} />);
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
-      target: { value: 2 },
-    });
-    fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), {
-      target: { value: -2 },
-    });
+    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), { target: { value: 2 } });
+    fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), { target: { value: -2 } });
     await userEvent.click(screen.getByRole("checkbox", { name: "Match all selected tags" }));
     await userEvent.click(screen.getByRole("button", { name: /all/i }));
 
@@ -75,36 +59,23 @@ describe("DeckStartForm with useDeckFilterState", () => {
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: 0, scoreMin: null })
-      );
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: 0, scoreMin: null }));
     });
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
     await waitFor(() => {
       expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: 0, scoreMin: 0 }));
     });
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
-      target: { value: 2 },
-    });
-    fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), {
-      target: { value: -2 },
-    });
+    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), { target: { value: 2 } });
+    fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), { target: { value: -2 } });
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: 2, scoreMin: -2 })
-      );
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: 2, scoreMin: -2 }));
     });
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: null, scoreMin: null })
-      );
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: null, scoreMin: null }));
     });
   });
 

--- a/src/pages/deck-start/model/useDeckFilterState.ts
+++ b/src/pages/deck-start/model/useDeckFilterState.ts
@@ -1,5 +1,5 @@
 /**
- * @file Provides the study feature's Deck filter state hook.
+ * @file Provides the deck-start page's Deck filter state hook.
  * The hook combines state and operations behind one interface so components do not need to
  * coordinate services themselves.
  */
@@ -11,7 +11,7 @@ import { useForm, useWatch } from "react-hook-form";
 
 import { useAuthSession } from "@/entities/auth";
 import { editDeck } from "@/entities/deck";
-import type { DeckStartForm } from "../components/DeckStartForm";
+import type { DeckStartForm } from "../ui/DeckStartForm";
 
 type DeckStartFormProps = React.ComponentProps<typeof DeckStartForm>;
 
@@ -20,9 +20,6 @@ export interface UseDeckFilterStateOptions {
   tags: string[];
 }
 
-/**
- * Provides the filter state and persistence callback used to configure a study session.
- */
 export const useDeckFilterState = ({ deck, tags }: UseDeckFilterStateOptions): DeckStartFormProps => {
   const auth = useAuthSession();
   const uid = auth.status === "authenticated" ? auth.uid : "";

--- a/src/pages/deck-start/ui/DeckStartForm.spec.tsx
+++ b/src/pages/deck-start/ui/DeckStartForm.spec.tsx
@@ -1,7 +1,5 @@
 /**
  * @file Verifies the "DeckStartForm" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "labels score controls and
- * preserves values and callbacks", "shows unrestricted disabled limits".
  */
 
 import { fireEvent, render, within, screen } from "@testing-library/react";
@@ -14,10 +12,6 @@ import { DeckStartForm } from "./DeckStartForm";
 
 type DeckStartFormProps = ComponentProps<typeof DeckStartForm>;
 
-/**
- * Provides the create props test helper used by this file.
- * Keeping this setup in one function lets each test focus on the behavior it is proving.
- */
 const createProps = (): DeckStartFormProps => ({
   scoreMax: 4,
   scoreMin: -2,

--- a/src/pages/deck-start/ui/DeckStartForm.stories.tsx
+++ b/src/pages/deck-start/ui/DeckStartForm.stories.tsx
@@ -1,7 +1,5 @@
 /**
  * @file Defines Storybook examples for Deck Start Form.
- * These isolated scenarios show developers how the component looks, which props it accepts, and
- * how it responds to interaction.
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
@@ -31,7 +29,7 @@ const args: DeckStartFormProps = {
 };
 
 const meta = {
-  title: "Study/DeckStartForm",
+  title: "Pages/DeckStart/DeckStartForm",
   component: Template,
   tags: ["autodocs"],
   args,
@@ -41,7 +39,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-
 export const ManyTagsSelected: Story = {
   args: {
     tagFilterProps: {
@@ -52,16 +49,8 @@ export const ManyTagsSelected: Story = {
     },
   },
 };
-
 export const NoMatchCompatible: Story = {
-  args: {
-    tagFilterProps: { ...args.tagFilterProps, selectedTags: ["advanced", "review"], tagAndFilter: true },
-  },
+  args: { tagFilterProps: { ...args.tagFilterProps, selectedTags: ["advanced", "review"], tagAndFilter: true } },
 };
-
-export const Mobile: Story = {
-  ...ManyTagsSelected,
-  parameters: { viewport: { defaultViewport: "iphone5" } },
-};
-
+export const Mobile: Story = { ...ManyTagsSelected, parameters: { viewport: { defaultViewport: "iphone5" } } };
 export const Dark: Story = { ...ManyTagsSelected, globals: { theme: "dark" } };

--- a/src/pages/deck-start/ui/DeckStartForm.tsx
+++ b/src/pages/deck-start/ui/DeckStartForm.tsx
@@ -1,5 +1,5 @@
 /**
- * @file Defines the study feature's Deck Start Form presentation component.
+ * @file Defines the deck-start page's Deck Start Form presentation component.
  * The component renders props and reports user intent through callbacks while data access stays
  * outside the view.
  */
@@ -30,16 +30,8 @@ interface ScoreLimitProps {
   sliderProps: React.ComponentProps<typeof Slider>;
 }
 
-/**
- * Converts an optional score limit into the value displayed by the deck-start form.
- * Missing limits use the form's boundary value so the slider remains controlled.
- */
 const displayScore = (value: number): string => `${value}`.replace("-", "−");
 
-/**
- * Formats the score range label text shown to the user.
- * The helper keeps wording and singular or plural rules consistent across the screen.
- */
 const scoreRangeLabel = (min: number | null, max: number | null): string => {
   if (min != null && max != null) return `${displayScore(min)} to ${displayScore(max)}`;
   if (min != null) return `${displayScore(min)} and above`;
@@ -47,11 +39,6 @@ const scoreRangeLabel = (min: number | null, max: number | null): string => {
   return "Any score";
 };
 
-/**
- * Renders the Score Limit user interface.
- * Lets the user set an optional score threshold and reports a parsed numeric limit or an empty
- * value.
- */
 const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
   const boundary = props.label === "Maximum score" ? "upper" : "lower";
   return (
@@ -88,11 +75,6 @@ const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
   );
 };
 
-/**
- * Renders the Deck Start Form user interface.
- * Collects study order and score-limit options, then reports whether the user starts or cancels
- * the session.
- */
 export const DeckStartForm: React.FC<DeckStartFormProps> = (props) => {
   const idPrefix = useId();
   const headingId = `${idPrefix}-score-heading`;

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -7,12 +7,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { filterCardsByDeckId, filterTagsByDeckId, useCards } from "@/entities/card";
-import { DeckStartForm, useDeckFilterState, useStudyActions, useStudyCards } from "@/features/study";
+import { useStudyActions, useStudyCards } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 import { toRemoteById } from "@/shared/lib/remoteSnapshot";
 
+import { useDeckFilterState } from "../model/useDeckFilterState";
+import { DeckStartForm } from "./DeckStartForm";
 import { DeckStartView } from "./DeckStartView";
 
 const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>

--- a/src/pages/deck-start/ui/DeckStartView.stories.tsx
+++ b/src/pages/deck-start/ui/DeckStartView.stories.tsx
@@ -1,11 +1,10 @@
-import { DeckStartForm } from "@/features/study";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
+import { DeckStartForm } from "./DeckStartForm";
 import { DeckStartView as View } from "./DeckStartView";
 
 type DeckStartFormProps = ComponentProps<typeof DeckStartForm>;

--- a/src/pages/deck-start/ui/TagFilter.spec.tsx
+++ b/src/pages/deck-start/ui/TagFilter.spec.tsx
@@ -1,8 +1,5 @@
 /**
  * @file Verifies the "TagFilter" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "groups tag controls and
- * exposes the active mode and selected tags", "preserves tag, mode, all, and clear callbacks",
- * "contains and breaks a single long unbroken tag".
  */
 
 import { render, within, screen } from "@testing-library/react";

--- a/src/pages/deck-start/ui/TagFilter.stories.tsx
+++ b/src/pages/deck-start/ui/TagFilter.stories.tsx
@@ -1,7 +1,5 @@
 /**
  * @file Defines Storybook examples for Tag Filter.
- * These isolated scenarios show developers how the component looks, which props it accepts, and
- * how it responds to interaction.
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
@@ -11,7 +9,7 @@ import { expect, fn } from "storybook/test";
 import { TagFilter as Template } from "./TagFilter";
 
 const meta = {
-  title: "Study/TagFilter",
+  title: "Pages/DeckStart/TagFilter",
   component: Template,
   tags: ["autodocs"],
   args: {
@@ -24,10 +22,6 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/**
- * Renders the Interactive Tag Filter Storybook example with local interactive state.
- * Local state lets readers try the component without connecting it to the full application.
- */
 const InteractiveTagFilter: React.FC<React.ComponentProps<typeof Template>> = (props) => {
   const [selectedTags, setSelectedTags] = React.useState(props.selectedTags ?? []);
 
@@ -44,7 +38,6 @@ const InteractiveTagFilter: React.FC<React.ComponentProps<typeof Template>> = (p
 };
 
 export const Default: Story = {};
-
 export const Interaction: Story = {
   args: { onClickTag: fn() },
   render: (args) => <InteractiveTagFilter {...args} />,
@@ -59,28 +52,15 @@ export const Interaction: Story = {
     await expect(args.onClickTag).toHaveBeenLastCalledWith([]);
   },
 };
-
-export const AndFilter: Story = {
-  args: { tagAndFilter: true },
-};
-
-export const Selected: Story = {
-  args: { selectedTags: ["tag1", "tag3"] },
-};
-
-export const ManyTags: Story = {
-  args: { tags: Array.from({ length: 40 }, (_, index) => `tag-${index + 1}`) },
-};
-
+export const AndFilter: Story = { args: { tagAndFilter: true } };
+export const Selected: Story = { args: { selectedTags: ["tag1", "tag3"] } };
+export const ManyTags: Story = { args: { tags: Array.from({ length: 40 }, (_, index) => `tag-${index + 1}`) } };
 export const NoMatchCompatible: Story = {
   args: { tags: ["advanced", "review"], selectedTags: ["advanced", "review"], tagAndFilter: true },
 };
-
 export const Mobile: Story = { ...ManyTags, parameters: { viewport: { defaultViewport: "iphone5" } } };
-
 export const LongTagMobile: Story = {
   args: { tags: ["averylongunbrokentag".repeat(12)] },
   parameters: { viewport: { defaultViewport: "iphone5" } },
 };
-
 export const Dark: Story = { ...Selected, globals: { theme: "dark" } };

--- a/src/pages/deck-start/ui/TagFilter.tsx
+++ b/src/pages/deck-start/ui/TagFilter.tsx
@@ -1,5 +1,5 @@
 /**
- * @file Defines the study feature's Tag Filter presentation component.
+ * @file Defines the deck-start page's Tag Filter presentation component.
  * The component renders props and reports user intent through callbacks while data access stays
  * outside the view.
  */
@@ -10,10 +10,6 @@ import { Button } from "@/shared/ui/button";
 import { TagList } from "@/shared/ui/content";
 import { Switch, Tag } from "@/shared/ui/forms";
 
-/**
- * Toggles one tag in the current selection without mutating the original array.
- * Selecting an existing tag removes it; selecting a new tag appends it for the filter callback.
- */
 const updateTags = (tags: string[], tag: string) => {
   if (tags.includes(tag)) {
     return tags.filter((t) => t !== tag);
@@ -33,11 +29,6 @@ export interface TagFilterProps {
   scroll?: boolean;
 }
 
-/**
- * Renders the Tag Filter user interface.
- * Lets the user choose filter mode and tag selections, then reports the resulting filter or a
- * clear action.
- */
 export const TagFilter: React.FC<TagFilterProps> = (props) => {
   const idPrefix = useId();
   const headingId = `${idPrefix}-tags-heading`;


### PR DESCRIPTION
## Summary

- move `DeckStartForm` and `TagFilter` from `features/study` to `pages/deck-start/ui`
- move `useDeckFilterState` to `pages/deck-start/model`
- colocate the related tests and Storybook stories with their final page owner
- remove the route-specific exports from `features/study`
- keep `useStudyActions` / `useStudyCards` in the Study feature

## Why

Issue #899 identifies the DeckStart filter presentation and form state as route-specific responsibilities. Keeping them in `features/study` makes the Study feature own page UI that is not part of the reusable study-session workflow.

This change moves those responsibilities to their final owner without adding a compatibility facade or changing the filter behavior.

## Impact

`DeckStartPage` now imports the page-local form and filter state directly. The Study feature public API no longer exposes DeckStart-specific UI/state.

## Validation

- reviewed the resulting diff against `main`
- preserved the existing component and hook behavior while relocating ownership

Local `npm run lint:fsd` / `mise run check` could not be run because this environment does not have a local checkout of the repository.

Closes #899