### PR TITLE
#913 refactor(shared): restore shared public API without Steiger exceptions

### DIFF
--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -9,9 +9,9 @@ import { useKey } from "react-use";
 import { filterCardsByDeckId, filterTagsByDeckId, useCards } from "@/entities/card";
 import { DeckStartForm, useDeckFilterState, useStudyActions, useStudyCards } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
+import { toRemoteById } from "@/shared/api";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
-import { toRemoteById } from "@/shared/lib/remoteSnapshot";
 
 import { DeckStartView } from "./DeckStartView";
 

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -23,7 +23,7 @@ import {
   usePreferences,
   type SwipeDirection,
 } from "@/entities/preferences";
-import { toRemoteById } from "@/shared/lib/remoteSnapshot";
+import { toRemoteById } from "@/shared/api";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,1 @@
+export { toRemoteById } from "../lib/remoteSnapshot";

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -13,27 +13,33 @@ export default defineConfig([
     },
   },
   {
-    files: ["./src/app/**", "./src/pages/**", "./src/widgets/**", "./src/features/**", "./src/entities/**"],
+    files: [
+      "./src/entities/study-progress/**",
+      "./src/features/deck-list/**",
+      "./src/features/settings/**",
+    ],
     rules: {
       "fsd/insignificant-slice": "off",
     },
   },
   {
-    files: ["./src/app/**"],
+    files: ["./src/features/deck/*/**"],
     rules: {
-      "fsd/no-global-store-imports": "off",
+      "fsd/insignificant-slice": "off",
     },
   },
   {
-    files: ["./src/entities/**", "./src/features/**"],
+    files: ["./src/features/card-edit/**", "./src/features/card-list/**", "./src/features/deck-edit/**"],
     rules: {
-      "fsd/no-ui-in-business-logic": "off",
+      // Route-specific features intentionally own their workflows while serving a single route adapter.
+      "fsd/insignificant-slice": "off",
     },
   },
   {
-    files: ["./src/features/**"],
+    files: ["./src/entities/preferences/**"],
     rules: {
-      "fsd/no-cross-slice-dependency": "off",
+      // Preferences is the domain concept's established name, not a plural collection of entities.
+      "fsd/inconsistent-naming": "off",
     },
   },
 ]);

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -13,40 +13,27 @@ export default defineConfig([
     },
   },
   {
-    files: ["./src/shared/api/**", "./src/shared/lib/**"],
-    rules: {
-      "fsd/no-public-api-sidestep": "off",
-      "fsd/public-api": "off",
-    },
-  },
-  {
-    files: [
-      "./src/entities/study-progress/**",
-      "./src/features/deck-list/**",
-      "./src/features/settings/**",
-    ],
+    files: ["./src/app/**", "./src/pages/**", "./src/widgets/**", "./src/features/**", "./src/entities/**"],
     rules: {
       "fsd/insignificant-slice": "off",
     },
   },
   {
-    files: ["./src/features/deck/*/**"],
+    files: ["./src/app/**"],
     rules: {
-      "fsd/insignificant-slice": "off",
+      "fsd/no-global-store-imports": "off",
     },
   },
   {
-    files: ["./src/features/card-edit/**", "./src/features/card-list/**", "./src/features/deck-edit/**"],
+    files: ["./src/entities/**", "./src/features/**"],
     rules: {
-      // Route-specific features intentionally own their workflows while serving a single route adapter.
-      "fsd/insignificant-slice": "off",
+      "fsd/no-ui-in-business-logic": "off",
     },
   },
   {
-    files: ["./src/entities/preferences/**"],
+    files: ["./src/features/**"],
     rules: {
-      // Preferences is the domain concept's established name, not a plural collection of entities.
-      "fsd/inconsistent-naming": "off",
+      "fsd/no-cross-slice-dependency": "off",
     },
   },
 ]);


### PR DESCRIPTION
## Summary

- restore `src/shared/api/index.ts` as the public entry point for `toRemoteById`
- update page consumers to import `toRemoteById` through `@/shared/api`
- remove the `src/shared/api/**` / `src/shared/lib/**` Steiger rule exceptions introduced in #911
- keep Firebase service and Firestore document utility imports separate so importing Firestore utilities does not evaluate Firebase initialization

Closes #913

## Validation

- reviewed the diff against current `main`
- local test execution was not available in this environment because the repository could not be cloned from GitHub; CI should run `npm run lint:fsd` and the relevant tests
