### PR TITLE
#902 refactor: Move Study autoplay to controller state

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -68,7 +68,13 @@ export const preparePageStory = async (parameters: PageStoryParameters): Promise
 
   const decks = (parameters.decks ?? []).map(cloneDeck);
   const cards = (parameters.cards ?? []).map(cloneCard);
-  const preferences = preferencesSchema.parse(parameters.preferences);
+  const preferences = preferencesSchema.parse({
+    ...parameters.preferences,
+    study: {
+      ...(parameters.preferences?.study ?? {}),
+      ...(parameters.autoPlay !== undefined ? { defaultAutoPlay: parameters.autoPlay } : {}),
+    },
+  });
   preferencesStore.setState({
     preferences: {
       ...preferences,
@@ -80,7 +86,6 @@ export const preparePageStory = async (parameters: PageStoryParameters): Promise
   });
   studyStore.setState({
     sessionsByDeckId: cloneSessions(parameters.sessionsByDeckId ?? {}),
-    autoPlay: parameters.autoPlay ?? false,
   });
   replaceDecks(decks);
   replaceCards(cards);

--- a/src/features/study/commands/studySessionCommands.spec.ts
+++ b/src/features/study/commands/studySessionCommands.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { studyStore } from "../state/studyStoreInstance";
-import { initializeStudySessionUi, removeStudySession, touchStudySession } from "./studySessionCommands";
+import { removeStudySession, touchStudySession } from "./studySessionCommands";
 
 describe("study session commands", () => {
   beforeEach(() => {
@@ -26,18 +26,6 @@ describe("study session commands", () => {
 
     expect(studyStore.getState().sessionsByDeckId).toEqual({
       first: { deckId: "first", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 900 },
-    });
-  });
-
-  it("initializes transient study controls", () => {
-    studyStore.setState({
-      autoPlay: false,
-    });
-
-    initializeStudySessionUi(true);
-
-    expect(studyStore.getState()).toMatchObject({
-      autoPlay: true,
     });
   });
 });

--- a/src/features/study/commands/studySessionCommands.ts
+++ b/src/features/study/commands/studySessionCommands.ts
@@ -2,10 +2,6 @@ import type { DeckId } from "@/entities/deck";
 
 import { studyStore } from "../state/studyStoreInstance";
 
-export const initializeStudySessionUi = (defaultAutoPlay: boolean) => {
-  studyStore.getState().initializeStudyUi(defaultAutoPlay);
-};
-
 export const removeStudySession = (deckId: DeckId) => {
   studyStore.getState().removeStudy(deckId);
 };

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -114,7 +114,6 @@ describe("useStudyActions", () => {
     mocks.state = createState();
     studyStore.setState({
       sessionsByDeckId: {},
-      autoPlay: false,
     });
   });
 
@@ -134,7 +133,6 @@ describe("useStudyActions", () => {
             lastStudiedAt: 946684800000,
           },
         },
-        autoPlay: true,
       });
     });
     const { result } = renderHook(() =>
@@ -356,6 +354,17 @@ describe("useStudyActions", () => {
     });
 
     expect(onToggleBackText).toHaveBeenCalledOnce();
+  });
+
+  it("calls onToggleAutoPlay when toggleAutoPlay is invoked", () => {
+    const onToggleAutoPlay = vi.fn();
+    const { result } = renderHook(() => useStudyActions(deck.id, { cardsById: getCardsById(), onToggleAutoPlay }));
+
+    act(() => {
+      result.current.toggleAutoPlay();
+    });
+
+    expect(onToggleAutoPlay).toHaveBeenCalledOnce();
   });
 
   it("finishes only the route session after the final card", async () => {

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -42,6 +42,7 @@ interface UseStudyActionsOptions {
   onHideBackText?: (() => void) | undefined;
   onToggleBackText?: (() => void) | undefined;
   onRestoreBackText?: ((showBackText: boolean) => void) | undefined;
+  onToggleAutoPlay?: (() => void) | undefined;
 }
 
 interface StudySwipeDependencies {
@@ -172,6 +173,7 @@ export const useStudyActions = (
     onHideBackText,
     onToggleBackText,
     onRestoreBackText,
+    onToggleAutoPlay,
   }: UseStudyActionsOptions
 ): StudyActions => {
   const preferences = usePreferences();
@@ -185,7 +187,6 @@ export const useStudyActions = (
     const cardOrderIds = buildStudySession(cards, preferences.study);
     const state = studyStore.getState();
     state.startStudy(deckId, cardOrderIds);
-    state.initializeStudyUi(preferences.study.defaultAutoPlay);
     onHideBackText?.();
     onStarted?.();
   };
@@ -223,7 +224,7 @@ export const useStudyActions = (
       state.setCurrentIndex(deckId, currentIndex);
     },
     toggleShowBackText: () => onToggleBackText?.(),
-    toggleAutoPlay: () => studyStore.getState().toggleAutoPlay(),
+    toggleAutoPlay: () => onToggleAutoPlay?.(),
     resetStudy: () => studyStore.getState().removeStudy(deckId),
   };
 };

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -1,7 +1,7 @@
 export { DeckStartForm } from "./components/DeckStartForm";
 export { Controller, type ControllerProps } from "./components/Controller";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
-export { initializeStudySessionUi, removeStudySession, touchStudySession } from "./commands/studySessionCommands";
+export { removeStudySession, touchStudySession } from "./commands/studySessionCommands";
 export { useStudyHydrated } from "./hooks/useStudyHydrated";
 export { useDeckFilterState } from "./hooks/useDeckFilterState";
 export { useStudyActions } from "./hooks/useStudyActions";

--- a/src/features/study/state/studyStore.spec.ts
+++ b/src/features/study/state/studyStore.spec.ts
@@ -118,16 +118,6 @@ describe("study store", () => {
     expect(selectStudySessionForRoute("missing-deck")(store.getState())).toBeNull();
   });
 
-  it("initializes and toggles transient study UI state", () => {
-    const store = createStudyStore({ storage: createMemoryStorage(), skipHydration: true });
-
-    store.getState().initializeStudyUi(true);
-    expect(store.getState()).toMatchObject({ autoPlay: true });
-
-    store.getState().toggleAutoPlay();
-    expect(store.getState()).toMatchObject({ autoPlay: false });
-  });
-
   it("persists exactly the session map in a v3 envelope", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
@@ -150,7 +140,6 @@ describe("study store", () => {
       sessionsByDeckId: {
         "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
       },
-      autoPlay: false,
     });
     expect(restored.getState()).not.toHaveProperty("session");
   });

--- a/src/features/study/state/studyStore.ts
+++ b/src/features/study/state/studyStore.ts
@@ -24,13 +24,10 @@ interface PersistedStudyState {
 }
 
 export interface StudyState extends PersistedStudyState {
-  autoPlay: boolean;
   startStudy: (deckId: DeckId, cardOrderIds: CardId[]) => void;
   touchStudy: (deckId: DeckId) => void;
   setCurrentIndex: (deckId: DeckId, currentIndex: number) => void;
   removeStudy: (deckId: DeckId) => void;
-  initializeStudyUi: (defaultAutoPlay: boolean) => void;
-  toggleAutoPlay: () => void;
 }
 
 interface CreateStudyStoreOptions {
@@ -117,7 +114,6 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
     persist<StudyState, [], [], PersistedStudyState>(
       (set) => ({
         sessionsByDeckId: {},
-        autoPlay: false,
         startStudy: (deckId, cardOrderIds) =>
           set((state) => ({
             sessionsByDeckId: {
@@ -164,11 +160,6 @@ export const createStudyStore = ({ storage, skipHydration }: CreateStudyStoreOpt
             const { [deckId]: _removed, ...sessionsByDeckId } = state.sessionsByDeckId;
             return { sessionsByDeckId };
           }),
-        initializeStudyUi: (defaultAutoPlay) =>
-          set({
-            autoPlay: defaultAutoPlay,
-          }),
-        toggleAutoPlay: () => set((state) => ({ autoPlay: !state.autoPlay })),
       }),
       {
         name: STUDY_STORAGE_KEY,

--- a/src/features/study/state/studyStoreInstance.ts
+++ b/src/features/study/state/studyStoreInstance.ts
@@ -9,7 +9,6 @@ export const studyStore = createStudyStore();
 export const clearStudyStore = async (): Promise<void> => {
   studyStore.setState({
     sessionsByDeckId: {},
-    autoPlay: false,
   });
   await studyStore.persist.clearStorage();
 };

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -35,9 +35,7 @@ const mocks = vi.hoisted(() => ({
   },
   studyState: {
     sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
-    autoPlay: false,
   },
-  initializeStudySessionUi: vi.fn(),
   touchStudySession: vi.fn(),
   hydrated: true,
   toggleShowHeader: vi.fn(),
@@ -77,7 +75,6 @@ vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
   return {
     ...actual,
-    initializeStudySessionUi: mocks.initializeStudySessionUi,
     touchStudySession: mocks.touchStudySession,
     useEditStudyProgress: () => mocks.cardMutation,
     useStudyActions: (
@@ -85,6 +82,7 @@ vi.mock("@/features/study", async (importOriginal) => {
       options?: {
         onSwipe?: (direction: SwipeDirection) => void;
         onToggleBackText?: () => void;
+        onToggleAutoPlay?: () => void;
       }
     ) => ({
       swipeUp: () => {
@@ -108,7 +106,10 @@ vi.mock("@/features/study", async (importOriginal) => {
         options?.onToggleBackText?.();
         mocks.toggleShowBackText();
       },
-      toggleAutoPlay: mocks.toggleAutoPlay,
+      toggleAutoPlay: () => {
+        options?.onToggleAutoPlay?.();
+        mocks.toggleAutoPlay();
+      },
       resetStudy: mocks.resetStudy,
     }),
     useStudyHydrated: () => mocks.hydrated,
@@ -181,10 +182,6 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
         lastStudiedAt: 0,
       },
     };
-    mocks.studyState.autoPlay = false;
-    mocks.initializeStudySessionUi.mockImplementation((defaultAutoPlay: boolean) => {
-      mocks.studyState.autoPlay = defaultAutoPlay;
-    });
     mocks.touchStudySession.mockImplementation((deckId: DeckId) => {
       const session = mocks.studyState.sessionsByDeckId[deckId];
       if (session != null) {
@@ -232,6 +229,7 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     expect(mocks.toggleShowHeader).toHaveBeenCalledOnce();
     expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
     expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("pause")).toBeInTheDocument();
   });
 
   it("owns header visibility across front and back content", () => {
@@ -318,22 +316,25 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     const session = mocks.studyState.sessionsByDeckId[deck.id];
     if (session == null) throw new Error("Expected an active study session");
     mocks.studyState.sessionsByDeckId[deck.id] = { ...session, lastStudiedAt: 100 };
-    mocks.studyState.autoPlay = true;
     const now = vi.spyOn(Date, "now").mockReturnValue(9000);
 
     render(<DeckSwiperPage />);
 
-    expect(mocks.initializeStudySessionUi).toHaveBeenCalledWith(false);
     expect(mocks.touchStudySession).toHaveBeenCalledWith(deck.id);
     expect(mocks.studyState.sessionsByDeckId[deck.id]?.lastStudiedAt).toBe(9000);
-    expect(mocks.studyState).toMatchObject({ autoPlay: false });
     now.mockRestore();
   });
 
   it("renders back text and controlled auto-play", () => {
-    const view = render(<DeckSwiperPage />);
-    mocks.studyState.autoPlay = true;
-    view.rerender(<DeckSwiperPage />);
+    if (mocks.state == null) throw new Error("Mock state is not initialized");
+    mocks.state.preferences = createPreferences({
+      ...mocks.state.preferences,
+      study: {
+        ...mocks.state.preferences.study,
+        defaultAutoPlay: true,
+      },
+    });
+    render(<DeckSwiperPage />);
 
     fireEvent.click(screen.getByText(card.frontText));
 
@@ -350,6 +351,7 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
 
     expect(mocks.toggleShowBackText).toHaveBeenCalled();
     expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("play")).toBeInTheDocument();
     expect(mocks.swipeLeft).toHaveBeenCalledOnce();
     expect(mocks.swipeRight).toHaveBeenCalledOnce();
   });

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -7,7 +7,6 @@ import { useKey } from "react-use";
 import { type Card, type CardId, useCards } from "@/entities/card";
 import { BackText, CardOverlay, FrontText } from "@/features/card-view";
 import {
-  initializeStudySessionUi,
   selectStudySessionForRoute,
   type SwipeButtonListProps,
   touchStudySession,
@@ -41,7 +40,7 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   const allCards = useCards();
   const session = useStudyStore(selectStudySessionForRoute(deckId));
   const [showBackText, setShowBackText] = React.useState(false);
-  const autoPlay = useStudyStore((state) => state.autoPlay);
+  const [autoPlay, setAutoPlay] = React.useState(preferences.study.defaultAutoPlay);
   const [lastSwipe, setLastSwipe] = React.useState<{ direction: SwipeDirection; eventId: number } | undefined>(
     undefined
   );
@@ -55,6 +54,9 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   }, []);
   const handleRestoreBackText = React.useCallback((show: boolean) => {
     setShowBackText(show);
+  }, []);
+  const handleToggleAutoPlay = React.useCallback(() => {
+    setAutoPlay((prev) => !prev);
   }, []);
 
   const handleSwipe = React.useCallback(
@@ -85,6 +87,7 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
     onHideBackText: handleHideBackText,
     onToggleBackText: handleToggleBackText,
     onRestoreBackText: handleRestoreBackText,
+    onToggleAutoPlay: handleToggleAutoPlay,
   });
   useKey("ArrowUp", studyActions.swipeUp);
   useKey("ArrowDown", studyActions.swipeDown);
@@ -119,9 +122,8 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
   const exitingDeck = React.useRef<DeckId>(undefined);
   React.useEffect(() => {
     if (!valid) return;
-    initializeStudySessionUi(preferences.study.defaultAutoPlay);
     touchStudySession(deckId);
-  }, [preferences.study.defaultAutoPlay, deckId, valid]);
+  }, [deckId, valid]);
 
   React.useEffect(() => {
     if (valid) {


### PR DESCRIPTION
## Summary

- move Study auto-play state from the persisted singleton store to the deck swiper controller lifecycle
- preserve initialization from `preferences.study.defaultAutoPlay`
- keep controller and Space-key toggle behavior while removing obsolete store commands
- update focused behavior tests and Storybook setup

## Why

`autoPlay` is transient controller UI state, not durable Study session state. Keeping it in the persisted singleton store mixed controller lifecycle concerns with session persistence.

## Impact

Study sessions continue to initialize auto-play from the saved preference. Controller and keyboard toggles remain available, while the persisted Study store now contains only session durability state.

## Validation

- `mise run check`
- 96 unit test files passed
- 474 unit tests passed

Closes #902