### PR TITLE
refactor(#920): separate remote and local collection state

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -4,9 +4,10 @@
  * normal containers, hooks, and route parameters.
  */
 
-import { replaceCards, type Card } from "@/entities/card";
+import type { Card } from "@/entities/card";
+import { replaceRemoteCards } from "@/entities/card/model/store";
 import type { Deck } from "@/entities/deck";
-import { replaceDecks } from "@/entities/deck/model/store";
+import { replaceRemoteDecks } from "@/entities/deck/model/store";
 
 import type { Decorator } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
@@ -87,8 +88,8 @@ export const preparePageStory = async (parameters: PageStoryParameters): Promise
   studyStore.setState({
     sessionsByDeckId: cloneSessions(parameters.sessionsByDeckId ?? {}),
   });
-  replaceDecks(decks);
-  replaceCards(cards);
+  replaceRemoteDecks(decks);
+  replaceRemoteCards(cards);
 };
 
 /** Wraps a page story with the providers normally supplied by the application entry point. */

--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -14,11 +14,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authState }));
 vi.mock("@/entities/card", () => ({
-  clearCards: () => mocks.operations.push("clear Cards"),
+  clearRemoteCards: () => mocks.operations.push("clear remote Cards"),
   subscribeCards: mocks.subscribeCards,
 }));
 vi.mock("@/entities/deck", () => ({
-  clearDecks: () => mocks.operations.push("clear Decks"),
+  clearRemoteDecks: () => mocks.operations.push("clear remote Decks"),
   subscribeDecks: mocks.subscribeDecks,
 }));
 
@@ -52,8 +52,8 @@ describe("FirestoreSubscriptionsProvider", () => {
       "start Decks test-user",
       "stop Cards test-user",
       "stop Decks test-user",
-      "clear Cards",
-      "clear Decks",
+      "clear remote Cards",
+      "clear remote Decks",
     ]);
   });
 
@@ -67,8 +67,8 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(mocks.operations).toEqual([
       "stop Cards test-user",
       "stop Decks test-user",
-      "clear Cards",
-      "clear Decks",
+      "clear remote Cards",
+      "clear remote Decks",
       "start Cards next-user",
       "start Decks next-user",
     ]);
@@ -93,6 +93,11 @@ describe("FirestoreSubscriptionsProvider", () => {
     mocks.authState = { status: "unauthenticated" };
     view.rerender(<FirestoreSubscriptionsProvider />);
 
-    expect(mocks.operations).toEqual(["stop Cards test-user", "stop Decks test-user", "clear Cards", "clear Decks"]);
+    expect(mocks.operations).toEqual([
+      "stop Cards test-user",
+      "stop Decks test-user",
+      "clear remote Cards",
+      "clear remote Decks",
+    ]);
   });
 });

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import { useAuthSession } from "@/entities/auth";
-import { clearCards, subscribeCards } from "@/entities/card";
-import { clearDecks, subscribeDecks } from "@/entities/deck";
+import { clearRemoteCards, subscribeCards } from "@/entities/card";
+import { clearRemoteDecks, subscribeDecks } from "@/entities/deck";
 
 export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const authState = useAuthSession();
@@ -15,8 +15,8 @@ export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> =
     return () => {
       stopCards?.();
       stopDecks?.();
-      clearCards();
-      clearDecks();
+      clearRemoteCards();
+      clearRemoteDecks();
     };
   }, [authenticatedUid]);
 

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -19,7 +19,7 @@ import {
   parseFirestoreDocument,
 } from "@/shared/api/firestoreDocument";
 import { createCardSchema, deleteCardSchema, editCardSchema } from "../model/schema";
-import { replaceCards } from "../model/store";
+import { replaceRemoteCards } from "../model/store";
 
 const CARD_COLLECTION = "card";
 
@@ -79,7 +79,7 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
         const cards = snapshot.docs
           .map((document) => convertCardDtoToCard(document.id, document.data()))
           .filter((card) => card.deletedAt === null);
-        replaceCards(cards);
+        replaceRemoteCards(cards);
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }

--- a/src/entities/card/api/subscription.spec.tsx
+++ b/src/entities/card/api/subscription.spec.tsx
@@ -2,8 +2,9 @@ import { act, renderHook } from "@testing-library/react";
 import { Timestamp } from "firebase/firestore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createCard } from "@/test/factories";
 import { useCards } from "../model/hooks";
-import { clearCards } from "../model/store";
+import { cardStore } from "../model/store";
 
 const mocks = vi.hoisted(() => ({
   collection: vi.fn((...parts: unknown[]) => parts),
@@ -51,12 +52,14 @@ const getErrorHandler = () => mocks.onSnapshot.mock.calls[0]?.[2] as (error: Err
 
 describe("Card Firestore subscription", () => {
   beforeEach(() => {
-    clearCards();
+    cardStore.setState({ remoteCards: [], localCards: [] });
     vi.clearAllMocks();
     mocks.onSnapshot.mockReturnValue(mocks.unsubscribe);
   });
 
   it("subscribes by UID and fully replaces active Cards from each snapshot", () => {
+    const localCard = createCard({ id: "local", frontText: "Local front" });
+    cardStore.setState({ localCards: [localCard] });
     const { result } = renderHook(useCards);
     const unsubscribe = subscribeCards("uid-a", vi.fn());
 
@@ -90,10 +93,11 @@ describe("Card Firestore subscription", () => {
         startLine: 8,
         endLine: 9,
       }),
+      localCard,
     ]);
 
     act(() => getSnapshotHandler()({ docs: [cardDocument("replacement", { frontText: "Current" })] }));
-    expect(result.current).toEqual([expect.objectContaining({ id: "replacement", frontText: "Current" })]);
+    expect(result.current).toEqual([expect.objectContaining({ id: "replacement", frontText: "Current" }), localCard]);
 
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,7 +1,6 @@
 export { createCard, deleteCard, editCard, fetchCards, generateCardId, subscribeCards } from "./api/firestore";
 export { useCard, useCards } from "./model/hooks";
-/** @public */
-export { clearCards, replaceCards } from "./model/store";
+export { clearRemoteCards } from "./model/store";
 export type {
   Card,
   CardCreateInput,

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -3,7 +3,13 @@ import { useStore } from "zustand";
 import { cardStore } from "./store";
 import type { Card, CardId } from "./types";
 
-export const useCards = (): Card[] => useStore(cardStore, (state) => state.cards);
+export const useCards = (): Card[] => {
+  const state = useStore(cardStore);
+  return [...state.remoteCards, ...state.localCards];
+};
 
 export const useCard = (id: CardId | undefined): Card | undefined =>
-  useStore(cardStore, (state) => state.cards.find((card) => card.id === id));
+  useStore(
+    cardStore,
+    (state) => state.remoteCards.find((card) => card.id === id) ?? state.localCards.find((card) => card.id === id)
+  );

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -3,27 +3,31 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { createCard } from "@/test/factories";
 import { useCard, useCards } from "./hooks";
-import { cardStore, clearCards, replaceCards } from "./store";
+import { cardStore, clearRemoteCards, replaceRemoteCards } from "./store";
 
 describe("Card store", () => {
-  beforeEach(clearCards);
+  beforeEach(() => cardStore.setState({ remoteCards: [], localCards: [] }));
 
-  it("replaces and clears the Card collection", () => {
-    const card = createCard({ id: "card" });
+  it("replaces and clears only the remote Card collection", () => {
+    const remoteCard = createCard({ id: "remote" });
+    const localCard = createCard({ id: "local" });
+    cardStore.setState({ localCards: [localCard] });
 
-    replaceCards([card]);
-    expect(cardStore.getState().cards).toEqual([card]);
+    replaceRemoteCards([remoteCard]);
+    expect(cardStore.getState()).toEqual({ remoteCards: [remoteCard], localCards: [localCard] });
 
-    clearCards();
-    expect(cardStore.getState().cards).toEqual([]);
+    clearRemoteCards();
+    expect(cardStore.getState()).toEqual({ remoteCards: [], localCards: [localCard] });
   });
 
-  it("exposes collection and individual Card selectors", () => {
-    const card = createCard({ id: "card" });
-    replaceCards([card]);
+  it("exposes combined collection and individual Card selectors", () => {
+    const remoteCard = createCard({ id: "remote" });
+    const localCard = createCard({ id: "local" });
+    cardStore.setState({ remoteCards: [remoteCard], localCards: [localCard] });
 
-    expect(renderHook(useCards).result.current).toEqual([card]);
-    expect(renderHook(() => useCard("card")).result.current).toEqual(card);
+    expect(renderHook(useCards).result.current).toEqual([remoteCard, localCard]);
+    expect(renderHook(() => useCard("remote")).result.current).toEqual(remoteCard);
+    expect(renderHook(() => useCard("local")).result.current).toEqual(localCard);
     expect(renderHook(() => useCard("missing")).result.current).toBeUndefined();
   });
 });

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -3,15 +3,16 @@ import { createStore } from "zustand/vanilla";
 import type { Card } from "./types";
 
 interface CardState {
-  cards: Card[];
+  remoteCards: Card[];
+  localCards: Card[];
 }
 
-export const cardStore = createStore<CardState>()(() => ({ cards: [] }));
+export const cardStore = createStore<CardState>()(() => ({ remoteCards: [], localCards: [] }));
 
-export const replaceCards = (cards: Card[]): void => {
-  cardStore.setState({ cards });
+export const replaceRemoteCards = (remoteCards: Card[]): void => {
+  cardStore.setState({ remoteCards });
 };
 
-export const clearCards = (): void => {
-  cardStore.setState({ cards: [] });
+export const clearRemoteCards = (): void => {
+  cardStore.setState({ remoteCards: [] });
 };

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { db } from "@/shared/api/firebase";
 import { getTimestamp, omitUndefined, parseFirestoreDocument } from "@/shared/api/firestoreDocument";
 import { createDeckSchema, deleteDeckSchema, editDeckSchema } from "../model/schema";
-import { replaceDecks } from "../model/store";
+import { replaceRemoteDecks } from "../model/store";
 
 const DECK_COLLECTION = "deck";
 const CARD_COLLECTION = "card";
@@ -51,7 +51,7 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
         const decks = snapshot.docs
           .map((document) => convertDeckDtoToDeck(document.id, document.data()))
           .filter((deck) => deck.deletedAt === null);
-        replaceDecks(decks);
+        replaceRemoteDecks(decks);
       } catch (cause) {
         onError(cause instanceof Error ? cause : new Error(String(cause)));
       }

--- a/src/entities/deck/api/subscription.spec.tsx
+++ b/src/entities/deck/api/subscription.spec.tsx
@@ -1,8 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createDeck } from "@/test/factories";
 import { useDecks } from "../model/hooks";
-import { clearDecks } from "../model/store";
+import { deckStore } from "../model/store";
 
 const mocks = vi.hoisted(() => ({
   collection: vi.fn((...parts: unknown[]) => parts),
@@ -47,12 +48,14 @@ const getErrorHandler = () => mocks.onSnapshot.mock.calls[0]?.[2] as (error: Err
 
 describe("Deck Firestore subscription", () => {
   beforeEach(() => {
-    clearDecks();
+    deckStore.setState({ remoteDecks: [], localDecks: [] });
     vi.clearAllMocks();
     mocks.onSnapshot.mockReturnValue(mocks.unsubscribe);
   });
 
   it("subscribes by UID and replaces the store with active Decks", () => {
+    const localDeck = createDeck({ id: "local", name: "Local Deck" });
+    deckStore.setState({ localDecks: [localDeck] });
     const { result } = renderHook(useDecks);
     const unsubscribe = subscribeDecks("uid-a", vi.fn());
 
@@ -64,7 +67,7 @@ describe("Deck Firestore subscription", () => {
       })
     );
 
-    expect(result.current).toEqual([expect.objectContaining({ id: "active", url: "https://example.com" })]);
+    expect(result.current).toEqual([expect.objectContaining({ id: "active", url: "https://example.com" }), localDeck]);
     unsubscribe();
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,5 +1,5 @@
 export { createDeck, deleteDeck, editDeck, fetchDecks, generateDeckId, subscribeDecks } from "./api/firestore";
 export { CATEGORY, getCategory, isHighlightLanguage } from "./model/rules";
 export { useDeck, useDecks } from "./model/hooks";
-export { clearDecks } from "./model/store";
+export { clearRemoteDecks } from "./model/store";
 export type { Deck, DeckCreateInput, DeckEdit, DeckId } from "./model/types";

--- a/src/entities/deck/model/hooks.ts
+++ b/src/entities/deck/model/hooks.ts
@@ -3,7 +3,13 @@ import { useStore } from "zustand";
 import { deckStore } from "./store";
 import type { Deck, DeckId } from "./types";
 
-export const useDecks = (): Deck[] => useStore(deckStore, (state) => state.decks);
+export const useDecks = (): Deck[] => {
+  const state = useStore(deckStore);
+  return [...state.remoteDecks, ...state.localDecks];
+};
 
 export const useDeck = (id: DeckId | undefined): Deck | undefined =>
-  useStore(deckStore, (state) => state.decks.find((deck) => deck.id === id));
+  useStore(
+    deckStore,
+    (state) => state.remoteDecks.find((deck) => deck.id === id) ?? state.localDecks.find((deck) => deck.id === id)
+  );

--- a/src/entities/deck/model/store.spec.tsx
+++ b/src/entities/deck/model/store.spec.tsx
@@ -3,27 +3,31 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { createDeck } from "@/test/factories";
 import { useDeck, useDecks } from "./hooks";
-import { clearDecks, deckStore, replaceDecks } from "./store";
+import { clearRemoteDecks, deckStore, replaceRemoteDecks } from "./store";
 
 describe("Deck store", () => {
-  beforeEach(clearDecks);
+  beforeEach(() => deckStore.setState({ remoteDecks: [], localDecks: [] }));
 
-  it("replaces and clears the Deck collection", () => {
-    const deck = createDeck({ id: "deck" });
+  it("replaces and clears only the remote Deck collection", () => {
+    const remoteDeck = createDeck({ id: "remote" });
+    const localDeck = createDeck({ id: "local" });
+    deckStore.setState({ localDecks: [localDeck] });
 
-    replaceDecks([deck]);
-    expect(deckStore.getState().decks).toEqual([deck]);
+    replaceRemoteDecks([remoteDeck]);
+    expect(deckStore.getState()).toEqual({ remoteDecks: [remoteDeck], localDecks: [localDeck] });
 
-    clearDecks();
-    expect(deckStore.getState().decks).toEqual([]);
+    clearRemoteDecks();
+    expect(deckStore.getState()).toEqual({ remoteDecks: [], localDecks: [localDeck] });
   });
 
-  it("exposes collection and individual Deck selectors", () => {
-    const deck = createDeck({ id: "deck" });
-    replaceDecks([deck]);
+  it("exposes combined collection and individual Deck selectors", () => {
+    const remoteDeck = createDeck({ id: "remote" });
+    const localDeck = createDeck({ id: "local" });
+    deckStore.setState({ remoteDecks: [remoteDeck], localDecks: [localDeck] });
 
-    expect(renderHook(useDecks).result.current).toEqual([deck]);
-    expect(renderHook(() => useDeck("deck")).result.current).toEqual(deck);
+    expect(renderHook(useDecks).result.current).toEqual([remoteDeck, localDeck]);
+    expect(renderHook(() => useDeck("remote")).result.current).toEqual(remoteDeck);
+    expect(renderHook(() => useDeck("local")).result.current).toEqual(localDeck);
     expect(renderHook(() => useDeck("missing")).result.current).toBeUndefined();
   });
 });

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -3,15 +3,16 @@ import { createStore } from "zustand/vanilla";
 import type { Deck } from "./types";
 
 interface DeckState {
-  decks: Deck[];
+  remoteDecks: Deck[];
+  localDecks: Deck[];
 }
 
-export const deckStore = createStore<DeckState>()(() => ({ decks: [] }));
+export const deckStore = createStore<DeckState>()(() => ({ remoteDecks: [], localDecks: [] }));
 
-export const replaceDecks = (decks: Deck[]): void => {
-  deckStore.setState({ decks });
+export const replaceRemoteDecks = (remoteDecks: Deck[]): void => {
+  deckStore.setState({ remoteDecks });
 };
 
-export const clearDecks = (): void => {
-  deckStore.setState({ decks: [] });
+export const clearRemoteDecks = (): void => {
+  deckStore.setState({ remoteDecks: [] });
 };

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -39,15 +39,17 @@ describe("Query realtime subscriptions", () => {
       await createDeckCommand(uid, deck);
       await createCardCommand(uid, card);
       await vi.waitFor(() => {
-        expect(deckStore.getState().decks).toContainEqual(expect.objectContaining({ id: deck.id }));
-        expect(cardStore.getState().cards).toContainEqual(expect.objectContaining({ id: card.id }));
+        expect(deckStore.getState().remoteDecks).toContainEqual(expect.objectContaining({ id: deck.id }));
+        expect(cardStore.getState().remoteCards).toContainEqual(expect.objectContaining({ id: card.id }));
       });
 
       await editDeck(uid, { ...deck, name: "Updated" });
       await editCard(uid, { ...card, frontText: "Updated" });
       await vi.waitFor(() => {
-        expect(deckStore.getState().decks).toContainEqual(expect.objectContaining({ id: deck.id, name: "Updated" }));
-        expect(cardStore.getState().cards).toContainEqual(
+        expect(deckStore.getState().remoteDecks).toContainEqual(
+          expect.objectContaining({ id: deck.id, name: "Updated" })
+        );
+        expect(cardStore.getState().remoteCards).toContainEqual(
           expect.objectContaining({ id: card.id, frontText: "Updated" })
         );
       });
@@ -55,8 +57,8 @@ describe("Query realtime subscriptions", () => {
       await deleteCard(uid, card);
       await deleteDeck(uid, deck);
       await vi.waitFor(() => {
-        expect(deckStore.getState().decks.find((candidate) => candidate.id === deck.id)).toBeUndefined();
-        expect(cardStore.getState().cards.find((candidate) => candidate.id === card.id)).toBeUndefined();
+        expect(deckStore.getState().remoteDecks.find((candidate) => candidate.id === deck.id)).toBeUndefined();
+        expect(cardStore.getState().remoteCards.find((candidate) => candidate.id === card.id)).toBeUndefined();
       });
       expect(errors).toEqual([]);
     } finally {


### PR DESCRIPTION
## Related issue

Fixes #920

## Summary

- split Deck and Card stores into explicit remote and local state
- keep existing collection and item hooks storage-agnostic by combining both sources
- restrict Firestore snapshots and subscription cleanup to remote state
- update Storybook fixtures and tests for the new state boundary

## Testing

- `mise run check`
- `mise run test-integration`