### PR TITLE
test(#867): Tighten card list presentation contract

### DIFF
--- a/src/features/card-list/ui/Card.stories.tsx
+++ b/src/features/card-list/ui/Card.stories.tsx
@@ -10,7 +10,7 @@ import { Card as Template } from "./Card";
 import * as fixture from "@/storybook/fixture";
 
 const meta = {
-  title: "Card/Card",
+  title: "Features/Card List/Card",
   component: Template,
   tags: ["autodocs"],
   args: {

--- a/src/features/card-list/ui/CardList.spec.tsx
+++ b/src/features/card-list/ui/CardList.spec.tsx
@@ -81,6 +81,32 @@ describe("CardList", () => {
     expect(onEditCard).toHaveBeenCalledExactlyOnceWith(card.id);
   });
 
+  it("renders a language card with the resolved back text presentation", async () => {
+    const languageCard = createCard({
+      ...card,
+      backText: "const answer = 42;",
+      tags: ["typescript"],
+    });
+    const renderBackText = vi.fn((backText: Parameters<CardListProps["renderBackText"]>[0]) => (
+      <div>{backText.text}</div>
+    ));
+
+    renderCardList({
+      cards: [languageCard],
+      preferences: createPreferences({ appearance: { darkMode: true } }),
+      renderBackText,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "View Front" }));
+
+    expect(renderBackText).toHaveBeenCalledExactlyOnceWith({
+      text: languageCard.backText,
+      category: "typescript",
+      code: true,
+      dark: true,
+    });
+  });
+
   it("owns deletion confirmation and success feedback", async () => {
     renderCardList();
     const trigger = screen.getByRole("button", { name: "Open actions for Front" });

--- a/src/features/card-list/ui/CardListView.stories.tsx
+++ b/src/features/card-list/ui/CardListView.stories.tsx
@@ -132,10 +132,6 @@ export const DarkCardView: Story = { ...CardView, globals: { theme: "dark" } };
 
 export const Dark: Story = { globals: { theme: "dark" } };
 
-export const Pending: Story = {
-  args: { isCardPending: (id) => id === fixture.cards.default[0]?.id },
-};
-
 export const IphoneX: Story = {
   parameters: { viewport: { defaultViewport: "iphonex" } },
 };

--- a/src/features/card-list/ui/CardListView.tsx
+++ b/src/features/card-list/ui/CardListView.tsx
@@ -31,7 +31,6 @@ export interface CardListViewProps {
   overlay?: CardListOverlayProps;
   onShowCard?: (card: CardEntity) => void;
   onRemoveTag?: (tag: string) => void;
-  isCardPending?: (id: CardId) => boolean;
 }
 
 /**
@@ -72,7 +71,7 @@ const emptyFilter: CardListFilterState = { scoreMax: null, scoreMin: null, selec
  * All data and callbacks arrive through props, allowing the same screen to run in tests and
  * Storybook.
  */
-const CardListRows: React.FC<Pick<CardListViewProps, "cards" | "card" | "onShowCard" | "isCardPending">> = (props) => {
+const CardListRows: React.FC<Pick<CardListViewProps, "cards" | "card" | "onShowCard">> = (props) => {
   const [openMenuCardId, setOpenMenuCardId] = React.useState<CardId>();
 
   return (
@@ -81,7 +80,6 @@ const CardListRows: React.FC<Pick<CardListViewProps, "cards" | "card" | "onShowC
         <Card
           key={card.id}
           card={card}
-          disabled={props.isCardPending?.(card.id) ?? false}
           menuOpen={openMenuCardId === card.id}
           onToggleMenu={(id) => setOpenMenuCardId((value) => (value === id ? undefined : id))}
           onCloseMenu={() => setOpenMenuCardId(undefined)}
@@ -157,7 +155,6 @@ export const CardListView: React.FC<CardListViewProps> = (props) => {
           cards={props.cards}
           {...(props.card !== undefined ? { card: props.card } : {})}
           {...(props.onShowCard !== undefined ? { onShowCard: props.onShowCard } : {})}
-          {...(props.isCardPending !== undefined ? { isCardPending: props.isCardPending } : {})}
         />
       )}
     </>


### PR DESCRIPTION
## Related issue

Fixes #867

## Summary

- cover the CardList renderBackText contract for language cards and dark mode
- remove the unused CardListView pending API and its Storybook-only story
- align the Card story title with the card-list feature ownership

## Testing

- mise run check