### PR TITLE
#919 Add local-only Deck persistence

### DIFF
--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -89,8 +89,6 @@ export const fetchCards = async (uid: string): Promise<Card[]> => {
     .filter((card) => card.deletedAt === null);
 };
 
-export const generateCardId = (): string => doc(collection(db, CARD_COLLECTION)).id;
-
 const createCardDocument = async (card: CardCreate): Promise<void> => {
   const createdAt = getTimestamp();
   const document = omitUndefined({ ...card, createdAt, updatedAt: createdAt } satisfies Card);

--- a/src/entities/card/api/local.spec.ts
+++ b/src/entities/card/api/local.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createCard } from "@/test/factories";
+import { cardStore } from "../model/store";
+import { createLocalCard, deleteLocalCard, deleteLocalCardsByDeckId, editLocalCard } from "./local";
+
+describe("local Card persistence", () => {
+  beforeEach(() => cardStore.setState({ remoteCards: [], localCards: [] }));
+
+  it("creates, edits, and deletes only local state", async () => {
+    const remote = createCard({ id: "remote" });
+    deckLocalCards([remote]);
+
+    await createLocalCard({
+      id: "local",
+      deckId: "deck",
+      uid: "local",
+      frontText: "Front",
+      backText: "Back",
+      tags: [],
+      uniqueKey: "key",
+    });
+    await editLocalCard({ id: "local", uid: "local", frontText: "Edited" });
+    expect(cardStore.getState().localCards.find((card) => card.id === "local")?.frontText).toBe("Edited");
+
+    await deleteLocalCard({ id: "local" });
+    expect(cardStore.getState().remoteCards).toEqual([remote]);
+  });
+
+  it("deletes all local Cards for a Deck", async () => {
+    cardStore.setState({
+      localCards: [createCard({ id: "a", deckId: "deck" }), createCard({ id: "b", deckId: "other" })],
+    });
+    await deleteLocalCardsByDeckId("deck");
+    expect(cardStore.getState().localCards.map((card) => card.id)).toEqual(["b"]);
+  });
+});
+
+const deckLocalCards = (remoteCards: ReturnType<typeof createCard>[]): void => {
+  cardStore.setState({ remoteCards });
+};

--- a/src/entities/card/api/local.ts
+++ b/src/entities/card/api/local.ts
@@ -1,0 +1,28 @@
+import { generateId } from "@/shared/lib/generateId";
+import { cardEditSchema, cardSchema } from "../model/schema";
+import { cardStore, replaceLocalCards } from "../model/store";
+import type { Card, CardCreateInput, CardEdit } from "../model/types";
+
+export const generateCardId = generateId;
+
+export const createLocalCard = async (input: CardCreateInput): Promise<void> => {
+  const now = Date.now();
+  const card = cardSchema.parse({ ...input, createdAt: now, updatedAt: now });
+  replaceLocalCards([...cardStore.getState().localCards.filter((candidate) => candidate.id !== card.id), card]);
+};
+
+export const editLocalCard = async (input: CardEdit): Promise<void> => {
+  const edit = cardEditSchema.parse(input);
+  const current = cardStore.getState().localCards.find((card) => card.id === edit.id);
+  if (current == null) throw new Error("Local Card not found");
+  const card = cardSchema.parse({ ...current, ...edit, updatedAt: Date.now() });
+  replaceLocalCards(cardStore.getState().localCards.map((candidate) => (candidate.id === card.id ? card : candidate)));
+};
+
+export const deleteLocalCard = async (card: Pick<Card, "id">): Promise<void> => {
+  replaceLocalCards(cardStore.getState().localCards.filter((candidate) => candidate.id !== card.id));
+};
+
+export const deleteLocalCardsByDeckId = async (deckId: string): Promise<void> => {
+  replaceLocalCards(cardStore.getState().localCards.filter((card) => card.deckId !== deckId));
+};

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,11 @@
-export { createCard, deleteCard, editCard, fetchCards, generateCardId, subscribeCards } from "./api/firestore";
+export { createCard, deleteCard, editCard, fetchCards, subscribeCards } from "./api/firestore";
+export {
+  createLocalCard,
+  deleteLocalCard,
+  deleteLocalCardsByDeckId,
+  editLocalCard,
+  generateCardId,
+} from "./api/local";
 export { useCard, useCards } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";
 export type {

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -1,12 +1,27 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
+import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
 import { createCard } from "@/test/factories";
 import { useCard, useCards } from "./hooks";
 import { cardStore, clearRemoteCards, replaceRemoteCards } from "./store";
 
+const useMemoryStorage = (initial: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initial));
+  const storage: StateStorage = {
+    getItem: (name) => values.get(name) ?? null,
+    setItem: (name, value) => values.set(name, value),
+    removeItem: (name) => values.delete(name),
+  };
+  cardStore.persist.setOptions({ storage: createJSONStorage(() => storage) });
+  return storage;
+};
+
 describe("Card store", () => {
-  beforeEach(() => cardStore.setState({ remoteCards: [], localCards: [] }));
+  beforeEach(() => {
+    useMemoryStorage();
+    cardStore.setState({ remoteCards: [], localCards: [] });
+  });
 
   it("replaces and clears only the remote Card collection", () => {
     const remoteCard = createCard({ id: "remote" });
@@ -29,5 +44,30 @@ describe("Card store", () => {
     expect(renderHook(() => useCard("remote")).result.current).toEqual(remoteCard);
     expect(renderHook(() => useCard("local")).result.current).toEqual(localCard);
     expect(renderHook(() => useCard("missing")).result.current).toBeUndefined();
+  });
+
+  it("hydrates validated local Cards without restoring remote state", async () => {
+    const localCard = createCard({ id: "local", nextSeeingAt: new Date("2026-08-15T00:00:00Z") });
+    useMemoryStorage({
+      "tango-local-cards": JSON.stringify({
+        state: { localCards: [localCard], remoteCards: [createCard()] },
+        version: 0,
+      }),
+    });
+
+    await cardStore.persist.rehydrate();
+
+    expect(cardStore.getState().remoteCards).toEqual([]);
+    expect(cardStore.getState().localCards).toEqual([localCard]);
+  });
+
+  it("rejects invalid persisted Cards", async () => {
+    useMemoryStorage({
+      "tango-local-cards": JSON.stringify({ state: { localCards: [{ id: "invalid" }] }, version: 0 }),
+    });
+
+    await cardStore.persist.rehydrate();
+
+    expect(cardStore.getState().localCards).toEqual([]);
   });
 });

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -1,5 +1,8 @@
+import { persist } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
+import { z } from "zod";
 
+import { cardSchema } from "./schema";
 import type { Card } from "./types";
 
 interface CardState {
@@ -7,7 +10,19 @@ interface CardState {
   localCards: Card[];
 }
 
-export const cardStore = createStore<CardState>()(() => ({ remoteCards: [], localCards: [] }));
+type PersistedCardState = Pick<CardState, "localCards">;
+const persistedCardSchema = cardSchema.extend({ nextSeeingAt: z.coerce.date().optional() });
+
+export const cardStore = createStore<CardState>()(
+  persist<CardState, [], [], PersistedCardState>(() => ({ remoteCards: [], localCards: [] }), {
+    name: "tango-local-cards",
+    partialize: ({ localCards }) => ({ localCards }),
+    merge: (persisted, current) => {
+      const result = persistedCardSchema.array().safeParse((persisted as Partial<CardState> | undefined)?.localCards);
+      return result.success ? { ...current, localCards: result.data } : current;
+    },
+  })
+);
 
 export const replaceRemoteCards = (remoteCards: Card[]): void => {
   cardStore.setState({ remoteCards });
@@ -15,4 +30,8 @@ export const replaceRemoteCards = (remoteCards: Card[]): void => {
 
 export const clearRemoteCards = (): void => {
   cardStore.setState({ remoteCards: [] });
+};
+
+export const replaceLocalCards = (localCards: Card[]): void => {
+  cardStore.setState({ localCards });
 };

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -38,7 +38,7 @@ const deckDtoSchema = z.object({
 
 const convertDeckDtoToDeck = (id: DeckId, value: unknown): Deck => {
   const dto = parseFirestoreDocument(deckDtoSchema, "deck", id, value);
-  const deck: Deck = { ...dto, id };
+  const deck: Deck = { ...dto, id, localMode: false };
   if (dto.url === undefined) delete deck.url;
   return deck;
 };
@@ -66,11 +66,10 @@ export const fetchDecks = async (uid: string): Promise<Deck[]> => {
     .filter((deck) => deck.deletedAt === null);
 };
 
-export const generateDeckId = (): string => doc(collection(db, DECK_COLLECTION)).id;
-
 const createDeckDocument = async (deck: DeckCreate): Promise<void> => {
   const createdAt = getTimestamp();
-  const document = omitUndefined({ ...deck, createdAt, updatedAt: createdAt } satisfies Deck);
+  const { localMode: _localMode, ...remoteDeck } = deck;
+  const document = omitUndefined({ ...remoteDeck, createdAt, updatedAt: createdAt });
   await setDoc(doc(db, DECK_COLLECTION, deck.id), document);
 };
 

--- a/src/entities/deck/api/local.spec.ts
+++ b/src/entities/deck/api/local.spec.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createDeck } from "@/test/factories";
+import { deckStore } from "../model/store";
+import { createLocalDeck, deleteLocalDeck, editLocalDeck } from "./local";
+
+describe("local Deck persistence", () => {
+  beforeEach(() => deckStore.setState({ remoteDecks: [], localDecks: [] }));
+
+  it("creates, edits, and deletes only local state", async () => {
+    const remote = createDeck({ id: "remote" });
+    deckStore.setState({ remoteDecks: [remote] });
+
+    await createLocalDeck({ id: "local", uid: "local", name: "Local" });
+    expect(deckStore.getState().localDecks[0]).toMatchObject({ id: "local", localMode: true });
+
+    await editLocalDeck({ id: "local", name: "Edited" });
+    expect(deckStore.getState().localDecks[0]?.name).toBe("Edited");
+
+    await deleteLocalDeck({ id: "local" });
+    expect(deckStore.getState()).toEqual({ remoteDecks: [remote], localDecks: [] });
+  });
+});

--- a/src/entities/deck/api/local.ts
+++ b/src/entities/deck/api/local.ts
@@ -1,0 +1,24 @@
+import { generateId } from "@/shared/lib/generateId";
+import { deckCreateSchema, deckEditSchema, deckSchema } from "../model/schema";
+import { deckStore, replaceLocalDecks } from "../model/store";
+import type { Deck, DeckCreateInput, DeckEdit } from "../model/types";
+
+export const generateDeckId = generateId;
+
+export const createLocalDeck = async (input: DeckCreateInput): Promise<void> => {
+  const now = Date.now();
+  const deck = deckSchema.parse({ ...deckCreateSchema.parse(input), localMode: true, createdAt: now, updatedAt: now });
+  replaceLocalDecks([...deckStore.getState().localDecks.filter((candidate) => candidate.id !== deck.id), deck]);
+};
+
+export const editLocalDeck = async (input: DeckEdit): Promise<void> => {
+  const edit = deckEditSchema.parse(input);
+  const current = deckStore.getState().localDecks.find((deck) => deck.id === edit.id);
+  if (current == null) throw new Error("Local Deck not found");
+  const deck = deckSchema.parse({ ...current, ...edit, localMode: true, updatedAt: Date.now() });
+  replaceLocalDecks(deckStore.getState().localDecks.map((candidate) => (candidate.id === deck.id ? deck : candidate)));
+};
+
+export const deleteLocalDeck = async (deck: Pick<Deck, "id">): Promise<void> => {
+  replaceLocalDecks(deckStore.getState().localDecks.filter((candidate) => candidate.id !== deck.id));
+};

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,4 +1,5 @@
-export { createDeck, deleteDeck, editDeck, fetchDecks, generateDeckId, subscribeDecks } from "./api/firestore";
+export { createDeck, deleteDeck, editDeck, fetchDecks, subscribeDecks } from "./api/firestore";
+export { createLocalDeck, deleteLocalDeck, editLocalDeck, generateDeckId } from "./api/local";
 export { CATEGORY, getCategory, isHighlightLanguage } from "./model/rules";
 export { useDeck, useDecks } from "./model/hooks";
 export { clearRemoteDecks } from "./model/store";

--- a/src/entities/deck/model/schema.spec.ts
+++ b/src/entities/deck/model/schema.spec.ts
@@ -22,6 +22,7 @@ describe("Deck operation schemas", () => {
           tagAndFilter: false,
           category: "",
           convertToBr: false,
+          localMode: false,
           deletedAt: null,
         },
       });

--- a/src/entities/deck/model/schema.ts
+++ b/src/entities/deck/model/schema.ts
@@ -27,6 +27,7 @@ export const deckCreateSchema = editableDeckFieldsSchema.extend({
   category: editableDeckFieldsSchema.shape.category.default(""),
   convertToBr: editableDeckFieldsSchema.shape.convertToBr.default(false),
   deletedAt: z.number().nullable().default(null),
+  localMode: z.boolean().default(false),
 });
 
 export const deckSchema = deckCreateSchema.extend({

--- a/src/entities/deck/model/store.spec.tsx
+++ b/src/entities/deck/model/store.spec.tsx
@@ -1,12 +1,27 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
+import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
 import { createDeck } from "@/test/factories";
 import { useDeck, useDecks } from "./hooks";
 import { clearRemoteDecks, deckStore, replaceRemoteDecks } from "./store";
 
+const useMemoryStorage = (initial: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initial));
+  const storage: StateStorage = {
+    getItem: (name) => values.get(name) ?? null,
+    setItem: (name, value) => values.set(name, value),
+    removeItem: (name) => values.delete(name),
+  };
+  deckStore.persist.setOptions({ storage: createJSONStorage(() => storage) });
+  return storage;
+};
+
 describe("Deck store", () => {
-  beforeEach(() => deckStore.setState({ remoteDecks: [], localDecks: [] }));
+  beforeEach(() => {
+    useMemoryStorage();
+    deckStore.setState({ remoteDecks: [], localDecks: [] });
+  });
 
   it("replaces and clears only the remote Deck collection", () => {
     const remoteDeck = createDeck({ id: "remote" });
@@ -29,5 +44,29 @@ describe("Deck store", () => {
     expect(renderHook(() => useDeck("remote")).result.current).toEqual(remoteDeck);
     expect(renderHook(() => useDeck("local")).result.current).toEqual(localDeck);
     expect(renderHook(() => useDeck("missing")).result.current).toBeUndefined();
+  });
+
+  it("hydrates validated local Decks without restoring remote state", async () => {
+    const localDeck = createDeck({ id: "local", localMode: true });
+    useMemoryStorage({
+      "tango-local-decks": JSON.stringify({
+        state: { localDecks: [localDeck], remoteDecks: [createDeck()] },
+        version: 0,
+      }),
+    });
+
+    await deckStore.persist.rehydrate();
+
+    expect(deckStore.getState()).toEqual({ remoteDecks: [], localDecks: [localDeck] });
+  });
+
+  it("rejects invalid persisted Decks", async () => {
+    useMemoryStorage({
+      "tango-local-decks": JSON.stringify({ state: { localDecks: [{ id: "invalid" }] }, version: 0 }),
+    });
+
+    await deckStore.persist.rehydrate();
+
+    expect(deckStore.getState().localDecks).toEqual([]);
   });
 });

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -1,5 +1,7 @@
+import { persist } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
 
+import { deckSchema } from "./schema";
 import type { Deck } from "./types";
 
 interface DeckState {
@@ -7,7 +9,18 @@ interface DeckState {
   localDecks: Deck[];
 }
 
-export const deckStore = createStore<DeckState>()(() => ({ remoteDecks: [], localDecks: [] }));
+type PersistedDeckState = Pick<DeckState, "localDecks">;
+
+export const deckStore = createStore<DeckState>()(
+  persist<DeckState, [], [], PersistedDeckState>(() => ({ remoteDecks: [], localDecks: [] }), {
+    name: "tango-local-decks",
+    partialize: ({ localDecks }) => ({ localDecks }),
+    merge: (persisted, current) => {
+      const result = deckSchema.array().safeParse((persisted as Partial<DeckState> | undefined)?.localDecks);
+      return result.success ? { ...current, localDecks: result.data.filter((deck) => deck.localMode) } : current;
+    },
+  })
+);
 
 export const replaceRemoteDecks = (remoteDecks: Deck[]): void => {
   deckStore.setState({ remoteDecks });
@@ -15,4 +28,8 @@ export const replaceRemoteDecks = (remoteDecks: Deck[]): void => {
 
 export const clearRemoteDecks = (): void => {
   deckStore.setState({ remoteDecks: [] });
+};
+
+export const replaceLocalDecks = (localDecks: Deck[]): void => {
+  deckStore.setState({ localDecks });
 };

--- a/src/features/card-edit/model/useCardEditAction.ts
+++ b/src/features/card-edit/model/useCardEditAction.ts
@@ -3,13 +3,14 @@ import type { CardEdit } from "@/entities/card";
 import * as React from "react";
 
 import { useAuthSession } from "@/entities/auth";
-import { editCard } from "@/entities/card";
+import { editCard, editLocalCard } from "@/entities/card";
 
 interface UseCardEditActionOptions {
+  localMode: boolean;
   onSaved?: () => void;
 }
 
-export const useCardEditAction = ({ onSaved }: UseCardEditActionOptions = {}) => {
+export const useCardEditAction = ({ localMode, onSaved }: UseCardEditActionOptions) => {
   const auth = useAuthSession();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const [error, setError] = React.useState<unknown>(null);
@@ -18,13 +19,13 @@ export const useCardEditAction = ({ onSaved }: UseCardEditActionOptions = {}) =>
     async (card: CardEdit) => {
       setError(null);
       try {
-        await editCard(uid, card);
+        await (localMode ? editLocalCard(card) : editCard(uid, card));
         onSaved?.();
       } catch (nextError) {
         setError(nextError);
       }
     },
-    [onSaved, uid]
+    [localMode, onSaved, uid]
   );
 
   return { error, update };

--- a/src/features/card-edit/ui/CardEditForm.tsx
+++ b/src/features/card-edit/ui/CardEditForm.tsx
@@ -11,12 +11,13 @@ import { CardForm } from "./CardForm";
 
 export interface CardEditFormProps {
   card: Card;
+  localMode?: boolean;
   onCancel: () => void;
   onSaved: () => void;
 }
 
-export const CardEditForm: React.FC<CardEditFormProps> = ({ card, onCancel, onSaved }) => {
-  const editAction = useCardEditAction({ onSaved });
+export const CardEditForm: React.FC<CardEditFormProps> = ({ card, localMode = false, onCancel, onSaved }) => {
+  const editAction = useCardEditAction({ localMode, onSaved });
   const cardForm = useCardFormState({
     card,
     categoryOptions: CATEGORY.map((category) => ({ label: category, value: category })),

--- a/src/features/card-list/ui/CardList.tsx
+++ b/src/features/card-list/ui/CardList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { useAuthSession } from "@/entities/auth";
-import { deleteCard, type Card, type CardId } from "@/entities/card";
+import { deleteCard, deleteLocalCard, type Card, type CardId } from "@/entities/card";
 import { getCategory, isHighlightLanguage, type Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
@@ -67,7 +67,7 @@ export const CardList: React.FC<CardListProps> = (props) => {
     const card = deletionTarget;
     setDeletionErrorCardId(undefined);
     try {
-      await deleteCard(uid, card);
+      await (props.deck.localMode ? deleteLocalCard(card) : deleteCard(uid, card));
       setDeletionTarget(undefined);
       setSuccessMessage(`Deleted card “${card.frontText}”.`);
     } catch {

--- a/src/features/deck-edit/model/useDeckEditAction.ts
+++ b/src/features/deck-edit/model/useDeckEditAction.ts
@@ -3,13 +3,14 @@ import type { DeckEdit } from "@/entities/deck";
 import * as React from "react";
 
 import { useAuthSession } from "@/entities/auth";
-import { editDeck } from "@/entities/deck";
+import { editDeck, editLocalDeck } from "@/entities/deck";
 
 interface UseDeckEditActionOptions {
+  localMode: boolean;
   onSaved?: () => void;
 }
 
-export const useDeckEditAction = ({ onSaved }: UseDeckEditActionOptions = {}) => {
+export const useDeckEditAction = ({ localMode, onSaved }: UseDeckEditActionOptions) => {
   const auth = useAuthSession();
   const uid = auth.status === "authenticated" ? auth.uid : "";
   const [error, setError] = React.useState<unknown>(null);
@@ -18,13 +19,13 @@ export const useDeckEditAction = ({ onSaved }: UseDeckEditActionOptions = {}) =>
     async (deck: DeckEdit) => {
       setError(null);
       try {
-        await editDeck(uid, deck);
+        await (localMode ? editLocalDeck(deck) : editDeck(uid, deck));
         onSaved?.();
       } catch (nextError) {
         setError(nextError);
       }
     },
-    [onSaved, uid]
+    [localMode, onSaved, uid]
   );
 
   return { error, update };

--- a/src/features/deck-edit/ui/DeckEditForm.tsx
+++ b/src/features/deck-edit/ui/DeckEditForm.tsx
@@ -15,7 +15,7 @@ export interface DeckEditFormProps {
 }
 
 export const DeckEditForm: React.FC<DeckEditFormProps> = ({ deck, onCancel, onSaved }) => {
-  const editAction = useDeckEditAction({ onSaved });
+  const editAction = useDeckEditAction({ localMode: deck.localMode, onSaved });
   const deckForm = useDeckFormState({ deck, onCancel, onSubmit: editAction.update });
 
   return (

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -4,8 +4,8 @@
  * writing until import is confirmed" and "keeps invalid files in preview without mutating state".
  */
 
-import type { Card, CardCreateInput } from "@/entities/card";
-import type { Deck, DeckCreateInput, DeckId } from "@/entities/deck";
+import { type Card, type CardCreateInput, useCards } from "@/entities/card";
+import { type Deck, type DeckCreateInput, type DeckId, useDecks } from "@/entities/deck";
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -112,7 +112,7 @@ describe("useDeckImport", () => {
       imported = await result.current.importPreview();
     });
     expect(mocks.createDeck).toHaveBeenCalledOnce();
-    expect(mocks.createDeck).toHaveBeenCalledWith({ id: "deck", uid: "uid-a", name: "deck.csv" });
+    expect(mocks.createDeck).toHaveBeenCalledWith({ id: "deck", uid: "uid-a", name: "deck.csv", localMode: false });
     expect(mocks.bulkUpsert).toHaveBeenCalledWith([
       {
         id: "card",
@@ -145,6 +145,24 @@ describe("useDeckImport", () => {
     await expect(result.current.importPreview()).rejects.toThrow("Fix invalid CSV rows");
     expect(mocks.createDeck).not.toHaveBeenCalled();
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("imports local-only data without remote writers or an authenticated user", async () => {
+    mocks.uid = "";
+    const { result } = renderHook(useTestDeckImport);
+    const file = new File(['"front","back","","key"'], "local.csv", { type: "text/csv" });
+
+    await actAsync(async () => result.current.selectFile(file, "local"));
+    await actAsync(async () => result.current.importPreview());
+
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+    expect(renderHook(useDecks).result.current).toContainEqual(
+      expect.objectContaining({ id: "deck", uid: "local", localMode: true })
+    );
+    expect(renderHook(useCards).result.current).toContainEqual(
+      expect.objectContaining({ id: "card", deckId: "deck", uid: "local" })
+    );
   });
 
   it("skips an identical CSV re-import by uniqueKey", async () => {
@@ -185,6 +203,7 @@ describe("useDeckImport", () => {
       id: "sample-v1-uid-a",
       name: "Sample Deck",
       uid: "uid-a",
+      localMode: false,
     });
     expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
   });

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -9,10 +9,10 @@ import type { Deck, DeckCreateInput, DeckId } from "@/entities/deck";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { fetchCards, filterCardsByDeckId } from "@/entities/card";
-import { fetchDecks } from "@/entities/deck";
+import { createLocalCard, editLocalCard, fetchCards, filterCardsByDeckId } from "@/entities/card";
+import { createLocalDeck, fetchDecks } from "@/entities/deck";
 import { useAuthSession } from "@/entities/auth";
-import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTypes";
+import type { DeckImportPreview, DeckImportResult, DeckImportStorageMode } from "../model/deckImportTypes";
 import { parseCsv } from "../lib/cardCsv";
 import { buildDeckImportPlan } from "../lib/deckImportAnalysis";
 import { upsertImportedCards } from "../api/upsertImportedCards";
@@ -88,6 +88,7 @@ interface FilePreviewDependencies {
   currentUid: { current: string };
   generation: number;
   currentGeneration: { current: number };
+  storageMode: DeckImportStorageMode;
 }
 
 /**
@@ -108,6 +109,7 @@ const previewDeckImportFile = async (
     currentUid,
     generation,
     currentGeneration,
+    storageMode,
   }: FilePreviewDependencies
 ) => {
   const isCurrent = () => currentGeneration.current === generation && currentUid.current === uid;
@@ -118,13 +120,16 @@ const previewDeckImportFile = async (
   try {
     const analysis = await parseCsv(await file.text());
     if (!isCurrent()) throw new Error("Deck import user changed before the preview could finish");
-    const deck = decks.find((candidate) => candidate.name === file.name);
+    const deck = decks.find(
+      (candidate) => candidate.name === file.name && candidate.localMode === (storageMode === "local")
+    );
     const existing = deck == null ? [] : cardsByDeckId(deck.id);
     const next = {
       fileName: file.name,
       deckName: file.name,
       analysis,
       plan: buildDeckImportPlan(analysis.rows, existing),
+      storageMode,
     };
     setPreview(next);
     return next;
@@ -176,9 +181,14 @@ export const useDeckImport = ({
       uid,
       decks,
       cardsByDeckId,
-      createDeck: (deck) => createDeck(uid, deck),
+      createDeck: (deck) => (deck.localMode ? createLocalDeck(deck) : createDeck(uid, deck)),
       generateCardId,
-      bulkUpsert: (cards, createdIds) => upsertImportedCards(uid, cards, createdIds, { createCard, editCard }),
+      bulkUpsert: (cards, createdIds, localMode) =>
+        localMode
+          ? Promise.all(
+              cards.map((card) => (createdIds.includes(card.id) ? createLocalCard(card) : editLocalCard(card)))
+            )
+          : upsertImportedCards(uid, cards, createdIds, { createCard, editCard }),
       fetchDecks,
       fetchCards,
     };
@@ -240,7 +250,7 @@ export const useDeckImport = ({
    * Validates the selected CSV file and stores its import preview.
    * No remote data is changed until the user confirms that preview.
    */
-  const selectFile = (file: File) =>
+  const selectFile = (file: File, storageMode: DeckImportStorageMode = "remote") =>
     previewDeckImportFile(file, {
       runningRef,
       setValidating,
@@ -252,6 +262,7 @@ export const useDeckImport = ({
       currentUid: generationUid,
       generation: generation.current,
       currentGeneration: generation,
+      storageMode,
     });
 
   /**
@@ -269,11 +280,16 @@ export const useDeckImport = ({
     if (preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
-    return run({ kind: "content", name: preview.deckName, rows: preview.analysis.rows });
+    return run({
+      kind: "content",
+      name: preview.deckName,
+      rows: preview.analysis.rows,
+      storageMode: preview.storageMode ?? "remote",
+    });
   };
 
   /** Downloads card CSV data from a public URL and runs it through the normal import workflow. */
-  const importUrl = async (url: string, name?: string) => {
+  const importUrl = async (url: string, name?: string, storageMode: DeckImportStorageMode = "remote") => {
     const operationGeneration = generation.current;
     const operationUid = uid;
     const parsedUrl = new URL(url);
@@ -289,17 +305,18 @@ export const useDeckImport = ({
       kind: "content",
       name: name ?? url.split("/").pop() ?? "no name",
       rows: analysis.rows,
+      storageMode,
     });
   };
 
   return {
     selectFile,
     importPreview,
-    addSample: () => run({ kind: "sample" }),
+    addSample: () => run({ kind: "sample", storageMode: "remote" }),
     importUrl,
     reimport: (deck: Deck) => {
       if (deck.url == null || deck.url === "") return Promise.reject(new Error("Deck has no import URL"));
-      return importUrl(deck.url, deck.name);
+      return importUrl(deck.url, deck.name, deck.localMode ? "local" : "remote");
     },
     preview,
     validating,

--- a/src/features/deck-import/index.ts
+++ b/src/features/deck-import/index.ts
@@ -1,4 +1,4 @@
-export type { DeckImportPreview, DeckImportResult } from "./model/deckImportTypes";
+export type { DeckImportPreview, DeckImportResult, DeckImportStorageMode } from "./model/deckImportTypes";
 export { useDeckImport } from "./hooks/useDeckImport";
 export { useSampleDeckBootstrap } from "./hooks/useSampleDeckBootstrap";
 export { downloadSampleCsv, SAMPLE_CSV_TEXT } from "./sampleCsv";

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -6,7 +6,7 @@ import { generateDeckId } from "@/entities/deck";
 import sampleCards from "../../../../sample/build/output.json";
 import { CardBulkMutationError } from "../api/upsertImportedCards";
 import { buildDeckImportPlan } from "../lib/deckImportAnalysis";
-import type { DeckImportResult, DeckImportRow } from "./deckImportTypes";
+import type { DeckImportResult, DeckImportRow, DeckImportStorageMode } from "./deckImportTypes";
 
 interface DeckImportAttempt {
   uid: string;
@@ -19,8 +19,14 @@ interface DeckImportAttempt {
 }
 
 export type DeckImportRequest =
-  | { kind: "content"; name: string; rows: DeckImportRow[]; attempt?: DeckImportAttempt }
-  | { kind: "sample"; attempt?: DeckImportAttempt };
+  | {
+      kind: "content";
+      name: string;
+      rows: DeckImportRow[];
+      storageMode: DeckImportStorageMode;
+      attempt?: DeckImportAttempt;
+    }
+  | { kind: "sample"; storageMode: DeckImportStorageMode; attempt?: DeckImportAttempt };
 
 export interface DeckImportDependencies {
   uid: string;
@@ -28,7 +34,7 @@ export interface DeckImportDependencies {
   cardsByDeckId: (id: DeckId) => Card[];
   createDeck: (deck: DeckCreateInput) => Promise<unknown>;
   generateCardId: () => string;
-  bulkUpsert: (cards: CardCreateInput[], createdIds: CardId[]) => Promise<unknown>;
+  bulkUpsert: (cards: CardCreateInput[], createdIds: CardId[], localMode: boolean) => Promise<unknown>;
   fetchDecks?: (uid: string) => Promise<Deck[]>;
   fetchCards?: (uid: string) => Promise<Card[]>;
 }
@@ -51,14 +57,18 @@ const prepareDeckImportAttempt = (
   { uid, decks, cardsByDeckId, generateCardId }: DeckImportPreparationDependencies
 ): DeckImportAttempt => {
   const name = request.kind === "sample" ? SAMPLE_DECK_NAME : request.name;
+  const localMode = request.storageMode === "local";
+  const ownerUid = uid === "" && localMode ? "local" : uid;
   const preferredDeckId = request.kind === "sample" ? sampleDeckId(uid) : undefined;
   const rows = request.kind === "sample" ? rowsFromCards(sampleCards as CardRaw[]) : request.rows;
-  let deck: DeckCreateInput | undefined = decks.find((candidate) =>
-    preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId
+  let deck: DeckCreateInput | undefined = decks.find(
+    (candidate) =>
+      candidate.localMode === localMode &&
+      (preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId)
   );
   const createDeckPending = deck == null;
   if (deck == null) {
-    deck = { id: preferredDeckId ?? generateDeckId(), uid, name };
+    deck = { id: preferredDeckId ?? generateDeckId(), uid: ownerUid, name, localMode };
   }
 
   const existing = cardsByDeckId(deck.id);
@@ -111,11 +121,11 @@ export const executeDeckImport = async (
   request: DeckImportRequest,
   { uid, decks, cardsByDeckId, createDeck, generateCardId, bulkUpsert, fetchDecks, fetchCards }: DeckImportDependencies
 ): Promise<DeckImportResult> => {
-  if (uid === "") throw new Error("A confirmed user is required for imports");
+  if (uid === "" && request.storageMode === "remote") throw new Error("A confirmed user is required for imports");
 
   let activeDecks = decks;
   let getCardsByDeckId = cardsByDeckId;
-  if (fetchDecks != null && fetchCards != null) {
+  if (request.storageMode === "remote" && fetchDecks != null && fetchCards != null) {
     try {
       const [remoteDecks, remoteCards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
       activeDecks = remoteDecks;
@@ -142,7 +152,7 @@ export const executeDeckImport = async (
 
   const upserts = attempt.remainingUpserts;
   try {
-    if (upserts.length > 0) await bulkUpsert(upserts, attempt.createdIds);
+    if (upserts.length > 0) await bulkUpsert(upserts, attempt.createdIds, attempt.deck.localMode === true);
   } catch (error) {
     const failedIds = error instanceof CardBulkMutationError ? error.failedIds : upserts.map((card) => card.id);
     const failed = new Set(failedIds);

--- a/src/features/deck-import/model/deckImportTypes.ts
+++ b/src/features/deck-import/model/deckImportTypes.ts
@@ -7,6 +7,8 @@
 import type { CardRaw } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 
+export type DeckImportStorageMode = "local" | "remote";
+
 export interface DeckImportRow {
   rowNumber: number;
   card: CardRaw;
@@ -43,6 +45,7 @@ export interface DeckImportPreview {
   deckName: string;
   analysis: DeckImportAnalysis;
   plan: DeckImportPlan;
+  storageMode?: DeckImportStorageMode;
 }
 
 export interface DeckImportResult {

--- a/src/features/deck-start/model/useDeckFilterState.ts
+++ b/src/features/deck-start/model/useDeckFilterState.ts
@@ -10,7 +10,7 @@ import * as React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 import { useAuthSession } from "@/entities/auth";
-import { editDeck } from "@/entities/deck";
+import { editDeck, editLocalDeck } from "@/entities/deck";
 import type { DeckStartForm } from "../ui/DeckStartForm";
 
 type DeckStartFormProps = React.ComponentProps<typeof DeckStartForm>;
@@ -37,9 +37,12 @@ export const useDeckFilterState = ({ deck, tags }: UseDeckFilterStateOptions): D
   React.useEffect(() => {
     return subscribe({
       formState: { values: true },
-      callback: () => void handleSubmit((data) => editDeck(uid, data).catch(() => undefined))(),
+      callback: () =>
+        void handleSubmit((data) =>
+          (deck.localMode ? editLocalDeck(data) : editDeck(uid, data)).catch(() => undefined)
+        )(),
     });
-  }, [handleSubmit, subscribe, uid]);
+  }, [deck.localMode, handleSubmit, subscribe, uid]);
 
   const onClickFilter = (value: boolean) => {
     setValue("tagAndFilter", value);

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -46,6 +46,7 @@ const deck: Deck = {
   deletedAt: null,
   category: "",
   convertToBr: false,
+  localMode: false,
   selectedTags: [],
   tagAndFilter: false,
   scoreMax: null,

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -2,17 +2,19 @@ import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { type Card, useCard } from "@/entities/card";
+import { useDeck } from "@/entities/deck";
 import { CardEditForm } from "@/features/card-edit";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 const CardFormContent = ({ card }: { card: Card }) => {
   const navigate = useNavigate();
+  const deck = useDeck(card.deckId);
   const goBack = () => void navigate(-1);
 
   return (
     <AppLayout showHeader>
-      <CardEditForm card={card} onSaved={goBack} onCancel={goBack} />
+      <CardEditForm card={card} localMode={deck?.localMode ?? false} onSaved={goBack} onCancel={goBack} />
     </AppLayout>
   );
 };

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -119,6 +119,16 @@ describe("DeckImportPage", () => {
     expect(mocks.downloadSampleCsv).toHaveBeenCalledOnce();
   });
 
+  it("passes the local-only selection to CSV preview", async () => {
+    render(<DeckImportPage />);
+    const file = new File(["front,back,,key"], "deck.csv", { type: "text/csv" });
+
+    await userEvent.click(screen.getByRole("radio", { name: "Local only" }));
+    fireEvent.change(screen.getByLabelText("Upload a csv file"), { target: { files: [file] } });
+
+    expect(mocks.selectFile).toHaveBeenCalledWith(file, "local");
+  });
+
   it("renders the import screen in the application shell", () => {
     render(<DeckImportPage />);
 

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -1,11 +1,11 @@
-import type React from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { createDeck, useDecks } from "@/entities/deck";
 import { createCard, editCard, generateCardId, useCards } from "@/entities/card";
 import { usePreferences } from "@/entities/preferences";
-import { downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/deck-import";
+import { type DeckImportStorageMode, downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/deck-import";
 import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckImportView } from "./DeckImportView";
@@ -15,6 +15,7 @@ export const DeckImportPage: React.FC = () => {
   const navigate = useNavigate();
   const cards = useCards();
   const decks = useDecks();
+  const [storageMode, setStorageMode] = React.useState<DeckImportStorageMode>("remote");
   const deckImport = useDeckImport({
     cards,
     createCard,
@@ -30,8 +31,10 @@ export const DeckImportPage: React.FC = () => {
     <AppLayout showHeader>
       <DeckImportView
         onChange={(file) => {
-          void deckImport.selectFile(file).catch(() => undefined);
+          void deckImport.selectFile(file, ...(storageMode === "local" ? [storageMode] : [])).catch(() => undefined);
         }}
+        storageMode={storageMode}
+        onStorageModeChange={setStorageMode}
         onAddSample={() => {
           void deckImport.addSample().catch(() => undefined);
         }}

--- a/src/pages/deck-import/ui/DeckImportView.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.tsx
@@ -9,7 +9,7 @@ import { AiOutlineCloudDownload } from "react-icons/ai";
 import { Button } from "@/shared/ui/button";
 import { Code, Description } from "@/shared/ui/content";
 import { Upload } from "@/shared/ui/forms";
-import type { DeckImportPreview, DeckImportResult } from "@/features/deck-import";
+import type { DeckImportPreview, DeckImportResult, DeckImportStorageMode } from "@/features/deck-import";
 
 interface DeckImportViewProps {
   onChange?: (file: File) => void;
@@ -26,6 +26,8 @@ interface DeckImportViewProps {
   result?: DeckImportResult;
   partialResult?: DeckImportResult;
   error?: unknown;
+  storageMode?: DeckImportStorageMode;
+  onStorageModeChange?: (mode: DeckImportStorageMode) => void;
 }
 
 /**
@@ -250,6 +252,29 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
         />
         <section>
           <h2 className="mb-3 break-words text-title font-bold text-ink">Choose a CSV file</h2>
+          <fieldset className="mb-4 flex flex-wrap gap-4" disabled={busy || props.preview != null}>
+            <legend className="mb-2 text-caption font-semibold text-ink">Storage</legend>
+            <label className="flex items-center gap-2 text-caption text-ink">
+              <input
+                type="radio"
+                name="storage-mode"
+                value="remote"
+                checked={(props.storageMode ?? "remote") === "remote"}
+                onChange={() => props.onStorageModeChange?.("remote")}
+              />
+              Sync with account
+            </label>
+            <label className="flex items-center gap-2 text-caption text-ink">
+              <input
+                type="radio"
+                name="storage-mode"
+                value="local"
+                checked={props.storageMode === "local"}
+                onChange={() => props.onStorageModeChange?.("local")}
+              />
+              Local only
+            </label>
+          </fieldset>
           <Upload
             disabled={busy}
             {...(props.preview !== undefined ? { fileName: props.preview.fileName } : {})}

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { useAuthSession } from "@/entities/auth";
-import { createCard, editCard, generateCardId, useCards } from "@/entities/card";
-import { createDeck, deleteDeck, useDecks } from "@/entities/deck";
+import { createCard, deleteLocalCardsByDeckId, editCard, generateCardId, useCards } from "@/entities/card";
+import { createDeck, deleteDeck, deleteLocalDeck, useDecks } from "@/entities/deck";
 import { useSampleDeckBootstrap } from "@/features/deck-import";
 import { DeckList } from "@/features/deck-list";
 import { removeStudySession, touchStudySession, useStudyHydrated, useStudySessions } from "@/features/study";
@@ -52,7 +52,11 @@ export const DeckListPage: React.FC = () => {
         onStartDeck={(id) => void navigate(`/deck/${id}/start`)}
         onEditDeck={(id) => void navigate(`/deck/${id}/edit`)}
         onDeleteDeck={async (deck) => {
-          await deleteDeck(uid, deck);
+          if (deck.localMode) {
+            await Promise.all([deleteLocalDeck(deck), deleteLocalCardsByDeckId(deck.id)]);
+          } else {
+            await deleteDeck(uid, deck);
+          }
           removeStudySession(deck.id);
         }}
       />

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -130,6 +130,7 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     deletedAt: null,
     category: "raw",
     convertToBr: false,
+    localMode: false,
     selectedTags: [],
     tagAndFilter: false,
     scoreMax: null,

--- a/src/shared/lib/generateId.ts
+++ b/src/shared/lib/generateId.ts
@@ -1,0 +1,1 @@
+export const generateId = (): string => crypto.randomUUID();

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -29,6 +29,7 @@ export const createDeck = (overrides: Partial<Deck> = {}): Deck => ({
   tagAndFilter: false,
   category: "",
   convertToBr: false,
+  localMode: false,
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary

- add validated browser persistence for local Decks and Cards while keeping Firestore snapshots remote-only
- route Deck and Card edits/deletes and CSV imports by the parent Deck's `localMode`
- generate Deck and Card IDs without Firebase and expose a Local only import option
- preserve the existing remote sample Deck behavior

## Why

Firestore subscriptions replace their remote mirror state, so browser-only data needs an independent persistence boundary. Local Decks and their Cards now remain in local state across snapshots, cleanup, and reloads without producing Firestore writes.

## User impact

Users can choose **Local only** when importing a CSV. Those Decks and Cards remain available in normal list, edit, delete, and study flows on the same browser without syncing to the account.

## Validation

- `mise run check`
- 98 unit test files / 483 tests passed
- TypeScript, ESLint, Biome, FSD, Knip, Markdown, Docker lint, and sample checks passed

Closes #919
Closes #921
Closes #922
Closes #923