### PR TITLE
refactor(#930): Remove study cardsById dependency

### DIFF
--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => {
   const cardUpdate = vi.fn();
 
   return {
-    state: null as { card: Record<CardId, Card>; preferences: Preferences } | null,
+    state: null as { cards: Card[]; preferences: Preferences } | null,
     cardUpdate,
     cardMutations: {
       update: cardUpdate,
@@ -99,11 +99,11 @@ const createPreferences = (overrides: PreferencesOverrides = {}): Preferences =>
  * Keeping this setup in one function lets each test focus on the behavior it is proving.
  */
 const createState = (preferences = createPreferences()) => ({
-  card: { [card1.id]: card1, [card2.id]: card2 },
+  cards: [card1, card2],
   preferences,
 });
 
-const getCardsById = () => mocks.state?.card ?? {};
+const getCards = () => mocks.state?.cards ?? [];
 
 describe("useStudyActions", () => {
   beforeEach(() => {
@@ -135,9 +135,7 @@ describe("useStudyActions", () => {
         },
       });
     });
-    const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), onStarted, onHideBackText })
-    );
+    const { result } = renderHook(() => useStudyActions(deck.id, { onStarted, onHideBackText }));
 
     act(() => {
       result.current.start([card1]);
@@ -150,7 +148,7 @@ describe("useStudyActions", () => {
   it("rejects a route and session mismatch before writing a card", async () => {
     studyStore.getState().startStudy("deck-2", [card1.id]);
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
     );
 
     await actAsync(async () => {
@@ -168,7 +166,7 @@ describe("useStudyActions", () => {
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     const { result } = renderHook(() =>
       useStudyActions(deck.id, {
-        cardsById: getCardsById(),
+        cards: getCards(),
         cardMutation: mocks.cardMutations,
         onSwipe,
         onHideBackText,
@@ -206,7 +204,7 @@ describe("useStudyActions", () => {
     mocks.cardUpdate.mockRejectedValueOnce(new Error("write failed"));
     const { result } = renderHook(() =>
       useStudyActions(deck.id, {
-        cardsById: getCardsById(),
+        cards: getCards(),
         cardMutation: mocks.cardMutations,
         showBackText: true,
         onRestoreBackText,
@@ -232,7 +230,7 @@ describe("useStudyActions", () => {
       })
     );
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
     );
 
     const swipe = result.current.swipeRight();
@@ -257,7 +255,7 @@ describe("useStudyActions", () => {
         })
     );
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
     );
 
     const firstSwipe = result.current.swipeRight();
@@ -280,7 +278,7 @@ describe("useStudyActions", () => {
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     const { result } = renderHook(() =>
       useStudyActions(deck.id, {
-        cardsById: getCardsById(),
+        cards: getCards(),
         cardMutation: mocks.cardMutations,
         showBackText: true,
         onHideBackText,
@@ -298,7 +296,7 @@ describe("useStudyActions", () => {
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     const before = studyStore.getState();
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
     );
 
     await actAsync(async () => {
@@ -315,7 +313,7 @@ describe("useStudyActions", () => {
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     studyStore.getState().setCurrentIndex(deck.id, 1);
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onSwipe })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations, onSwipe })
     );
 
     await actAsync(async () => {
@@ -334,7 +332,7 @@ describe("useStudyActions", () => {
     const onHideBackText = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations, onHideBackText })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations, onHideBackText })
     );
 
     act(() => {
@@ -347,7 +345,7 @@ describe("useStudyActions", () => {
 
   it("calls onToggleBackText when toggleShowBackText is invoked", () => {
     const onToggleBackText = vi.fn();
-    const { result } = renderHook(() => useStudyActions(deck.id, { cardsById: getCardsById(), onToggleBackText }));
+    const { result } = renderHook(() => useStudyActions(deck.id, { onToggleBackText }));
 
     act(() => {
       result.current.toggleShowBackText();
@@ -358,7 +356,7 @@ describe("useStudyActions", () => {
 
   it("calls onToggleAutoPlay when toggleAutoPlay is invoked", () => {
     const onToggleAutoPlay = vi.fn();
-    const { result } = renderHook(() => useStudyActions(deck.id, { cardsById: getCardsById(), onToggleAutoPlay }));
+    const { result } = renderHook(() => useStudyActions(deck.id, { onToggleAutoPlay }));
 
     act(() => {
       result.current.toggleAutoPlay();
@@ -371,7 +369,7 @@ describe("useStudyActions", () => {
     studyStore.getState().startStudy(deck.id, [card1.id]);
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cardsById: getCardsById(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
     );
 
     await actAsync(async () => {

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -4,7 +4,7 @@
  * coordinate services themselves.
  */
 
-import type { Card, CardId } from "@/entities/card";
+import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { StudyProgressEdit } from "@/entities/study-progress";
 import type { Preferences, SwipeDirection } from "@/entities/preferences";
@@ -34,7 +34,7 @@ interface StudyCardMutation {
 }
 
 interface UseStudyActionsOptions {
-  cardsById: Partial<Record<CardId, Card>>;
+  cards?: readonly Card[] | undefined;
   cardMutation?: StudyCardMutation | undefined;
   onStarted?: (() => void) | undefined;
   onSwipe?: ((direction: SwipeDirection) => void) | undefined;
@@ -49,7 +49,7 @@ interface StudySwipeDependencies {
   mutationTokenRef: { current: symbol | undefined };
   deckId: DeckId;
   preferences: Preferences;
-  cardsById: Partial<Record<CardId, Card>>;
+  cards: readonly Card[];
   update: (progress: StudyProgressEdit) => Promise<void>;
   onSwipe?: ((direction: SwipeDirection) => void) | undefined;
   showBackText?: boolean | undefined;
@@ -99,7 +99,7 @@ const runStudySwipe = async (
     mutationTokenRef,
     deckId,
     preferences,
-    cardsById,
+    cards,
     update,
     onSwipe,
     showBackText,
@@ -122,7 +122,7 @@ const runStudySwipe = async (
   }
 
   const cardId = session.cardOrderIds[session.currentIndex];
-  const card = cardId == null ? undefined : cardsById[cardId];
+  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
   if (card == null) return;
 
   const previous = {
@@ -166,7 +166,7 @@ export const useStudyActions = (
   deckId: DeckId,
   {
     cardMutation,
-    cardsById,
+    cards = [],
     onStarted,
     onSwipe,
     showBackText,
@@ -202,7 +202,7 @@ export const useStudyActions = (
       mutationTokenRef,
       deckId,
       preferences,
-      cardsById,
+      cards,
       update: cardMutation.update,
       onSwipe,
       showBackText,

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -1,4 +1,4 @@
-import type { Card, CardId } from "@/entities/card";
+import type { Card } from "@/entities/card";
 import { type Deck, useDeck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
@@ -12,24 +12,16 @@ import { useStudyActions, useStudyCards } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
-import { toRemoteById } from "@/shared/lib/remoteSnapshot";
 
 import { DeckStartView } from "./DeckStartView";
 
 const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
   target instanceof Element && target.closest("a[href], button, input, select, textarea") != null;
 
-const DeckStartContent = (props: {
-  cardsById: Partial<Record<CardId, Card>>;
-  deck: Deck;
-  cards: Card[];
-  preferences: Preferences;
-  tags: string[];
-}) => {
-  const { cardsById, deck, cards, preferences, tags } = props;
+const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
+  const { deck, cards, preferences, tags } = props;
   const navigate = useNavigate();
   const studyActions = useStudyActions(deck.id, {
-    cardsById,
     onStarted: () => void navigate(`/deck/${deck.id}/study`, { replace: true }),
   });
   const deckStartForm = useDeckFilterState({ deck, tags });
@@ -60,7 +52,6 @@ export const DeckStartPage: React.FC = () => {
   if (deckId == null) throw Error("invalid deck id");
   const preferences = usePreferences();
   const allCards = useCards();
-  const cardsById = React.useMemo(() => toRemoteById(allCards), [allCards]);
   const deck = useDeck(deckId);
   const deckCards = React.useMemo(() => filterCardsByDeckId(allCards, deckId), [allCards, deckId]);
   const cards = useStudyCards(deck, deckCards, preferences);
@@ -78,5 +69,5 @@ export const DeckStartPage: React.FC = () => {
     );
   }
 
-  return <DeckStartContent cardsById={cardsById} deck={deck} cards={cards} preferences={preferences} tags={tags} />;
+  return <DeckStartContent deck={deck} cards={cards} preferences={preferences} tags={tags} />;
 };

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { type Card, type CardId, useCards } from "@/entities/card";
+import { type Card, useCards } from "@/entities/card";
 import { BackText, CardOverlay, FrontText } from "@/features/card-view";
 import {
   selectStudySessionForRoute,
@@ -22,7 +22,6 @@ import {
   usePreferences,
   type SwipeDirection,
 } from "@/entities/preferences";
-import { toRemoteById } from "@/shared/lib/remoteSnapshot";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -33,11 +32,10 @@ const SWIPE_FEEDBACK_DURATION_MS = 900;
 const isHistoryState = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value != null && !Array.isArray(value);
 
-const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<CardId, Card>>; deck: Deck }) => {
+const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const navigate = useNavigate();
   const deckId = deck.id;
   const preferences = usePreferences();
-  const allCards = useCards();
   const session = useStudyStore(selectStudySessionForRoute(deckId));
   const [showBackText, setShowBackText] = React.useState(false);
   const [autoPlay, setAutoPlay] = React.useState(preferences.study.defaultAutoPlay);
@@ -75,10 +73,10 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
 
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
-  const card = cardId == null ? undefined : cardsById[cardId];
+  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
   const cardMutation = useEditStudyProgress();
   const studyActions = useStudyActions(deckId, {
-    cardsById,
+    cards,
     cardMutation: {
       update: cardMutation.update,
     },
@@ -107,7 +105,7 @@ const DeckSwiperContent = ({ cardsById, deck }: { cardsById: Partial<Record<Card
 
   const valid = session != null && index >= 0 && index < session.cardOrderIds.length && card != null;
   const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
-  const isWaitingForCards = sessionHasTargetCard && card == null && allCards.length === 0;
+  const isWaitingForCards = sessionHasTargetCard && card == null && cards.length === 0;
 
   const controller = useStudyControllerState({
     autoPlay,
@@ -213,12 +211,11 @@ export const DeckSwiperPage: React.FC = () => {
   if (deckId == null) throw Error("invalid deck id");
 
   const cards = useCards();
-  const cardsById = React.useMemo(() => toRemoteById(cards), [cards]);
   const deck = useDeck(deckId);
 
   if (deck == null) {
     return <RouteFeedback title="Study session unavailable." tone="not-found" />;
   }
 
-  return <DeckSwiperContent key={deck.id} cardsById={cardsById} deck={deck} />;
+  return <DeckSwiperContent key={deck.id} cards={cards} deck={deck} />;
 };

--- a/src/shared/lib/remoteSnapshot.ts
+++ b/src/shared/lib/remoteSnapshot.ts
@@ -1,4 +1,0 @@
-type RemoteById<T extends { id: string }> = Readonly<Record<string, T | undefined>>;
-
-export const toRemoteById = <T extends { id: string }>(items: readonly T[]): RemoteById<T> =>
-  Object.fromEntries(items.map((item) => [item.id, item]));


### PR DESCRIPTION
## Related issue

Fixes #930

## Summary

- Remove `remoteSnapshot.ts` and all `toRemoteById` usage.
- Let deck start create a study session without building or passing a card record.
- Pass `Card[]` directly to deck swiper study actions and update the hook fixtures accordingly.

## Testing

- `mise run check`