### PR TITLE
#933 Add useAuthUid to Auth Entity

### DIFF
--- a/src/entities/auth/index.ts
+++ b/src/entities/auth/index.ts
@@ -1,2 +1,2 @@
-export { useAuthSession } from "./model/hooks";
+export { useAuthSession, useAuthUid } from "./model/hooks";
 export { getAuthSession, replaceAuthSession } from "./model/store";

--- a/src/entities/auth/model/hooks.spec.ts
+++ b/src/entities/auth/model/hooks.spec.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { useAuthSession } from "./hooks";
+import { useAuthSession, useAuthUid } from "./hooks";
 import { replaceAuthSession } from "./store";
 
 describe("useAuthSession", () => {
@@ -25,5 +25,35 @@ describe("useAuthSession", () => {
       isAnonymous: true,
       displayName: null,
     });
+  });
+});
+
+describe("useAuthUid", () => {
+  beforeEach(() => replaceAuthSession({ status: "initializing" }));
+
+  it("returns the authenticated user UID", () => {
+    replaceAuthSession({
+      status: "authenticated",
+      uid: "uid-a",
+      isAnonymous: true,
+      displayName: null,
+    });
+
+    const { result } = renderHook(useAuthUid);
+
+    expect(result.current).toBe("uid-a");
+  });
+
+  it.each([
+    { status: "initializing" as const },
+    { status: "unauthenticated" as const },
+    { status: "authenticating" as const, attemptId: Symbol("attempt-a") },
+    { status: "error" as const, error: new Error("authentication failed") },
+  ])("returns an empty string when the session is $status", (session) => {
+    replaceAuthSession(session);
+
+    const { result } = renderHook(useAuthUid);
+
+    expect(result.current).toBe("");
   });
 });

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -4,3 +4,6 @@ import { authSessionStore } from "./store";
 import type { AuthSessionState } from "./types";
 
 export const useAuthSession = (): AuthSessionState => useStore(authSessionStore);
+
+export const useAuthUid = (): string =>
+  useStore(authSessionStore, (auth) => (auth.status === "authenticated" ? auth.uid : ""));

--- a/src/features/card-edit/model/useCardEditAction.ts
+++ b/src/features/card-edit/model/useCardEditAction.ts
@@ -2,7 +2,7 @@ import type { CardEdit } from "@/entities/card";
 
 import * as React from "react";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { editCard } from "@/entities/card";
 
 interface UseCardEditActionOptions {
@@ -10,8 +10,7 @@ interface UseCardEditActionOptions {
 }
 
 export const useCardEditAction = ({ onSaved }: UseCardEditActionOptions = {}) => {
-  const auth = useAuthSession();
-  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const uid = useAuthUid();
   const [error, setError] = React.useState<unknown>(null);
 
   const update = React.useCallback(

--- a/src/features/card-edit/ui/CardEditForm.spec.tsx
+++ b/src/features/card-edit/ui/CardEditForm.spec.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthSession: () => ({ status: "authenticated" as const, uid: "user-id", isAnonymous: false, displayName: null }),
+  useAuthUid: () => "user-id",
 }));
 vi.mock("@/entities/card", () => ({ editCard: mocks.editCard }));
 vi.mock("@/entities/deck", () => ({ CATEGORY: ["language", "math"] }));

--- a/src/features/card-list/ui/CardList.spec.tsx
+++ b/src/features/card-list/ui/CardList.spec.tsx
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({ deleteCard: vi.fn() }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/auth", () => ({
-  useAuthSession: () => ({ status: "authenticated" as const, uid: "user-id" }),
+  useAuthUid: () => "user-id",
 }));
 vi.mock("@/entities/card", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/card")>()),

--- a/src/features/card-list/ui/CardList.tsx
+++ b/src/features/card-list/ui/CardList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { deleteCard, type Card, type CardId } from "@/entities/card";
 import { getCategory, isHighlightLanguage, type Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
@@ -35,8 +35,7 @@ export interface CardListProps {
 }
 
 export const CardList: React.FC<CardListProps> = (props) => {
-  const auth = useAuthSession();
-  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const uid = useAuthUid();
   const [shownCard, setShownCard] = React.useState<Card>();
   const [deletionTarget, setDeletionTarget] = React.useState<Card>();
   const [deletionErrorCardId, setDeletionErrorCardId] = React.useState<CardId>();

--- a/src/features/deck-edit/model/useDeckEditAction.ts
+++ b/src/features/deck-edit/model/useDeckEditAction.ts
@@ -2,7 +2,7 @@ import type { DeckEdit } from "@/entities/deck";
 
 import * as React from "react";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { editDeck } from "@/entities/deck";
 
 interface UseDeckEditActionOptions {
@@ -10,8 +10,7 @@ interface UseDeckEditActionOptions {
 }
 
 export const useDeckEditAction = ({ onSaved }: UseDeckEditActionOptions = {}) => {
-  const auth = useAuthSession();
-  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const uid = useAuthUid();
   const [error, setError] = React.useState<unknown>(null);
 
   const update = React.useCallback(

--- a/src/features/deck-edit/ui/DeckEditForm.spec.tsx
+++ b/src/features/deck-edit/ui/DeckEditForm.spec.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthSession: () => ({ status: "authenticated" as const, uid: "user-id", isAnonymous: false, displayName: null }),
+  useAuthUid: () => "user-id",
 }));
 vi.mock("@/entities/deck", () => ({
   CATEGORY: ["language", "science"],

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -29,10 +29,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthSession: () =>
-    mocks.uid === ""
-      ? { status: "signedOut" }
-      : { status: "authenticated", uid: mocks.uid, isAnonymous: true, displayName: null },
+  useAuthUid: () => mocks.uid,
 }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/card", async (importOriginal) => {

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchCards, filterCardsByDeckId } from "@/entities/card";
 import { fetchDecks } from "@/entities/deck";
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTypes";
 import { parseCsv } from "../lib/cardCsv";
 import { buildDeckImportPlan } from "../lib/deckImportAnalysis";
@@ -146,9 +146,8 @@ export const useDeckImport = ({
   editCard,
   generateCardId,
 }: DeckImportOptions) => {
-  const auth = useAuthSession();
+  const uid = useAuthUid();
   const cardsByDeckId = useCallback((deckId: DeckId) => filterCardsByDeckId(cards, deckId), [cards]);
-  const uid = auth.status === "authenticated" ? auth.uid : "";
   const generation = useRef(0);
   const generationUid = useRef(uid);
   const runningRef = useRef(false);

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -19,7 +19,9 @@ const mocks = vi.hoisted(() => ({
   addSample: vi.fn<() => Promise<unknown>>(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.auth }));
+vi.mock("@/entities/auth", () => ({
+  useAuthUid: () => (mocks.auth.status === "authenticated" ? mocks.auth.uid : ""),
+}));
 vi.mock("./useDeckImport", () => ({
   useDeckImport: () => ({ addSample: mocks.addSample }),
 }));

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -6,7 +6,7 @@
 
 import { useEffect } from "react";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { useDeckImport } from "./useDeckImport";
 import type { DeckImportOptions } from "./useDeckImport";
 
@@ -49,9 +49,8 @@ const sampleDeckBootstrapController = createSampleDeckBootstrapController();
  * services themselves.
  */
 export const useSampleDeckBootstrap = (options: DeckImportOptions) => {
-  const auth = useAuthSession();
+  const uid = useAuthUid();
   const deckImport = useDeckImport(options);
-  const uid = auth.status === "authenticated" ? auth.uid : "";
 
   useEffect(() => {
     if (uid === "" || options.decks.length > 0) {

--- a/src/features/deck-start/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-start/model/useDeckFilterState.spec.tsx
@@ -21,7 +21,7 @@ import { createDeck } from "@/test/factories";
 const mocks = vi.hoisted(() => ({ editDeck: vi.fn() }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthSession: () => ({ status: "authenticated" as const, uid: "user-id", isAnonymous: false, displayName: null }),
+  useAuthUid: () => "user-id",
 }));
 vi.mock("@/entities/deck", () => ({ editDeck: mocks.editDeck }));
 

--- a/src/features/deck-start/model/useDeckFilterState.ts
+++ b/src/features/deck-start/model/useDeckFilterState.ts
@@ -9,7 +9,7 @@ import type { Deck } from "@/entities/deck";
 import * as React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { editDeck } from "@/entities/deck";
 import type { DeckStartForm } from "../ui/DeckStartForm";
 
@@ -24,8 +24,7 @@ export interface UseDeckFilterStateOptions {
  * Provides the filter state and persistence callback used to configure a study session.
  */
 export const useDeckFilterState = ({ deck, tags }: UseDeckFilterStateOptions): DeckStartFormProps => {
-  const auth = useAuthSession();
-  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const uid = useAuthUid();
   const [scoreMaxEnabled, setScoreMaxEnabled] = React.useState(deck.scoreMax != null);
   const [scoreMinEnabled, setScoreMinEnabled] = React.useState(deck.scoreMin != null);
   const { control, handleSubmit, register, setValue, subscribe } = useForm<Deck>({ defaultValues: deck });

--- a/src/features/study/hooks/useEditStudyProgress.ts
+++ b/src/features/study/hooks/useEditStudyProgress.ts
@@ -1,13 +1,12 @@
 import type { Card } from "@/entities/card";
 import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 
 export type StudyProgressPatch = Omit<StudyProgressEdit, "cardId">;
 
 export const useEditStudyProgress = () => {
-  const auth = useAuthSession();
-  const uid = auth.status === "authenticated" ? auth.uid : "";
+  const uid = useAuthUid();
   const update = (progress: StudyProgressEdit) => editStudyProgress(uid, progress);
 
   return {

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -30,12 +30,7 @@ vi.mock("@/entities/preferences", () => ({
   setDarkMode: vi.fn(),
 }));
 vi.mock("@/entities/auth", () => ({
-  useAuthSession: () => ({
-    status: "authenticated",
-    uid: mocks.authUid,
-    isAnonymous: true,
-    displayName: null,
-  }),
+  useAuthUid: () => mocks.authUid,
 }));
 vi.mock("@/entities/card", () => ({
   createCard: vi.fn(),

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -2,7 +2,7 @@ import type * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { createCard, editCard, generateCardId, useCards } from "@/entities/card";
 import { createDeck, deleteDeck, useDecks } from "@/entities/deck";
 import { useSampleDeckBootstrap } from "@/features/deck-import";
@@ -12,12 +12,11 @@ import { AppLayout } from "@/widgets/app-layout";
 
 export const DeckListPage: React.FC = () => {
   const navigate = useNavigate();
-  const auth = useAuthSession();
+  const uid = useAuthUid();
   const cards = useCards();
   const decks = useDecks();
   const sessionsByDeckId = useStudySessions();
   const hydrated = useStudyHydrated();
-  const uid = auth.status === "authenticated" ? auth.uid : "";
 
   useSampleDeckBootstrap({
     cards,


### PR DESCRIPTION
## Summary

- add `useAuthUid()` to the Auth Entity public API
- replace repeated authenticated-session UID selection across Features and Pages
- update hook coverage and existing Auth Entity mocks

## Why

Callers repeated the same auth-state check whenever they needed the current Firebase UID. Keeping this derived value in the Auth Entity removes duplication while preserving the existing auth lifecycle semantics.

## Impact

Authenticated users, including anonymous Firebase users, receive their UID. Initializing, unauthenticated, authenticating, and error states continue to return an empty string. The selector subscribes only to the derived UID, avoiding rerenders for unrelated auth-state updates.

## Validation

- `mise run check`
- 96 unit test files passed, 480 tests passed

Closes #933