### PR TITLE
fix: Roll back failed swipe feedback (#908)

### DIFF
--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -161,7 +161,8 @@ describe("useStudyActions", () => {
   });
 
   it("writes a card patch, notifies onSwipe and onHideBackText, and advances the Zustand session", async () => {
-    const onSwipe = vi.fn();
+    const rollbackSwipe = vi.fn();
+    const onSwipe = vi.fn(() => rollbackSwipe);
     const onHideBackText = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     const { result } = renderHook(() =>
@@ -185,6 +186,7 @@ describe("useStudyActions", () => {
     };
     expect(mocks.cardUpdate).toHaveBeenCalledWith(patch);
     expect(onSwipe).toHaveBeenCalledWith("cardSwipeRight");
+    expect(rollbackSwipe).not.toHaveBeenCalled();
     expect(onHideBackText).toHaveBeenCalledOnce();
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: {
@@ -200,12 +202,15 @@ describe("useStudyActions", () => {
 
   it("rolls the optimistic study index back and restores back text when the Card write fails", async () => {
     const onRestoreBackText = vi.fn();
+    const rollbackSwipe = vi.fn();
+    const onSwipe = vi.fn(() => rollbackSwipe);
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     mocks.cardUpdate.mockRejectedValueOnce(new Error("write failed"));
     const { result } = renderHook(() =>
       useStudyActions(deck.id, {
         cards: getCards(),
         cardMutation: mocks.cardMutations,
+        onSwipe,
         showBackText: true,
         onRestoreBackText,
       })
@@ -218,10 +223,13 @@ describe("useStudyActions", () => {
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: { [deck.id]: { currentIndex: 0 } },
     });
+    expect(onSwipe).toHaveBeenCalledWith("cardSwipeRight");
+    expect(rollbackSwipe).toHaveBeenCalledOnce();
     expect(onRestoreBackText).toHaveBeenCalledWith(true);
   });
 
   it("does not roll back a newer same-index session update", async () => {
+    const rollbackSwipe = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     let rejectWrite: ((error: Error) => void) | undefined;
     mocks.cardUpdate.mockReturnValueOnce(
@@ -230,7 +238,11 @@ describe("useStudyActions", () => {
       })
     );
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, {
+        cards: getCards(),
+        cardMutation: mocks.cardMutations,
+        onSwipe: () => rollbackSwipe,
+      })
     );
 
     const swipe = result.current.swipeRight();
@@ -243,6 +255,7 @@ describe("useStudyActions", () => {
       currentIndex: 1,
       lastStudiedAt: 946684800100,
     });
+    expect(rollbackSwipe).not.toHaveBeenCalled();
   });
 
   it("blocks a second swipe while the first Card write is unresolved", async () => {
@@ -293,10 +306,11 @@ describe("useStudyActions", () => {
   });
 
   it("leaves all study and card state unchanged for DoNothing", async () => {
+    const onSwipe = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     const before = studyStore.getState();
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations, onSwipe })
     );
 
     await actAsync(async () => {
@@ -304,11 +318,13 @@ describe("useStudyActions", () => {
     });
 
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
+    expect(onSwipe).not.toHaveBeenCalled();
     expect(studyStore.getState()).toEqual(before);
   });
 
   it("removes only the route session for GoBack without a card write", async () => {
-    const onSwipe = vi.fn();
+    const rollbackSwipe = vi.fn();
+    const onSwipe = vi.fn(() => rollbackSwipe);
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     studyStore.getState().setCurrentIndex(deck.id, 1);
@@ -322,6 +338,7 @@ describe("useStudyActions", () => {
 
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
     expect(onSwipe).toHaveBeenCalledWith("cardSwipeLeft");
+    expect(rollbackSwipe).not.toHaveBeenCalled();
     expect(studyStore.getState()).toMatchObject({
       sessionsByDeckId: { "deck-2": { deckId: "deck-2" } },
     });

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -33,11 +33,13 @@ interface StudyCardMutation {
   update: (progress: StudyProgressEdit) => Promise<void>;
 }
 
+type SwipeRollback = () => void;
+
 interface UseStudyActionsOptions {
   cards?: readonly Card[] | undefined;
   cardMutation?: StudyCardMutation | undefined;
   onStarted?: (() => void) | undefined;
-  onSwipe?: ((direction: SwipeDirection) => void) | undefined;
+  onSwipe?: ((direction: SwipeDirection) => SwipeRollback | undefined) | undefined;
   showBackText?: boolean | undefined;
   onHideBackText?: (() => void) | undefined;
   onToggleBackText?: (() => void) | undefined;
@@ -51,7 +53,7 @@ interface StudySwipeDependencies {
   preferences: Preferences;
   cards: readonly Card[];
   update: (progress: StudyProgressEdit) => Promise<void>;
-  onSwipe?: ((direction: SwipeDirection) => void) | undefined;
+  onSwipe?: ((direction: SwipeDirection) => SwipeRollback | undefined) | undefined;
   showBackText?: boolean | undefined;
   onHideBackText?: (() => void) | undefined;
   onRestoreBackText?: ((showBackText: boolean) => void) | undefined;
@@ -81,12 +83,13 @@ const revertOptimisticUpdate = (
   const changeStillCurrent =
     mutationTokenRef.current === mutationToken &&
     (nextIndex < 0 ? currentSession == null : currentSession === optimisticSession);
-  if (changeStillCurrent) {
-    studyStore.setState((state) => ({
-      sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
-    }));
-    onRestoreBackText?.(previous.showBackText);
-  }
+  if (!changeStillCurrent) return false;
+
+  studyStore.setState((state) => ({
+    sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previous.session },
+  }));
+  onRestoreBackText?.(previous.showBackText);
+  return true;
 };
 
 /**
@@ -130,7 +133,7 @@ const runStudySwipe = async (
     showBackText: showBackText ?? false,
   };
 
-  onSwipe?.(direction);
+  const rollbackSwipe = onSwipe?.(direction);
   if (preferences.appearance.hideBodyWhenCardChanged) {
     onHideBackText?.();
   }
@@ -143,7 +146,7 @@ const runStudySwipe = async (
   try {
     await update(patch);
   } catch {
-    revertOptimisticUpdate(
+    const reverted = revertOptimisticUpdate(
       deckId,
       nextIndex,
       mutationTokenRef,
@@ -152,6 +155,7 @@ const runStudySwipe = async (
       previous,
       onRestoreBackText
     );
+    if (reverted) rollbackSwipe?.();
   } finally {
     if (mutationTokenRef.current === mutationToken) mutationTokenRef.current = undefined;
   }

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -80,26 +80,26 @@ vi.mock("@/features/study", async (importOriginal) => {
     useStudyActions: (
       _deckId: DeckId,
       options?: {
-        onSwipe?: (direction: SwipeDirection) => void;
+        onSwipe?: (direction: SwipeDirection) => (() => void) | undefined;
         onToggleBackText?: () => void;
         onToggleAutoPlay?: () => void;
       }
     ) => ({
       swipeUp: () => {
-        options?.onSwipe?.("cardSwipeUp");
-        mocks.swipeUp();
+        const rollback = options?.onSwipe?.("cardSwipeUp");
+        mocks.swipeUp(rollback);
       },
       swipeDown: () => {
-        options?.onSwipe?.("cardSwipeDown");
-        mocks.swipeDown();
+        const rollback = options?.onSwipe?.("cardSwipeDown");
+        mocks.swipeDown(rollback);
       },
       swipeLeft: () => {
-        options?.onSwipe?.("cardSwipeLeft");
-        mocks.swipeLeft();
+        const rollback = options?.onSwipe?.("cardSwipeLeft");
+        mocks.swipeLeft(rollback);
       },
       swipeRight: () => {
-        options?.onSwipe?.("cardSwipeRight");
-        mocks.swipeRight();
+        const rollback = options?.onSwipe?.("cardSwipeRight");
+        mocks.swipeRight(rollback);
       },
       updateIndex: mocks.updateIndex,
       toggleShowBackText: () => {
@@ -292,6 +292,26 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
 
     act(() => vi.advanceTimersByTime(1));
     expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
+  });
+
+  it("rolls back only the feedback event associated with a failed swipe", () => {
+    if (mocks.state == null) throw new Error("Mock state is not initialized");
+    mocks.state.preferences = createPreferences({
+      ...mocks.state.preferences,
+      appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: true },
+    });
+    render(<DeckSwiperPage />);
+
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    const rollbackLeft = mocks.swipeLeft.mock.calls[0]?.[0] as (() => void) | undefined;
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    act(() => rollbackLeft?.());
+    expect(screen.getByText("Swiped right")).toBeInTheDocument();
+
+    const rollbackRight = mocks.swipeRight.mock.calls[0]?.[0] as (() => void) | undefined;
+    act(() => rollbackRight?.());
+    expect(screen.queryByText("Swiped right")).not.toBeInTheDocument();
   });
 
   it("installs one back-navigation guard when StrictMode replays the effect", () => {

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -42,6 +42,7 @@ const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const [lastSwipe, setLastSwipe] = React.useState<{ direction: SwipeDirection; eventId: number } | undefined>(
     undefined
   );
+  const nextSwipeEventId = React.useRef(0);
   const hydrated = useStudyHydrated();
 
   const handleHideBackText = React.useCallback(() => {
@@ -60,10 +61,11 @@ const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const handleSwipe = React.useCallback(
     (direction: SwipeDirection) => {
       if (!preferences.appearance.showSwipeFeedback) return;
-      setLastSwipe((prev) => ({
-        direction,
-        eventId: (prev?.eventId ?? 0) + 1,
-      }));
+      const eventId = ++nextSwipeEventId.current;
+      setLastSwipe({ direction, eventId });
+      return () => {
+        setLastSwipe((current) => (current?.eventId === eventId ? undefined : current));
+      };
     },
     [preferences.appearance.showSwipeFeedback]
   );


### PR DESCRIPTION
## Summary

- let swipe feedback owners return an event-scoped rollback handle
- invoke that handle only when the matching optimistic Study transition is reverted
- keep successful feedback timing and GoBack / DoNothing behavior unchanged
- cover failed writes, stale failures, successful writes, and event-scoped cleanup

## Root cause

Swipe feedback moved from the persisted Study store to local Page state, but the Card write failure path could only restore the Study session and back-text state. The Page had no contract for cancelling the feedback created by the failed transition.

## Impact

A failed Card write now removes its optimistic swipe feedback together with the Study state rollback. Older rollback handles cannot clear a newer feedback event.

## Checks

- `npm run test:unit -- src/features/study/hooks/useStudyActions.spec.tsx src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx`
- `mise run check`

Closes #908