### PR TITLE
#931 Refactor Firestore document utilities

### DIFF
--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -12,7 +12,9 @@ import { collection, doc, getDocs, onSnapshot, query, setDoc, updateDoc, where }
 import { z } from "zod";
 
 import { db } from "@/shared/firebase";
-import { firestoreTimestampDateSchema, getTimestamp, omitUndefined, parseFirestoreDocument } from "@/shared/api";
+import { firestoreTimestampDateSchema, parseFirestoreDocument } from "@/shared/api";
+import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
+import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { createCardSchema, deleteCardSchema, editCardSchema } from "../model/schema";
 import { replaceRemoteCards } from "../model/store";
 
@@ -92,7 +94,7 @@ export const fetchCards = async (uid: string): Promise<Card[]> => {
 export const generateCardId = (): string => doc(collection(db, CARD_COLLECTION)).id;
 
 const createCardDocument = async (card: CardCreate): Promise<void> => {
-  const createdAt = getTimestamp();
+  const createdAt = getCurrentTimeMillis();
   const document = omitUndefined({ ...card, createdAt, updatedAt: createdAt } satisfies Card);
   await setDoc(doc(db, CARD_COLLECTION, card.id), document);
 };
@@ -111,7 +113,7 @@ const updateCardDocument = async (card: CardEdit): Promise<void> => {
     url: card.url,
     startLine: card.startLine,
     endLine: card.endLine,
-    updatedAt: getTimestamp(),
+    updatedAt: getCurrentTimeMillis(),
   });
   await updateDoc(doc(db, CARD_COLLECTION, card.id), document);
 };
@@ -122,7 +124,7 @@ export const editCard = async (uid: string, card: EditCardInput["card"]): Promis
 };
 
 const removeCardDocument = async (id: string): Promise<void> => {
-  const updatedAt = getTimestamp();
+  const updatedAt = getCurrentTimeMillis();
   await updateDoc(doc(db, CARD_COLLECTION, id), { updatedAt, deletedAt: updatedAt });
 };
 

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -12,7 +12,9 @@ import { collection, deleteDoc, doc, getDocs, onSnapshot, query, setDoc, updateD
 import { z } from "zod";
 
 import { db } from "@/shared/firebase";
-import { getTimestamp, omitUndefined, parseFirestoreDocument } from "@/shared/api";
+import { parseFirestoreDocument } from "@/shared/api";
+import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
+import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { createDeckSchema, deleteDeckSchema, editDeckSchema } from "../model/schema";
 import { replaceRemoteDecks } from "../model/store";
 
@@ -69,7 +71,7 @@ export const fetchDecks = async (uid: string): Promise<Deck[]> => {
 export const generateDeckId = (): string => doc(collection(db, DECK_COLLECTION)).id;
 
 const createDeckDocument = async (deck: DeckCreate): Promise<void> => {
-  const createdAt = getTimestamp();
+  const createdAt = getCurrentTimeMillis();
   const document = omitUndefined({ ...deck, createdAt, updatedAt: createdAt } satisfies Deck);
   await setDoc(doc(db, DECK_COLLECTION, deck.id), document);
 };
@@ -84,7 +86,7 @@ const updateDeckDocument = async (deck: DeckEdit): Promise<void> => {
     name: deck.name,
     url: deck.url,
     isPublic: deck.isPublic,
-    updatedAt: getTimestamp(),
+    updatedAt: getCurrentTimeMillis(),
     scoreMax: deck.scoreMax,
     scoreMin: deck.scoreMin,
     selectedTags: deck.selectedTags,

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -3,12 +3,13 @@ import type { EditStudyProgressInput } from "../model/types";
 import { doc, updateDoc } from "firebase/firestore";
 
 import { db } from "@/shared/firebase";
-import { getTimestamp, omitUndefined } from "@/shared/api";
+import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
+import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { editStudyProgressSchema } from "../model/schema";
 
 export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });
   const { cardId, ...fields } = input.progress;
-  const document = omitUndefined({ ...fields, updatedAt: getTimestamp() });
+  const document = omitUndefined({ ...fields, updatedAt: getCurrentTimeMillis() });
   await updateDoc(doc(db, "card", cardId), document);
 };

--- a/src/shared/api/firestoreDocument.spec.ts
+++ b/src/shared/api/firestoreDocument.spec.ts
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Timestamp } from "firebase/firestore";
 import { z } from "zod";
 
-import { firestoreTimestampDateSchema, getTimestamp, omitUndefined, parseFirestoreDocument } from "./firestoreDocument";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+import { firestoreTimestampDateSchema, parseFirestoreDocument } from "./firestoreDocument";
 
 describe("Firestore document utilities", () => {
   it("parses an arbitrary collection document", () => {
@@ -16,14 +12,15 @@ describe("Firestore document utilities", () => {
   });
 
   it("reports validation details for an arbitrary collection", () => {
-    const schema = z.object({ title: z.string() });
+    const schema = z.object({ metadata: z.object({ title: z.string() }) });
 
-    expect(() => parseFirestoreDocument(schema, "note", "note-a", { title: 42 })).toThrowError(
+    expect(() => parseFirestoreDocument(schema, "note", "note-a", { metadata: { title: 42 } })).toThrowError(
       expect.objectContaining({
         name: "FirestoreDocumentValidationError",
         collectionName: "note",
         documentId: "note-a",
-        message: expect.stringContaining("title"),
+        message: expect.stringContaining('Invalid Firestore note document "note-a": metadata.title'),
+        issues: [expect.objectContaining({ path: ["metadata", "title"] })],
       })
     );
     expect(() => parseFirestoreDocument(schema, "note", "note-a", {})).toThrowError(
@@ -38,35 +35,26 @@ describe("Firestore document utilities", () => {
     expect(firestoreTimestampDateSchema.parse(date)).toBe(date);
   });
 
-  it("rejects malformed timestamp values", () => {
-    const malformed = { seconds: 0, nanoseconds: 0, toDate: () => new Date(Number.NaN) };
-
-    expect(() => firestoreTimestampDateSchema.parse(malformed)).toThrow();
-  });
-
-  it("returns the current numeric timestamp", () => {
-    vi.spyOn(Date, "now").mockReturnValue(123);
-
-    expect(getTimestamp()).toBe(123);
-  });
-
-  it("omits undefined fields while preserving null and concrete values", () => {
-    const input = {
-      keepNull: null,
-      keepString: "text",
-      keepNumber: 0,
-      keepBoolean: false,
-      keepArray: [1, 2],
-      omitThis: undefined,
-    };
-
-    expect(omitUndefined(input)).toEqual({
-      keepNull: null,
-      keepString: "text",
-      keepNumber: 0,
-      keepBoolean: false,
-      keepArray: [1, 2],
-    });
-    expect(omitUndefined(input)).not.toHaveProperty("omitThis");
+  it.each([
+    new Date(Number.NaN),
+    { seconds: 0, nanoseconds: 0, toDate: () => new Date(Number.NaN) },
+    { seconds: 0, nanoseconds: 0, toDate: () => "not a date" },
+    { seconds: 0, nanoseconds: 1_000_000_000, toDate: () => new Date(0) },
+    {
+      get seconds(): number {
+        throw new Error("malformed");
+      },
+      nanoseconds: 0,
+      toDate: () => new Date(0),
+    },
+    {
+      seconds: 0,
+      nanoseconds: 0,
+      toDate: () => {
+        throw new Error("malformed");
+      },
+    },
+  ])("rejects malformed dates and timestamps through the schema boundary", (value) => {
+    expect(firestoreTimestampDateSchema.safeParse(value).success).toBe(false);
   });
 });

--- a/src/shared/api/firestoreDocument.ts
+++ b/src/shared/api/firestoreDocument.ts
@@ -1,38 +1,52 @@
-import type { Timestamp } from "firebase/firestore";
 import { z } from "zod";
 
-const validJavaScriptDateSchema = z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date");
-const firestoreTimestampSchema = z.custom<Timestamp>(
-  (value) =>
-    typeof value === "object" &&
-    value !== null &&
-    typeof Reflect.get(value, "toDate") === "function" &&
-    Number.isInteger(Reflect.get(value, "seconds")) &&
-    Number.isInteger(Reflect.get(value, "nanoseconds")) &&
-    Reflect.get(value, "nanoseconds") >= 0 &&
-    Reflect.get(value, "nanoseconds") < 1_000_000_000,
-  "Expected a Firestore Timestamp"
-);
+type FirestoreTimestamp = {
+  readonly seconds: number;
+  readonly nanoseconds: number;
+  toDate: () => Date;
+};
+
+const isFirestoreTimestamp = (value: unknown): value is FirestoreTimestamp => {
+  if (typeof value !== "object" || value === null) return false;
+
+  try {
+    const { seconds, nanoseconds, toDate } = value as Partial<FirestoreTimestamp>;
+    return (
+      Number.isInteger(seconds) &&
+      Number.isInteger(nanoseconds) &&
+      nanoseconds !== undefined &&
+      nanoseconds >= 0 &&
+      nanoseconds < 1_000_000_000 &&
+      typeof toDate === "function"
+    );
+  } catch {
+    return false;
+  }
+};
+
+const javascriptDateSchema = z.date();
+const firestoreTimestampSchema = z.custom<FirestoreTimestamp>(isFirestoreTimestamp, "Expected a Firestore Timestamp");
 
 export const firestoreTimestampDateSchema = z
-  .union([validJavaScriptDateSchema, firestoreTimestampSchema])
+  .union([javascriptDateSchema, firestoreTimestampSchema])
   .transform((value, context) => {
     if (value instanceof Date) return value;
     try {
-      const date = value.toDate();
-      if (!Number.isNaN(date.getTime())) return date;
+      return value.toDate();
     } catch {
-      // Report malformed Timestamp implementations through the schema error boundary below.
+      context.addIssue({ code: "custom", message: "Invalid Firestore Timestamp" });
+      return z.NEVER;
     }
-    context.addIssue({ code: "custom", message: "Invalid Firestore Timestamp" });
-    return z.NEVER;
-  });
+  })
+  .pipe(javascriptDateSchema);
+
+type FirestoreDocumentIssues = z.ZodError["issues"];
 
 class FirestoreDocumentValidationError extends Error {
   constructor(
     readonly collectionName: string,
     readonly documentId: string,
-    readonly issues: z.core.$ZodIssue[]
+    readonly issues: FirestoreDocumentIssues
   ) {
     const details = issues
       .map((issue) => `${issue.path.length === 0 ? "<document>" : issue.path.join(".")}: ${issue.message}`)
@@ -54,14 +68,3 @@ export const parseFirestoreDocument = <T>(
   }
   return result.data;
 };
-
-export const getTimestamp = (): number => Date.now();
-
-export type OmitUndefined<T extends Record<string, unknown>> = {
-  [K in keyof T as undefined extends T[K] ? never : K]: T[K];
-} & {
-  [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<T[K], undefined>;
-};
-
-export const omitUndefined = <T extends Record<string, unknown>>(value: T): OmitUndefined<T> =>
-  Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as OmitUndefined<T>;

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,6 +1,1 @@
-export {
-  firestoreTimestampDateSchema,
-  getTimestamp,
-  omitUndefined,
-  parseFirestoreDocument,
-} from "./firestoreDocument";
+export { firestoreTimestampDateSchema, parseFirestoreDocument } from "./firestoreDocument";

--- a/src/shared/lib/currentTime.spec.ts
+++ b/src/shared/lib/currentTime.spec.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getCurrentTimeMillis } from "./currentTime";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getCurrentTimeMillis", () => {
+  it("returns the current time in milliseconds", () => {
+    vi.spyOn(Date, "now").mockReturnValue(123);
+
+    expect(getCurrentTimeMillis()).toBe(123);
+  });
+});

--- a/src/shared/lib/currentTime.ts
+++ b/src/shared/lib/currentTime.ts
@@ -1,0 +1,1 @@
+export const getCurrentTimeMillis = (): number => Date.now();

--- a/src/shared/lib/omitUndefined.spec.ts
+++ b/src/shared/lib/omitUndefined.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { omitUndefined } from "./omitUndefined";
+
+describe("omitUndefined", () => {
+  it("omits top-level undefined fields while preserving other values", () => {
+    const input = {
+      keepNull: null,
+      keepString: "text",
+      keepNumber: 0,
+      keepBoolean: false,
+      keepArray: [1, 2],
+      keepNested: { nestedUndefined: undefined },
+      omitThis: undefined,
+    };
+
+    expect(omitUndefined(input)).toEqual({
+      keepNull: null,
+      keepString: "text",
+      keepNumber: 0,
+      keepBoolean: false,
+      keepArray: [1, 2],
+      keepNested: { nestedUndefined: undefined },
+    });
+    expect(omitUndefined(input)).not.toHaveProperty("omitThis");
+  });
+});

--- a/src/shared/lib/omitUndefined.ts
+++ b/src/shared/lib/omitUndefined.ts
@@ -1,0 +1,8 @@
+export type OmitUndefined<T extends Record<string, unknown>> = {
+  [K in keyof T as undefined extends T[K] ? never : K]: T[K];
+} & {
+  [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<T[K], undefined>;
+};
+
+export const omitUndefined = <T extends Record<string, unknown>>(value: T): OmitUndefined<T> =>
+  Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as OmitUndefined<T>;

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -18,16 +18,13 @@ import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { collection, deleteDoc, getDocs, getFirestore, doc, getDoc, query, where } from "firebase/firestore";
 import { upsertImportedCards } from "@/features/deck-import/api/upsertImportedCards";
 import { editStudyProgress } from "@/entities/study-progress";
-import { getTimestamp } from "@/shared/api";
+import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as UUID from "uuid";
 import { createCard, createDeck } from "@/test/factories";
 
 const uuid = UUID.v4;
 
-vi.mock("@/shared/api", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/shared/api")>()),
-  getTimestamp: vi.fn(),
-}));
+vi.mock("@/shared/lib/currentTime", () => ({ getCurrentTimeMillis: vi.fn() }));
 vi.mock("@/shared/firebase", async () => ({
   db: (await import("@/test/initializeTestFirestore")).testDb,
 }));
@@ -45,7 +42,7 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
   });
 
   beforeEach(async () => {
-    (getTimestamp as Mock).mockReturnValue(timestamp);
+    (getCurrentTimeMillis as Mock).mockReturnValue(timestamp);
   });
 
   // card needs to belong to its deck

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -9,16 +9,13 @@ import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { doc, getDoc, getFirestore } from "firebase/firestore";
 import { createCard as createCardCommand } from "@/entities/card";
-import { getTimestamp } from "@/shared/api";
+import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as UUID from "uuid";
 import { createCard, createDeck as createDeckFixture } from "@/test/factories";
 
 const uuid = UUID.v4;
 
-vi.mock("@/shared/api", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/shared/api")>()),
-  getTimestamp: vi.fn(),
-}));
+vi.mock("@/shared/lib/currentTime", () => ({ getCurrentTimeMillis: vi.fn() }));
 vi.mock("@/shared/firebase", async () => ({
   db: (await import("@/test/initializeTestFirestore")).testDb,
 }));
@@ -35,7 +32,7 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
 
   beforeEach(async () => {
     // must return the same value (no need to reset mock in parallel)
-    (getTimestamp as Mock).mockReturnValue(timestamp);
+    (getCurrentTimeMillis as Mock).mockReturnValue(timestamp);
   });
 
   it("should create a deck and check if exists", async () => {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -14,10 +14,7 @@ import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture } from "@/test/factories";
 
-vi.mock("@/shared/api", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/shared/api")>()),
-  getTimestamp: vi.fn(() => 100),
-}));
+vi.mock("@/shared/lib/currentTime", () => ({ getCurrentTimeMillis: vi.fn(() => 100) }));
 vi.mock("@/shared/firebase", async () => ({
   db: (await import("@/test/initializeTestFirestore")).testDb,
 }));


### PR DESCRIPTION
## Summary

- simplify structural Firestore Timestamp detection and validate every normalized value with the Date schema
- preserve collection, document ID, and issue-path context while removing the direct `z.core.$ZodIssue` dependency
- move current-time and top-level undefined helpers into focused shared library modules, renaming the clock API to `getCurrentTimeMillis`

## Why

The Firestore document module combined validation, time access, and generic object cleanup. Timestamp detection also repeated reflective property access, making malformed inputs harder to reason about.

## Impact

Firestore reads continue to accept valid JavaScript Dates and Firestore Timestamps while malformed values remain schema errors. Firestore writes retain the same millisecond timestamps and top-level undefined filtering through clearer APIs.

## Validation

- `mise run check`
- `mise run test-integration` (4 files, 40 tests)

Closes #931