### PR TITLE
refactor(#939): Centralize required route parameters

### DIFF
--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -90,9 +90,9 @@ describe("CardFormPage", () => {
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, -1);
   });
 
-  it("preserves the invalid route error", () => {
+  it("rejects a route without a card id", () => {
     mocks.params.id = undefined;
 
-    expect(() => render(<CardFormPage />)).toThrowError("invalid card id");
+    expect(() => render(<CardFormPage />)).toThrowError("Missing route parameter: id");
   });
 });

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -1,8 +1,9 @@
 import type * as React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { type Card, useCard } from "@/entities/card";
 import { CardEditForm } from "@/features/card-edit";
+import { useRequiredRouteParam } from "@/shared/router";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -18,10 +19,8 @@ const CardFormContent = ({ card }: { card: Card }) => {
 };
 
 export const CardFormPage: React.FC = () => {
-  const params = useParams();
   const navigate = useNavigate();
-  const cardId = params.id;
-  if (cardId == null) throw Error("invalid card id");
+  const cardId = useRequiredRouteParam("id");
   const card = useCard(cardId);
 
   if (card == null) {

--- a/src/pages/deck-form/ui/DeckFormPage.spec.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.spec.tsx
@@ -84,6 +84,6 @@ describe("DeckFormPage", () => {
 
   it("rejects a route without a deck id", () => {
     mocks.params.id = undefined;
-    expect(() => render(<DeckFormPage />)).toThrowError("invalid deck id");
+    expect(() => render(<DeckFormPage />)).toThrowError("Missing route parameter: id");
   });
 });

--- a/src/pages/deck-form/ui/DeckFormPage.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.tsx
@@ -1,8 +1,9 @@
 import type * as React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { type Deck, useDeck } from "@/entities/deck";
 import { DeckEditForm } from "@/features/deck-edit";
+import { useRequiredRouteParam } from "@/shared/router";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -18,10 +19,8 @@ const DeckFormContent = ({ deck }: { deck: Deck }) => {
 };
 
 export const DeckFormPage: React.FC = () => {
-  const params = useParams();
   const navigate = useNavigate();
-  const deckId = params.id;
-  if (deckId == null) throw Error("invalid deck id");
+  const deckId = useRequiredRouteParam("id");
   const deck = useDeck(deckId);
 
   if (deck != null) return <DeckFormContent deck={deck} />;

--- a/src/shared/router/index.ts
+++ b/src/shared/router/index.ts
@@ -1,0 +1,1 @@
+export { useRequiredRouteParam } from "./useRequiredRouteParam";

--- a/src/shared/router/useRequiredRouteParam.spec.tsx
+++ b/src/shared/router/useRequiredRouteParam.spec.tsx
@@ -1,0 +1,39 @@
+import type { PropsWithChildren } from "react";
+
+import { renderHook } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { useRequiredRouteParam } from "./useRequiredRouteParam";
+
+const Router = ({ children, path, route }: PropsWithChildren<{ path: string; route: string }>) => (
+  <MemoryRouter initialEntries={[route]}>
+    <Routes>
+      <Route path={path} element={children} />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe("useRequiredRouteParam", () => {
+  it("returns the requested route parameter", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Router path="/cards/:id" route="/cards/card-id">
+        {children}
+      </Router>
+    );
+
+    expect(renderHook(() => useRequiredRouteParam("id"), { wrapper }).result.current).toBe("card-id");
+  });
+
+  it("rejects a route without the requested parameter", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Router path="/cards" route="/cards">
+        {children}
+      </Router>
+    );
+
+    expect(() => renderHook(() => useRequiredRouteParam("id"), { wrapper })).toThrowError(
+      "Missing route parameter: id"
+    );
+  });
+});

--- a/src/shared/router/useRequiredRouteParam.ts
+++ b/src/shared/router/useRequiredRouteParam.ts
@@ -1,0 +1,12 @@
+import { useParams } from "react-router-dom";
+
+export const useRequiredRouteParam = (name: string): string => {
+  const params = useParams();
+  const value = params[name];
+
+  if (value == null) {
+    throw new Error(`Missing route parameter: ${name}`);
+  }
+
+  return value;
+};


### PR DESCRIPTION
## Related issue

Fixes #939

## Summary

- Add a domain-agnostic `useRequiredRouteParam` hook for required React Router parameters.
- Replace duplicated `useParams` and null checks in `CardFormPage` and `DeckFormPage`.
- Keep entity lookup, route feedback, and navigation behavior in the Page layer.

## Testing

- `mise run check`