### PR TITLE
#938 Add deck-scoped card query hook

### DIFF
--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,5 +1,5 @@
 export { createCard, deleteCard, editCard, fetchCards, generateCardId, subscribeCards } from "./api/firestore";
-export { useCard, useCards } from "./model/hooks";
+export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";
 export type {
   Card,
@@ -8,4 +8,4 @@ export type {
   CardId,
   CardRaw,
 } from "./model/types";
-export { filterCardsByDeckId, filterTagsByDeckId } from "./model/rules";
+export { filterCardsByDeckId } from "./model/rules";

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
 import { useStore } from "zustand";
 
+import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
 import { cardStore } from "./store";
 import type { Card, CardId } from "./types";
 
@@ -13,3 +15,14 @@ export const useCard = (id: CardId | undefined): Card | undefined =>
     cardStore,
     (state) => state.remoteCards.find((card) => card.id === id) ?? state.localCards.find((card) => card.id === id)
   );
+
+export const useCardsByDeckId = (deckId: string): { cards: Card[]; tags: string[] } => {
+  const allCards = useCards();
+  return useMemo(
+    () => ({
+      cards: filterCardsByDeckId(allCards, deckId),
+      tags: filterTagsByDeckId(allCards, deckId),
+    }),
+    [allCards, deckId]
+  );
+};

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createCard } from "@/test/factories";
-import { useCard, useCards } from "./hooks";
+import { useCard, useCards, useCardsByDeckId } from "./hooks";
 import { cardStore, clearRemoteCards, replaceRemoteCards } from "./store";
 
 describe("Card store", () => {
@@ -29,5 +29,17 @@ describe("Card store", () => {
     expect(renderHook(() => useCard("remote")).result.current).toEqual(remoteCard);
     expect(renderHook(() => useCard("local")).result.current).toEqual(localCard);
     expect(renderHook(() => useCard("missing")).result.current).toBeUndefined();
+  });
+
+  it("selects cards and tags for a deck", () => {
+    const remoteCard = createCard({ id: "remote", deckId: "deck-a", tags: ["verb", "n5"] });
+    const localCard = createCard({ id: "local", deckId: "deck-a", tags: ["n5", "kanji"] });
+    const otherCard = createCard({ id: "other", deckId: "deck-b", tags: ["other"] });
+    cardStore.setState({ remoteCards: [remoteCard, otherCard], localCards: [localCard] });
+
+    expect(renderHook(() => useCardsByDeckId("deck-a")).result.current).toEqual({
+      cards: [remoteCard, localCard],
+      tags: ["kanji", "n5", "verb"],
+    });
   });
 });

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -23,11 +23,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
 vi.mock("@/entities/preferences", () => ({ usePreferences: () => mocks.preferences, setDarkMode: vi.fn() }));
 vi.mock("@/entities/card", () => ({
-  filterCardsByDeckId: (cards: Card[], id: string) => cards.filter((card) => card.deckId === id),
-  filterTagsByDeckId: (cards: Card[], id: string) => [
-    ...new Set(cards.filter((card) => card.deckId === id).flatMap((card) => card.tags)),
-  ],
-  useCards: () => mocks.cards,
+  useCardsByDeckId: (id: string) => {
+    const cards = mocks.cards.filter((card) => card.deckId === id);
+    return { cards, tags: [...new Set(cards.flatMap((card) => card.tags))] };
+  },
 }));
 vi.mock("@/entities/deck", () => ({ useDeck: () => mocks.deck ?? undefined }));
 vi.mock("@/features/card-list", () => ({

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
+import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { filterCardsByDeckId, filterTagsByDeckId, type Card, type CardId, useCards } from "@/entities/card";
+import { type Card, type CardId, useCardsByDeckId } from "@/entities/card";
 import { type Deck, useDeck } from "@/entities/deck";
 import { type Preferences, usePreferences } from "@/entities/preferences";
 import { CardList } from "@/features/card-list";
@@ -47,11 +47,9 @@ export const CardListPage: React.FC = () => {
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
   const preferences = usePreferences();
-  const allCards = useCards();
   const deck = useDeck(deckId);
-  const deckCards = React.useMemo(() => filterCardsByDeckId(allCards, deckId), [allCards, deckId]);
+  const { cards: deckCards, tags } = useCardsByDeckId(deckId);
   const cards = useStudyCards(deck, deckCards, preferences);
-  const tags = filterTagsByDeckId(allCards, deckId);
 
   useKey("t", () => void navigate("/"));
   useKey("s", () => void navigate("/settings"));

--- a/src/pages/deck-start/ui/DeckStartPage.spec.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.spec.tsx
@@ -19,9 +19,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/card", () => ({
-  filterCardsByDeckId: () => mocks.cards,
-  filterTagsByDeckId: () => [],
-  useCards: () => mocks.cards,
+  useCardsByDeckId: () => ({ cards: mocks.cards, tags: [] }),
 }));
 vi.mock("@/entities/deck", () => ({
   useDeck: () => mocks.deck ?? undefined,

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -2,11 +2,11 @@ import type { Card } from "@/entities/card";
 import { type Deck, useDeck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
-import * as React from "react";
+import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { filterCardsByDeckId, filterTagsByDeckId, useCards } from "@/entities/card";
+import { useCardsByDeckId } from "@/entities/card";
 import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
 import { useStudyActions, useStudyCards } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
@@ -51,11 +51,9 @@ export const DeckStartPage: React.FC = () => {
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
   const preferences = usePreferences();
-  const allCards = useCards();
   const deck = useDeck(deckId);
-  const deckCards = React.useMemo(() => filterCardsByDeckId(allCards, deckId), [allCards, deckId]);
+  const { cards: deckCards, tags } = useCardsByDeckId(deckId);
   const cards = useStudyCards(deck, deckCards, preferences);
-  const tags = filterTagsByDeckId(allCards, deckId);
 
   if (deck == null) {
     return (


### PR DESCRIPTION
## Summary

- add `useCardsByDeckId` to the `entities/card` public API
- return deck-scoped cards and sorted unique tags from the hook
- migrate `CardListPage` and `DeckStartPage` away from composing card filters directly
- keep tag filtering internal now that pages consume the entity hook

## Why

Deck-scoped card and tag lookup is a shared card entity query. Centralizing it removes duplicated page-level filtering and hides card collection details from route adapters.

## Impact

Pages now consume a single entity API while study-card generation remains in the study feature. No new dependency between the card and deck entities is introduced.

## Validation

- `mise run check`
- 99 unit test files passed (489 tests)

Closes #938