### PR TITLE
refactor(#745): Move study workflow into feature

### DIFF
--- a/src/features/study/components/StudyWorkflow.spec.tsx
+++ b/src/features/study/components/StudyWorkflow.spec.tsx
@@ -1,0 +1,195 @@
+import type { Card } from "@/entities/card";
+import type { DeckId } from "@/entities/deck";
+import type { Preferences } from "@/entities/preferences";
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPreferences } from "@/test/factories";
+
+const mocks = vi.hoisted(() => ({
+  preferences: null as Preferences | null,
+  hydrated: true,
+  update: vi.fn(),
+  onUnavailable: vi.fn(),
+  touchStudySession: vi.fn(),
+  toggleShowHeader: vi.fn(),
+  toggleShowSwipeButtonList: vi.fn(),
+}));
+
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+vi.mock("@/entities/preferences", () => ({
+  usePreferences: () => {
+    if (mocks.preferences == null) throw new Error("Preferences not initialized");
+    return mocks.preferences;
+  },
+  toggleShowHeader: mocks.toggleShowHeader,
+  toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
+}));
+vi.mock("../hooks/useEditStudyProgress", () => ({
+  useEditStudyProgress: () => ({ update: mocks.update }),
+}));
+vi.mock("../hooks/useStudyHydrated", () => ({
+  useStudyHydrated: () => mocks.hydrated,
+}));
+vi.mock("../commands/studySessionCommands", () => ({
+  touchStudySession: mocks.touchStudySession,
+}));
+
+import { StudyWorkflow, type StudyWorkflowState } from "./StudyWorkflow";
+import { studyStore } from "../state/studyStoreInstance";
+
+const deckId: DeckId = "deck-id";
+const createCard = (id: string): Card => ({
+  id,
+  deckId,
+  uid: "user-id",
+  frontText: id,
+  backText: `${id}-back`,
+  tags: [],
+  uniqueKey: id,
+  score: 0,
+  numberOfSeen: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  lastSeenAt: 0,
+});
+const cards = [createCard("card-1"), createCard("card-2"), createCard("card-3")];
+
+const WorkflowView = ({ state }: { state: StudyWorkflowState }) => {
+  if (state.status !== "ready") return <div>{state.status}</div>;
+  return (
+    <div>
+      <div>{state.card.id}</div>
+      <div data-testid="back">{String(state.showBackText)}</div>
+      <div data-testid="autoplay">{String(state.controller.autoPlay)}</div>
+      <div data-testid="index">{state.controller.index}</div>
+      <div data-testid="feedback">{state.swipeFeedback ?? "none"}</div>
+      <button type="button" onClick={state.actions.toggleShowBackText}>
+        toggle back
+      </button>
+      <button type="button" onClick={state.actions.swipeLeft}>
+        swipe left
+      </button>
+      <button type="button" onClick={state.actions.swipeRight}>
+        swipe right
+      </button>
+    </div>
+  );
+};
+
+const renderWorkflow = (currentCards: readonly Card[] = cards) =>
+  render(
+    <StudyWorkflow cards={currentCards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
+      {(state) => <WorkflowView state={state} />}
+    </StudyWorkflow>
+  );
+
+describe("StudyWorkflow", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    mocks.hydrated = true;
+    mocks.update.mockResolvedValue(undefined);
+    mocks.preferences = createPreferences({
+      cardInterval: 1,
+      defaultAutoPlay: false,
+      showHeader: true,
+      showSwipeFeedback: true,
+      cardSwipeLeft: "GoToNextCardMastered",
+      cardSwipeRight: "GoToNextCardMastered",
+    });
+    studyStore.setState({ sessionsByDeckId: {} });
+    studyStore.getState().startStudy(
+      deckId,
+      cards.map(({ id }) => id)
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("selects the active Card and connects shortcuts to current actions", async () => {
+    renderWorkflow();
+
+    expect(screen.getByText("card-1")).toBeVisible();
+    expect(mocks.touchStudySession).toHaveBeenCalledWith(deckId);
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(screen.getByTestId("back")).toHaveTextContent("true");
+    fireEvent.keyDown(window, { key: "h" });
+    fireEvent.keyDown(window, { key: "b" });
+    expect(mocks.toggleShowHeader).toHaveBeenCalledOnce();
+    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    await waitFor(() => expect(screen.getByText("card-2")).toBeVisible());
+    expect(mocks.update).toHaveBeenCalledOnce();
+  });
+
+  it("waits for Card readiness and exits only after hydration confirms unavailability", async () => {
+    const { unmount } = renderWorkflow([]);
+    expect(screen.getByText("loading")).toBeVisible();
+    expect(mocks.onUnavailable).not.toHaveBeenCalled();
+    unmount();
+
+    studyStore.setState({ sessionsByDeckId: {} });
+    mocks.hydrated = false;
+    const view = renderWorkflow();
+    expect(screen.getByText("unavailable")).toBeVisible();
+    expect(mocks.onUnavailable).not.toHaveBeenCalled();
+
+    mocks.hydrated = true;
+    view.rerender(
+      <StudyWorkflow cards={cards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
+        {(state) => <WorkflowView state={state} />}
+      </StudyWorkflow>
+    );
+    await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+  });
+
+  it("restarts repeated swipe feedback timing", async () => {
+    vi.useFakeTimers();
+    renderWorkflow();
+
+    fireEvent.click(screen.getByRole("button", { name: "swipe left" }));
+    await Promise.resolve();
+    expect(screen.getByTestId("feedback")).toHaveTextContent("cardSwipeLeft");
+    act(() => vi.advanceTimersByTime(500));
+    fireEvent.click(screen.getByRole("button", { name: "swipe left" }));
+    await Promise.resolve();
+
+    act(() => vi.advanceTimersByTime(899));
+    expect(screen.getByTestId("feedback")).toHaveTextContent("cardSwipeLeft");
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByTestId("feedback")).toHaveTextContent("none");
+  });
+
+  it("rolls back feedback, Card position, and back visibility after mutation failure", async () => {
+    mocks.update.mockRejectedValueOnce(new Error("write failed"));
+    renderWorkflow();
+    fireEvent.click(screen.getByRole("button", { name: "toggle back" }));
+    fireEvent.click(screen.getByRole("button", { name: "swipe right" }));
+
+    await waitFor(() => expect(screen.getByTestId("index")).toHaveTextContent("0"));
+    expect(screen.getByTestId("back")).toHaveTextContent("true");
+    expect(screen.getByTestId("feedback")).toHaveTextContent("none");
+  });
+
+  it("drives the controller from autoplay preferences", () => {
+    vi.useFakeTimers();
+    if (mocks.preferences == null) throw new Error("Preferences not initialized");
+    mocks.preferences = createPreferences({
+      ...mocks.preferences,
+      study: { ...mocks.preferences.study, defaultAutoPlay: true, cardInterval: 1 },
+    });
+    renderWorkflow();
+
+    expect(screen.getByTestId("autoplay")).toHaveTextContent("true");
+    act(() => vi.advanceTimersByTime(1000));
+    expect(screen.getByTestId("index")).toHaveTextContent("1");
+  });
+});

--- a/src/features/study/components/StudyWorkflow.tsx
+++ b/src/features/study/components/StudyWorkflow.tsx
@@ -1,0 +1,94 @@
+import type { Card } from "@/entities/card";
+import type { DeckId } from "@/entities/deck";
+import type { SwipeDirection } from "@/entities/preferences";
+
+import type * as React from "react";
+
+import type { ControllerProps } from "./Controller";
+import type { SwipeButtonListProps } from "./SwipeButtonList";
+import { useActiveStudySession, useStudySessionLifecycle } from "../hooks/useActiveStudySession";
+import { useEditStudyProgress } from "../hooks/useEditStudyProgress";
+import { useStudyActions, type StudyActions } from "../hooks/useStudyActions";
+import { useStudyControllerState } from "../hooks/useStudyControllerState";
+import { useStudyDisplayState } from "../hooks/useStudyDisplayState";
+import { useStudyShortcuts } from "../hooks/useStudyShortcuts";
+import { useSwipeFeedback } from "../hooks/useSwipeFeedback";
+
+type PresentationActions = Pick<
+  StudyActions,
+  "swipeUp" | "swipeDown" | "swipeLeft" | "swipeRight" | "toggleShowBackText"
+>;
+
+export type StudyWorkflowState =
+  | { status: "loading" | "unavailable" }
+  | {
+      status: "ready";
+      card: Card;
+      showHeader: boolean;
+      showBackText: boolean;
+      showController: boolean;
+      showSwipeButtonList: boolean;
+      swipeFeedback?: SwipeDirection;
+      actions: PresentationActions;
+      controller: ControllerProps;
+      swipeActions: SwipeButtonListProps;
+    };
+
+interface StudyWorkflowProps {
+  cards: readonly Card[];
+  deckId: DeckId;
+  onUnavailable: () => void;
+  children: (state: StudyWorkflowState) => React.ReactNode;
+}
+
+export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyWorkflowProps) => {
+  const display = useStudyDisplayState();
+  const feedback = useSwipeFeedback(display.preferences.appearance.showSwipeFeedback);
+  const cardMutation = useEditStudyProgress();
+  const actions = useStudyActions(deckId, {
+    cards,
+    cardMutation: { update: cardMutation.update },
+    onSwipe: feedback.showSwipe,
+    showBackText: display.showBackText,
+    onHideBackText: display.hideBackText,
+    onToggleBackText: display.toggleBackText,
+    onRestoreBackText: display.restoreBackText,
+    onToggleAutoPlay: display.toggleAutoPlay,
+  });
+  const session = useActiveStudySession(deckId, cards);
+  useStudySessionLifecycle({ deckId, session, resetStudy: actions.resetStudy, onUnavailable });
+  useStudyShortcuts(actions);
+
+  const controller = useStudyControllerState({
+    autoPlay: display.autoPlay,
+    cardInterval: display.preferences.study.cardInterval,
+    enabled: session.status === "ready" && display.preferences.study.cardInterval > 0,
+    index: session.status === "ready" ? session.index : -1,
+    numberOfCards: session.status === "ready" ? session.numberOfCards : 0,
+    onChange: actions.updateIndex,
+    onToggleAutoPlay: actions.toggleAutoPlay,
+  });
+
+  if (session.status !== "ready") return children(session);
+
+  const swipeActions: SwipeButtonListProps = {
+    disabled: false,
+    onClickUp: actions.swipeUp,
+    onClickDown: actions.swipeDown,
+    onClickLeft: actions.swipeLeft,
+    onClickRight: actions.swipeRight,
+  };
+  const state: StudyWorkflowState = {
+    status: "ready",
+    card: session.card,
+    showHeader: display.preferences.appearance.showHeader && !display.showBackText,
+    showBackText: display.showBackText,
+    showController: display.preferences.study.cardInterval > 0,
+    showSwipeButtonList: display.preferences.controls.showSwipeButtonList,
+    actions,
+    controller,
+    swipeActions,
+    ...(feedback.lastSwipe !== undefined ? { swipeFeedback: feedback.lastSwipe } : {}),
+  };
+  return children(state);
+};

--- a/src/features/study/hooks/useActiveStudySession.ts
+++ b/src/features/study/hooks/useActiveStudySession.ts
@@ -1,0 +1,64 @@
+import type { Card } from "@/entities/card";
+import type { DeckId } from "@/entities/deck";
+
+import * as React from "react";
+
+import { touchStudySession } from "../commands/studySessionCommands";
+import { selectStudySessionForRoute } from "../state/studyStore";
+import { useStudyHydrated } from "./useStudyHydrated";
+import { useStudyStore } from "./useStudyStore";
+
+export type ActiveStudySession =
+  | { status: "loading" | "unavailable" }
+  | {
+      status: "ready";
+      card: Card;
+      index: number;
+      numberOfCards: number;
+    };
+
+export const useActiveStudySession = (deckId: DeckId, cards: readonly Card[]): ActiveStudySession => {
+  const session = useStudyStore(selectStudySessionForRoute(deckId));
+  const index = session?.currentIndex ?? -1;
+  const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
+  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
+  const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
+
+  if (card != null && sessionHasTargetCard) {
+    return { status: "ready", card, index, numberOfCards: session.cardOrderIds.length };
+  }
+  if (sessionHasTargetCard && cards.length === 0) return { status: "loading" };
+  return { status: "unavailable" };
+};
+
+export const useStudySessionLifecycle = ({
+  deckId,
+  session,
+  resetStudy,
+  onUnavailable,
+}: {
+  deckId: DeckId;
+  session: ActiveStudySession;
+  resetStudy: () => void;
+  onUnavailable: () => void;
+}) => {
+  const hydrated = useStudyHydrated();
+  const exitingDeck = React.useRef<DeckId>(undefined);
+
+  React.useEffect(() => {
+    if (session.status !== "ready") return;
+    touchStudySession(deckId);
+  }, [deckId, session.status]);
+
+  React.useEffect(() => {
+    if (session.status === "ready") {
+      exitingDeck.current = undefined;
+      return;
+    }
+    if (!hydrated || session.status === "loading" || exitingDeck.current === deckId) return;
+
+    exitingDeck.current = deckId;
+    resetStudy();
+    onUnavailable();
+  }, [deckId, hydrated, onUnavailable, resetStudy, session.status]);
+};

--- a/src/features/study/hooks/useStudyDisplayState.ts
+++ b/src/features/study/hooks/useStudyDisplayState.ts
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { usePreferences } from "@/entities/preferences";
+
+export const useStudyDisplayState = () => {
+  const preferences = usePreferences();
+  const [showBackText, setShowBackText] = React.useState(false);
+  const [autoPlay, setAutoPlay] = React.useState(preferences.study.defaultAutoPlay);
+
+  return {
+    autoPlay,
+    showBackText,
+    preferences,
+    hideBackText: React.useCallback(() => setShowBackText(false), []),
+    toggleBackText: React.useCallback(() => setShowBackText((visible) => !visible), []),
+    restoreBackText: React.useCallback((visible: boolean) => setShowBackText(visible), []),
+    toggleAutoPlay: React.useCallback(() => setAutoPlay((playing) => !playing), []),
+  };
+};

--- a/src/features/study/hooks/useStudyShortcuts.ts
+++ b/src/features/study/hooks/useStudyShortcuts.ts
@@ -1,0 +1,16 @@
+import { toggleShowHeader, toggleShowSwipeButtonList } from "@/entities/preferences";
+
+import { useKey } from "react-use";
+
+import type { StudyActions } from "./useStudyActions";
+
+export const useStudyShortcuts = (actions: StudyActions) => {
+  useKey("ArrowUp", actions.swipeUp);
+  useKey("ArrowDown", actions.swipeDown);
+  useKey("ArrowLeft", actions.swipeLeft);
+  useKey("ArrowRight", actions.swipeRight);
+  useKey("Enter", actions.toggleShowBackText);
+  useKey("h", toggleShowHeader);
+  useKey("b", toggleShowSwipeButtonList);
+  useKey(" ", actions.toggleAutoPlay);
+};

--- a/src/features/study/hooks/useSwipeFeedback.ts
+++ b/src/features/study/hooks/useSwipeFeedback.ts
@@ -1,0 +1,30 @@
+import type { SwipeDirection } from "@/entities/preferences";
+
+import * as React from "react";
+
+const SWIPE_FEEDBACK_DURATION_MS = 900;
+
+export const useSwipeFeedback = (enabled: boolean) => {
+  const [lastSwipe, setLastSwipe] = React.useState<{ direction: SwipeDirection; eventId: number }>();
+  const nextEventId = React.useRef(0);
+
+  const showSwipe = React.useCallback(
+    (direction: SwipeDirection) => {
+      if (!enabled) return;
+      const eventId = ++nextEventId.current;
+      setLastSwipe({ direction, eventId });
+      return () => {
+        setLastSwipe((current) => (current?.eventId === eventId ? undefined : current));
+      };
+    },
+    [enabled]
+  );
+
+  React.useEffect(() => {
+    if (lastSwipe === undefined) return;
+    const timeout = window.setTimeout(() => setLastSwipe(undefined), SWIPE_FEEDBACK_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [lastSwipe]);
+
+  return { lastSwipe: enabled ? lastSwipe?.direction : undefined, showSwipe };
+};

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -1,12 +1,10 @@
 export { Controller, type ControllerProps } from "./components/Controller";
+export { StudyWorkflow, type StudyWorkflowState } from "./components/StudyWorkflow";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
 export { removeStudySession, touchStudySession } from "./commands/studySessionCommands";
 export { useStudyHydrated } from "./hooks/useStudyHydrated";
 export { useStudyActions } from "./hooks/useStudyActions";
 export { useStudyCards } from "./hooks/useStudyCards";
-export { useStudyControllerState } from "./hooks/useStudyControllerState";
 export { useStudySessions } from "./hooks/useStudySessions";
-export { useStudyStore } from "./hooks/useStudyStore";
-export { selectStudySessionForRoute } from "./state/studyStore";
 export { clearStudyStore } from "./state/studyStoreInstance";
 export { useEditStudyProgress } from "./hooks/useEditStudyProgress";

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -1,317 +1,144 @@
-/**
- * @file Verifies the "DeckSwiperPage with DeckSwiperView" contract with automated
- * examples.
- * The examples make the expected behavior concrete with cases such as "renders the active session
- * card and forwards study callbacks", "keeps pending study saves silent while disabling swipe
- * controls", "installs one back-navigation guard when StrictMode replays the effect".
- */
+import type { Card } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import type { StudyWorkflowState } from "@/features/study";
 
-import type { Card, CardId } from "@/entities/card";
-import type { Deck, DeckId } from "@/entities/deck";
-import type { Preferences, SwipeDirection } from "@/entities/preferences";
-
-import { act, fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import React from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import type { useStudySessions } from "@/features/study";
-import { createPreferences } from "@/test/factories";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   params: { id: "deck-id" as string | undefined },
-  state: null as { deck: Record<DeckId, Deck>; card: Record<CardId, Card>; preferences: Preferences } | null,
+  deck: undefined as Deck | undefined,
+  cards: [] as Card[],
   navigate: vi.fn(),
-  toggleShowBackText: vi.fn(),
-  toggleAutoPlay: vi.fn(),
-  swipeUp: vi.fn(),
-  swipeDown: vi.fn(),
-  swipeLeft: vi.fn(),
-  swipeRight: vi.fn(),
-  updateIndex: vi.fn(),
-  resetStudy: vi.fn(),
-  cardMutation: {
-    update: vi.fn(),
-  },
-  studyState: {
-    sessionsByDeckId: {} as ReturnType<typeof useStudySessions>,
-  },
-  touchStudySession: vi.fn(),
-  hydrated: true,
-  toggleShowHeader: vi.fn(),
-  toggleShowSwipeButtonList: vi.fn(),
-  setDarkMode: vi.fn(),
+  workflowState: { status: "unavailable" } as StudyWorkflowState,
+  workflowProps: undefined as { cards: readonly Card[]; deckId: string; onUnavailable: () => void } | undefined,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-
-vi.mock("@/entities/preferences", () => ({
-  usePreferences: () => {
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    return mocks.state.preferences;
-  },
-  toggleShowHeader: mocks.toggleShowHeader,
-  toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
-  setDarkMode: mocks.setDarkMode,
-}));
-
 vi.mock("@/entities/deck", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/deck")>();
-  return {
-    ...actual,
-    useDeck: (id: DeckId) => mocks.state?.deck[id],
-  };
+  return { ...actual, useDeck: () => mocks.deck };
 });
-vi.mock("@/entities/card", () => ({
-  useCards: () => Object.values(mocks.state?.card ?? {}),
-}));
-
+vi.mock("@/entities/card", () => ({ useCards: () => mocks.cards }));
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
   useParams: () => mocks.params,
 }));
-
 vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
   return {
     ...actual,
-    touchStudySession: mocks.touchStudySession,
-    useEditStudyProgress: () => mocks.cardMutation,
-    useStudyActions: (
-      _deckId: DeckId,
-      options?: {
-        onSwipe?: (direction: SwipeDirection) => (() => void) | undefined;
-        onToggleBackText?: () => void;
-        onToggleAutoPlay?: () => void;
-      }
-    ) => ({
-      swipeUp: () => {
-        const rollback = options?.onSwipe?.("cardSwipeUp");
-        mocks.swipeUp(rollback);
-      },
-      swipeDown: () => {
-        const rollback = options?.onSwipe?.("cardSwipeDown");
-        mocks.swipeDown(rollback);
-      },
-      swipeLeft: () => {
-        const rollback = options?.onSwipe?.("cardSwipeLeft");
-        mocks.swipeLeft(rollback);
-      },
-      swipeRight: () => {
-        const rollback = options?.onSwipe?.("cardSwipeRight");
-        mocks.swipeRight(rollback);
-      },
-      updateIndex: mocks.updateIndex,
-      toggleShowBackText: () => {
-        options?.onToggleBackText?.();
-        mocks.toggleShowBackText();
-      },
-      toggleAutoPlay: () => {
-        options?.onToggleAutoPlay?.();
-        mocks.toggleAutoPlay();
-      },
-      resetStudy: mocks.resetStudy,
-    }),
-    useStudyHydrated: () => mocks.hydrated,
-    useStudyStore: (selector: (state: typeof mocks.studyState) => unknown) => selector(mocks.studyState),
+    StudyWorkflow: ({
+      children,
+      ...props
+    }: { children: (state: StudyWorkflowState) => React.ReactNode } & {
+      cards: readonly Card[];
+      deckId: string;
+      onUnavailable: () => void;
+    }) => {
+      mocks.workflowProps = props;
+      return children(mocks.workflowState);
+    },
   };
 });
 
 import { DeckSwiperPage } from "./DeckSwiperPage";
 
-describe("DeckSwiperPage with DeckSwiperView", () => {
-  const deck: Deck = {
-    id: "deck-id",
-    uid: "user-id",
-    name: "Deck",
-    isPublic: false,
-    createdAt: 0,
-    updatedAt: 0,
-    deletedAt: null,
-    category: "raw",
-    convertToBr: false,
-    selectedTags: [],
-    tagAndFilter: false,
-    scoreMax: null,
-    scoreMin: null,
-  };
-  const card: Card = {
-    id: "card-id",
-    deckId: deck.id,
-    uid: "user-id",
-    frontText: "FRONT SLOT",
-    backText: "const answer = 42;",
-    tags: ["typescript"],
-    uniqueKey: "unique-key",
-    score: 2,
-    numberOfSeen: 3,
-    createdAt: 0,
-    updatedAt: 0,
-    deletedAt: null,
-    lastSeenAt: 1,
-  };
-  const legacyCard: Card = {
-    ...card,
-    id: "legacy-card-id",
-    frontText: "LEGACY FRONT",
-    uniqueKey: "legacy-key",
-  };
+const deck: Deck = {
+  id: "deck-id",
+  uid: "user-id",
+  name: "Deck",
+  isPublic: false,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  category: "raw",
+  convertToBr: false,
+  selectedTags: [],
+  tagAndFilter: false,
+  scoreMax: null,
+  scoreMin: null,
+};
+const card: Card = {
+  id: "card-id",
+  deckId: deck.id,
+  uid: "user-id",
+  frontText: "FRONT SLOT",
+  backText: "const answer = 42;",
+  tags: ["typescript"],
+  uniqueKey: "unique-key",
+  score: 2,
+  numberOfSeen: 3,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  lastSeenAt: 1,
+};
+const noop = vi.fn();
+const readyState = (): StudyWorkflowState => ({
+  status: "ready",
+  card,
+  showHeader: true,
+  showBackText: false,
+  showController: true,
+  showSwipeButtonList: true,
+  actions: {
+    swipeUp: noop,
+    swipeDown: noop,
+    swipeLeft: noop,
+    swipeRight: noop,
+    toggleShowBackText: noop,
+  },
+  controller: { autoPlay: false, cardInterval: 1, index: 0, numberOfCards: 1, onToggleAutoPlay: noop },
+  swipeActions: { disabled: false },
+});
 
-  const createState = (currentDeck: Deck = deck) => ({
-    deck: { [currentDeck.id]: currentDeck },
-    card: { [card.id]: card, [legacyCard.id]: legacyCard },
-    preferences: createPreferences({
-      cardInterval: 1,
-      darkMode: false,
-      showHeader: true,
-      showSwipeButtonList: true,
-    }),
-  });
-
+describe("DeckSwiperPage", () => {
   beforeEach(() => {
-    localStorage.clear();
     vi.clearAllMocks();
     mocks.params.id = deck.id;
-    mocks.state = createState();
-    mocks.hydrated = true;
-    mocks.studyState.sessionsByDeckId = {
-      [deck.id]: {
-        deckId: deck.id,
-        cardOrderIds: [card.id, legacyCard.id],
-        currentIndex: 0,
-        lastStudiedAt: 0,
-      },
-    };
-    mocks.touchStudySession.mockImplementation((deckId: DeckId) => {
-      const session = mocks.studyState.sessionsByDeckId[deckId];
-      if (session != null) {
-        mocks.studyState.sessionsByDeckId[deckId] = { ...session, lastStudiedAt: Date.now() };
-      }
-    });
+    mocks.deck = deck;
+    mocks.cards = [card];
+    mocks.workflowState = readyState();
+    mocks.workflowProps = undefined;
     window.history.replaceState(null, document.title, document.location.href);
-    mocks.resetStudy.mockImplementation(() => {
-      const { [deck.id]: _removed, ...sessionsByDeckId } = mocks.studyState.sessionsByDeckId;
-      mocks.studyState.sessionsByDeckId = sessionsByDeckId;
-    });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  it("validates the route parameter", () => {
+    mocks.params.id = undefined;
+    expect(() => render(<DeckSwiperPage />)).toThrow("invalid deck id");
   });
 
-  it("renders the active session card and responds to study controls", () => {
+  it("passes Entity reads to StudyWorkflow and composes the application shell", () => {
     render(<DeckSwiperPage />);
 
-    expect(screen.getByText(card.frontText)).toBeVisible();
-    expect(screen.queryByText(legacyCard.frontText)).not.toBeInTheDocument();
-    expect(screen.getByText(/3 times/)).toBeVisible();
-    fireEvent.click(screen.getByText(card.frontText));
-    fireEvent.change(screen.getByRole("slider"), { target: { value: 1 } });
-
-    expect(mocks.toggleShowBackText).toHaveBeenCalledOnce();
-    expect(mocks.updateIndex).toHaveBeenCalledWith(1);
-
-    mocks.toggleShowBackText.mockClear();
-    fireEvent.keyDown(window, { key: "ArrowUp" });
-    fireEvent.keyDown(window, { key: "ArrowDown" });
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-    fireEvent.keyDown(window, { key: "ArrowRight" });
-    fireEvent.keyDown(window, { key: "Enter" });
-    fireEvent.keyDown(window, { key: "h" });
-    fireEvent.keyDown(window, { key: "b" });
-    fireEvent.keyDown(window, { key: " " });
-
-    expect(mocks.swipeUp).toHaveBeenCalledOnce();
-    expect(mocks.swipeDown).toHaveBeenCalledOnce();
-    expect(mocks.swipeLeft).toHaveBeenCalledOnce();
-    expect(mocks.swipeRight).toHaveBeenCalledOnce();
-    expect(mocks.toggleShowBackText).toHaveBeenCalledOnce();
-    expect(mocks.toggleShowHeader).toHaveBeenCalledOnce();
-    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
-    expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
-    expect(screen.getByTestId("pause")).toBeInTheDocument();
-  });
-
-  it("owns header visibility across front and back content", () => {
-    render(<DeckSwiperPage />);
-
-    expect(screen.getByRole("button", { name: "tango" })).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText(card.frontText));
-
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-  });
-
-  it("renders the application shell for the ready study screen", () => {
-    render(<DeckSwiperPage />);
-
+    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, cards: [card] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
+    expect(screen.getByText(card.frontText)).toBeVisible();
+    expect(screen.getByText(/3 times/)).toBeVisible();
   });
 
-  it("shows the last swipe briefly only when feedback is enabled", () => {
-    vi.useFakeTimers();
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.preferences = createPreferences({
-      ...mocks.state.preferences,
-      appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: true },
-    });
+  it.each([
+    ["loading", "Loading…"],
+    ["unavailable", "Study session unavailable."],
+  ] as const)("renders route feedback for %s workflow state", (status, title) => {
+    mocks.workflowState = { status };
     render(<DeckSwiperPage />);
-
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-    expect(screen.getByText("Swiped left")).toHaveAttribute("role", "status");
-
-    act(() => vi.advanceTimersByTime(899));
-    expect(screen.getByText("Swiped left")).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(1));
-    expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
-
-    mocks.state.preferences = createPreferences({
-      ...mocks.state.preferences,
-      appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: false },
-    });
-    fireEvent.keyDown(window, { key: "ArrowRight" });
-    expect(screen.queryByText("Swiped right")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: title })).toBeVisible();
   });
 
-  it("restarts swipe feedback timing for repeated identical swipes", () => {
-    vi.useFakeTimers();
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.preferences = createPreferences({
-      ...mocks.state.preferences,
-      appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: true },
-    });
+  it("converts unavailable intent into current route navigation", () => {
     render(<DeckSwiperPage />);
-
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-    act(() => vi.advanceTimersByTime(500));
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-
-    act(() => vi.advanceTimersByTime(899));
-    expect(screen.getByText("Swiped left")).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(1));
-    expect(screen.queryByText("Swiped left")).not.toBeInTheDocument();
+    act(() => mocks.workflowProps?.onUnavailable());
+    expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("rolls back only the feedback event associated with a failed swipe", () => {
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.preferences = createPreferences({
-      ...mocks.state.preferences,
-      appearance: { ...mocks.state.preferences.appearance, showSwipeFeedback: true },
-    });
+  it("shows route feedback when the Deck Entity is unavailable", () => {
+    mocks.deck = undefined;
     render(<DeckSwiperPage />);
-
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-    const rollbackLeft = mocks.swipeLeft.mock.calls[0]?.[0] as (() => void) | undefined;
-    fireEvent.keyDown(window, { key: "ArrowRight" });
-
-    act(() => rollbackLeft?.());
-    expect(screen.getByText("Swiped right")).toBeInTheDocument();
-
-    const rollbackRight = mocks.swipeRight.mock.calls[0]?.[0] as (() => void) | undefined;
-    act(() => rollbackRight?.());
-    expect(screen.queryByText("Swiped right")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
   });
 
   it("installs one back-navigation guard when StrictMode replays the effect", () => {
@@ -330,147 +157,5 @@ describe("DeckSwiperPage with DeckSwiperView", () => {
     mocks.navigate.mockClear();
     act(() => window.dispatchEvent(new PopStateEvent("popstate")));
     expect(mocks.navigate).not.toHaveBeenCalled();
-  });
-
-  it("updates the route session activity when the study screen opens", () => {
-    const session = mocks.studyState.sessionsByDeckId[deck.id];
-    if (session == null) throw new Error("Expected an active study session");
-    mocks.studyState.sessionsByDeckId[deck.id] = { ...session, lastStudiedAt: 100 };
-    const now = vi.spyOn(Date, "now").mockReturnValue(9000);
-
-    render(<DeckSwiperPage />);
-
-    expect(mocks.touchStudySession).toHaveBeenCalledWith(deck.id);
-    expect(mocks.studyState.sessionsByDeckId[deck.id]?.lastStudiedAt).toBe(9000);
-    now.mockRestore();
-  });
-
-  it("renders back text and controlled auto-play", () => {
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.preferences = createPreferences({
-      ...mocks.state.preferences,
-      study: {
-        ...mocks.state.preferences.study,
-        defaultAutoPlay: true,
-      },
-    });
-    render(<DeckSwiperPage />);
-
-    fireEvent.click(screen.getByText(card.frontText));
-
-    const code = screen.getByText(/answer =/);
-    expect(code).toHaveTextContent(card.backText);
-    expect(screen.getByTestId("pause")).toBeInTheDocument();
-    fireEvent.click(code);
-    fireEvent.click(screen.getByTestId("pause"));
-    const swipeLeftButton = screen.getAllByRole("button", { name: "Swipe left" })[0];
-    const swipeRightButton = screen.getAllByRole("button", { name: "Swipe right" })[0];
-    if (swipeLeftButton == null || swipeRightButton == null) throw new Error("Expected swipe controls");
-    fireEvent.click(swipeLeftButton);
-    fireEvent.click(swipeRightButton);
-
-    expect(mocks.toggleShowBackText).toHaveBeenCalled();
-    expect(mocks.toggleAutoPlay).toHaveBeenCalledOnce();
-    expect(screen.getByTestId("play")).toBeInTheDocument();
-    expect(mocks.swipeLeft).toHaveBeenCalledOnce();
-    expect(mocks.swipeRight).toHaveBeenCalledOnce();
-  });
-
-  it("waits for hydration, then rejects an old-shaped deck without a current session", async () => {
-    const legacyDeck = {
-      ...deck,
-      currentIndex: 0,
-      cardOrderIds: [card.id],
-    };
-    mocks.state = createState(legacyDeck);
-    delete mocks.studyState.sessionsByDeckId[deck.id];
-    mocks.hydrated = false;
-
-    const view = render(<DeckSwiperPage />);
-
-    expect(screen.getByRole("status")).toHaveTextContent("Study session unavailable.");
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-    expect(mocks.resetStudy).not.toHaveBeenCalled();
-    expect(mocks.navigate).not.toHaveBeenCalled();
-    expect(mocks.studyState.sessionsByDeckId[deck.id]).toBeUndefined();
-
-    mocks.hydrated = true;
-    view.rerender(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-    expect(mocks.studyState.sessionsByDeckId[deck.id]).toBeUndefined();
-  });
-
-  it("exits without removing a session that belongs to another deck", async () => {
-    delete mocks.studyState.sessionsByDeckId[deck.id];
-    mocks.studyState.sessionsByDeckId["other-deck"] = {
-      deckId: "other-deck",
-      cardOrderIds: [card.id],
-      currentIndex: 0,
-      lastStudiedAt: 0,
-    };
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-    expect(mocks.studyState.sessionsByDeckId["other-deck"]).toMatchObject({ deckId: "other-deck" });
-  });
-
-  it("resets and exits when no session or legacy candidate exists", async () => {
-    delete mocks.studyState.sessionsByDeckId[deck.id];
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-  });
-
-  it("resets and exits at a terminal session index", async () => {
-    const session = mocks.studyState.sessionsByDeckId[deck.id];
-    if (session == null) throw new Error("Expected an active study session");
-    mocks.studyState.sessionsByDeckId[deck.id] = { ...session, currentIndex: -1 };
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-  });
-
-  it("resets and exits when the session card is missing", async () => {
-    mocks.studyState.sessionsByDeckId[deck.id] = {
-      deckId: deck.id,
-      cardOrderIds: ["missing-card"],
-      currentIndex: 0,
-      lastStudiedAt: 0,
-    };
-
-    render(<DeckSwiperPage />);
-
-    await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-    });
-    expect(mocks.resetStudy).toHaveBeenCalledOnce();
-  });
-
-  it("keeps the study session while Card store is empty before initial snapshot arrives", () => {
-    if (mocks.state == null) throw new Error("Mock state is not initialized");
-    mocks.state.card = {};
-
-    render(<DeckSwiperPage />);
-
-    expect(screen.getByRole("heading", { name: "Loading…" })).toBeInTheDocument();
-    expect(mocks.resetStudy).not.toHaveBeenCalled();
-    expect(mocks.navigate).not.toHaveBeenCalledWith("/", { replace: true });
-    expect(mocks.studyState.sessionsByDeckId[deck.id]).toBeDefined();
   });
 });

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -64,12 +64,7 @@ const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
         }
         cardOverlaySlot={<CardOverlay card={state.card} />}
         backTextSlot={
-          <CardView
-            card={state.card}
-            deck={deck}
-            onClick={state.actions.toggleShowBackText}
-            variant="bare"
-          />
+          <CardView card={state.card} deck={deck} onClick={state.actions.toggleShowBackText} variant="bare" />
         }
         controller={state.controller}
         swipeButtonList={state.swipeActions}

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -1,142 +1,21 @@
-import { getCategory, type Deck, type DeckId, useDeck } from "@/entities/deck";
+import { getCategory, type Deck, useDeck } from "@/entities/deck";
 
 import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useKey } from "react-use";
 
 import { type Card, useCards } from "@/entities/card";
 import { CardOverlay, CardView, FrontText } from "@/features/card-view";
-import {
-  selectStudySessionForRoute,
-  type SwipeButtonListProps,
-  touchStudySession,
-  useEditStudyProgress,
-  useStudyActions,
-  useStudyControllerState,
-  useStudyHydrated,
-  useStudyStore,
-} from "@/features/study";
-import {
-  toggleShowHeader,
-  toggleShowSwipeButtonList,
-  usePreferences,
-  type SwipeDirection,
-} from "@/entities/preferences";
+import { StudyWorkflow, type StudyWorkflowState } from "@/features/study";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckSwiperView } from "./DeckSwiperView";
 
 const STUDY_HISTORY_GUARD = "tangoStudyDeckId";
-const SWIPE_FEEDBACK_DURATION_MS = 900;
 const isHistoryState = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value != null && !Array.isArray(value);
 
-const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
-  const navigate = useNavigate();
-  const deckId = deck.id;
-  const preferences = usePreferences();
-  const session = useStudyStore(selectStudySessionForRoute(deckId));
-  const [showBackText, setShowBackText] = React.useState(false);
-  const [autoPlay, setAutoPlay] = React.useState(preferences.study.defaultAutoPlay);
-  const [lastSwipe, setLastSwipe] = React.useState<{ direction: SwipeDirection; eventId: number } | undefined>(
-    undefined
-  );
-  const nextSwipeEventId = React.useRef(0);
-  const hydrated = useStudyHydrated();
-
-  const handleHideBackText = React.useCallback(() => {
-    setShowBackText(false);
-  }, []);
-  const handleToggleBackText = React.useCallback(() => {
-    setShowBackText((prev) => !prev);
-  }, []);
-  const handleRestoreBackText = React.useCallback((show: boolean) => {
-    setShowBackText(show);
-  }, []);
-  const handleToggleAutoPlay = React.useCallback(() => {
-    setAutoPlay((prev) => !prev);
-  }, []);
-
-  const handleSwipe = React.useCallback(
-    (direction: SwipeDirection) => {
-      if (!preferences.appearance.showSwipeFeedback) return;
-      const eventId = ++nextSwipeEventId.current;
-      setLastSwipe({ direction, eventId });
-      return () => {
-        setLastSwipe((current) => (current?.eventId === eventId ? undefined : current));
-      };
-    },
-    [preferences.appearance.showSwipeFeedback]
-  );
-  const clearLastSwipe = React.useCallback(() => {
-    setLastSwipe(undefined);
-  }, []);
-
-  const index = session?.currentIndex ?? -1;
-  const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  const cardMutation = useEditStudyProgress();
-  const studyActions = useStudyActions(deckId, {
-    cards,
-    cardMutation: {
-      update: cardMutation.update,
-    },
-    onSwipe: handleSwipe,
-    showBackText,
-    onHideBackText: handleHideBackText,
-    onToggleBackText: handleToggleBackText,
-    onRestoreBackText: handleRestoreBackText,
-    onToggleAutoPlay: handleToggleAutoPlay,
-  });
-  useKey("ArrowUp", studyActions.swipeUp);
-  useKey("ArrowDown", studyActions.swipeDown);
-  useKey("ArrowLeft", studyActions.swipeLeft);
-  useKey("ArrowRight", studyActions.swipeRight);
-  useKey("Enter", studyActions.toggleShowBackText);
-  useKey("h", toggleShowHeader);
-  useKey("b", toggleShowSwipeButtonList);
-  useKey(" ", studyActions.toggleAutoPlay);
-
-  React.useEffect(() => {
-    if (lastSwipe === undefined) return;
-
-    const timeout = window.setTimeout(clearLastSwipe, SWIPE_FEEDBACK_DURATION_MS);
-    return () => window.clearTimeout(timeout);
-  }, [clearLastSwipe, lastSwipe]);
-
-  const valid = session != null && index >= 0 && index < session.cardOrderIds.length && card != null;
-  const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
-  const isWaitingForCards = sessionHasTargetCard && card == null && cards.length === 0;
-
-  const controller = useStudyControllerState({
-    autoPlay,
-    cardInterval: preferences.study.cardInterval,
-    enabled: card != null && preferences.study.cardInterval > 0,
-    index,
-    numberOfCards: session?.cardOrderIds.length ?? 0,
-    onChange: studyActions.updateIndex,
-    onToggleAutoPlay: studyActions.toggleAutoPlay,
-  });
-
-  const exitingDeck = React.useRef<DeckId>(undefined);
-  React.useEffect(() => {
-    if (!valid) return;
-    touchStudySession(deckId);
-  }, [deckId, valid]);
-
-  React.useEffect(() => {
-    if (valid) {
-      exitingDeck.current = undefined;
-      return;
-    }
-    if (!hydrated || isWaitingForCards || exitingDeck.current === deckId) return;
-
-    exitingDeck.current = deckId;
-    studyActions.resetStudy();
-    void navigate("/", { replace: true });
-  }, [deckId, hydrated, isWaitingForCards, navigate, studyActions, valid]);
-
+const useStudyHistoryGuard = (deckId: string, navigate: ReturnType<typeof useNavigate>) => {
   // Keep the active study session on the route when browser history moves backward.
   React.useEffect(() => {
     const currentState: unknown = window.history.state;
@@ -152,50 +31,65 @@ const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
       window.removeEventListener("popstate", handlePopState);
     };
   }, [deckId, navigate]);
+};
 
-  if (card == null) {
-    if (isWaitingForCards) {
-      return <RouteFeedback title="Loading…" tone="loading" />;
-    }
-    return <RouteFeedback title="Study session unavailable." tone="not-found" />;
+const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
+  if (state.status !== "ready") {
+    return state.status === "loading" ? (
+      <RouteFeedback title="Loading…" tone="loading" />
+    ) : (
+      <RouteFeedback title="Study session unavailable." tone="not-found" />
+    );
   }
 
-  const category = getCategory(deck.category, card.tags);
-  const swipeActions: SwipeButtonListProps = {
-    disabled: false,
-    onClickUp: studyActions.swipeUp,
-    onClickDown: studyActions.swipeDown,
-    onClickLeft: studyActions.swipeLeft,
-    onClickRight: studyActions.swipeRight,
-  };
+  const category = getCategory(deck.category, state.card.tags);
 
   return (
-    <AppLayout fullscreen scroll={showBackText} showHeader={preferences.appearance.showHeader && !showBackText}>
+    <AppLayout fullscreen scroll={state.showBackText} showHeader={state.showHeader}>
       <DeckSwiperView
-        showController={preferences.study.cardInterval > 0}
-        showBackText={showBackText}
-        showSwipeButtonList={preferences.controls.showSwipeButtonList}
-        {...(preferences.appearance.showSwipeFeedback && lastSwipe !== undefined
-          ? { swipeFeedback: lastSwipe.direction }
-          : {})}
+        showController={state.showController}
+        showBackText={state.showBackText}
+        showSwipeButtonList={state.showSwipeButtonList}
+        {...(state.swipeFeedback !== undefined ? { swipeFeedback: state.swipeFeedback } : {})}
         frontTextSlot={
           <FrontText
             category={category}
-            text={card.frontText}
-            onSwipeUp={studyActions.swipeUp}
-            onSwipeDown={studyActions.swipeDown}
-            onSwipeLeft={studyActions.swipeLeft}
-            onSwipeRight={studyActions.swipeRight}
-            onClick={studyActions.toggleShowBackText}
+            text={state.card.frontText}
+            onSwipeUp={state.actions.swipeUp}
+            onSwipeDown={state.actions.swipeDown}
+            onSwipeLeft={state.actions.swipeLeft}
+            onSwipeRight={state.actions.swipeRight}
+            onClick={state.actions.toggleShowBackText}
           />
         }
-        cardOverlaySlot={<CardOverlay card={card} />}
-        backTextSlot={<CardView card={card} deck={deck} onClick={studyActions.toggleShowBackText} variant="bare" />}
-        controller={controller}
-        swipeButtonList={swipeActions}
-        swipeOverlay={swipeActions}
+        cardOverlaySlot={<CardOverlay card={state.card} />}
+        backTextSlot={
+          <CardView
+            card={state.card}
+            deck={deck}
+            onClick={state.actions.toggleShowBackText}
+            variant="bare"
+          />
+        }
+        controller={state.controller}
+        swipeButtonList={state.swipeActions}
+        swipeOverlay={state.swipeActions}
       />
     </AppLayout>
+  );
+};
+
+const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
+  const navigate = useNavigate();
+  useStudyHistoryGuard(deck.id, navigate);
+  const handleUnavailable = React.useCallback(() => {
+    void navigate("/", { replace: true });
+  }, [navigate]);
+
+  return (
+    <StudyWorkflow key={deck.id} cards={cards} deckId={deck.id} onUnavailable={handleUnavailable}>
+      {(state) => renderStudyScreen(deck, state)}
+    </StudyWorkflow>
   );
 };
 


### PR DESCRIPTION
## Related issue

Fixes #745

## Summary

- Move active session selection, Study actions and mutations, controller state, shortcuts, swipe feedback, and session lifecycle into a focused `StudyWorkflow` facade under `features/study`
- Keep `DeckSwiperPage` limited to route validation, Entity reads, navigation/history guard, route feedback, application shell, and cross-feature presentation composition
- Add focused observable-behavior tests for the Study workflow and narrow Page tests to the route adapter boundary
- Preserve the latest `CardView` presentation contract from current `main`

## Testing

- `mise run check`