### PR TITLE
fix: prepare deck imports from server state (#946)

### DIFF
--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -8,7 +8,7 @@ import type {
   EditCardInput,
 } from "../model/types";
 
-import { collection, doc, getDocs, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
 
 import { db } from "@/shared/firebase";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
@@ -61,7 +61,7 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
   );
 
 export const fetchCards = async (uid: string): Promise<Card[]> => {
-  const snapshot = await getDocs(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
+  const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return snapshot.docs
     .map((document) => convertCardDocumentToCard(document.id, document.data()))
     .filter((card) => card.deletedAt === null);

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -8,7 +8,18 @@ import type {
   EditDeckInput,
 } from "../model/types";
 
-import { collection, deleteDoc, doc, getDocs, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  getDocsFromServer,
+  onSnapshot,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 import { z } from "zod";
 
 import { db } from "@/shared/firebase";
@@ -62,7 +73,7 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
   );
 
 export const fetchDecks = async (uid: string): Promise<Deck[]> => {
-  const snapshot = await getDocs(query(collection(db, DECK_COLLECTION), where("uid", "==", uid)));
+  const snapshot = await getDocsFromServer(query(collection(db, DECK_COLLECTION), where("uid", "==", uid)));
   return snapshot.docs
     .map((document) => convertDeckDtoToDeck(document.id, document.data()))
     .filter((deck) => deck.deletedAt === null);

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -137,9 +137,13 @@ describe("useDeckImport", () => {
     const { result } = renderHook(useTestDeckImport);
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
 
-    await expect(result.current.selectFile(file)).rejects.toThrow("server read failed");
+    await actAsync(async () => {
+      await expect(result.current.selectFile(file)).rejects.toThrow("server read failed");
+    });
 
     expect(result.current.preview).toBeUndefined();
+    expect(result.current.previewError).toEqual(new Error("server read failed"));
+    expect(result.current.error).toBeNull();
     expect(mocks.createDeck).not.toHaveBeenCalled();
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
   });
@@ -450,6 +454,28 @@ describe("useDeckImport", () => {
     mocks.uid = "uid-b";
     rerender();
     finishFetch(new Response('"front","back","","key"'));
+
+    await rejection;
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("does not write when the UID changes during server-backed preparation", async () => {
+    let finishServerRead!: (decks: Deck[]) => void;
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response('"front","back","","key"'));
+    mocks.fetchDecks.mockReturnValueOnce(new Promise<Deck[]>((resolve) => (finishServerRead = resolve)));
+    const { result, rerender } = renderHook(useTestDeckImport);
+
+    const operation = result.current.importUrl("https://example.test/deck.csv");
+    const rejection = expect(operation).rejects.toThrow("user changed");
+    await waitFor(() => expect(mocks.fetchDecks).toHaveBeenCalledWith("uid-a"));
+
+    mocks.uid = "uid-b";
+    rerender();
+    finishServerRead([]);
 
     await rejection;
     expect(mocks.createDeck).not.toHaveBeenCalled();

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -26,6 +26,8 @@ const mocks = vi.hoisted(() => ({
   editCard: vi.fn(),
   createDeck: vi.fn(),
   bulkUpsert: vi.fn(),
+  fetchDecks: vi.fn(),
+  fetchCards: vi.fn(),
 }));
 
 vi.mock("@/entities/auth", () => ({
@@ -37,6 +39,7 @@ vi.mock("@/entities/card", async (importOriginal) => {
   return {
     ...actual,
     filterCardsByDeckId: (cards: Card[], id: DeckId) => cards.filter((card) => card.deckId === id),
+    fetchCards: mocks.fetchCards,
   };
 });
 vi.mock("../api/upsertImportedCards", async (importOriginal) => {
@@ -51,6 +54,7 @@ vi.mock("@/entities/deck", async (importOriginal) => {
   return {
     ...actual,
     generateDeckId: mocks.generateDeckId,
+    fetchDecks: mocks.fetchDecks,
   };
 });
 vi.mock("../lib/cardCsv", async (importOriginal) => {
@@ -85,6 +89,8 @@ describe("useDeckImport", () => {
     mocks.editCard.mockResolvedValue(undefined);
     mocks.createDeck.mockResolvedValue(undefined);
     mocks.bulkUpsert.mockResolvedValue(undefined);
+    mocks.fetchDecks.mockResolvedValue([]);
+    mocks.fetchCards.mockResolvedValue([]);
   });
 
   it("previews a file without writing until import is confirmed", async () => {
@@ -122,6 +128,49 @@ describe("useDeckImport", () => {
       },
     ]);
     expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" });
+    expect(mocks.fetchDecks).toHaveBeenCalledOnce();
+    expect(mocks.fetchCards).toHaveBeenCalledOnce();
+  });
+
+  it("does not mutate when server-backed preview reads fail", async () => {
+    mocks.fetchDecks.mockRejectedValueOnce(new Error("server read failed"));
+    const { result } = renderHook(useTestDeckImport);
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await expect(result.current.selectFile(file)).rejects.toThrow("server read failed");
+
+    expect(result.current.preview).toBeUndefined();
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("previews and executes the same server-backed plan when local state is stale", async () => {
+    const serverDeck = createDeck({ id: "server-deck", name: "deck.csv", uid: "uid-a" });
+    const serverCard = createCard({
+      id: "server-card",
+      deckId: serverDeck.id,
+      uid: "uid-a",
+      frontText: "front",
+      backText: "old back",
+      tags: [],
+      uniqueKey: "key",
+    });
+    mocks.fetchDecks.mockResolvedValueOnce([serverDeck]);
+    mocks.fetchCards.mockResolvedValueOnce([serverCard]);
+    const { result } = renderHook(useTestDeckImport);
+    const file = new File(['"front","new back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await actAsync(async () => result.current.selectFile(file));
+    expect(result.current.preview?.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
+
+    await actAsync(async () => result.current.importPreview());
+
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).toHaveBeenCalledWith([
+      expect.objectContaining({ id: "server-card", backText: "new back" }),
+    ]);
+    expect(mocks.fetchDecks).toHaveBeenCalledOnce();
+    expect(mocks.fetchCards).toHaveBeenCalledOnce();
   });
 
   it("keeps invalid files in preview without mutating state", async () => {
@@ -156,6 +205,8 @@ describe("useDeckImport", () => {
         uniqueKey: "key",
       }),
     ];
+    mocks.fetchDecks.mockResolvedValueOnce(mocks.decks);
+    mocks.fetchCards.mockResolvedValueOnce(mocks.cards);
     const { result } = renderHook(useTestDeckImport);
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
     let imported: DeckImportResult | undefined;
@@ -233,6 +284,17 @@ describe("useDeckImport", () => {
     const { result } = renderHook(useTestDeckImport);
 
     await expect(result.current.importUrl("https://example.test/invalid.csv")).rejects.toThrow("Fix invalid CSV rows");
+
+    expect(mocks.createDeck).not.toHaveBeenCalled();
+    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate when URL import server reads fail", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('"front","back","","key"'));
+    mocks.fetchCards.mockRejectedValueOnce(new Error("server read failed"));
+    const { result } = renderHook(useTestDeckImport);
+
+    await expect(result.current.importUrl("https://example.test/deck.csv")).rejects.toThrow("server read failed");
 
     expect(mocks.createDeck).not.toHaveBeenCalled();
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -16,7 +16,7 @@ import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTyp
 import { parseCsv } from "../lib/cardCsv";
 import { upsertImportedCards } from "../api/upsertImportedCards";
 import type { DeckImportAttempt, DeckImportDependencies, DeckImportRequest } from "../model/deckImportExecution";
-import { executeDeckImport, partialResultFrom, prepareDeckImport } from "../model/deckImportExecution";
+import { executePreparedDeckImport, partialResultFrom, prepareDeckImport } from "../model/deckImportExecution";
 
 export interface DeckImportOptions {
   cards: Card[];
@@ -32,6 +32,7 @@ interface DeckImportState {
   running: boolean;
   validating: boolean;
   preview: DeckImportPreview | undefined;
+  previewError: unknown;
   error: unknown;
   data: DeckImportResult | undefined;
 }
@@ -41,6 +42,7 @@ const initialDeckImportState = (uid: string): DeckImportState => ({
   running: false,
   validating: false,
   preview: undefined,
+  previewError: null,
   error: null,
   data: undefined,
 });
@@ -80,6 +82,7 @@ interface FilePreviewDependencies {
   runningRef: { current: boolean };
   setValidating: (validating: boolean) => void;
   setPreview: (preview: DeckImportPreview | undefined) => void;
+  setPreviewError: (error: unknown) => void;
   reset: () => void;
   prepare: (request: DeckImportRequest) => Promise<DeckImportAttempt>;
   preparedRequest: { current: DeckImportRequest | undefined };
@@ -100,6 +103,7 @@ const previewDeckImportFile = async (
     runningRef,
     setValidating,
     setPreview,
+    setPreviewError,
     reset,
     prepare,
     preparedRequest,
@@ -129,6 +133,9 @@ const previewDeckImportFile = async (
     preparedRequest.current = request;
     setPreview(next);
     return next;
+  } catch (error) {
+    if (isCurrent()) setPreviewError(error);
+    throw error;
   } finally {
     if (isCurrent()) setValidating(false);
   }
@@ -194,6 +201,7 @@ export const useDeckImport = ({
   const setRunning = (running: boolean) => updateState({ running });
   const setValidating = (validating: boolean) => updateState({ validating });
   const setPreview = (preview: DeckImportPreview | undefined) => updateState({ preview });
+  const setPreviewError = (previewError: unknown) => updateState({ previewError });
   const setError = (error: unknown) => updateState({ error });
 
   const mutateAsync = async (request: DeckImportRequest) => {
@@ -203,7 +211,11 @@ export const useDeckImport = ({
       const dependencies = dependenciesRef.current;
       // biome-ignore lint/suspicious/noUnnecessaryConditions: React refs are mutable; remove after biomejs/biome#11174.
       if (dependencies == null) throw new Error("Deck import dependencies are not available");
-      const result = await executeDeckImport(request, dependencies);
+      const attempt = await prepareDeckImport(request, dependencies);
+      if (generation.current !== operationGeneration || generationUid.current !== dependencies.uid) {
+        throw new Error("Deck import user changed before the import could start");
+      }
+      const result = await executePreparedDeckImport(attempt, dependencies);
       if (generation.current === operationGeneration) updateState({ data: result });
       return result;
     } catch (nextError) {
@@ -217,7 +229,7 @@ export const useDeckImport = ({
   const resetOperation = () => {
     lastRequest.current = undefined;
     preparedPreviewRequest.current = undefined;
-    updateState({ data: undefined, error: null });
+    updateState({ data: undefined, previewError: null, error: null });
   };
 
   /**
@@ -237,7 +249,7 @@ export const useDeckImport = ({
     runRef.current = run;
   });
 
-  const { preview, validating, running, error, data } = currentState;
+  const { preview, previewError, validating, running, error, data } = currentState;
 
   /**
    * Validates the selected CSV file and stores its import preview.
@@ -248,6 +260,7 @@ export const useDeckImport = ({
       runningRef,
       setValidating,
       setPreview,
+      setPreviewError,
       reset: resetOperation,
       prepare: async (request) => {
         const dependencies = dependenciesRef.current;
@@ -316,6 +329,7 @@ export const useDeckImport = ({
     validating,
     pending: running,
     error,
+    previewError,
     data,
     partialResult: partialResultFrom(error),
     retry,

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -14,10 +14,9 @@ import { fetchDecks } from "@/entities/deck";
 import { useAuthUid } from "@/entities/auth";
 import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTypes";
 import { parseCsv } from "../lib/cardCsv";
-import { buildDeckImportPlan } from "../lib/deckImportAnalysis";
 import { upsertImportedCards } from "../api/upsertImportedCards";
-import type { DeckImportDependencies, DeckImportRequest } from "../model/deckImportExecution";
-import { executeDeckImport, partialResultFrom } from "../model/deckImportExecution";
+import type { DeckImportAttempt, DeckImportDependencies, DeckImportRequest } from "../model/deckImportExecution";
+import { executeDeckImport, partialResultFrom, prepareDeckImport } from "../model/deckImportExecution";
 
 export interface DeckImportOptions {
   cards: Card[];
@@ -82,8 +81,8 @@ interface FilePreviewDependencies {
   setValidating: (validating: boolean) => void;
   setPreview: (preview: DeckImportPreview | undefined) => void;
   reset: () => void;
-  decks: Deck[];
-  cardsByDeckId: (id: DeckId) => Card[];
+  prepare: (request: DeckImportRequest) => Promise<DeckImportAttempt>;
+  preparedRequest: { current: DeckImportRequest | undefined };
   uid: string;
   currentUid: { current: string };
   generation: number;
@@ -102,8 +101,8 @@ const previewDeckImportFile = async (
     setValidating,
     setPreview,
     reset,
-    decks,
-    cardsByDeckId,
+    prepare,
+    preparedRequest,
     uid,
     currentUid,
     generation,
@@ -118,14 +117,16 @@ const previewDeckImportFile = async (
   try {
     const analysis = await parseCsv(await file.text());
     if (!isCurrent()) throw new Error("Deck import user changed before the preview could finish");
-    const deck = decks.find((candidate) => candidate.name === file.name);
-    const existing = deck == null ? [] : cardsByDeckId(deck.id);
+    const request = { kind: "content", name: file.name, rows: analysis.rows } satisfies DeckImportRequest;
+    const attempt = await prepare(request);
+    if (!isCurrent()) throw new Error("Deck import user changed before the preview could finish");
     const next = {
       fileName: file.name,
       deckName: file.name,
       analysis,
-      plan: buildDeckImportPlan(analysis.rows, existing),
+      plan: attempt.plan,
     };
+    preparedRequest.current = request;
     setPreview(next);
     return next;
   } finally {
@@ -155,6 +156,7 @@ export const useDeckImport = ({
   const currentState = state.uid === uid ? state : initialDeckImportState(uid);
   if (state.uid !== uid) setState(currentState);
   const lastRequest = useRef<DeckImportRequest>(undefined);
+  const preparedPreviewRequest = useRef<DeckImportRequest>(undefined);
   const dependenciesRef = useRef<DeckImportDependencies>(undefined);
   const runRef = useRef<(request: DeckImportRequest) => Promise<DeckImportResult>>(undefined);
   const [retry] = useState(() => () => {
@@ -169,6 +171,7 @@ export const useDeckImport = ({
     generation.current += 1;
     runningRef.current = false;
     lastRequest.current = undefined;
+    preparedPreviewRequest.current = undefined;
   }, [uid]);
   useEffect(() => {
     dependenciesRef.current = {
@@ -213,6 +216,7 @@ export const useDeckImport = ({
 
   const resetOperation = () => {
     lastRequest.current = undefined;
+    preparedPreviewRequest.current = undefined;
     updateState({ data: undefined, error: null });
   };
 
@@ -245,8 +249,13 @@ export const useDeckImport = ({
       setValidating,
       setPreview,
       reset: resetOperation,
-      decks,
-      cardsByDeckId,
+      prepare: async (request) => {
+        const dependencies = dependenciesRef.current;
+        // biome-ignore lint/suspicious/noUnnecessaryConditions: React refs are mutable; remove after biomejs/biome#11174.
+        if (dependencies == null) throw new Error("Deck import dependencies are not available");
+        return await prepareDeckImport(request, dependencies);
+      },
+      preparedRequest: preparedPreviewRequest,
       uid,
       currentUid: generationUid,
       generation: generation.current,
@@ -268,7 +277,10 @@ export const useDeckImport = ({
     if (preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
-    return run({ kind: "content", name: preview.deckName, rows: preview.analysis.rows });
+    const request = preparedPreviewRequest.current;
+    // biome-ignore lint/suspicious/noUnnecessaryConditions: React refs are mutable; remove after biomejs/biome#11174.
+    if (request == null) return Promise.reject(new Error("The prepared Deck import is not available"));
+    return run(request);
   };
 
   /** Downloads card CSV data from a public URL and runs it through the normal import workflow. */

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -6,15 +6,16 @@ import { generateDeckId } from "@/entities/deck";
 import sampleCards from "../../../../sample/build/output.json";
 import { CardBulkMutationError } from "../api/upsertImportedCards";
 import { buildDeckImportPlan } from "../lib/deckImportAnalysis";
-import type { DeckImportResult, DeckImportRow } from "./deckImportTypes";
+import type { DeckImportPlan, DeckImportResult, DeckImportRow } from "./deckImportTypes";
 
-interface DeckImportAttempt {
+export interface DeckImportAttempt {
   uid: string;
   deck: DeckCreateInput;
   createDeckPending: boolean;
   remainingUpserts: CardCreateInput[];
   createdIds: CardId[];
   updatedIds: CardId[];
+  plan: DeckImportPlan;
   totals: Pick<DeckImportResult, "created" | "updated" | "skipped">;
 }
 
@@ -86,8 +87,37 @@ const prepareDeckImportAttempt = (
     remainingUpserts,
     createdIds,
     updatedIds,
+    plan,
     totals: { created: plan.created, updated: plan.updated, skipped: plan.unchanged },
   };
+};
+
+export const prepareDeckImport = async (
+  request: DeckImportRequest,
+  { uid, decks, cardsByDeckId, generateCardId, fetchDecks, fetchCards }: DeckImportDependencies
+): Promise<DeckImportAttempt> => {
+  if (uid === "") throw new Error("A confirmed user is required for imports");
+  if (request.attempt?.uid === uid) return request.attempt;
+
+  let activeDecks = decks;
+  let getCardsByDeckId = cardsByDeckId;
+  if (request.kind === "content") {
+    if (fetchDecks == null || fetchCards == null) {
+      throw new Error("Server-backed Deck import dependencies are not available");
+    }
+    const [remoteDecks, remoteCards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
+    activeDecks = remoteDecks;
+    getCardsByDeckId = (deckId: DeckId) => remoteCards.filter((card) => card.deckId === deckId);
+  }
+
+  const attempt = prepareDeckImportAttempt(request, {
+    uid,
+    decks: activeDecks,
+    cardsByDeckId: getCardsByDeckId,
+    generateCardId,
+  });
+  request.attempt = attempt;
+  return attempt;
 };
 
 export const partialResultFrom = (error: unknown): DeckImportResult | undefined => {
@@ -109,32 +139,10 @@ export const partialResultFrom = (error: unknown): DeckImportResult | undefined 
 
 export const executeDeckImport = async (
   request: DeckImportRequest,
-  { uid, decks, cardsByDeckId, createDeck, generateCardId, bulkUpsert, fetchDecks, fetchCards }: DeckImportDependencies
+  dependencies: DeckImportDependencies
 ): Promise<DeckImportResult> => {
-  if (uid === "") throw new Error("A confirmed user is required for imports");
-
-  let activeDecks = decks;
-  let getCardsByDeckId = cardsByDeckId;
-  if (fetchDecks != null && fetchCards != null) {
-    try {
-      const [remoteDecks, remoteCards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
-      activeDecks = remoteDecks;
-      getCardsByDeckId = (deckId: DeckId) => remoteCards.filter((card) => card.deckId === deckId);
-    } catch {
-      // Fall back to passed dependencies if remote fetch fails
-    }
-  }
-
-  let attempt = request.attempt;
-  if (attempt == null || attempt.uid !== uid) {
-    attempt = prepareDeckImportAttempt(request, {
-      uid,
-      decks: activeDecks,
-      cardsByDeckId: getCardsByDeckId,
-      generateCardId,
-    });
-    request.attempt = attempt;
-  }
+  const { createDeck, bulkUpsert } = dependencies;
+  const attempt = await prepareDeckImport(request, dependencies);
   if (attempt.createDeckPending) {
     await createDeck(attempt.deck);
     attempt.createDeckPending = false;

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -137,12 +137,11 @@ export const partialResultFrom = (error: unknown): DeckImportResult | undefined 
   return result as DeckImportResult;
 };
 
-export const executeDeckImport = async (
-  request: DeckImportRequest,
-  dependencies: DeckImportDependencies
+export const executePreparedDeckImport = async (
+  attempt: DeckImportAttempt,
+  { uid, createDeck, bulkUpsert }: DeckImportDependencies
 ): Promise<DeckImportResult> => {
-  const { createDeck, bulkUpsert } = dependencies;
-  const attempt = await prepareDeckImport(request, dependencies);
+  if (attempt.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
   if (attempt.createDeckPending) {
     await createDeck(attempt.deck);
     attempt.createDeckPending = false;

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   pending: false,
   validating: false,
   error: null as unknown,
+  previewError: null as unknown,
 }));
 
 vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
@@ -51,6 +52,7 @@ vi.mock("@/features/deck-import", () => ({
     pending: mocks.pending,
     validating: mocks.validating,
     error: mocks.error,
+    previewError: mocks.previewError,
   }),
 }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
@@ -102,6 +104,7 @@ describe("DeckImportPage", () => {
     mocks.pending = false;
     mocks.validating = false;
     mocks.error = null;
+    mocks.previewError = null;
   });
 
   it("selects a CSV without importing or navigating automatically", async () => {

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -50,6 +50,7 @@ export const DeckImportPage: React.FC = () => {
         {...(deckImport.data !== undefined ? { result: deckImport.data } : {})}
         {...(deckImport.partialResult !== undefined ? { partialResult: deckImport.partialResult } : {})}
         error={deckImport.error}
+        previewError={deckImport.previewError}
         dark={preferences.appearance.darkMode}
         sampleText={SAMPLE_CSV_TEXT}
       />

--- a/src/pages/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.spec.tsx
@@ -144,6 +144,15 @@ describe("DeckImportView", () => {
     expect(screen.getByText("Choose a corrected CSV file to continue.")).toBeVisible();
   });
 
+  it("shows preview preparation failures without an ineffective retry action", () => {
+    render(<DeckImportView sampleText="front,back,,key" previewError={new Error("server read failed")} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Unable to prepare preview");
+    expect(alert).toHaveTextContent("server read failed");
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+  });
+
   it("keeps success and partial failure results visible with recovery actions", async () => {
     const onBack = vi.fn();
     const onRetry = vi.fn();

--- a/src/pages/deck-import/ui/DeckImportView.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.tsx
@@ -26,6 +26,7 @@ interface DeckImportViewProps {
   result?: DeckImportResult;
   partialResult?: DeckImportResult;
   error?: unknown;
+  previewError?: unknown;
 }
 
 /**
@@ -99,6 +100,18 @@ const ImportResult = (props: ImportResultProps) => {
       >
         Back to decks
       </Button>
+    </section>
+  );
+};
+
+const PreviewError = ({ error }: { error: unknown }) => {
+  if (error == null) return null;
+  const message = error instanceof Error ? error.message : "The import preview could not be prepared.";
+  return (
+    <section role="alert" className="rounded-surface border border-danger bg-surface-muted p-4 text-ink">
+      <h2 className="font-bold">Unable to prepare preview</h2>
+      <p className="mt-1 break-words text-caption text-ink-muted">{message}</p>
+      <p className="mt-2 text-caption text-ink-muted">Choose the CSV file again to retry.</p>
     </section>
   );
 };
@@ -248,6 +261,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
           onRetry={props.onRetry}
           onBack={props.onBack}
         />
+        <PreviewError error={props.previewError} />
         <section>
           <h2 className="mb-3 break-words text-title font-bold text-ink">Choose a CSV file</h2>
           <Upload


### PR DESCRIPTION
## Summary

- read Deck and Card import state explicitly from the Firestore server
- prepare content import attempts before preview and execute the exact prepared attempt after confirmation
- fail content previews and URL imports before any mutation when server reads fail
- preserve local-state Sample Deck behavior and partial-failure retry semantics

## Why

Content import previews previously used subscription-backed local state while execution rebuilt the plan from a remote read, and remote read failures silently fell back to local state. This could make preview counts differ from execution or create mutations from stale data.

## Impact

File previews, confirmed imports, URL imports, and reimports now use authoritative server-backed state. A server read failure is surfaced without creating a Deck or upserting Cards. Sample Deck imports remain unchanged.

## Validation

- `mise run test -- src/features/deck-import/hooks/useDeckImport.spec.tsx`
- `mise run check` (99 test files, 492 tests)

Closes #946