### PR TITLE
refactor(#719): Extract Card Firestore document parser

### DIFF
--- a/src/entities/card/api/document.spec.ts
+++ b/src/entities/card/api/document.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCardDocument } from "./document";
+
+const requiredDocument = {
+  frontText: "Front",
+  backText: "Back",
+  tags: ["science"],
+  uniqueKey: "key-card-a",
+  deckId: "deck-a",
+  uid: "uid-a",
+  createdAt: 1,
+  updatedAt: 2,
+  deletedAt: null,
+  score: 3,
+  numberOfSeen: 4,
+};
+
+describe("Card document", () => {
+  it("parses a valid document without adding optional fields", () => {
+    expect(parseCardDocument("card-a", requiredDocument)).toEqual(requiredDocument);
+  });
+
+  it("preserves optional fields", () => {
+    const document = {
+      ...requiredDocument,
+      id: "legacy-card-a",
+      lastSeenAt: 5,
+      interval: 6,
+      url: "https://example.com/card-a",
+      startLine: 7,
+      endLine: 8,
+    };
+
+    expect(parseCardDocument("card-a", document)).toEqual(document);
+  });
+
+  it("normalizes a Firestore Timestamp-like value to a Date", () => {
+    const date = new Date(60);
+    const nextSeeingAt = { seconds: 0, nanoseconds: 60_000_000, toDate: () => date };
+
+    expect(parseCardDocument("card-a", { ...requiredDocument, nextSeeingAt }).nextSeeingAt).toBe(date);
+  });
+
+  it.each([
+    ["missing", { ...requiredDocument, frontText: undefined }],
+    ["malformed", { ...requiredDocument, tags: [42] }],
+  ])("rejects a %s required field", (_case, document) => {
+    expect(() => parseCardDocument("card-a", document)).toThrowError(
+      expect.objectContaining({
+        name: "FirestoreDocumentValidationError",
+        collectionName: "card",
+        documentId: "card-a",
+      })
+    );
+  });
+
+  it("keeps the collection and document context in parse errors", () => {
+    expect(() => parseCardDocument("card-a", { ...requiredDocument, nextSeeingAt: null })).toThrowError(
+      'Invalid Firestore card document "card-a": nextSeeingAt'
+    );
+  });
+});

--- a/src/entities/card/api/document.ts
+++ b/src/entities/card/api/document.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+import { firestoreTimestampDateSchema, parseFirestoreDocument } from "@/shared/api";
+
+const cardDocumentSchema = z.object({
+  id: z.string().optional(),
+  frontText: z.string(),
+  backText: z.string(),
+  tags: z.array(z.string()),
+  uniqueKey: z.string(),
+  deckId: z.string(),
+  uid: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  deletedAt: z.number().nullable(),
+  score: z.number(),
+  numberOfSeen: z.number(),
+  lastSeenAt: z.number().optional(),
+  nextSeeingAt: firestoreTimestampDateSchema.optional(),
+  interval: z.number().optional(),
+  url: z.string().optional(),
+  startLine: z.number().optional(),
+  endLine: z.number().optional(),
+});
+
+export type CardDocument = z.infer<typeof cardDocumentSchema>;
+
+export const parseCardDocument = (id: string, value: unknown): CardDocument =>
+  parseFirestoreDocument(cardDocumentSchema, "card", id, value);

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -9,62 +9,38 @@ import type {
 } from "../model/types";
 
 import { collection, doc, getDocs, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
-import { z } from "zod";
 
 import { db } from "@/shared/firebase";
-import { firestoreTimestampDateSchema, parseFirestoreDocument } from "@/shared/api";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { createCardSchema, deleteCardSchema, editCardSchema } from "../model/schema";
 import { replaceRemoteCards } from "../model/store";
+import { parseCardDocument } from "./document";
 
 const CARD_COLLECTION = "card";
 
-const cardDtoSchema = z.object({
-  id: z.string().optional(),
-  frontText: z.string(),
-  backText: z.string(),
-  tags: z.array(z.string()),
-  uniqueKey: z.string(),
-  deckId: z.string(),
-  uid: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
-  deletedAt: z.number().nullable(),
-  score: z.number(),
-  numberOfSeen: z.number(),
-  lastSeenAt: z.number().optional(),
-  nextSeeingAt: firestoreTimestampDateSchema.optional(),
-  interval: z.number().optional(),
-  url: z.string().optional(),
-  startLine: z.number().optional(),
-  endLine: z.number().optional(),
-});
-
-type CardDto = z.infer<typeof cardDtoSchema>;
-
-const convertCardDtoToCard = (id: CardId, value: unknown): Card => {
-  const dto: CardDto = parseFirestoreDocument(cardDtoSchema, "card", id, value);
+const convertCardDocumentToCard = (id: CardId, value: unknown): Card => {
+  const document = parseCardDocument(id, value);
   const card: Card = {
     id,
-    frontText: dto.frontText,
-    backText: dto.backText,
-    tags: dto.tags,
-    uniqueKey: dto.uniqueKey,
-    deckId: dto.deckId,
-    uid: dto.uid,
-    createdAt: dto.createdAt,
-    updatedAt: dto.updatedAt,
-    deletedAt: dto.deletedAt,
-    score: dto.score,
-    numberOfSeen: dto.numberOfSeen,
+    frontText: document.frontText,
+    backText: document.backText,
+    tags: document.tags,
+    uniqueKey: document.uniqueKey,
+    deckId: document.deckId,
+    uid: document.uid,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+    deletedAt: document.deletedAt,
+    score: document.score,
+    numberOfSeen: document.numberOfSeen,
   };
-  if (dto.lastSeenAt !== undefined) card.lastSeenAt = dto.lastSeenAt;
-  if (dto.nextSeeingAt !== undefined) card.nextSeeingAt = dto.nextSeeingAt;
-  if (dto.interval !== undefined) card.interval = dto.interval;
-  if (dto.url !== undefined) card.url = dto.url;
-  if (dto.startLine !== undefined) card.startLine = dto.startLine;
-  if (dto.endLine !== undefined) card.endLine = dto.endLine;
+  if (document.lastSeenAt !== undefined) card.lastSeenAt = document.lastSeenAt;
+  if (document.nextSeeingAt !== undefined) card.nextSeeingAt = document.nextSeeingAt;
+  if (document.interval !== undefined) card.interval = document.interval;
+  if (document.url !== undefined) card.url = document.url;
+  if (document.startLine !== undefined) card.startLine = document.startLine;
+  if (document.endLine !== undefined) card.endLine = document.endLine;
   return card;
 };
 
@@ -74,7 +50,7 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
     (snapshot) => {
       try {
         const cards = snapshot.docs
-          .map((document) => convertCardDtoToCard(document.id, document.data()))
+          .map((document) => convertCardDocumentToCard(document.id, document.data()))
           .filter((card) => card.deletedAt === null);
         replaceRemoteCards(cards);
       } catch (cause) {
@@ -87,7 +63,7 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
 export const fetchCards = async (uid: string): Promise<Card[]> => {
   const snapshot = await getDocs(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return snapshot.docs
-    .map((document) => convertCardDtoToCard(document.id, document.data()))
+    .map((document) => convertCardDocumentToCard(document.id, document.data()))
     .filter((card) => card.deletedAt === null);
 };
 


### PR DESCRIPTION
## Summary

- extract the Card Firestore document schema and parser into a pure `document.ts` module
- keep Firestore persistence and Card entity mapping in `firestore.ts`
- add Firebase-independent unit coverage for valid documents, optional fields, timestamp normalization, malformed fields, and parse error context

## Why

The Card document contract was defined inside the Firestore persistence module. This coupled the physical document format to persistence and made the parsed contract difficult to reuse for the follow-up Card/StudyProgress read-mapping work.

This change preserves the stored fields, optionality, timestamp normalization, and validation error behavior. There is no document migration or UI behavior change.

## Validation

- `mise run check`
  - 101 unit test files passed
  - 492 unit tests passed
  - TypeScript, ESLint, Biome, FSD, Knip, Markdown, and Docker lint passed

Closes #719