### PR TITLE
feat(#208): Add complete Study workflow

### DIFF
--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -8,7 +8,17 @@ import type {
   EditCardInput,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  onSnapshot,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 
 import { db } from "@/shared/firebase";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
@@ -65,6 +75,11 @@ export const fetchCards = async (uid: string): Promise<Card[]> => {
   return snapshot.docs
     .map((document) => convertCardDocumentToCard(document.id, document.data()))
     .filter((card) => card.deletedAt === null);
+};
+
+export const fetchCardFromServer = async (cardId: CardId): Promise<Card | null> => {
+  const snapshot = await getDocFromServer(doc(db, CARD_COLLECTION, cardId));
+  return snapshot.exists() ? convertCardDocumentToCard(snapshot.id, snapshot.data()) : null;
 };
 
 export const generateCardId = (): string => doc(collection(db, CARD_COLLECTION)).id;

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,12 @@
-export { createCard, deleteCard, editCard, fetchCards, generateCardId, subscribeCards } from "./api/firestore";
+export {
+  createCard,
+  deleteCard,
+  editCard,
+  fetchCardFromServer,
+  fetchCards,
+  generateCardId,
+  subscribeCards,
+} from "./api/firestore";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";
 export type {

--- a/src/features/study/components/StudyHelpDialog.tsx
+++ b/src/features/study/components/StudyHelpDialog.tsx
@@ -1,0 +1,101 @@
+import type { SwipeState } from "@/entities/preferences";
+
+import * as React from "react";
+
+import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
+import { Button } from "@/shared/ui/button";
+import { buildStudyHelpItems } from "../model/help";
+
+interface StudyHelpDialogProps {
+  controls: SwipeState;
+  onClose: () => void;
+}
+
+const StudyHelpDialog = ({ controls, onClose }: StudyHelpDialogProps) => {
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const closeRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeRef.current?.focus();
+    return () => {
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableElementSelector) ?? []);
+    const first = focusable[0];
+    const last = focusable.at(-1);
+    if (first == null || last == null) {
+      event.preventDefault();
+    } else if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-canvas/70 px-shell-gutter py-6">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Study help"
+        className="w-full max-w-reading rounded-surface border border-border bg-surface-elevated p-4 text-ink shadow-elevated sm:p-6"
+        onKeyDown={handleKeyDown}
+      >
+        <h2 className="text-title font-bold">Study help</h2>
+        <dl className="mt-4 divide-y divide-border">
+          {buildStudyHelpItems(controls).map((item) => (
+            <div key={item.control} className="grid gap-1 py-2 sm:grid-cols-2 sm:gap-4">
+              <dt className="font-semibold">{item.control}</dt>
+              <dd className="text-ink-muted">{item.action}</dd>
+            </div>
+          ))}
+        </dl>
+        <div className="mt-6 flex justify-end">
+          <button
+            ref={closeRef}
+            type="button"
+            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-control border border-border px-4 py-2 font-bold hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface StudyActionsBarProps {
+  controls: SwipeState;
+  onExit: () => void;
+}
+
+export const StudyActionsBar = ({ controls, onExit }: StudyActionsBarProps) => {
+  const [helpOpen, setHelpOpen] = React.useState(false);
+  return (
+    <>
+      <div className="fixed right-3 top-3 z-50 flex gap-2">
+        <Button variant="quiet" size="sm" onClick={() => setHelpOpen(true)}>
+          Help
+        </Button>
+        <Button variant="quiet" size="sm" onClick={onExit}>
+          Exit study
+        </Button>
+      </div>
+      {helpOpen ? <StudyHelpDialog controls={controls} onClose={() => setHelpOpen(false)} /> : null}
+    </>
+  );
+};

--- a/src/features/study/components/StudyStatusScreen.tsx
+++ b/src/features/study/components/StudyStatusScreen.tsx
@@ -1,0 +1,63 @@
+import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { Button } from "@/shared/ui/button";
+import { Layout } from "@/shared/ui/layout";
+
+export const StudyCompletionScreen = ({
+  deckName,
+  cardCount,
+  onRestart,
+  onBackToDeck,
+}: {
+  deckName: string;
+  cardCount: number;
+  onRestart: () => void;
+  onBackToDeck: () => void;
+}) => (
+  <Layout>
+    <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 text-center text-ink shadow-surface md:p-6">
+      <h1 className="text-title font-bold">Study complete</h1>
+      <p className="mt-2 text-body font-semibold">{deckName}</p>
+      <p className="mt-1 text-body text-ink-muted">Completed {cardCount} cards</p>
+      <div className="mt-6 flex flex-wrap justify-center gap-2">
+        <Button variant="quiet" onClick={onBackToDeck}>
+          Back to deck
+        </Button>
+        <Button variant="primary" onClick={onRestart}>
+          Restart session
+        </Button>
+      </div>
+    </section>
+  </Layout>
+);
+
+export const StudyUnavailableScreen = ({
+  onSetupStudy,
+  onBackToDeck,
+}: {
+  onSetupStudy: () => void;
+  onBackToDeck: () => void;
+}) => (
+  <RouteFeedback
+    title="Study session unavailable"
+    description="This study session can no longer be continued."
+    tone="not-found"
+    primaryAction={{ label: "Set up study", onClick: onSetupStudy }}
+    secondaryAction={{ label: "Back to deck", onClick: onBackToDeck }}
+  />
+);
+
+export const StudyVerificationErrorScreen = ({
+  retry,
+  onBackToDeck,
+}: {
+  retry: () => void;
+  onBackToDeck: () => void;
+}) => (
+  <RouteFeedback
+    title="Unable to verify study session"
+    description="The current card could not be checked. Your study session has been preserved."
+    tone="error"
+    primaryAction={{ label: "Retry", onClick: retry }}
+    secondaryAction={{ label: "Back to deck", onClick: onBackToDeck }}
+  />
+);

--- a/src/features/study/components/StudyWorkflow.spec.tsx
+++ b/src/features/study/components/StudyWorkflow.spec.tsx
@@ -12,13 +12,21 @@ const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
   hydrated: true,
   update: vi.fn(),
-  onUnavailable: vi.fn(),
+  fetchCardFromServer: vi.fn(),
+  onExit: vi.fn(),
+  onSetupStudy: vi.fn(),
+  onBackToDeck: vi.fn(),
   touchStudySession: vi.fn(),
   toggleShowHeader: vi.fn(),
   toggleShowSwipeButtonList: vi.fn(),
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/card", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/entities/card")>()),
+  fetchCardFromServer: mocks.fetchCardFromServer,
+}));
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => {
     if (mocks.preferences == null) throw new Error("Preferences not initialized");
@@ -37,7 +45,7 @@ vi.mock("../commands/studySessionCommands", () => ({
   touchStudySession: mocks.touchStudySession,
 }));
 
-import { StudyWorkflow, type StudyWorkflowState } from "./StudyWorkflow";
+import { StudyWorkflow, type ActiveStudyWorkflowState } from "./StudyWorkflow";
 import { studyStore } from "../state/studyStoreInstance";
 
 const deckId: DeckId = "deck-id";
@@ -58,31 +66,35 @@ const createCard = (id: string): Card => ({
 });
 const cards = [createCard("card-1"), createCard("card-2"), createCard("card-3")];
 
-const WorkflowView = ({ state }: { state: StudyWorkflowState }) => {
-  if (state.status !== "ready") return <div>{state.status}</div>;
-  return (
-    <div>
-      <div>{state.card.id}</div>
-      <div data-testid="back">{String(state.showBackText)}</div>
-      <div data-testid="autoplay">{String(state.controller.autoPlay)}</div>
-      <div data-testid="index">{state.controller.index}</div>
-      <div data-testid="feedback">{state.swipeFeedback ?? "none"}</div>
-      <button type="button" onClick={state.actions.toggleShowBackText}>
-        toggle back
-      </button>
-      <button type="button" onClick={state.actions.swipeLeft}>
-        swipe left
-      </button>
-      <button type="button" onClick={state.actions.swipeRight}>
-        swipe right
-      </button>
-    </div>
-  );
-};
+const WorkflowView = ({ state }: { state: ActiveStudyWorkflowState }) => (
+  <div>
+    <div>{state.card.id}</div>
+    <div data-testid="back">{String(state.showBackText)}</div>
+    <div data-testid="autoplay">{String(state.controller.autoPlay)}</div>
+    <div data-testid="index">{state.controller.index}</div>
+    <div data-testid="feedback">{state.swipeFeedback ?? "none"}</div>
+    <button type="button" onClick={state.actions.toggleShowBackText}>
+      toggle back
+    </button>
+    <button type="button" onClick={state.actions.swipeLeft}>
+      swipe left
+    </button>
+    <button type="button" onClick={state.actions.swipeRight}>
+      swipe right
+    </button>
+  </div>
+);
 
 const renderWorkflow = (currentCards: readonly Card[] = cards) =>
   render(
-    <StudyWorkflow cards={currentCards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
+    <StudyWorkflow
+      cards={currentCards}
+      deckId={deckId}
+      deckName="Deck name"
+      onExit={mocks.onExit}
+      onSetupStudy={mocks.onSetupStudy}
+      onBackToDeck={mocks.onBackToDeck}
+    >
       {(state) => <WorkflowView state={state} />}
     </StudyWorkflow>
   );
@@ -93,12 +105,13 @@ describe("StudyWorkflow", () => {
     vi.clearAllMocks();
     mocks.hydrated = true;
     mocks.update.mockResolvedValue(undefined);
+    mocks.fetchCardFromServer.mockResolvedValue(null);
     mocks.preferences = createPreferences({
       cardInterval: 1,
       defaultAutoPlay: false,
       showHeader: true,
       showSwipeFeedback: true,
-      cardSwipeLeft: "GoToNextCardMastered",
+      cardSwipeLeft: "GoToPrevCard",
       cardSwipeRight: "GoToNextCardMastered",
     });
     studyStore.setState({ sessionsByDeckId: {} });
@@ -129,67 +142,136 @@ describe("StudyWorkflow", () => {
     expect(mocks.update).toHaveBeenCalledOnce();
   });
 
-  it("waits for Card readiness and exits only after hydration confirms unavailability", async () => {
-    const { unmount } = renderWorkflow([]);
-    expect(screen.getByText("loading")).toBeVisible();
-    expect(mocks.onUnavailable).not.toHaveBeenCalled();
-    unmount();
+  it("shows current controls in an accessible Help dialog and restores focus", () => {
+    renderWorkflow();
+    const trigger = screen.getByRole("button", { name: "Help" });
+    trigger.focus();
+    fireEvent.click(trigger);
 
-    studyStore.setState({ sessionsByDeckId: {} });
-    mocks.hydrated = false;
-    const view = renderWorkflow();
-    expect(screen.getByText("unavailable")).toBeVisible();
-    expect(mocks.onUnavailable).not.toHaveBeenCalled();
-
-    mocks.hydrated = true;
-    view.rerender(
-      <StudyWorkflow cards={cards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
-        {(state) => <WorkflowView state={state} />}
-      </StudyWorkflow>
-    );
-    await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
-    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+    const dialog = screen.getByRole("dialog", { name: "Study help" });
+    expect(dialog).toHaveTextContent("Swipe/Arrow Right");
+    expect(dialog).toHaveTextContent("Mark mastered and next");
+    expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Close" }), { key: "ArrowRight" });
+    expect(mocks.update).not.toHaveBeenCalled();
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Study help" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
   });
 
-  it("restarts repeated swipe feedback timing", async () => {
-    vi.useFakeTimers();
+  it("preserves the session for explicit Exit and configured GoBack", async () => {
+    const view = renderWorkflow();
+    fireEvent.click(screen.getByRole("button", { name: "Exit study" }));
+    expect(mocks.onExit).toHaveBeenCalledWith(deckId);
+    expect(studyStore.getState().sessionsByDeckId[deckId]?.currentIndex).toBe(0);
+
+    if (mocks.preferences == null) throw new Error("Preferences not initialized");
+    mocks.preferences = createPreferences({
+      ...mocks.preferences,
+      controls: { ...mocks.preferences.controls, cardSwipeLeft: "GoBack" },
+    });
+    view.unmount();
+    renderWorkflow();
+    fireEvent.click(screen.getByRole("button", { name: "swipe left" }));
+    await waitFor(() => expect(mocks.onExit).toHaveBeenCalledTimes(2));
+    expect(studyStore.getState().sessionsByDeckId[deckId]?.cardOrderIds).toEqual(cards.map(({ id }) => id));
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("completes only after the final forward mutation succeeds and restarts the same order", async () => {
+    const order = [cards[1]?.id ?? "", cards[0]?.id ?? ""];
+    studyStore.getState().startStudy(deckId, order);
+    studyStore.getState().setCurrentIndex(deckId, 1);
     renderWorkflow();
 
-    fireEvent.click(screen.getByRole("button", { name: "swipe left" }));
-    await Promise.resolve();
-    expect(screen.getByTestId("feedback")).toHaveTextContent("cardSwipeLeft");
-    act(() => vi.advanceTimersByTime(500));
-    fireEvent.click(screen.getByRole("button", { name: "swipe left" }));
-    await Promise.resolve();
+    fireEvent.click(screen.getByRole("button", { name: "swipe right" }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Study complete" })).toBeVisible());
+    expect(screen.getByText("Deck name")).toBeVisible();
+    expect(screen.getByText("Completed 2 cards")).toBeVisible();
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
 
-    act(() => vi.advanceTimersByTime(899));
-    expect(screen.getByTestId("feedback")).toHaveTextContent("cardSwipeLeft");
-    act(() => vi.advanceTimersByTime(1));
-    expect(screen.getByTestId("feedback")).toHaveTextContent("none");
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck" }));
+    expect(mocks.onBackToDeck).toHaveBeenCalledWith(deckId);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart session" }));
+    expect(screen.getByText("card-2")).toBeVisible();
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toMatchObject({ cardOrderIds: order, currentIndex: 0 });
   });
 
-  it("rolls back feedback, Card position, and back visibility after mutation failure", async () => {
+  it("keeps the final Card, session, and feedback contract when mutation fails", async () => {
+    studyStore.getState().startStudy(deckId, [cards[0]?.id ?? ""]);
     mocks.update.mockRejectedValueOnce(new Error("write failed"));
     renderWorkflow();
     fireEvent.click(screen.getByRole("button", { name: "toggle back" }));
     fireEvent.click(screen.getByRole("button", { name: "swipe right" }));
 
-    await waitFor(() => expect(screen.getByTestId("index")).toHaveTextContent("0"));
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledOnce());
+    expect(screen.queryByRole("heading", { name: "Study complete" })).not.toBeInTheDocument();
     expect(screen.getByTestId("back")).toHaveTextContent("true");
     expect(screen.getByTestId("feedback")).toHaveTextContent("none");
+    expect(studyStore.getState().sessionsByDeckId[deckId]?.currentIndex).toBe(0);
   });
 
-  it("drives the controller from autoplay preferences", () => {
+  it("treats previous on the first Card as a no-op", async () => {
+    renderWorkflow();
+    fireEvent.click(screen.getByRole("button", { name: "swipe left" }));
+    await Promise.resolve();
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(screen.getByTestId("index")).toHaveTextContent("0");
+  });
+
+  it("verifies a missing local Card before cleaning up a stale session", async () => {
+    renderWorkflow([]);
+    expect(screen.getByRole("heading", { name: "Loading…" })).toBeVisible();
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeDefined();
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Study session unavailable" })).toBeVisible());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+    fireEvent.click(screen.getByRole("button", { name: "Set up study" }));
+    expect(mocks.onSetupStudy).toHaveBeenCalledWith(deckId);
+  });
+
+  it("does not verify or clean up while the Study store is hydrating", () => {
+    mocks.hydrated = false;
+    renderWorkflow([]);
+
+    expect(screen.getByRole("heading", { name: "Loading…" })).toBeVisible();
+    expect(mocks.fetchCardFromServer).not.toHaveBeenCalled();
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeDefined();
+  });
+
+  it("cleans up a remotely confirmed deleted or mismatched Card", async () => {
+    mocks.fetchCardFromServer.mockResolvedValueOnce({ ...cards[0], deletedAt: 1 });
+    renderWorkflow([]);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Study session unavailable" })).toBeVisible());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+  });
+
+  it("preserves the session and offers retry when Card verification fails", async () => {
+    mocks.fetchCardFromServer.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce(cards[0]);
+    renderWorkflow([]);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Unable to verify study session" })).toBeVisible());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText("card-1")).toBeVisible());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeDefined();
+  });
+
+  it("stops autoplay on the final Card without completing", () => {
     vi.useFakeTimers();
+    studyStore.getState().startStudy(deckId, [cards[0]?.id ?? ""]);
     if (mocks.preferences == null) throw new Error("Preferences not initialized");
     mocks.preferences = createPreferences({
       ...mocks.preferences,
       study: { ...mocks.preferences.study, defaultAutoPlay: true, cardInterval: 1 },
     });
     renderWorkflow();
-
     expect(screen.getByTestId("autoplay")).toHaveTextContent("true");
     act(() => vi.advanceTimersByTime(1000));
-    expect(screen.getByTestId("index")).toHaveTextContent("1");
+    expect(screen.getByTestId("autoplay")).toHaveTextContent("false");
+    expect(screen.queryByRole("heading", { name: "Study complete" })).not.toBeInTheDocument();
+    expect(studyStore.getState().sessionsByDeckId[deckId]?.currentIndex).toBe(0);
   });
 });

--- a/src/features/study/components/StudyWorkflow.tsx
+++ b/src/features/study/components/StudyWorkflow.tsx
@@ -1,10 +1,13 @@
-import type { Card } from "@/entities/card";
+import type { Card, CardId } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { SwipeDirection } from "@/entities/preferences";
 
-import type * as React from "react";
+import * as React from "react";
 
+import { RouteFeedback } from "@/shared/ui/route-feedback";
 import type { ControllerProps } from "./Controller";
+import { StudyActionsBar } from "./StudyHelpDialog";
+import { StudyCompletionScreen, StudyUnavailableScreen, StudyVerificationErrorScreen } from "./StudyStatusScreen";
 import type { SwipeButtonListProps } from "./SwipeButtonList";
 import { useActiveStudySession, useStudySessionLifecycle } from "../hooks/useActiveStudySession";
 import { useEditStudyProgress } from "../hooks/useEditStudyProgress";
@@ -19,31 +22,41 @@ type PresentationActions = Pick<
   "swipeUp" | "swipeDown" | "swipeLeft" | "swipeRight" | "toggleShowBackText"
 >;
 
-export type StudyWorkflowState =
-  | { status: "loading" | "unavailable" }
-  | {
-      status: "ready";
-      card: Card;
-      showHeader: boolean;
-      showBackText: boolean;
-      showController: boolean;
-      showSwipeButtonList: boolean;
-      swipeFeedback?: SwipeDirection;
-      actions: PresentationActions;
-      controller: ControllerProps;
-      swipeActions: SwipeButtonListProps;
-    };
+export interface ActiveStudyWorkflowState {
+  status: "active";
+  card: Card;
+  showHeader: boolean;
+  showBackText: boolean;
+  showController: boolean;
+  showSwipeButtonList: boolean;
+  swipeFeedback?: SwipeDirection;
+  actions: PresentationActions;
+  controller: ControllerProps;
+  swipeActions: SwipeButtonListProps;
+}
 
 interface StudyWorkflowProps {
   cards: readonly Card[];
   deckId: DeckId;
-  onUnavailable: () => void;
-  children: (state: StudyWorkflowState) => React.ReactNode;
+  deckName: string;
+  onExit: (deckId: DeckId) => void;
+  onSetupStudy: (deckId: DeckId) => void;
+  onBackToDeck: (deckId: DeckId) => void;
+  children: (state: ActiveStudyWorkflowState) => React.ReactNode;
 }
 
-export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyWorkflowProps) => {
+export const StudyWorkflow = ({
+  cards,
+  deckId,
+  deckName,
+  onExit,
+  onSetupStudy,
+  onBackToDeck,
+  children,
+}: StudyWorkflowProps) => {
   const display = useStudyDisplayState();
   const feedback = useSwipeFeedback(display.preferences.appearance.showSwipeFeedback);
+  const [completedOrder, setCompletedOrder] = React.useState<CardId[] | undefined>(undefined);
   const cardMutation = useEditStudyProgress();
   const actions = useStudyActions(deckId, {
     cards,
@@ -54,22 +67,47 @@ export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyW
     onToggleBackText: display.toggleBackText,
     onRestoreBackText: display.restoreBackText,
     onToggleAutoPlay: display.toggleAutoPlay,
+    onStopAutoPlay: display.stopAutoPlay,
+    onExit,
+    onCompleted: ({ cardOrderIds }) => setCompletedOrder(cardOrderIds),
   });
   const session = useActiveStudySession(deckId, cards);
-  useStudySessionLifecycle({ deckId, session, resetStudy: actions.resetStudy, onUnavailable });
-  useStudyShortcuts(actions);
+  useStudySessionLifecycle({ deckId, session, resetStudy: actions.resetStudy });
+  useStudyShortcuts(actions, session.status === "active" && completedOrder == null);
 
   const controller = useStudyControllerState({
     autoPlay: display.autoPlay,
     cardInterval: display.preferences.study.cardInterval,
-    enabled: session.status === "ready" && display.preferences.study.cardInterval > 0,
-    index: session.status === "ready" ? session.index : -1,
-    numberOfCards: session.status === "ready" ? session.numberOfCards : 0,
+    enabled: session.status === "active" && completedOrder == null && display.preferences.study.cardInterval > 0,
+    index: session.status === "active" ? session.index : -1,
+    numberOfCards: session.status === "active" ? session.cardOrderIds.length : 0,
     onChange: actions.updateIndex,
     onToggleAutoPlay: actions.toggleAutoPlay,
+    onStopAutoPlay: display.stopAutoPlay,
   });
 
-  if (session.status !== "ready") return children(session);
+  if (completedOrder != null) {
+    return (
+      <StudyCompletionScreen
+        deckName={deckName}
+        cardCount={completedOrder.length}
+        onRestart={() => {
+          actions.restart(completedOrder);
+          setCompletedOrder(undefined);
+        }}
+        onBackToDeck={() => onBackToDeck(deckId)}
+      />
+    );
+  }
+  if (session.status === "loading") return <RouteFeedback title="Loading…" tone="loading" />;
+  if (session.status === "unavailable") {
+    return (
+      <StudyUnavailableScreen onSetupStudy={() => onSetupStudy(deckId)} onBackToDeck={() => onBackToDeck(deckId)} />
+    );
+  }
+  if (session.status === "error") {
+    return <StudyVerificationErrorScreen retry={session.retry} onBackToDeck={() => onBackToDeck(deckId)} />;
+  }
 
   const swipeActions: SwipeButtonListProps = {
     disabled: false,
@@ -78,8 +116,8 @@ export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyW
     onClickLeft: actions.swipeLeft,
     onClickRight: actions.swipeRight,
   };
-  const state: StudyWorkflowState = {
-    status: "ready",
+  const state: ActiveStudyWorkflowState = {
+    status: "active",
     card: session.card,
     showHeader: display.preferences.appearance.showHeader && !display.showBackText,
     showBackText: display.showBackText,
@@ -90,5 +128,11 @@ export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyW
     swipeActions,
     ...(feedback.lastSwipe !== undefined ? { swipeFeedback: feedback.lastSwipe } : {}),
   };
-  return children(state);
+
+  return (
+    <>
+      {children(state)}
+      <StudyActionsBar controls={display.preferences.controls} onExit={actions.exitStudy} />
+    </>
+  );
 };

--- a/src/features/study/hooks/useActiveStudySession.ts
+++ b/src/features/study/hooks/useActiveStudySession.ts
@@ -1,4 +1,5 @@
-import type { Card } from "@/entities/card";
+import { useAuthUid } from "@/entities/auth";
+import { fetchCardFromServer, type Card, type CardId } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 
 import * as React from "react";
@@ -9,56 +10,107 @@ import { useStudyHydrated } from "./useStudyHydrated";
 import { useStudyStore } from "./useStudyStore";
 
 export type ActiveStudySession =
-  | { status: "loading" | "unavailable" }
+  | { status: "loading" }
+  | { status: "unavailable"; reason: "missing-session" | "missing-card" }
+  | { status: "error"; reason: "card-verification-failed"; retry: () => void }
   | {
-      status: "ready";
+      status: "active";
       card: Card;
       index: number;
-      numberOfCards: number;
+      cardOrderIds: CardId[];
     };
 
+type Verification =
+  | { key: string; status: "loading" }
+  | { key: string; status: "available"; card: Card }
+  | { key: string; status: "missing" }
+  | { key: string; status: "error" };
+
+const isSessionCard = (card: Card, cardId: CardId, deckId: DeckId, uid: string) =>
+  card.id === cardId && card.deckId === deckId && card.uid === uid && card.deletedAt === null;
+
+const resolveVerifiedSession = (
+  verificationKey: string | undefined,
+  verification: Verification | undefined,
+  session: NonNullable<ReturnType<ReturnType<typeof selectStudySessionForRoute>>>,
+  index: number
+): ActiveStudySession => {
+  if (verificationKey == null || verification?.key !== verificationKey || verification.status === "loading") {
+    return { status: "loading" };
+  }
+  if (verification.status === "error") {
+    return { status: "error", reason: "card-verification-failed", retry: () => undefined };
+  }
+  if (verification.status === "missing") return { status: "unavailable", reason: "missing-card" };
+  return { status: "active", card: verification.card, index, cardOrderIds: [...session.cardOrderIds] };
+};
+
 export const useActiveStudySession = (deckId: DeckId, cards: readonly Card[]): ActiveStudySession => {
+  const uid = useAuthUid();
+  const hydrated = useStudyHydrated();
   const session = useStudyStore(selectStudySessionForRoute(deckId));
+  const [retryAttempt, setRetryAttempt] = React.useState(0);
+  const [verification, setVerification] = React.useState<Verification | undefined>(undefined);
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
+  const localCard = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
+  const validTarget = session != null && cardId != null && index >= 0 && index < session.cardOrderIds.length;
+  const verifiedLocalCard =
+    localCard != null && cardId != null && isSessionCard(localCard, cardId, deckId, uid) ? localCard : undefined;
+  const verificationKey =
+    validTarget && verifiedLocalCard == null ? `${uid}:${deckId}:${cardId}:${retryAttempt}` : undefined;
 
-  if (card != null && sessionHasTargetCard) {
-    return { status: "ready", card, index, numberOfCards: session.cardOrderIds.length };
+  React.useEffect(() => {
+    if (!hydrated || verificationKey == null || cardId == null) return;
+    let current = true;
+    void fetchCardFromServer(cardId)
+      .then((card) => {
+        if (!current) return;
+        setVerification(
+          card != null && isSessionCard(card, cardId, deckId, uid)
+            ? { key: verificationKey, status: "available", card }
+            : { key: verificationKey, status: "missing" }
+        );
+      })
+      .catch(() => {
+        if (current) setVerification({ key: verificationKey, status: "error" });
+      });
+    return () => {
+      current = false;
+    };
+  }, [cardId, deckId, hydrated, uid, verificationKey]);
+
+  if (!hydrated) return { status: "loading" };
+  if (!validTarget || session == null) return { status: "unavailable", reason: "missing-session" };
+  if (verifiedLocalCard != null) {
+    return { status: "active", card: verifiedLocalCard, index, cardOrderIds: [...session.cardOrderIds] };
   }
-  if (sessionHasTargetCard && cards.length === 0) return { status: "loading" };
-  return { status: "unavailable" };
+  const result = resolveVerifiedSession(verificationKey, verification, session, index);
+  return result.status === "error" ? { ...result, retry: () => setRetryAttempt((attempt) => attempt + 1) } : result;
 };
 
 export const useStudySessionLifecycle = ({
   deckId,
   session,
   resetStudy,
-  onUnavailable,
 }: {
   deckId: DeckId;
   session: ActiveStudySession;
   resetStudy: () => void;
-  onUnavailable: () => void;
 }) => {
-  const hydrated = useStudyHydrated();
-  const exitingDeck = React.useRef<DeckId>(undefined);
+  const removedStaleCard = React.useRef<string>(undefined);
 
   React.useEffect(() => {
-    if (session.status !== "ready") return;
+    if (session.status !== "active") return;
+    removedStaleCard.current = undefined;
     touchStudySession(deckId);
   }, [deckId, session.status]);
 
   React.useEffect(() => {
-    if (session.status === "ready") {
-      exitingDeck.current = undefined;
-      return;
-    }
-    if (!hydrated || session.status === "loading" || exitingDeck.current === deckId) return;
-
-    exitingDeck.current = deckId;
+    if (session.status !== "unavailable" || session.reason !== "missing-card") return;
+    const staleCard = `${deckId}:${session.reason}`;
+    if (removedStaleCard.current === staleCard) return;
+    removedStaleCard.current = staleCard;
     resetStudy();
-    onUnavailable();
-  }, [deckId, hydrated, onUnavailable, resetStudy, session.status]);
+  }, [deckId, resetStudy, session]);
 };

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -322,14 +322,15 @@ describe("useStudyActions", () => {
     expect(studyStore.getState()).toEqual(before);
   });
 
-  it("removes only the route session for GoBack without a card write", async () => {
+  it("preserves the route session and emits Exit for GoBack without a card write", async () => {
     const rollbackSwipe = vi.fn();
     const onSwipe = vi.fn(() => rollbackSwipe);
+    const onExit = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id, card2.id]);
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     studyStore.getState().setCurrentIndex(deck.id, 1);
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations, onSwipe })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations, onSwipe, onExit })
     );
 
     await actAsync(async () => {
@@ -339,10 +340,13 @@ describe("useStudyActions", () => {
     expect(mocks.cardUpdate).not.toHaveBeenCalled();
     expect(onSwipe).toHaveBeenCalledWith("cardSwipeLeft");
     expect(rollbackSwipe).not.toHaveBeenCalled();
+    expect(onExit).toHaveBeenCalledWith(deck.id);
     expect(studyStore.getState()).toMatchObject({
-      sessionsByDeckId: { "deck-2": { deckId: "deck-2" } },
+      sessionsByDeckId: {
+        [deck.id]: { deckId: deck.id, currentIndex: 1 },
+        "deck-2": { deckId: "deck-2" },
+      },
     });
-    expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
   });
 
   it("updates the session index and notifies onHideBackText", () => {
@@ -382,11 +386,44 @@ describe("useStudyActions", () => {
     expect(onToggleAutoPlay).toHaveBeenCalledOnce();
   });
 
-  it("finishes only the route session after the final card", async () => {
+  it("preserves a final session when explicit Exit wins a pending completion", async () => {
+    let finishWrite: () => void = () => undefined;
+    mocks.cardUpdate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishWrite = resolve;
+        })
+    );
+    const onCompleted = vi.fn();
+    const onExit = vi.fn();
+    studyStore.getState().startStudy(deck.id, [card1.id]);
+    const { result } = renderHook(() =>
+      useStudyActions(deck.id, {
+        cards: getCards(),
+        cardMutation: mocks.cardMutations,
+        onCompleted,
+        onExit,
+      })
+    );
+
+    const completion = result.current.swipeRight();
+    act(() => result.current.exitStudy());
+    await actAsync(async () => {
+      finishWrite();
+      await completion;
+    });
+
+    expect(onExit).toHaveBeenCalledWith(deck.id);
+    expect(onCompleted).not.toHaveBeenCalled();
+    expect(studyStore.getState().sessionsByDeckId[deck.id]?.currentIndex).toBe(0);
+  });
+
+  it("completes only the route session after the final Card mutation succeeds", async () => {
+    const onCompleted = vi.fn();
     studyStore.getState().startStudy(deck.id, [card1.id]);
     studyStore.getState().startStudy("deck-2", ["other-card"]);
     const { result } = renderHook(() =>
-      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations })
+      useStudyActions(deck.id, { cards: getCards(), cardMutation: mocks.cardMutations, onCompleted })
     );
 
     await actAsync(async () => {
@@ -394,6 +431,7 @@ describe("useStudyActions", () => {
     });
 
     expect(mocks.cardUpdate).toHaveBeenCalledOnce();
+    expect(onCompleted).toHaveBeenCalledWith({ deckId: deck.id, cardOrderIds: [card1.id] });
     expect(studyStore.getState().sessionsByDeckId[deck.id]).toBeUndefined();
     expect(studyStore.getState().sessionsByDeckId["deck-2"]).toMatchObject({ deckId: "deck-2" });
   });

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -11,7 +11,7 @@ import type { Preferences, SwipeDirection } from "@/entities/preferences";
 
 import React from "react";
 
-import { buildStudySession, calculateNextIndex } from "../model/session";
+import { buildStudySession, resolveStudyTransition } from "../model/session";
 import { createStudyCard } from "../model/studyCard";
 import { buildStudyPatch, resolveSwipeAction } from "../model/swipe";
 import { studyStore } from "../state/studyStoreInstance";
@@ -19,6 +19,8 @@ import { usePreferences } from "@/entities/preferences";
 
 export interface StudyActions {
   start: (cards: Card[]) => void;
+  restart: (cardOrderIds: string[]) => void;
+  exitStudy: () => void;
   swipeUp: () => Promise<void>;
   swipeDown: () => Promise<void>;
   swipeLeft: () => Promise<void>;
@@ -45,10 +47,14 @@ interface UseStudyActionsOptions {
   onToggleBackText?: (() => void) | undefined;
   onRestoreBackText?: ((showBackText: boolean) => void) | undefined;
   onToggleAutoPlay?: (() => void) | undefined;
+  onStopAutoPlay?: (() => void) | undefined;
+  onExit?: ((deckId: DeckId) => void) | undefined;
+  onCompleted?: ((completion: { deckId: DeckId; cardOrderIds: string[] }) => void) | undefined;
 }
 
 interface StudySwipeDependencies {
   mutationTokenRef: { current: symbol | undefined };
+  exitGenerationRef: { current: number };
   deckId: DeckId;
   preferences: Preferences;
   cards: readonly Card[];
@@ -57,12 +63,14 @@ interface StudySwipeDependencies {
   showBackText?: boolean | undefined;
   onHideBackText?: (() => void) | undefined;
   onRestoreBackText?: ((showBackText: boolean) => void) | undefined;
+  onStopAutoPlay?: (() => void) | undefined;
+  onExit?: ((deckId: DeckId) => void) | undefined;
+  onCompleted?: ((completion: { deckId: DeckId; cardOrderIds: string[] }) => void) | undefined;
 }
 
-const applyOptimisticUpdate = (deckId: DeckId, nextIndex: number) => {
+const applyOptimisticMove = (deckId: DeckId, nextIndex: number) => {
   const state = studyStore.getState();
-  if (nextIndex < 0) state.removeStudy(deckId);
-  else state.setCurrentIndex(deckId, nextIndex);
+  state.setCurrentIndex(deckId, nextIndex);
   return studyStore.getState().sessionsByDeckId[deckId];
 };
 
@@ -71,7 +79,6 @@ type Session = StudyState["sessionsByDeckId"][string];
 
 const revertOptimisticUpdate = (
   deckId: DeckId,
-  nextIndex: number,
   mutationTokenRef: { current: symbol | undefined },
   mutationToken: symbol,
   optimisticSession: Session,
@@ -80,9 +87,7 @@ const revertOptimisticUpdate = (
 ) => {
   const current = studyStore.getState();
   const currentSession = current.sessionsByDeckId[deckId];
-  const changeStillCurrent =
-    mutationTokenRef.current === mutationToken &&
-    (nextIndex < 0 ? currentSession == null : currentSession === optimisticSession);
+  const changeStillCurrent = mutationTokenRef.current === mutationToken && currentSession === optimisticSession;
   if (!changeStillCurrent) return false;
 
   studyStore.setState((state) => ({
@@ -90,6 +95,28 @@ const revertOptimisticUpdate = (
   }));
   onRestoreBackText?.(previous.showBackText);
   return true;
+};
+
+const completeStudyIfCurrent = (
+  deckId: DeckId,
+  session: NonNullable<Session>,
+  mutationTokenRef: { current: symbol | undefined },
+  mutationToken: symbol,
+  exitGenerationRef: { current: number },
+  exitGeneration: number,
+  onStopAutoPlay: (() => void) | undefined,
+  onCompleted: ((completion: { deckId: DeckId; cardOrderIds: string[] }) => void) | undefined
+) => {
+  if (
+    mutationTokenRef.current !== mutationToken ||
+    exitGenerationRef.current !== exitGeneration ||
+    studyStore.getState().sessionsByDeckId[deckId] !== session
+  ) {
+    return;
+  }
+  studyStore.getState().removeStudy(deckId);
+  onStopAutoPlay?.();
+  onCompleted?.({ deckId, cardOrderIds: [...session.cardOrderIds] });
 };
 
 /**
@@ -100,6 +127,7 @@ const runStudySwipe = async (
   direction: SwipeDirection,
   {
     mutationTokenRef,
+    exitGenerationRef,
     deckId,
     preferences,
     cards,
@@ -108,6 +136,9 @@ const runStudySwipe = async (
     showBackText,
     onHideBackText,
     onRestoreBackText,
+    onStopAutoPlay,
+    onExit,
+    onCompleted,
   }: StudySwipeDependencies
 ): Promise<void> => {
   if (mutationTokenRef.current !== undefined) return;
@@ -116,11 +147,13 @@ const runStudySwipe = async (
   if (session == null) return;
 
   const swipeAction = resolveSwipeAction(preferences.controls, direction);
-  if (swipeAction === "DoNothing") return;
-
-  if (swipeAction === "GoBack") {
+  const transition = resolveStudyTransition(session.currentIndex, session.cardOrderIds.length, swipeAction);
+  if (transition.type === "no-op") return;
+  if (transition.type === "exit") {
     onSwipe?.(direction);
-    state.removeStudy(deckId);
+    exitGenerationRef.current += 1;
+    onStopAutoPlay?.();
+    onExit?.(deckId);
     return;
   }
 
@@ -139,16 +172,30 @@ const runStudySwipe = async (
   }
 
   const patch = buildStudyPatch(createStudyCard(card), swipeAction, Date.now());
-  const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
   const mutationToken = Symbol();
+  const exitGeneration = exitGenerationRef.current;
   mutationTokenRef.current = mutationToken;
-  const optimisticSession = applyOptimisticUpdate(deckId, nextIndex);
+  const optimisticSession =
+    transition.type === "move"
+      ? applyOptimisticMove(deckId, transition.index)
+      : studyStore.getState().sessionsByDeckId[deckId];
   try {
     await update(patch);
+    if (transition.type === "complete") {
+      completeStudyIfCurrent(
+        deckId,
+        session,
+        mutationTokenRef,
+        mutationToken,
+        exitGenerationRef,
+        exitGeneration,
+        onStopAutoPlay,
+        onCompleted
+      );
+    }
   } catch {
     const reverted = revertOptimisticUpdate(
       deckId,
-      nextIndex,
       mutationTokenRef,
       mutationToken,
       optimisticSession,
@@ -178,10 +225,14 @@ export const useStudyActions = (
     onToggleBackText,
     onRestoreBackText,
     onToggleAutoPlay,
+    onStopAutoPlay,
+    onExit,
+    onCompleted,
   }: UseStudyActionsOptions
 ): StudyActions => {
   const preferences = usePreferences();
   const mutationTokenRef = React.useRef<symbol | undefined>(undefined);
+  const exitGenerationRef = React.useRef(0);
 
   /**
    * Creates a new study session from the currently filtered cards.
@@ -195,6 +246,18 @@ export const useStudyActions = (
     onStarted?.();
   };
 
+  const restart = (cardOrderIds: string[]) => {
+    studyStore.getState().startStudy(deckId, cardOrderIds);
+    onHideBackText?.();
+    onStopAutoPlay?.();
+  };
+
+  const exitStudy = () => {
+    exitGenerationRef.current += 1;
+    onStopAutoPlay?.();
+    onExit?.(deckId);
+  };
+
   /**
    * Runs the study workflow for one swipe direction.
    * Direction-specific callbacks reuse this function so pending checks, optimistic state, and
@@ -204,6 +267,7 @@ export const useStudyActions = (
     if (cardMutation == null) return Promise.resolve();
     return runStudySwipe(direction, {
       mutationTokenRef,
+      exitGenerationRef,
       deckId,
       preferences,
       cards,
@@ -212,11 +276,16 @@ export const useStudyActions = (
       showBackText,
       onHideBackText,
       onRestoreBackText,
+      onStopAutoPlay,
+      onExit,
+      onCompleted,
     });
   };
 
   return {
     start,
+    restart,
+    exitStudy,
     swipeUp: () => swipe("cardSwipeUp"),
     swipeDown: () => swipe("cardSwipeDown"),
     swipeLeft: () => swipe("cardSwipeLeft"),

--- a/src/features/study/hooks/useStudyControllerState.spec.tsx
+++ b/src/features/study/hooks/useStudyControllerState.spec.tsx
@@ -74,13 +74,47 @@ describe("Controller with useStudyControllerState", () => {
     expect(onChange).toHaveBeenLastCalledWith(3);
   });
 
-  it("does not advance past the existing terminal index behavior", () => {
+  it("stops autoplay on the last Card without advancing to an invalid index", () => {
     const onChange = vi.fn();
-    render(<ControllerHarness onChange={onChange} autoPlay index={5} numberOfCards={5} cardInterval={1} />);
+    const onStopAutoPlay = vi.fn();
+    const LastCardHarness = () => {
+      const controller = useStudyControllerState({
+        onChange,
+        onStopAutoPlay,
+        autoPlay: true,
+        index: 4,
+        numberOfCards: 5,
+        cardInterval: 1,
+      });
+      return <Controller {...controller} />;
+    };
+    render(<LastCardHarness />);
 
     act(() => {
       vi.advanceTimersByTime(1000);
     });
     expect(onChange).not.toHaveBeenCalled();
+    expect(onStopAutoPlay).toHaveBeenCalledOnce();
+  });
+
+  it("uses the same terminal behavior for a one-Card session", () => {
+    const onChange = vi.fn();
+    const onStopAutoPlay = vi.fn();
+    const OneCardHarness = () => {
+      const controller = useStudyControllerState({
+        onChange,
+        onStopAutoPlay,
+        autoPlay: true,
+        index: 0,
+        numberOfCards: 1,
+        cardInterval: 1,
+      });
+      return <Controller {...controller} />;
+    };
+    render(<OneCardHarness />);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onStopAutoPlay).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/study/hooks/useStudyControllerState.ts
+++ b/src/features/study/hooks/useStudyControllerState.ts
@@ -9,6 +9,7 @@ import type { ControllerProps } from "../components/Controller";
 
 export interface UseStudyControllerStateOptions extends ControllerProps {
   enabled?: boolean;
+  onStopAutoPlay?: () => void;
 }
 
 export type StudyControllerState = ControllerProps & {
@@ -28,19 +29,22 @@ export const useStudyControllerState = (props: UseStudyControllerStateOptions): 
   const autoPlay = props.autoPlay ?? false;
   const enabled = props.enabled ?? true;
   const onChange = props.onChange;
+  const onStopAutoPlay = props.onStopAutoPlay;
 
   React.useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !autoPlay || numberOfCards <= 0 || index < 0 || index >= numberOfCards) return;
 
     const timeout = setTimeout(() => {
-      if (autoPlay && index < numberOfCards) {
+      if (index < numberOfCards - 1) {
         onChange?.(index + 1);
+      } else {
+        onStopAutoPlay?.();
       }
     }, cardInterval * 1000);
     return () => {
       clearTimeout(timeout);
     };
-  }, [autoPlay, cardInterval, enabled, index, numberOfCards, onChange]);
+  }, [autoPlay, cardInterval, enabled, index, numberOfCards, onChange, onStopAutoPlay]);
 
   const onToggleAutoPlay = props.onToggleAutoPlay ?? (() => undefined);
 

--- a/src/features/study/hooks/useStudyDisplayState.ts
+++ b/src/features/study/hooks/useStudyDisplayState.ts
@@ -15,5 +15,6 @@ export const useStudyDisplayState = () => {
     toggleBackText: React.useCallback(() => setShowBackText((visible) => !visible), []),
     restoreBackText: React.useCallback((visible: boolean) => setShowBackText(visible), []),
     toggleAutoPlay: React.useCallback(() => setAutoPlay((playing) => !playing), []),
+    stopAutoPlay: React.useCallback(() => setAutoPlay(false), []),
   };
 };

--- a/src/features/study/hooks/useStudyShortcuts.ts
+++ b/src/features/study/hooks/useStudyShortcuts.ts
@@ -2,15 +2,19 @@ import { toggleShowHeader, toggleShowSwipeButtonList } from "@/entities/preferen
 
 import { useKey } from "react-use";
 
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import type { StudyActions } from "./useStudyActions";
 
-export const useStudyShortcuts = (actions: StudyActions) => {
-  useKey("ArrowUp", actions.swipeUp);
-  useKey("ArrowDown", actions.swipeDown);
-  useKey("ArrowLeft", actions.swipeLeft);
-  useKey("ArrowRight", actions.swipeRight);
-  useKey("Enter", actions.toggleShowBackText);
-  useKey("h", toggleShowHeader);
-  useKey("b", toggleShowSwipeButtonList);
-  useKey(" ", actions.toggleAutoPlay);
+export const useStudyShortcuts = (actions: StudyActions, enabled = true) => {
+  const runUnlessInteractive = (action: () => void | Promise<void>) => (event: KeyboardEvent) => {
+    if (enabled && !isInteractiveShortcutTarget(event.target)) void action();
+  };
+  useKey("ArrowUp", runUnlessInteractive(actions.swipeUp));
+  useKey("ArrowDown", runUnlessInteractive(actions.swipeDown));
+  useKey("ArrowLeft", runUnlessInteractive(actions.swipeLeft));
+  useKey("ArrowRight", runUnlessInteractive(actions.swipeRight));
+  useKey("Enter", runUnlessInteractive(actions.toggleShowBackText));
+  useKey("h", runUnlessInteractive(toggleShowHeader));
+  useKey("b", runUnlessInteractive(toggleShowSwipeButtonList));
+  useKey(" ", runUnlessInteractive(actions.toggleAutoPlay));
 };

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -1,5 +1,5 @@
 export { Controller, type ControllerProps } from "./components/Controller";
-export { StudyWorkflow, type StudyWorkflowState } from "./components/StudyWorkflow";
+export { StudyWorkflow, type ActiveStudyWorkflowState } from "./components/StudyWorkflow";
 export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeButtonList";
 export { removeStudySession, touchStudySession } from "./commands/studySessionCommands";
 export { useStudyHydrated } from "./hooks/useStudyHydrated";

--- a/src/features/study/model/help.spec.ts
+++ b/src/features/study/model/help.spec.ts
@@ -1,0 +1,44 @@
+import type { SwipeAction } from "@/entities/preferences";
+
+import { describe, expect, it } from "vitest";
+
+import { buildStudyHelpItems } from "./help";
+
+describe("Study help model", () => {
+  it.each<[SwipeAction, string]>([
+    ["DoNothing", "No action"],
+    ["GoBack", "Exit study"],
+    ["GoToPrevCard", "Previous card"],
+    ["GoToNextCard", "Next card"],
+    ["GoToNextCardMastered", "Mark mastered and next"],
+    ["GoToNextCardNotMastered", "Mark not mastered and next"],
+    ["GoToNextCardToggleMastered", "Toggle mastery and next"],
+  ])("maps %s to its current user-facing label", (action, label) => {
+    const [item] = buildStudyHelpItems({
+      cardSwipeUp: action,
+      cardSwipeDown: "DoNothing",
+      cardSwipeLeft: "DoNothing",
+      cardSwipeRight: "DoNothing",
+    });
+    expect(item?.action).toBe(label);
+  });
+
+  it("builds the guide from current controls", () => {
+    expect(
+      buildStudyHelpItems({
+        cardSwipeUp: "GoBack",
+        cardSwipeDown: "DoNothing",
+        cardSwipeLeft: "GoToPrevCard",
+        cardSwipeRight: "GoToNextCardMastered",
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        { control: "Swipe/Arrow Up", action: "Exit study" },
+        { control: "Swipe/Arrow Down", action: "No action" },
+        { control: "Swipe/Arrow Left", action: "Previous card" },
+        { control: "Swipe/Arrow Right", action: "Mark mastered and next" },
+        { control: "Enter", action: "Show/hide answer" },
+      ])
+    );
+  });
+});

--- a/src/features/study/model/help.ts
+++ b/src/features/study/model/help.ts
@@ -1,0 +1,29 @@
+import type { SwipeAction, SwipeState } from "@/entities/preferences";
+
+const swipeActionLabels: Record<SwipeAction, string> = {
+  DoNothing: "No action",
+  GoBack: "Exit study",
+  GoToPrevCard: "Previous card",
+  GoToNextCard: "Next card",
+  GoToNextCardMastered: "Mark mastered and next",
+  GoToNextCardNotMastered: "Mark not mastered and next",
+  GoToNextCardToggleMastered: "Toggle mastery and next",
+};
+
+export interface StudyHelpItem {
+  control: string;
+  action: string;
+}
+
+const getSwipeActionLabel = (action: SwipeAction): string => swipeActionLabels[action];
+
+export const buildStudyHelpItems = (controls: SwipeState): StudyHelpItem[] => [
+  { control: "Swipe/Arrow Up", action: getSwipeActionLabel(controls.cardSwipeUp) },
+  { control: "Swipe/Arrow Down", action: getSwipeActionLabel(controls.cardSwipeDown) },
+  { control: "Swipe/Arrow Left", action: getSwipeActionLabel(controls.cardSwipeLeft) },
+  { control: "Swipe/Arrow Right", action: getSwipeActionLabel(controls.cardSwipeRight) },
+  { control: "Enter", action: "Show/hide answer" },
+  { control: "Space", action: "Play/pause autoplay" },
+  { control: "H", action: "Show/hide header" },
+  { control: "B", action: "Show/hide study buttons" },
+];

--- a/src/features/study/model/session.spec.ts
+++ b/src/features/study/model/session.spec.ts
@@ -3,24 +3,25 @@ import type { StudyPreferences } from "@/entities/preferences";
 
 import { describe, expect, it } from "vitest";
 
-import { buildStudySession, calculateNextIndex } from "./session";
+import { buildStudySession, resolveStudyTransition } from "./session";
 
-describe("calculateNextIndex", () => {
-  it("moves forward for non-prev actions", () => {
-    expect(calculateNextIndex(0, 3, "GoToNextCard")).toBe(1);
-    expect(calculateNextIndex(1, 3, "GoToNextCardMastered")).toBe(2);
+describe("resolveStudyTransition", () => {
+  it("distinguishes forward movement from completion", () => {
+    expect(resolveStudyTransition(0, 3, "GoToNextCard")).toEqual({ type: "move", index: 1 });
+    expect(resolveStudyTransition(2, 3, "GoToNextCardMastered")).toEqual({ type: "complete" });
   });
 
-  it("returns -1 when advancing past the last card", () => {
-    expect(calculateNextIndex(2, 3, "GoToNextCard")).toBe(-1);
+  it("keeps previous on the first Card as a no-op", () => {
+    expect(resolveStudyTransition(0, 3, "GoToPrevCard")).toEqual({ type: "no-op" });
   });
 
-  it("moves backward for GoToPrevCard", () => {
-    expect(calculateNextIndex(2, 3, "GoToPrevCard")).toBe(1);
+  it("moves backward after the first Card", () => {
+    expect(resolveStudyTransition(2, 3, "GoToPrevCard")).toEqual({ type: "move", index: 1 });
   });
 
-  it("returns -1 when moving before the first card", () => {
-    expect(calculateNextIndex(0, 3, "GoToPrevCard")).toBe(-1);
+  it("distinguishes Exit and DoNothing", () => {
+    expect(resolveStudyTransition(1, 3, "GoBack")).toEqual({ type: "exit" });
+    expect(resolveStudyTransition(1, 3, "DoNothing")).toEqual({ type: "no-op" });
   });
 });
 

--- a/src/features/study/model/session.ts
+++ b/src/features/study/model/session.ts
@@ -3,17 +3,33 @@ import * as lodash from "lodash";
 import type { Card } from "@/entities/card";
 import type { StudyPreferences, SwipeAction } from "@/entities/preferences";
 
-export const calculateNextIndex = (currentIndex: number, cardCount: number, swipeAction: SwipeAction): number => {
-  let nextIndex = currentIndex;
+export type StudyTransition =
+  | { type: "no-op" }
+  | { type: "move"; index: number }
+  | { type: "complete" }
+  | { type: "exit" };
+
+const forwardActions = new Set<SwipeAction>([
+  "GoToNextCard",
+  "GoToNextCardMastered",
+  "GoToNextCardNotMastered",
+  "GoToNextCardToggleMastered",
+]);
+
+export const resolveStudyTransition = (
+  currentIndex: number,
+  cardCount: number,
+  swipeAction: SwipeAction
+): StudyTransition => {
+  if (swipeAction === "DoNothing") return { type: "no-op" };
+  if (swipeAction === "GoBack") return { type: "exit" };
   if (swipeAction === "GoToPrevCard") {
-    nextIndex -= 1;
-  } else {
-    nextIndex += 1;
+    return currentIndex > 0 ? { type: "move", index: currentIndex - 1 } : { type: "no-op" };
   }
-  if (nextIndex >= 0 && nextIndex < cardCount) {
-    return nextIndex;
+  if (!forwardActions.has(swipeAction) || currentIndex < 0 || currentIndex >= cardCount) {
+    return { type: "no-op" };
   }
-  return -1;
+  return currentIndex === cardCount - 1 ? { type: "complete" } : { type: "move", index: currentIndex + 1 };
 };
 
 export const buildStudySession = (

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -10,6 +10,7 @@ import { BackText } from "@/features/card-view";
 import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
 import { useEditStudyProgress, useStudyCards } from "@/features/study";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { AppLayout } from "@/widgets/app-layout";
 
 const CardListComposition = (props: {
@@ -51,8 +52,12 @@ export const CardListPage: React.FC = () => {
   const { cards: deckCards, tags } = useCardsByDeckId(deckId);
   const cards = useStudyCards(deck, deckCards, preferences);
 
-  useKey("t", () => void navigate("/"));
-  useKey("s", () => void navigate("/settings"));
+  useKey("t", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/");
+  });
+  useKey("s", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/settings");
+  });
 
   if (deck == null) {
     return (

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -7,6 +7,7 @@ import { createCard, editCard, generateCardId, useCards } from "@/entities/card"
 import { usePreferences } from "@/entities/preferences";
 import { downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/deck-import";
 import { AppLayout } from "@/widgets/app-layout";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 
 import { DeckImportView } from "./DeckImportView";
 
@@ -23,8 +24,12 @@ export const DeckImportPage: React.FC = () => {
     editCard,
     generateCardId,
   });
-  useKey("t", () => void navigate("/"));
-  useKey("s", () => void navigate("/settings"));
+  useKey("t", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/");
+  });
+  useKey("s", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/settings");
+  });
 
   return (
     <AppLayout showHeader>

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -9,6 +9,7 @@ import { useSampleDeckBootstrap } from "@/features/deck-import";
 import { DeckList } from "@/features/deck-list";
 import { removeStudySession, touchStudySession, useStudyHydrated, useStudySessions } from "@/features/study";
 import { AppLayout } from "@/widgets/app-layout";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 
 export const DeckListPage: React.FC = () => {
   const navigate = useNavigate();
@@ -26,8 +27,12 @@ export const DeckListPage: React.FC = () => {
     editCard,
     generateCardId,
   });
-  useKey("s", () => void navigate("/settings"));
-  useKey("i", () => void navigate("/import"));
+  useKey("s", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/settings");
+  });
+  useKey("i", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/import");
+  });
 
   if (!hydrated) {
     return (

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -11,12 +11,10 @@ import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
 import { useStudyActions, useStudyCards } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckStartView } from "./DeckStartView";
-
-const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
-  target instanceof Element && target.closest("a[href], button, input, select, textarea") != null;
 
 const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
   const { deck, cards, preferences, tags } = props;
@@ -27,7 +25,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Prefe
   const deckStartForm = useDeckFilterState({ deck, tags });
   const start = () => studyActions.start(cards);
   const startFromEnter = (event: KeyboardEvent) => {
-    if (cards.length === 0 || hasInteractiveShortcutTarget(event.target)) return;
+    if (cards.length === 0 || isInteractiveShortcutTarget(event.target)) return;
     start();
   };
   useKey("Enter", startFromEnter, {}, [startFromEnter]);

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -1,19 +1,28 @@
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
-import type { StudyWorkflowState } from "@/features/study";
+import type { ActiveStudyWorkflowState } from "@/features/study";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import React from "react";
+import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface WorkflowProps {
+  cards: readonly Card[];
+  deckId: string;
+  deckName: string;
+  onExit: (deckId: string) => void;
+  onSetupStudy: (deckId: string) => void;
+  onBackToDeck: (deckId: string) => void;
+}
 
 const mocks = vi.hoisted(() => ({
   params: { id: "deck-id" as string | undefined },
   deck: undefined as Deck | undefined,
   cards: [] as Card[],
   navigate: vi.fn(),
-  workflowState: { status: "unavailable" } as StudyWorkflowState,
-  workflowProps: undefined as { cards: readonly Card[]; deckId: string; onUnavailable: () => void } | undefined,
+  workflowState: undefined as ActiveStudyWorkflowState | undefined,
+  workflowProps: undefined as WorkflowProps | undefined,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -33,12 +42,9 @@ vi.mock("@/features/study", async (importOriginal) => {
     StudyWorkflow: ({
       children,
       ...props
-    }: { children: (state: StudyWorkflowState) => React.ReactNode } & {
-      cards: readonly Card[];
-      deckId: string;
-      onUnavailable: () => void;
-    }) => {
+    }: { children: (state: ActiveStudyWorkflowState) => React.ReactNode } & WorkflowProps) => {
       mocks.workflowProps = props;
+      if (mocks.workflowState == null) throw new Error("Workflow state not initialized");
       return children(mocks.workflowState);
     },
   };
@@ -77,8 +83,8 @@ const card: Card = {
   lastSeenAt: 1,
 };
 const noop = vi.fn();
-const readyState = (): StudyWorkflowState => ({
-  status: "ready",
+const activeState = (): ActiveStudyWorkflowState => ({
+  status: "active",
   card,
   showHeader: true,
   showBackText: false,
@@ -101,9 +107,8 @@ describe("DeckSwiperPage", () => {
     mocks.params.id = deck.id;
     mocks.deck = deck;
     mocks.cards = [card];
-    mocks.workflowState = readyState();
+    mocks.workflowState = activeState();
     mocks.workflowProps = undefined;
-    window.history.replaceState(null, document.title, document.location.href);
   });
 
   it("validates the route parameter", () => {
@@ -111,51 +116,34 @@ describe("DeckSwiperPage", () => {
     expect(() => render(<DeckSwiperPage />)).toThrow("invalid deck id");
   });
 
-  it("passes Entity reads to StudyWorkflow and composes the application shell", () => {
+  it("passes Entity reads and Deck presentation to StudyWorkflow", () => {
     render(<DeckSwiperPage />);
 
-    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, cards: [card] });
+    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, deckName: deck.name, cards: [card] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     expect(screen.getByText(card.frontText)).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });
 
-  it.each([
-    ["loading", "Loading…"],
-    ["unavailable", "Study session unavailable."],
-  ] as const)("renders route feedback for %s workflow state", (status, title) => {
-    mocks.workflowState = { status };
+  it("maps Study navigation intents without installing a browser Back trap", () => {
+    const pushState = vi.spyOn(window.history, "pushState");
     render(<DeckSwiperPage />);
-    expect(screen.getByRole("heading", { name: title })).toBeVisible();
+
+    act(() => mocks.workflowProps?.onExit(deck.id));
+    expect(mocks.navigate).toHaveBeenCalledWith(`/deck/${deck.id}`, { replace: true });
+    act(() => mocks.workflowProps?.onSetupStudy(deck.id));
+    expect(mocks.navigate).toHaveBeenCalledWith(`/deck/${deck.id}/start`);
+    act(() => mocks.workflowProps?.onBackToDeck(deck.id));
+    expect(mocks.navigate).toHaveBeenLastCalledWith(`/deck/${deck.id}`, { replace: true });
+    expect(pushState).not.toHaveBeenCalled();
   });
 
-  it("converts unavailable intent into current route navigation", () => {
-    render(<DeckSwiperPage />);
-    act(() => mocks.workflowProps?.onUnavailable());
-    expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
-  });
-
-  it("shows route feedback when the Deck Entity is unavailable", () => {
+  it("shows missing Deck recovery with only Go home", () => {
     mocks.deck = undefined;
     render(<DeckSwiperPage />);
-    expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
-  });
-
-  it("installs one back-navigation guard when StrictMode replays the effect", () => {
-    const pushState = vi.spyOn(window.history, "pushState");
-    const view = render(
-      <React.StrictMode>
-        <DeckSwiperPage />
-      </React.StrictMode>
-    );
-
-    expect(pushState).toHaveBeenCalledOnce();
-    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
-    expect(mocks.navigate).toHaveBeenCalledWith(1);
-
-    view.unmount();
-    mocks.navigate.mockClear();
-    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
-    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "Deck not found" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Back to deck" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+    expect(mocks.navigate).toHaveBeenCalledWith("/");
   });
 });

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -1,47 +1,17 @@
 import { getCategory, type Deck, useDeck } from "@/entities/deck";
 
-import * as React from "react";
+import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { type Card, useCards } from "@/entities/card";
 import { CardOverlay, CardView, FrontText } from "@/features/card-view";
-import { StudyWorkflow, type StudyWorkflowState } from "@/features/study";
+import { StudyWorkflow, type ActiveStudyWorkflowState } from "@/features/study";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckSwiperView } from "./DeckSwiperView";
 
-const STUDY_HISTORY_GUARD = "tangoStudyDeckId";
-const isHistoryState = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value != null && !Array.isArray(value);
-
-const useStudyHistoryGuard = (deckId: string, navigate: ReturnType<typeof useNavigate>) => {
-  // Keep the active study session on the route when browser history moves backward.
-  React.useEffect(() => {
-    const currentState: unknown = window.history.state;
-    const state = isHistoryState(currentState) ? currentState : {};
-    if (state[STUDY_HISTORY_GUARD] !== deckId) {
-      window.history.pushState({ ...state, [STUDY_HISTORY_GUARD]: deckId }, document.title, document.location.href);
-    }
-    const handlePopState = () => {
-      void navigate(1);
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
-  }, [deckId, navigate]);
-};
-
-const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
-  if (state.status !== "ready") {
-    return state.status === "loading" ? (
-      <RouteFeedback title="Loading…" tone="loading" />
-    ) : (
-      <RouteFeedback title="Study session unavailable." tone="not-found" />
-    );
-  }
-
+const renderStudyScreen = (deck: Deck, state: ActiveStudyWorkflowState) => {
   const category = getCategory(deck.category, state.card.tags);
 
   return (
@@ -76,13 +46,17 @@ const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
 
 const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const navigate = useNavigate();
-  useStudyHistoryGuard(deck.id, navigate);
-  const handleUnavailable = React.useCallback(() => {
-    void navigate("/", { replace: true });
-  }, [navigate]);
 
   return (
-    <StudyWorkflow key={deck.id} cards={cards} deckId={deck.id} onUnavailable={handleUnavailable}>
+    <StudyWorkflow
+      key={deck.id}
+      cards={cards}
+      deckId={deck.id}
+      deckName={deck.name}
+      onExit={(deckId) => void navigate(`/deck/${deckId}`, { replace: true })}
+      onSetupStudy={(deckId) => void navigate(`/deck/${deckId}/start`)}
+      onBackToDeck={(deckId) => void navigate(`/deck/${deckId}`, { replace: true })}
+    >
       {(state) => renderStudyScreen(deck, state)}
     </StudyWorkflow>
   );
@@ -90,6 +64,7 @@ const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
 
 export const DeckSwiperPage: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
 
@@ -97,7 +72,14 @@ export const DeckSwiperPage: React.FC = () => {
   const deck = useDeck(deckId);
 
   if (deck == null) {
-    return <RouteFeedback title="Study session unavailable." tone="not-found" />;
+    return (
+      <RouteFeedback
+        title="Deck not found"
+        description="The requested deck is unavailable or has been removed."
+        tone="not-found"
+        primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+      />
+    );
   }
 
   return <DeckSwiperContent key={deck.id} cards={cards} deck={deck} />;

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { useSignIn } from "@/features/sign-in";
 import { useSignOut } from "@/features/sign-out";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { AppLayout } from "@/widgets/app-layout";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 
 interface SettingsPageProps {
   login: () => Promise<void>;
@@ -33,7 +34,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
     preferences,
     onSubmit: updatePreferences,
   });
-  useKey("t", () => void navigate("/"));
+  useKey("t", (event) => {
+    if (!isInteractiveShortcutTarget(event.target)) void navigate("/");
+  });
 
   return (
     <AppLayout showHeader>

--- a/src/shared/lib/isInteractiveShortcutTarget.spec.ts
+++ b/src/shared/lib/isInteractiveShortcutTarget.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { isInteractiveShortcutTarget } from "./isInteractiveShortcutTarget";
+
+describe("isInteractiveShortcutTarget", () => {
+  it.each(["a", "button", "input", "select", "textarea"])("recognizes %s controls", (tagName) => {
+    const element = document.createElement(tagName);
+    if (element instanceof HTMLAnchorElement) element.href = "/";
+    expect(isInteractiveShortcutTarget(element)).toBe(true);
+  });
+
+  it("recognizes editable content and descendants of controls", () => {
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    const child = document.createElement("span");
+    editable.append(child);
+    expect(isInteractiveShortcutTarget(child)).toBe(true);
+  });
+
+  it("allows ordinary page targets", () => {
+    expect(isInteractiveShortcutTarget(document.createElement("div"))).toBe(false);
+    expect(isInteractiveShortcutTarget(window)).toBe(false);
+  });
+});

--- a/src/shared/lib/isInteractiveShortcutTarget.ts
+++ b/src/shared/lib/isInteractiveShortcutTarget.ts
@@ -1,0 +1,3 @@
+export const isInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  target.closest('a[href], button, input, select, textarea, [contenteditable="true"], [contenteditable=""]') != null;


### PR DESCRIPTION
## Summary

- add an accessible Study help dialog backed by the current control preferences
- add session-preserving Exit and configured GoBack behavior, and remove the browser Back history trap
- distinguish no-op, move, Exit, and completion transitions without the previous `-1` sentinel
- show completion, restart, unavailable, missing Deck, and retryable verification screens
- verify missing target Cards with a scoped server read before cleaning up stale sessions
- stop autoplay at the final Card and guard global shortcuts while interactive controls are focused

## Why

The Study route previously conflated boundary navigation with session removal, redirected invalid states without recovery guidance, inferred Card readiness from `cards.length`, and trapped browser Back. This made it possible to lose resumable sessions and made completion or failure states unclear.

## User impact

Users can inspect the active controls, leave and resume a Study session safely, see an explicit completion screen, restart with the same Card order, and recover from unavailable or temporarily unverifiable sessions without destructive cleanup.

## Root cause

Study transitions used a shared `-1` sentinel for multiple meanings, Page-level lifecycle effects owned destructive cleanup and history behavior, and local collection emptiness was used as a proxy for remote Card readiness.

## Validation

- `CHOKIDAR_USEPOLLING=1 mise run check`
- 102 unit test files, 516 tests passed
- TypeScript, ESLint, Biome, FSD, Knip, Markdown, Docker lint, and sample formatting passed

Closes #208

Related: #385, #386, #745, #947, #950, #951, #952, #953