### PR TITLE
feat(#922): Route Deck and Card mutations by local mode

### DIFF
--- a/src/entities/card/@x/deck.ts
+++ b/src/entities/card/@x/deck.ts
@@ -1,0 +1,1 @@
+export { deleteLocalCardsByDeckId } from "../model/store";

--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -25,7 +25,7 @@ vi.mock("@/entities/deck/@x/card", () => ({
 describe("Card mutations", () => {
   beforeEach(() => {
     cardStore.setState({ remoteCards: [], localCards: [] });
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("routes Card create, edit, and delete by its local parent Deck", async () => {
@@ -51,6 +51,7 @@ describe("Card mutations", () => {
     const card = createCardFixture({ id: "remote-card", deckId: deck.id });
     const edit = { id: card.id, uid: card.uid, frontText: "Updated" };
     mocks.findDeckById.mockReturnValue(deck);
+    cardStore.setState({ remoteCards: [card] });
 
     await createCard("uid", card);
     await editCard("uid", edit);
@@ -59,5 +60,30 @@ describe("Card mutations", () => {
     expect(mocks.createRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
     expect(mocks.editRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", edit);
     expect(mocks.deleteRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
+  });
+
+  it("rejects edit and delete when the Card cannot be resolved", async () => {
+    const card = createCardFixture({ id: "missing" });
+
+    await expect(editCard("uid", { id: card.id, uid: card.uid, frontText: "Updated" })).rejects.toThrow(
+      'Card "missing" was not found'
+    );
+    await expect(deleteCard("uid", card)).rejects.toThrow('Card "missing" was not found');
+
+    expect(mocks.editRemoteCard).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
+  });
+
+  it("rejects edit and delete when the Card parent Deck cannot be resolved", async () => {
+    const card = createCardFixture({ id: "orphan", deckId: "missing-deck" });
+    cardStore.setState({ remoteCards: [card] });
+
+    await expect(editCard("uid", { id: card.id, uid: card.uid, frontText: "Updated" })).rejects.toThrow(
+      'Deck "missing-deck" was not found'
+    );
+    await expect(deleteCard("uid", card)).rejects.toThrow('Deck "missing-deck" was not found');
+
+    expect(mocks.editRemoteCard).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCard as createCardFixture, createDeck as createDeckFixture } from "@/test/factories";
+
+import { createCard, deleteCard, editCard } from "./mutations";
+import { cardStore, findCardById } from "../model/store";
+
+const mocks = vi.hoisted(() => ({
+  createRemoteCard: vi.fn(),
+  deleteRemoteCard: vi.fn(),
+  editRemoteCard: vi.fn(),
+  findDeckById: vi.fn(),
+}));
+
+vi.mock("./firestore", () => ({
+  createCard: mocks.createRemoteCard,
+  deleteCard: mocks.deleteRemoteCard,
+  editCard: mocks.editRemoteCard,
+}));
+
+vi.mock("@/entities/deck/@x/card", () => ({
+  findDeckById: mocks.findDeckById,
+}));
+
+describe("Card mutations", () => {
+  beforeEach(() => {
+    cardStore.setState({ remoteCards: [], localCards: [] });
+    vi.clearAllMocks();
+  });
+
+  it("routes Card create, edit, and delete by its local parent Deck", async () => {
+    const deck = createDeckFixture({ id: "local-deck", localMode: true });
+    const card = createCardFixture({ id: "local-card", deckId: deck.id });
+    mocks.findDeckById.mockReturnValue(deck);
+
+    await createCard("", card);
+    await editCard("", { id: card.id, uid: card.uid, frontText: "Updated" });
+
+    expect(findCardById(card.id)).toMatchObject({ id: card.id, frontText: "Updated" });
+    expect(mocks.createRemoteCard).not.toHaveBeenCalled();
+    expect(mocks.editRemoteCard).not.toHaveBeenCalled();
+
+    await deleteCard("", card);
+
+    expect(findCardById(card.id)).toBeUndefined();
+    expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
+  });
+
+  it("preserves remote Card mutation behavior", async () => {
+    const deck = createDeckFixture({ id: "remote-deck", localMode: false });
+    const card = createCardFixture({ id: "remote-card", deckId: deck.id });
+    const edit = { id: card.id, uid: card.uid, frontText: "Updated" };
+    mocks.findDeckById.mockReturnValue(deck);
+
+    await createCard("uid", card);
+    await editCard("uid", edit);
+    await deleteCard("uid", card);
+
+    expect(mocks.createRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
+    expect(mocks.editRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", edit);
+    expect(mocks.deleteRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
+  });
+});

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -1,0 +1,37 @@
+import type { CardCreateInput, DeleteCardInput, EditCardInput } from "../model/types";
+
+import { findDeckById } from "@/entities/deck/@x/card";
+import { createLocalCard, deleteLocalCard, editLocalCard, findCardById } from "../model/store";
+import {
+  createCard as createRemoteCard,
+  deleteCard as deleteRemoteCard,
+  editCard as editRemoteCard,
+} from "./firestore";
+
+const isLocalDeck = (deckId: string): boolean => findDeckById(deckId)?.localMode === true;
+
+export const createCard = async (uid: string, card: CardCreateInput): Promise<void> => {
+  if (isLocalDeck(card.deckId)) {
+    createLocalCard(card);
+    return;
+  }
+  await createRemoteCard(uid, card);
+};
+
+export const editCard = async (uid: string, card: EditCardInput["card"]): Promise<void> => {
+  const currentCard = findCardById(card.id);
+  if (currentCard !== undefined && isLocalDeck(currentCard.deckId)) {
+    editLocalCard(card);
+    return;
+  }
+  await editRemoteCard(uid, card);
+};
+
+export const deleteCard = async (uid: string, card: DeleteCardInput["card"]): Promise<void> => {
+  const currentCard = findCardById(card.id);
+  if (currentCard !== undefined && isLocalDeck(currentCard.deckId)) {
+    deleteLocalCard(card.id);
+    return;
+  }
+  await deleteRemoteCard(uid, card);
+};

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -1,4 +1,4 @@
-import type { CardCreateInput, DeleteCardInput, EditCardInput } from "../model/types";
+import type { CardCreateInput, CardId, DeleteCardInput, EditCardInput } from "../model/types";
 
 import { findDeckById } from "@/entities/deck/@x/card";
 import { createLocalCard, deleteLocalCard, editLocalCard, findCardById } from "../model/store";
@@ -10,6 +10,18 @@ import {
 
 const isLocalDeck = (deckId: string): boolean => findDeckById(deckId)?.localMode === true;
 
+const requireCard = (id: CardId) => {
+  const card = findCardById(id);
+  if (card === undefined) throw new Error(`Card "${id}" was not found`);
+  return card;
+};
+
+const requireLocalMode = (deckId: string): boolean => {
+  const deck = findDeckById(deckId);
+  if (deck === undefined) throw new Error(`Deck "${deckId}" was not found`);
+  return deck.localMode;
+};
+
 export const createCard = async (uid: string, card: CardCreateInput): Promise<void> => {
   if (isLocalDeck(card.deckId)) {
     createLocalCard(card);
@@ -19,8 +31,8 @@ export const createCard = async (uid: string, card: CardCreateInput): Promise<vo
 };
 
 export const editCard = async (uid: string, card: EditCardInput["card"]): Promise<void> => {
-  const currentCard = findCardById(card.id);
-  if (currentCard !== undefined && isLocalDeck(currentCard.deckId)) {
+  const currentCard = requireCard(card.id);
+  if (requireLocalMode(currentCard.deckId)) {
     editLocalCard(card);
     return;
   }
@@ -28,8 +40,8 @@ export const editCard = async (uid: string, card: EditCardInput["card"]): Promis
 };
 
 export const deleteCard = async (uid: string, card: DeleteCardInput["card"]): Promise<void> => {
-  const currentCard = findCardById(card.id);
-  if (currentCard !== undefined && isLocalDeck(currentCard.deckId)) {
+  const currentCard = requireCard(card.id);
+  if (requireLocalMode(currentCard.deckId)) {
     deleteLocalCard(card.id);
     return;
   }

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,5 @@
-export { createCard, deleteCard, editCard, fetchCards, subscribeCards } from "./api/firestore";
+export { fetchCards, subscribeCards } from "./api/firestore";
+export { createCard, deleteCard, editCard } from "./api/mutations";
 export { generateCardId } from "./model/id";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -54,6 +54,12 @@ export const clearRemoteCards = (): void => {
   cardStore.setState({ remoteCards: [] });
 };
 
+export const findCardById = (id: CardId): Card | undefined => {
+  const cardId = cardIdSchema.parse(id);
+  const state = cardStore.getState();
+  return state.remoteCards.find((card) => card.id === cardId) ?? state.localCards.find((card) => card.id === cardId);
+};
+
 /** @public */
 export const createLocalCard = (input: CardCreateInput): Card => {
   const card = cardCreateSchema.parse(input);

--- a/src/entities/deck/@x/card.ts
+++ b/src/entities/deck/@x/card.ts
@@ -1,0 +1,1 @@
+export { findDeckById } from "../model/store";

--- a/src/entities/deck/api/mutations.spec.ts
+++ b/src/entities/deck/api/mutations.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDeck as createDeckFixture } from "@/test/factories";
+
+import { createDeck, deleteDeck, editDeck } from "./mutations";
+import { deckStore, findDeckById } from "../model/store";
+
+const mocks = vi.hoisted(() => ({
+  createRemoteDeck: vi.fn(),
+  deleteRemoteDeck: vi.fn(),
+  editRemoteDeck: vi.fn(),
+  deleteLocalCardsByDeckId: vi.fn(),
+}));
+
+vi.mock("./firestore", () => ({
+  createDeck: mocks.createRemoteDeck,
+  deleteDeck: mocks.deleteRemoteDeck,
+  editDeck: mocks.editRemoteDeck,
+}));
+
+vi.mock("@/entities/card/@x/deck", () => ({
+  deleteLocalCardsByDeckId: mocks.deleteLocalCardsByDeckId,
+}));
+
+describe("Deck mutations", () => {
+  beforeEach(() => {
+    deckStore.setState({ remoteDecks: [], localDecks: [] });
+    vi.clearAllMocks();
+  });
+
+  it("routes local Deck create, edit, and delete to local persistence", async () => {
+    const deck = createDeckFixture({ id: "local", localMode: true });
+
+    await createDeck("", deck);
+    await editDeck("", { id: deck.id, name: "Renamed" });
+
+    expect(findDeckById(deck.id)).toMatchObject({ id: deck.id, name: "Renamed", localMode: true });
+    expect(mocks.createRemoteDeck).not.toHaveBeenCalled();
+    expect(mocks.editRemoteDeck).not.toHaveBeenCalled();
+
+    await deleteDeck("", deck);
+
+    expect(findDeckById(deck.id)).toBeUndefined();
+    expect(mocks.deleteLocalCardsByDeckId).toHaveBeenCalledExactlyOnceWith(deck.id);
+    expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
+  });
+
+  it("preserves remote Deck mutation behavior", async () => {
+    const deck = createDeckFixture({ id: "remote", localMode: false });
+    const edit = { id: deck.id, name: "Renamed" };
+
+    await createDeck("uid", deck);
+    await editDeck("uid", edit);
+    await deleteDeck("uid", deck);
+
+    expect(mocks.createRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", deck);
+    expect(mocks.editRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", edit);
+    expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", deck);
+    expect(mocks.deleteLocalCardsByDeckId).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/deck/api/mutations.spec.ts
+++ b/src/entities/deck/api/mutations.spec.ts
@@ -48,6 +48,7 @@ describe("Deck mutations", () => {
   it("preserves remote Deck mutation behavior", async () => {
     const deck = createDeckFixture({ id: "remote", localMode: false });
     const edit = { id: deck.id, name: "Renamed" };
+    deckStore.setState({ remoteDecks: [deck] });
 
     await createDeck("uid", deck);
     await editDeck("uid", edit);
@@ -57,5 +58,15 @@ describe("Deck mutations", () => {
     expect(mocks.editRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", edit);
     expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", deck);
     expect(mocks.deleteLocalCardsByDeckId).not.toHaveBeenCalled();
+  });
+
+  it("rejects edit and delete when the Deck cannot be resolved", async () => {
+    const deck = createDeckFixture({ id: "missing" });
+
+    await expect(editDeck("uid", { id: deck.id, name: "Renamed" })).rejects.toThrow('Deck "missing" was not found');
+    await expect(deleteDeck("uid", deck)).rejects.toThrow('Deck "missing" was not found');
+
+    expect(mocks.editRemoteDeck).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/deck/api/mutations.ts
+++ b/src/entities/deck/api/mutations.ts
@@ -1,0 +1,34 @@
+import type { DeckCreateInput, DeleteDeckInput, EditDeckInput } from "../model/types";
+
+import { deleteLocalCardsByDeckId } from "@/entities/card/@x/deck";
+import { createLocalDeck, deleteLocalDeck, editLocalDeck, findDeckById } from "../model/store";
+import {
+  createDeck as createRemoteDeck,
+  deleteDeck as deleteRemoteDeck,
+  editDeck as editRemoteDeck,
+} from "./firestore";
+
+export const createDeck = async (uid: string, deck: DeckCreateInput): Promise<void> => {
+  if (deck.localMode === true) {
+    createLocalDeck({ ...deck, localMode: true });
+    return;
+  }
+  await createRemoteDeck(uid, deck);
+};
+
+export const editDeck = async (uid: string, deck: EditDeckInput["deck"]): Promise<void> => {
+  if (findDeckById(deck.id)?.localMode === true) {
+    editLocalDeck(deck);
+    return;
+  }
+  await editRemoteDeck(uid, deck);
+};
+
+export const deleteDeck = async (uid: string, deck: DeleteDeckInput["deck"]): Promise<void> => {
+  if (findDeckById(deck.id)?.localMode === true) {
+    deleteLocalCardsByDeckId(deck.id);
+    deleteLocalDeck(deck.id);
+    return;
+  }
+  await deleteRemoteDeck(uid, deck);
+};

--- a/src/entities/deck/api/mutations.ts
+++ b/src/entities/deck/api/mutations.ts
@@ -1,4 +1,4 @@
-import type { DeckCreateInput, DeleteDeckInput, EditDeckInput } from "../model/types";
+import type { DeckCreateInput, DeckId, DeleteDeckInput, EditDeckInput } from "../model/types";
 
 import { deleteLocalCardsByDeckId } from "@/entities/card/@x/deck";
 import { createLocalDeck, deleteLocalDeck, editLocalDeck, findDeckById } from "../model/store";
@@ -7,6 +7,12 @@ import {
   deleteDeck as deleteRemoteDeck,
   editDeck as editRemoteDeck,
 } from "./firestore";
+
+const requireDeck = (id: DeckId) => {
+  const deck = findDeckById(id);
+  if (deck === undefined) throw new Error(`Deck "${id}" was not found`);
+  return deck;
+};
 
 export const createDeck = async (uid: string, deck: DeckCreateInput): Promise<void> => {
   if (deck.localMode === true) {
@@ -17,7 +23,7 @@ export const createDeck = async (uid: string, deck: DeckCreateInput): Promise<vo
 };
 
 export const editDeck = async (uid: string, deck: EditDeckInput["deck"]): Promise<void> => {
-  if (findDeckById(deck.id)?.localMode === true) {
+  if (requireDeck(deck.id).localMode) {
     editLocalDeck(deck);
     return;
   }
@@ -25,7 +31,7 @@ export const editDeck = async (uid: string, deck: EditDeckInput["deck"]): Promis
 };
 
 export const deleteDeck = async (uid: string, deck: DeleteDeckInput["deck"]): Promise<void> => {
-  if (findDeckById(deck.id)?.localMode === true) {
+  if (requireDeck(deck.id).localMode) {
     deleteLocalCardsByDeckId(deck.id);
     deleteLocalDeck(deck.id);
     return;

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,4 +1,5 @@
-export { createDeck, deleteDeck, editDeck, fetchDecks, subscribeDecks } from "./api/firestore";
+export { fetchDecks, subscribeDecks } from "./api/firestore";
+export { createDeck, deleteDeck, editDeck } from "./api/mutations";
 export { generateDeckId } from "./model/id";
 export { CATEGORY, getCategory, isHighlightLanguage } from "./model/rules";
 export { useDeck, useDecks } from "./model/hooks";

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -54,6 +54,12 @@ export const clearRemoteDecks = (): void => {
   deckStore.setState({ remoteDecks: [] });
 };
 
+export const findDeckById = (id: DeckId): Deck | undefined => {
+  const deckId = deckIdSchema.parse(id);
+  const state = deckStore.getState();
+  return state.remoteDecks.find((deck) => deck.id === deckId) ?? state.localDecks.find((deck) => deck.id === deckId);
+};
+
 /** @public */
 export const createLocalDeck = (input: LocalDeckCreateInput): Deck => {
   const deck = localDeckCreateSchema.parse(input);

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -4,18 +4,13 @@
  * "should update a card", and "should import cards".
  */
 
-import {
-  createCard as createCardCommand,
-  deleteCard,
-  editCard,
-  type Card,
-  type CardCreateInput,
-} from "@/entities/card";
-import { createDeck as createDeckCommand } from "@/entities/deck";
+import type { Card, CardCreateInput } from "@/entities/card";
 
 import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { collection, deleteDoc, getDocs, getFirestore, doc, getDoc, query, where } from "firebase/firestore";
+import { createCard as createCardCommand, deleteCard, editCard } from "@/entities/card/api/firestore";
+import { createDeck as createDeckCommand } from "@/entities/deck/api/firestore";
 import { upsertImportedCards } from "@/features/deck-import/api/upsertImportedCards";
 import { editStudyProgress } from "@/entities/study-progress";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -3,12 +3,13 @@
  * The examples cover creating, updating, checking, and deleting Deck documents.
  */
 
-import { createDeck, deleteDeck, editDeck, type Deck, type DeckCreateInput } from "@/entities/deck";
+import type { Deck, DeckCreateInput } from "@/entities/deck";
 
 import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
 import { doc, getDoc, getFirestore } from "firebase/firestore";
-import { createCard as createCardCommand } from "@/entities/card";
+import { createCard as createCardCommand } from "@/entities/card/api/firestore";
+import { createDeck, deleteDeck, editDeck } from "@/entities/deck/api/firestore";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as UUID from "uuid";
 import { createCard, createDeck as createDeckFixture } from "@/test/factories";


### PR DESCRIPTION
## Related issue

Fixes #922

## Summary

- route Deck create, edit, and delete mutations by the target Deck's `localMode`
- resolve each Card's parent Deck before routing Card mutations
- remove local Cards when deleting a local Deck while keeping Firestore mutation behavior unchanged for remote data
- cover local and remote routing behavior with unit tests

## Testing

- `CHOKIDAR_USEPOLLING=1 mise run check`