### PR TITLE
refactor: separate local data from authenticated owners (#959)

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -4,9 +4,9 @@
  * normal containers, hooks, and route parameters.
  */
 
-import type { Card } from "@/entities/card";
+import type { RemoteCard } from "@/entities/card";
 import { replaceRemoteCards } from "@/entities/card/model/store";
-import type { Deck, DeckId } from "@/entities/deck";
+import type { DeckId, RemoteDeck } from "@/entities/deck";
 import { replaceRemoteDecks } from "@/entities/deck/model/store";
 
 import type { Decorator } from "@storybook/react";
@@ -28,19 +28,19 @@ type PartialPreferences = {
 
 export interface PageStoryParameters {
   path: string;
-  decks?: Deck[];
-  cards?: Card[];
+  decks?: RemoteDeck[];
+  cards?: RemoteCard[];
   preferences?: PartialPreferences;
   sessionsByDeckId?: StudySessions;
   autoPlay?: boolean;
 }
 
-const cloneDeck = (deck: Deck): Deck => ({
+const cloneDeck = (deck: RemoteDeck): RemoteDeck => ({
   ...deck,
   selectedTags: [...deck.selectedTags],
 });
 
-const cloneCard = (card: Card): Card => ({
+const cloneCard = (card: RemoteCard): RemoteCard => ({
   ...card,
   tags: [...card.tags],
   ...(card.nextSeeingAt === undefined ? {} : { nextSeeingAt: new Date(card.nextSeeingAt.getTime()) }),

--- a/.storybook/support/pageFixture.ts
+++ b/.storybook/support/pageFixture.ts
@@ -1,7 +1,7 @@
 /** @file Defines deterministic application data shared by route-level Storybook stories. */
 
-import type { Card, CardId } from "@/entities/card";
-import type { Deck, DeckId } from "@/entities/deck";
+import type { CardId, RemoteCard } from "@/entities/card";
+import type { DeckId, RemoteDeck } from "@/entities/deck";
 
 import { createCard, createDeck, createPreferences } from "@/test/factories";
 import { STORYBOOK_DECK_IMPORT_URL } from "@/storybook/handlers";
@@ -13,7 +13,7 @@ export const PAGE_STORY_CARD_ID: CardId = "storybook-hello";
 
 const timestamp = Date.UTC(2026, 6, 1, 9, 0, 0);
 
-const pageStoryDecks: Deck[] = [
+const pageStoryDecks: RemoteDeck[] = [
   createDeck({
     id: PAGE_STORY_DECK_ID,
     uid: PAGE_STORY_UID,
@@ -34,7 +34,7 @@ const pageStoryDecks: Deck[] = [
   }),
 ];
 
-const pageStoryCards: Card[] = [
+const pageStoryCards: RemoteCard[] = [
   createCard({
     id: PAGE_STORY_CARD_ID,
     deckId: PAGE_STORY_DECK_ID,

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -1,11 +1,11 @@
 import type {
-  Card,
   CardCreate,
   CardCreateInput,
   CardEdit,
   CardId,
   DeleteCardInput,
   EditCardInput,
+  RemoteCard,
 } from "../model/types";
 
 import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
@@ -19,9 +19,9 @@ import { parseCardDocument } from "./document";
 
 const CARD_COLLECTION = "card";
 
-const convertCardDocumentToCard = (id: CardId, value: unknown): Card => {
+const convertCardDocumentToCard = (id: CardId, value: unknown): RemoteCard => {
   const document = parseCardDocument(id, value);
-  const card: Card = {
+  const card: RemoteCard = {
     id,
     frontText: document.frontText,
     backText: document.backText,
@@ -60,7 +60,7 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
     onError
   );
 
-export const fetchCards = async (uid: string): Promise<Card[]> => {
+export const fetchCards = async (uid: string): Promise<RemoteCard[]> => {
   const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return snapshot.docs
     .map((document) => convertCardDocumentToCard(document.id, document.data()))
@@ -69,7 +69,7 @@ export const fetchCards = async (uid: string): Promise<Card[]> => {
 
 const createCardDocument = async (card: CardCreate): Promise<void> => {
   const createdAt = getCurrentTimeMillis();
-  const document = omitUndefined({ ...card, createdAt, updatedAt: createdAt } satisfies Card);
+  const document = omitUndefined({ ...card, createdAt, updatedAt: createdAt } satisfies RemoteCard);
   await setDoc(doc(db, CARD_COLLECTION, card.id), document);
 };
 

--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createCard as createCardFixture, createDeck as createDeckFixture } from "@/test/factories";
+import {
+  createCard as createCardFixture,
+  createDeck as createDeckFixture,
+  createLocalCard,
+  createLocalDeck,
+} from "@/test/factories";
 
 import { type CardBulkMutationError, type CardMutation, deleteCard, editCard, mutateCards } from "./mutations";
 import { cardStore, findCardById } from "../model/store";
@@ -29,12 +34,12 @@ describe("Card mutations", () => {
   });
 
   it("routes Card create, edit, and delete by its local parent Deck", async () => {
-    const deck = createDeckFixture({ id: "local-deck", localMode: true });
-    const card = createCardFixture({ id: "local-card", deckId: deck.id });
+    const deck = createLocalDeck({ id: "local-deck" });
+    const card = createLocalCard({ id: "local-card", deckId: deck.id });
     mocks.findDeckById.mockReturnValue(deck);
 
     await mutateCards("", [{ kind: "create", card }]);
-    await editCard("", { id: card.id, uid: card.uid, frontText: "Updated" });
+    await editCard("", { id: card.id, frontText: "Updated" });
 
     expect(findCardById(card.id)).toMatchObject({ id: card.id, frontText: "Updated" });
     expect(mocks.createRemoteCard).not.toHaveBeenCalled();
@@ -49,7 +54,7 @@ describe("Card mutations", () => {
   it("preserves remote Card mutation behavior", async () => {
     const deck = createDeckFixture({ id: "remote-deck", localMode: false });
     const card = createCardFixture({ id: "remote-card", deckId: deck.id });
-    const edit = { id: card.id, uid: card.uid, frontText: "Updated" };
+    const edit = { id: card.id, frontText: "Updated" };
     mocks.findDeckById.mockReturnValue(deck);
     cardStore.setState({ remoteCards: [card] });
 
@@ -58,8 +63,20 @@ describe("Card mutations", () => {
     await deleteCard("uid", card);
 
     expect(mocks.createRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
-    expect(mocks.editRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", edit);
-    expect(mocks.deleteRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
+    expect(mocks.editRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", { ...edit, uid: card.uid });
+    expect(mocks.deleteRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", { id: card.id, uid: card.uid });
+  });
+
+  it("rejects a remote Card create without an owner UID", async () => {
+    const deck = createDeckFixture({ id: "remote-deck", localMode: false });
+    const card = createLocalCard({ id: "ownerless-card", deckId: deck.id });
+    mocks.findDeckById.mockReturnValue(deck);
+
+    await expect(mutateCards("uid", [{ kind: "create", card }])).rejects.toMatchObject({
+      failedIds: [card.id],
+    });
+
+    expect(mocks.createRemoteCard).not.toHaveBeenCalled();
   });
 
   it("executes each explicit Card mutation through the existing routing", async () => {
@@ -102,7 +119,7 @@ describe("Card mutations", () => {
   it("rejects edit and delete when the Card cannot be resolved", async () => {
     const card = createCardFixture({ id: "missing" });
 
-    await expect(editCard("uid", { id: card.id, uid: card.uid, frontText: "Updated" })).rejects.toThrow(
+    await expect(editCard("uid", { id: card.id, frontText: "Updated" })).rejects.toThrow(
       'Card "missing" was not found'
     );
     await expect(deleteCard("uid", card)).rejects.toThrow('Card "missing" was not found');
@@ -115,7 +132,7 @@ describe("Card mutations", () => {
     const card = createCardFixture({ id: "orphan", deckId: "missing-deck" });
     cardStore.setState({ remoteCards: [card] });
 
-    await expect(editCard("uid", { id: card.id, uid: card.uid, frontText: "Updated" })).rejects.toThrow(
+    await expect(editCard("uid", { id: card.id, frontText: "Updated" })).rejects.toThrow(
       'Deck "missing-deck" was not found'
     );
     await expect(deleteCard("uid", card)).rejects.toThrow('Deck "missing-deck" was not found');

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -1,6 +1,7 @@
-import type { CardCreateInput, CardEdit, CardId, DeleteCardInput, EditCardInput } from "../model/types";
+import type { CardCreateInput, CardEditInput, CardId, LocalCardCreateInput, RemoteCard } from "../model/types";
 
 import { findDeckById } from "@/entities/deck/@x/card";
+import { cardCreateSchema } from "../model/schema";
 import { createLocalCard, deleteLocalCard, editLocalCard, findCardById } from "../model/store";
 import {
   createCard as createRemoteCard,
@@ -8,7 +9,9 @@ import {
   editCard as editRemoteCard,
 } from "./firestore";
 
-export type CardMutation = { kind: "create"; card: CardCreateInput } | { kind: "edit"; card: CardEdit };
+type CardMutationCreateInput = CardCreateInput | LocalCardCreateInput;
+
+export type CardMutation = { kind: "create"; card: CardMutationCreateInput } | { kind: "edit"; card: CardEditInput };
 
 export class CardBulkMutationError extends Error {
   constructor(
@@ -34,21 +37,29 @@ const requireLocalMode = (deckId: string): boolean => {
   return deck.localMode;
 };
 
-const createCard = async (uid: string, card: CardCreateInput): Promise<void> => {
+const requireRemoteCardCreate = (card: CardMutationCreateInput): CardCreateInput =>
+  "uid" in card ? card : cardCreateSchema.parse(card);
+
+const createCard = async (uid: string, card: CardMutationCreateInput): Promise<void> => {
   if (isLocalDeck(card.deckId)) {
     createLocalCard(card);
     return;
   }
-  await createRemoteCard(uid, card);
+  await createRemoteCard(uid, requireRemoteCardCreate(card));
 };
 
-export const editCard = async (uid: string, card: EditCardInput["card"]): Promise<void> => {
+const requireRemoteCard = (card: ReturnType<typeof requireCard>): RemoteCard => {
+  if (!("uid" in card)) throw new Error(`Card "${card.id}" is not owned by a remote Deck`);
+  return card;
+};
+
+export const editCard = async (uid: string, card: CardEditInput): Promise<void> => {
   const currentCard = requireCard(card.id);
   if (requireLocalMode(currentCard.deckId)) {
     editLocalCard(card);
     return;
   }
-  await editRemoteCard(uid, card);
+  await editRemoteCard(uid, { ...card, uid: requireRemoteCard(currentCard).uid });
 };
 
 export const mutateCards = async (uid: string, mutations: CardMutation[]): Promise<void> => {
@@ -64,11 +75,11 @@ export const mutateCards = async (uid: string, mutations: CardMutation[]): Promi
   if (failedIds.length > 0) throw new CardBulkMutationError(failedIds, mutations.length);
 };
 
-export const deleteCard = async (uid: string, card: DeleteCardInput["card"]): Promise<void> => {
+export const deleteCard = async (uid: string, card: { id: CardId }): Promise<void> => {
   const currentCard = requireCard(card.id);
   if (requireLocalMode(currentCard.deckId)) {
     deleteLocalCard(card.id);
     return;
   }
-  await deleteRemoteCard(uid, card);
+  await deleteRemoteCard(uid, { id: card.id, uid: requireRemoteCard(currentCard).uid });
 };

--- a/src/entities/card/api/subscription.spec.tsx
+++ b/src/entities/card/api/subscription.spec.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { Timestamp } from "firebase/firestore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createCard } from "@/test/factories";
+import { createLocalCard } from "@/test/factories";
 import { useCards } from "../model/hooks";
 import { cardStore } from "../model/store";
 
@@ -58,7 +58,7 @@ describe("Card Firestore subscription", () => {
   });
 
   it("subscribes by UID and fully replaces active Cards from each snapshot", () => {
-    const localCard = createCard({ id: "local", frontText: "Local front" });
+    const localCard = createLocalCard({ id: "local", frontText: "Local front" });
     cardStore.setState({ localCards: [localCard] });
     const { result } = renderHook(useCards);
     const unsubscribe = subscribeCards("uid-a", vi.fn());

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -6,8 +6,9 @@ export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";
 export type {
   Card,
-  CardEdit,
+  CardEditInput,
   CardId,
   CardRaw,
+  RemoteCard,
 } from "./model/types";
 export { filterCardsByDeckId, mustFindCardById } from "./model/rules";

--- a/src/entities/card/model/schema.ts
+++ b/src/entities/card/model/schema.ts
@@ -14,10 +14,9 @@ const editableCardFieldsSchema = z.object({
   endLine: z.number().optional(),
 });
 
-export const cardCreateSchema = editableCardFieldsSchema.extend({
+const cardCreateFieldsSchema = editableCardFieldsSchema.extend({
   id: cardIdSchema,
   deckId: z.string().min(1, "Card deck is required"),
-  uid: cardUidSchema,
   deletedAt: z.number().nullable().default(null),
   score: z.number().default(0),
   numberOfSeen: z.number().default(0),
@@ -26,7 +25,15 @@ export const cardCreateSchema = editableCardFieldsSchema.extend({
   interval: z.number().optional(),
 });
 
+export const cardCreateSchema = cardCreateFieldsSchema.extend({ uid: cardUidSchema });
+export const localCardCreateSchema = cardCreateFieldsSchema;
+
 export const cardSchema = cardCreateSchema.extend({
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const localCardSchema = localCardCreateSchema.extend({
   createdAt: z.number(),
   updatedAt: z.number(),
 });
@@ -36,9 +43,10 @@ const persistedDateSchema = z.preprocess(
   z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date")
 );
 
-export const persistedCardSchema = cardSchema.extend({ nextSeeingAt: persistedDateSchema.optional() });
+export const persistedCardSchema = localCardSchema.extend({ nextSeeingAt: persistedDateSchema.optional() });
 
-export const cardEditSchema = editableCardFieldsSchema.partial().extend({ id: cardIdSchema, uid: cardUidSchema });
+export const localCardEditSchema = editableCardFieldsSchema.partial().extend({ id: cardIdSchema });
+export const cardEditSchema = localCardEditSchema.extend({ uid: cardUidSchema });
 const cardIdentitySchema = z.object({ id: cardIdSchema, uid: cardUidSchema });
 
 const validateCardOwner = (input: { uid: string; card: { uid: string } }, context: z.RefinementCtx): void => {

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
-import { createCard } from "@/test/factories";
+import { createCard, createLocalCard as createLocalCardFixture } from "@/test/factories";
 import { useCard, useCards, useCardsByDeckId } from "./hooks";
 import {
   cardStore,
@@ -17,7 +17,6 @@ import {
 const cardInput = (id: string, deckId = "deck") => ({
   id,
   deckId,
-  uid: "uid",
   frontText: "front",
   backText: "back",
   tags: [],
@@ -48,7 +47,7 @@ describe("Card store", () => {
 
   it("replaces and clears only the remote Card collection", () => {
     const remoteCard = createCard({ id: "remote" });
-    const localCard = createCard({ id: "local" });
+    const localCard = createLocalCardFixture({ id: "local" });
     cardStore.setState({ localCards: [localCard] });
 
     replaceRemoteCards([remoteCard]);
@@ -60,7 +59,7 @@ describe("Card store", () => {
 
   it("exposes combined collection and individual Card selectors", () => {
     const remoteCard = createCard({ id: "remote" });
-    const localCard = createCard({ id: "local" });
+    const localCard = createLocalCardFixture({ id: "local" });
     cardStore.setState({ remoteCards: [remoteCard], localCards: [localCard] });
 
     expect(renderHook(useCards).result.current).toEqual([remoteCard, localCard]);
@@ -71,7 +70,7 @@ describe("Card store", () => {
 
   it("selects cards and tags for a deck", () => {
     const remoteCard = createCard({ id: "remote", deckId: "deck-a", tags: ["verb", "n5"] });
-    const localCard = createCard({ id: "local", deckId: "deck-a", tags: ["n5", "kanji"] });
+    const localCard = createLocalCardFixture({ id: "local", deckId: "deck-a", tags: ["n5", "kanji"] });
     const otherCard = createCard({ id: "other", deckId: "deck-b", tags: ["other"] });
     cardStore.setState({ remoteCards: [remoteCard, otherCard], localCards: [localCard] });
 
@@ -84,7 +83,7 @@ describe("Card store", () => {
   it("persists only local Cards and restores dates after hydration", async () => {
     const storage = useMemoryStorage();
     const remoteCard = createCard({ id: "remote" });
-    const localCard = createCard({ id: "local", nextSeeingAt: new Date(1_000) });
+    const localCard = createLocalCardFixture({ id: "local", nextSeeingAt: new Date(1_000) });
     cardStore.setState({ remoteCards: [remoteCard], localCards: [localCard] });
 
     const persistedValue = (await storage.getItem("tango-local-cards")) ?? "{}";
@@ -97,6 +96,23 @@ describe("Card store", () => {
     useMemoryStorage({ "tango-local-cards": persistedValue });
     await cardStore.persist.rehydrate();
     expect(cardStore.getState()).toEqual({ remoteCards: [], localCards: [localCard] });
+  });
+
+  it("hydrates version 1 local Cards without retaining a UID", async () => {
+    const localCard = createLocalCardFixture({ id: "persisted-local", nextSeeingAt: new Date(1_000) });
+    useMemoryStorage({
+      "tango-local-cards": JSON.stringify({
+        state: {
+          localCards: [{ ...localCard, uid: "previous-user", nextSeeingAt: localCard.nextSeeingAt?.toISOString() }],
+        },
+        version: 1,
+      }),
+    });
+
+    await cardStore.persist.rehydrate();
+
+    expect(cardStore.getState().localCards).toEqual([localCard]);
+    expect(cardStore.getState().localCards[0]).not.toHaveProperty("uid");
   });
 
   it("rejects invalid persisted Cards", async () => {
@@ -118,7 +134,9 @@ describe("Card store", () => {
 
     expect(createdCard).toEqual(expect.objectContaining({ id: "local", createdAt: 10, updatedAt: 10 }));
 
-    const updatedCard = editLocalCard({ id: "local", uid: "uid", frontText: "updated" });
+    expect(createdCard).not.toHaveProperty("uid");
+
+    const updatedCard = editLocalCard({ id: "local", frontText: "updated" });
     expect(updatedCard).toEqual(expect.objectContaining({ frontText: "updated", createdAt: 10, updatedAt: 20 }));
 
     deleteLocalCard("local");

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -2,16 +2,22 @@ import { createJSONStorage, persist, type StateStorage } from "zustand/middlewar
 import { createStore } from "zustand/vanilla";
 import { z } from "zod";
 
-import { cardCreateSchema, cardEditSchema, cardIdSchema, cardSchema, persistedCardSchema } from "./schema";
-import type { Card, CardCreateInput, CardEdit, CardId } from "./types";
+import {
+  cardIdSchema,
+  localCardCreateSchema,
+  localCardEditSchema,
+  localCardSchema,
+  persistedCardSchema,
+} from "./schema";
+import type { Card, CardId, LocalCard, LocalCardCreateInput, LocalCardEdit, RemoteCard } from "./types";
 
 interface CardState {
-  remoteCards: Card[];
-  localCards: Card[];
+  remoteCards: RemoteCard[];
+  localCards: LocalCard[];
 }
 
 interface PersistedCardState {
-  localCards: Card[];
+  localCards: LocalCard[];
 }
 
 interface CreateCardStoreOptions {
@@ -34,7 +40,6 @@ const createCardStore = ({ storage, skipHydration }: CreateCardStoreOptions = {}
       version: 1,
       ...(persistStorage !== undefined ? { storage: persistStorage } : {}),
       ...(skipHydration !== undefined ? { skipHydration } : {}),
-      migrate: parsePersistedCardState,
       merge: (persistedState, currentState) => ({
         ...currentState,
         ...parsePersistedCardState(persistedState),
@@ -46,7 +51,7 @@ const createCardStore = ({ storage, skipHydration }: CreateCardStoreOptions = {}
 
 export const cardStore = createCardStore();
 
-export const replaceRemoteCards = (remoteCards: Card[]): void => {
+export const replaceRemoteCards = (remoteCards: RemoteCard[]): void => {
   cardStore.setState({ remoteCards });
 };
 
@@ -60,22 +65,22 @@ export const findCardById = (id: CardId): Card | undefined => {
   return state.remoteCards.find((card) => card.id === cardId) ?? state.localCards.find((card) => card.id === cardId);
 };
 
-export const createLocalCard = (input: CardCreateInput): Card => {
-  const card = cardCreateSchema.parse(input);
+export const createLocalCard = (input: LocalCardCreateInput): LocalCard => {
+  const card = localCardCreateSchema.parse(input);
   const timestamp = Date.now();
-  const createdCard = cardSchema.parse({ ...card, createdAt: timestamp, updatedAt: timestamp });
+  const createdCard = localCardSchema.parse({ ...card, createdAt: timestamp, updatedAt: timestamp });
   const localCards = cardStore.getState().localCards.filter(({ id }) => id !== createdCard.id);
   cardStore.setState({ localCards: [...localCards, createdCard] });
   return createdCard;
 };
 
-export const editLocalCard = (input: CardEdit): Card => {
-  const edit = cardEditSchema.parse(input);
+export const editLocalCard = (input: LocalCardEdit): LocalCard => {
+  const edit = localCardEditSchema.parse(input);
   const localCards = cardStore.getState().localCards;
   const currentCard = localCards.find(({ id }) => id === edit.id);
   if (currentCard === undefined) throw new Error(`Local Card "${edit.id}" was not found`);
 
-  const updatedCard = cardSchema.parse({ ...currentCard, ...edit, updatedAt: Date.now() });
+  const updatedCard = localCardSchema.parse({ ...currentCard, ...edit, updatedAt: Date.now() });
   cardStore.setState({ localCards: localCards.map((card) => (card.id === updatedCard.id ? updatedCard : card)) });
   return updatedCard;
 };

--- a/src/entities/card/model/types.ts
+++ b/src/entities/card/model/types.ts
@@ -7,13 +7,21 @@ import type {
   cardSchema,
   deleteCardSchema,
   editCardSchema,
+  localCardCreateSchema,
+  localCardEditSchema,
+  localCardSchema,
 } from "./schema";
 
-export type Card = z.infer<typeof cardSchema>;
+export type RemoteCard = z.infer<typeof cardSchema>;
+export type LocalCard = z.infer<typeof localCardSchema>;
+export type Card = RemoteCard | LocalCard;
 export type CardCreate = z.infer<typeof cardCreateSchema>;
 export type CardCreateInput = z.input<typeof cardCreateSchema>;
+export type LocalCardCreateInput = z.input<typeof localCardCreateSchema>;
 export type CardId = z.infer<typeof cardIdSchema>;
 export type CardEdit = z.infer<typeof cardEditSchema>;
+export type LocalCardEdit = z.infer<typeof localCardEditSchema>;
+export type CardEditInput = LocalCardEdit;
 export type CardRaw = Pick<Card, "frontText" | "backText" | "uniqueKey" | "tags">;
 export type EditCardInput = z.infer<typeof editCardSchema>;
 export type DeleteCardInput = z.infer<typeof deleteCardSchema>;

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -1,11 +1,11 @@
 import type {
-  Deck,
   DeckCreate,
   DeckCreateInput,
   DeckEdit,
   DeckId,
   DeleteDeckInput,
   EditDeckInput,
+  RemoteDeck,
 } from "../model/types";
 
 import {
@@ -49,9 +49,9 @@ const deckDtoSchema = z.object({
   convertToBr: z.boolean(),
 });
 
-const convertDeckDtoToDeck = (id: DeckId, value: unknown): Deck => {
+const convertDeckDtoToDeck = (id: DeckId, value: unknown): RemoteDeck => {
   const dto = parseFirestoreDocument(deckDtoSchema, "deck", id, value);
-  const deck: Deck = { ...dto, id, localMode: false };
+  const deck: RemoteDeck = { ...dto, id, localMode: false };
   if (dto.url === undefined) delete deck.url;
   return deck;
 };
@@ -72,7 +72,7 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
     onError
   );
 
-export const fetchDecks = async (uid: string): Promise<Deck[]> => {
+export const fetchDecks = async (uid: string): Promise<RemoteDeck[]> => {
   const snapshot = await getDocsFromServer(query(collection(db, DECK_COLLECTION), where("uid", "==", uid)));
   return snapshot.docs
     .map((document) => convertDeckDtoToDeck(document.id, document.data()))

--- a/src/entities/deck/api/mutations.spec.ts
+++ b/src/entities/deck/api/mutations.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createDeck as createDeckFixture } from "@/test/factories";
+import { createDeck as createDeckFixture, createLocalDeck } from "@/test/factories";
 
 import { createDeck, deleteDeck, editDeck } from "./mutations";
 import { deckStore, findDeckById } from "../model/store";
@@ -29,7 +29,7 @@ describe("Deck mutations", () => {
   });
 
   it("routes local Deck create, edit, and delete to local persistence", async () => {
-    const deck = createDeckFixture({ id: "local", localMode: true });
+    const deck = createLocalDeck({ id: "local" });
 
     await createDeck("", deck);
     await editDeck("", { id: deck.id, name: "Renamed" });
@@ -56,7 +56,7 @@ describe("Deck mutations", () => {
 
     expect(mocks.createRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", deck);
     expect(mocks.editRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", edit);
-    expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", deck);
+    expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", { id: deck.id, uid: deck.uid });
     expect(mocks.deleteLocalCardsByDeckId).not.toHaveBeenCalled();
   });
 

--- a/src/entities/deck/api/mutations.ts
+++ b/src/entities/deck/api/mutations.ts
@@ -1,4 +1,4 @@
-import type { DeckCreateInput, DeckId, DeleteDeckInput, EditDeckInput } from "../model/types";
+import type { DeckCreateInput, DeckId, EditDeckInput, LocalDeckCreateInput } from "../model/types";
 
 import { deleteLocalCardsByDeckId } from "@/entities/card/@x/deck";
 import { createLocalDeck, deleteLocalDeck, editLocalDeck, findDeckById } from "../model/store";
@@ -14,7 +14,7 @@ const requireDeck = (id: DeckId) => {
   return deck;
 };
 
-export const createDeck = async (uid: string, deck: DeckCreateInput): Promise<void> => {
+export const createDeck = async (uid: string, deck: DeckCreateInput | LocalDeckCreateInput): Promise<void> => {
   if (deck.localMode === true) {
     createLocalDeck({ ...deck, localMode: true });
     return;
@@ -30,11 +30,12 @@ export const editDeck = async (uid: string, deck: EditDeckInput["deck"]): Promis
   await editRemoteDeck(uid, deck);
 };
 
-export const deleteDeck = async (uid: string, deck: DeleteDeckInput["deck"]): Promise<void> => {
-  if (requireDeck(deck.id).localMode) {
+export const deleteDeck = async (uid: string, deck: { id: DeckId }): Promise<void> => {
+  const currentDeck = requireDeck(deck.id);
+  if (currentDeck.localMode) {
     deleteLocalCardsByDeckId(deck.id);
     deleteLocalDeck(deck.id);
     return;
   }
-  await deleteRemoteDeck(uid, deck);
+  await deleteRemoteDeck(uid, { id: deck.id, uid: currentDeck.uid });
 };

--- a/src/entities/deck/api/subscription.spec.tsx
+++ b/src/entities/deck/api/subscription.spec.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createDeck } from "@/test/factories";
+import { createLocalDeck } from "@/test/factories";
 import { useDecks } from "../model/hooks";
 import { deckStore } from "../model/store";
 
@@ -54,7 +54,7 @@ describe("Deck Firestore subscription", () => {
   });
 
   it("subscribes by UID and replaces the store with active Decks", () => {
-    const localDeck = createDeck({ id: "local", name: "Local Deck", localMode: true });
+    const localDeck = createLocalDeck({ id: "local", name: "Local Deck" });
     deckStore.setState({ localDecks: [localDeck] });
     const { result } = renderHook(useDecks);
     const unsubscribe = subscribeDecks("uid-a", vi.fn());

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -4,7 +4,4 @@ export { generateDeckId } from "./model/id";
 export { CATEGORY, getCategory, isHighlightLanguage, mustFindDeckById } from "./model/rules";
 export { useDeck, useDecks } from "./model/hooks";
 export { clearRemoteDecks } from "./model/store";
-/** @public */
-export { createLocalDeck, deleteLocalDeck, editLocalDeck } from "./model/store";
-/** @public */
-export type { Deck, DeckCreateInput, DeckEdit, DeckId, LocalDeckCreateInput } from "./model/types";
+export type { Deck, DeckCreateInput, DeckEdit, DeckId, RemoteDeck } from "./model/types";

--- a/src/entities/deck/model/schema.ts
+++ b/src/entities/deck/model/schema.ts
@@ -16,10 +16,8 @@ const editableDeckFieldsSchema = z.object({
   convertToBr: z.boolean(),
 });
 
-export const deckCreateSchema = editableDeckFieldsSchema.extend({
+const deckCreateFieldsSchema = editableDeckFieldsSchema.extend({
   id: deckIdSchema,
-  uid: deckUidSchema,
-  localMode: z.boolean().default(false),
   isPublic: editableDeckFieldsSchema.shape.isPublic.default(false),
   scoreMax: editableDeckFieldsSchema.shape.scoreMax.default(null),
   scoreMin: editableDeckFieldsSchema.shape.scoreMin.default(null),
@@ -30,14 +28,24 @@ export const deckCreateSchema = editableDeckFieldsSchema.extend({
   deletedAt: z.number().nullable().default(null),
 });
 
-export const deckSchema = deckCreateSchema.extend({
+export const deckCreateSchema = deckCreateFieldsSchema.extend({
+  uid: deckUidSchema,
+  localMode: z.literal(false).default(false),
+});
+
+export const localDeckCreateSchema = deckCreateFieldsSchema.extend({ localMode: z.literal(true) });
+
+export const remoteDeckSchema = deckCreateSchema.extend({
   createdAt: z.number(),
   updatedAt: z.number(),
 });
 
-export const localDeckCreateSchema = deckCreateSchema.extend({ localMode: z.literal(true) });
-export const localDeckSchema = deckSchema.extend({ localMode: z.literal(true) });
-const remoteDeckCreateSchema = deckCreateSchema.extend({ localMode: z.literal(false).default(false) });
+export const localDeckSchema = localDeckCreateSchema.extend({
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const deckSchema = z.discriminatedUnion("localMode", [remoteDeckSchema, localDeckSchema]);
 
 export const deckEditSchema = editableDeckFieldsSchema.partial().extend({ id: deckIdSchema });
 const deckIdentitySchema = z.object({ id: deckIdSchema, uid: deckUidSchema });
@@ -53,7 +61,7 @@ const validateDeckOwner = (input: { uid: string; deck: { uid: string } }, contex
 };
 
 export const createDeckSchema = z
-  .object({ uid: authenticatedUidSchema, deck: remoteDeckCreateSchema })
+  .object({ uid: authenticatedUidSchema, deck: deckCreateSchema })
   .superRefine(validateDeckOwner);
 
 export const editDeckSchema = z.object({

--- a/src/entities/deck/model/store.spec.tsx
+++ b/src/entities/deck/model/store.spec.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
-import { createDeck } from "@/test/factories";
+import { createDeck, createLocalDeck as createLocalDeckFixture } from "@/test/factories";
 import { useDeck, useDecks } from "./hooks";
 import {
   clearRemoteDecks,
@@ -37,7 +37,7 @@ describe("Deck store", () => {
 
   it("replaces and clears only the remote Deck collection", () => {
     const remoteDeck = createDeck({ id: "remote" });
-    const localDeck = createDeck({ id: "local", localMode: true });
+    const localDeck = createLocalDeckFixture({ id: "local" });
     deckStore.setState({ localDecks: [localDeck] });
 
     replaceRemoteDecks([remoteDeck]);
@@ -49,7 +49,7 @@ describe("Deck store", () => {
 
   it("exposes combined collection and individual Deck selectors", () => {
     const remoteDeck = createDeck({ id: "remote" });
-    const localDeck = createDeck({ id: "local", localMode: true });
+    const localDeck = createLocalDeckFixture({ id: "local" });
     deckStore.setState({ remoteDecks: [remoteDeck], localDecks: [localDeck] });
 
     expect(renderHook(useDecks).result.current).toEqual([remoteDeck, localDeck]);
@@ -61,7 +61,7 @@ describe("Deck store", () => {
   it("persists only local Decks and restores them after hydration", async () => {
     const storage = useMemoryStorage();
     const remoteDeck = createDeck({ id: "remote" });
-    const localDeck = createDeck({ id: "local", localMode: true });
+    const localDeck = createLocalDeckFixture({ id: "local" });
     deckStore.setState({ remoteDecks: [remoteDeck], localDecks: [localDeck] });
 
     const persistedValue = (await storage.getItem("tango-local-decks")) ?? "{}";
@@ -74,6 +74,21 @@ describe("Deck store", () => {
     useMemoryStorage({ "tango-local-decks": persistedValue });
     await deckStore.persist.rehydrate();
     expect(deckStore.getState()).toEqual({ remoteDecks: [], localDecks: [localDeck] });
+  });
+
+  it("hydrates version 1 local Decks without retaining a UID", async () => {
+    const localDeck = createLocalDeckFixture({ id: "persisted-local" });
+    useMemoryStorage({
+      "tango-local-decks": JSON.stringify({
+        state: { localDecks: [{ ...localDeck, uid: "previous-user" }] },
+        version: 1,
+      }),
+    });
+
+    await deckStore.persist.rehydrate();
+
+    expect(deckStore.getState().localDecks).toEqual([localDeck]);
+    expect(deckStore.getState().localDecks[0]).not.toHaveProperty("uid");
   });
 
   it("rejects invalid persisted Decks", async () => {
@@ -89,11 +104,12 @@ describe("Deck store", () => {
 
   it("creates, edits, and deletes a local Deck synchronously", () => {
     vi.spyOn(Date, "now").mockReturnValueOnce(10).mockReturnValueOnce(20);
-    const createdDeck = createLocalDeck({ id: "local", uid: "uid", name: "Local", localMode: true });
+    const createdDeck = createLocalDeck({ id: "local", name: "Local", localMode: true });
 
     expect(createdDeck).toEqual(
       expect.objectContaining({ id: "local", localMode: true, createdAt: 10, updatedAt: 10 })
     );
+    expect(createdDeck).not.toHaveProperty("uid");
 
     const updatedDeck = editLocalDeck({ id: "local", name: "Renamed" });
     expect(updatedDeck).toEqual(expect.objectContaining({ name: "Renamed", createdAt: 10, updatedAt: 20 }));

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -3,15 +3,15 @@ import { createStore } from "zustand/vanilla";
 import { z } from "zod";
 
 import { deckEditSchema, deckIdSchema, localDeckCreateSchema, localDeckSchema } from "./schema";
-import type { Deck, DeckEdit, DeckId, LocalDeckCreateInput } from "./types";
+import type { Deck, DeckEdit, DeckId, LocalDeck, LocalDeckCreateInput, RemoteDeck } from "./types";
 
 interface DeckState {
-  remoteDecks: Deck[];
-  localDecks: Deck[];
+  remoteDecks: RemoteDeck[];
+  localDecks: LocalDeck[];
 }
 
 interface PersistedDeckState {
-  localDecks: Deck[];
+  localDecks: LocalDeck[];
 }
 
 interface CreateDeckStoreOptions {
@@ -34,7 +34,6 @@ const createDeckStore = ({ storage, skipHydration }: CreateDeckStoreOptions = {}
       version: 1,
       ...(persistStorage !== undefined ? { storage: persistStorage } : {}),
       ...(skipHydration !== undefined ? { skipHydration } : {}),
-      migrate: parsePersistedDeckState,
       merge: (persistedState, currentState) => ({
         ...currentState,
         ...parsePersistedDeckState(persistedState),
@@ -46,7 +45,7 @@ const createDeckStore = ({ storage, skipHydration }: CreateDeckStoreOptions = {}
 
 export const deckStore = createDeckStore();
 
-export const replaceRemoteDecks = (remoteDecks: Deck[]): void => {
+export const replaceRemoteDecks = (remoteDecks: RemoteDeck[]): void => {
   deckStore.setState({ remoteDecks });
 };
 
@@ -60,8 +59,7 @@ export const findDeckById = (id: DeckId): Deck | undefined => {
   return state.remoteDecks.find((deck) => deck.id === deckId) ?? state.localDecks.find((deck) => deck.id === deckId);
 };
 
-/** @public */
-export const createLocalDeck = (input: LocalDeckCreateInput): Deck => {
+export const createLocalDeck = (input: LocalDeckCreateInput): LocalDeck => {
   const deck = localDeckCreateSchema.parse(input);
   const timestamp = Date.now();
   const createdDeck = localDeckSchema.parse({ ...deck, createdAt: timestamp, updatedAt: timestamp });
@@ -70,8 +68,7 @@ export const createLocalDeck = (input: LocalDeckCreateInput): Deck => {
   return createdDeck;
 };
 
-/** @public */
-export const editLocalDeck = (input: DeckEdit): Deck => {
+export const editLocalDeck = (input: DeckEdit): LocalDeck => {
   const edit = deckEditSchema.parse(input);
   const localDecks = deckStore.getState().localDecks;
   const currentDeck = localDecks.find(({ id }) => id === edit.id);
@@ -82,7 +79,6 @@ export const editLocalDeck = (input: DeckEdit): Deck => {
   return updatedDeck;
 };
 
-/** @public */
 export const deleteLocalDeck = (input: DeckId): void => {
   const deckId = deckIdSchema.parse(input);
   deckStore.setState({ localDecks: deckStore.getState().localDecks.filter(({ id }) => id !== deckId) });

--- a/src/entities/deck/model/types.ts
+++ b/src/entities/deck/model/types.ts
@@ -8,6 +8,8 @@ import type {
   deleteDeckSchema,
   editDeckSchema,
   localDeckCreateSchema,
+  localDeckSchema,
+  remoteDeckSchema,
 } from "./schema";
 
 export type Category = string;
@@ -15,6 +17,8 @@ export type Deck = z.infer<typeof deckSchema>;
 export type DeckCreate = z.infer<typeof deckCreateSchema>;
 export type DeckCreateInput = z.input<typeof deckCreateSchema>;
 export type LocalDeckCreateInput = z.input<typeof localDeckCreateSchema>;
+export type LocalDeck = z.infer<typeof localDeckSchema>;
+export type RemoteDeck = z.infer<typeof remoteDeckSchema>;
 export type DeckId = z.infer<typeof deckIdSchema>;
 export type DeckEdit = z.infer<typeof deckEditSchema>;
 export type EditDeckInput = z.infer<typeof editDeckSchema>;

--- a/src/features/card-edit/model/useCardEditAction.ts
+++ b/src/features/card-edit/model/useCardEditAction.ts
@@ -1,4 +1,4 @@
-import type { CardEdit } from "@/entities/card";
+import type { CardEditInput } from "@/entities/card";
 
 import * as React from "react";
 
@@ -14,7 +14,7 @@ export const useCardEditAction = ({ onSaved }: UseCardEditActionOptions = {}) =>
   const [error, setError] = React.useState<unknown>(null);
 
   const update = React.useCallback(
-    async (card: CardEdit) => {
+    async (card: CardEditInput) => {
       setError(null);
       try {
         await editCard(uid, card);

--- a/src/features/card-edit/model/useCardFormState.ts
+++ b/src/features/card-edit/model/useCardFormState.ts
@@ -1,4 +1,4 @@
-import type { Card, CardEdit } from "@/entities/card";
+import type { Card, CardEditInput } from "@/entities/card";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -11,7 +11,7 @@ interface UseCardFormStateOptions {
   card: Card;
   categoryOptions: Option[];
   onCancel: () => void;
-  onSubmit: (card: CardEdit) => Promise<void>;
+  onSubmit: (card: CardEditInput) => Promise<void>;
 }
 
 export const useCardFormState = ({
@@ -46,6 +46,6 @@ export const useCardFormState = ({
     },
     isSubmitting: formState.isSubmitting,
     onCancel,
-    onSubmit: handleSubmit((values) => onSubmit({ id: card.id, uid: card.uid, ...values })),
+    onSubmit: handleSubmit((values) => onSubmit({ id: card.id, ...values })),
   };
 };

--- a/src/features/card-edit/ui/CardEditForm.spec.tsx
+++ b/src/features/card-edit/ui/CardEditForm.spec.tsx
@@ -1,4 +1,4 @@
-import type { Card } from "@/entities/card";
+import type { RemoteCard } from "@/entities/card";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -20,7 +20,7 @@ vi.mock("@/entities/deck", () => ({ CATEGORY: ["language", "math"] }));
 import { CardEditForm } from "./CardEditForm";
 
 describe("CardEditForm", () => {
-  const card: Card = createCard({
+  const card: RemoteCard = createCard({
     id: "card-id",
     uid: "user-id",
     frontText: "Front text",
@@ -48,7 +48,6 @@ describe("CardEditForm", () => {
     await waitFor(() =>
       expect(mocks.editCard).toHaveBeenCalledWith("user-id", {
         id: card.id,
-        uid: card.uid,
         frontText: "Updated front",
         backText: "Updated back",
         tags: ["language", "math"],

--- a/src/features/deck-edit/model/useDeckFormState.ts
+++ b/src/features/deck-edit/model/useDeckFormState.ts
@@ -1,4 +1,4 @@
-import type { Deck } from "@/entities/deck";
+import type { Deck, DeckEdit } from "@/entities/deck";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -10,7 +10,7 @@ import { deckFormSchema, type DeckFormValues } from "./deckFormSchema";
 interface UseDeckFormStateOptions {
   deck: Deck;
   onCancel: () => void;
-  onSubmit: (deck: Deck) => Promise<void>;
+  onSubmit: (deck: DeckEdit) => Promise<void>;
 }
 
 export const useDeckFormState = ({ deck, onCancel, onSubmit }: UseDeckFormStateOptions): DeckFormProps => {
@@ -41,6 +41,6 @@ export const useDeckFormState = ({ deck, onCancel, onSubmit }: UseDeckFormStateO
     },
     isSubmitting: formState.isSubmitting,
     onCancel,
-    onSubmit: handleSubmit((values) => onSubmit({ ...deck, ...values, url: values.url ?? "" })),
+    onSubmit: handleSubmit((values) => onSubmit({ id: deck.id, ...values, url: values.url ?? "" })),
   };
 };

--- a/src/features/deck-edit/ui/DeckEditForm.spec.tsx
+++ b/src/features/deck-edit/ui/DeckEditForm.spec.tsx
@@ -48,7 +48,7 @@ describe("DeckEditForm", () => {
 
     await waitFor(() =>
       expect(mocks.editDeck).toHaveBeenCalledWith("user-id", {
-        ...deck,
+        id: deck.id,
         name: "Updated deck",
         url: "https://example.com/deck.csv",
         convertToBr: true,

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -1,5 +1,5 @@
-import type { Card, CardId, CardMutation, CardRaw } from "@/entities/card";
-import type { Deck, DeckCreateInput, DeckId } from "@/entities/deck";
+import type { Card, CardId, CardMutation, CardRaw, RemoteCard } from "@/entities/card";
+import type { Deck, DeckCreateInput, DeckId, RemoteDeck } from "@/entities/deck";
 
 import { CardBulkMutationError } from "@/entities/card";
 import { generateDeckId } from "@/entities/deck";
@@ -30,8 +30,8 @@ export interface DeckImportDependencies {
   createDeck: (deck: DeckCreateInput) => Promise<unknown>;
   generateCardId: () => string;
   mutateCards: (mutations: CardMutation[]) => Promise<unknown>;
-  fetchDecks?: (uid: string) => Promise<Deck[]>;
-  fetchCards?: (uid: string) => Promise<Card[]>;
+  fetchDecks?: (uid: string) => Promise<RemoteDeck[]>;
+  fetchCards?: (uid: string) => Promise<RemoteCard[]>;
 }
 
 type DeckImportPreparationDependencies = Pick<
@@ -54,15 +54,17 @@ const prepareDeckImportAttempt = (
   const name = request.kind === "sample" ? SAMPLE_DECK_NAME : request.name;
   const preferredDeckId = request.kind === "sample" ? sampleDeckId(uid) : undefined;
   const rows = request.kind === "sample" ? rowsFromCards(sampleCards as CardRaw[]) : request.rows;
-  let deck: DeckCreateInput | undefined = decks.find((candidate) =>
-    preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId
+  let deck: DeckCreateInput | undefined = decks.find(
+    (candidate): candidate is RemoteDeck =>
+      !candidate.localMode &&
+      (preferredDeckId === undefined ? candidate.name === name : candidate.id === preferredDeckId)
   );
   const createDeckPending = deck == null;
   if (deck == null) {
     deck = { id: preferredDeckId ?? generateDeckId(), uid, name };
   }
 
-  const existing = cardsByDeckId(deck.id);
+  const existing = cardsByDeckId(deck.id).filter((card): card is RemoteCard => "uid" in card);
   const byUniqueKey = new Map(existing.map((card) => [card.uniqueKey, card]));
   const plan = buildDeckImportPlan(rows, existing);
   const remainingMutations: CardMutation[] = [];

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -4,8 +4,10 @@
  * objects.
  */
 
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
+import type { RemoteCard } from "@/entities/card";
+import type { LocalCard } from "@/entities/card/model/types";
+import type { RemoteDeck } from "@/entities/deck";
+import type { LocalDeck } from "@/entities/deck/model/types";
 import type { Preferences, StudyPreferences, SwipeAction } from "@/entities/preferences";
 
 type AppearancePreferences = Preferences["appearance"];
@@ -15,7 +17,7 @@ type ControlPreferences = Preferences["controls"];
  * Builds a complete test deck with predictable defaults and optional field overrides.
  * Tests can describe only the deck fields relevant to their scenario.
  */
-export const createDeck = (overrides: Partial<Deck> = {}): Deck => ({
+export const createDeck = (overrides: Partial<RemoteDeck> = {}): RemoteDeck => ({
   id: "deck-id",
   uid: "user-id",
   localMode: false,
@@ -33,14 +35,46 @@ export const createDeck = (overrides: Partial<Deck> = {}): Deck => ({
   ...overrides,
 });
 
+export const createLocalDeck = (overrides: Partial<LocalDeck> = {}): LocalDeck => ({
+  id: "local-deck-id",
+  localMode: true,
+  name: "Local Deck",
+  isPublic: false,
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  scoreMax: null,
+  scoreMin: null,
+  selectedTags: [],
+  tagAndFilter: false,
+  category: "",
+  convertToBr: false,
+  ...overrides,
+});
+
 /**
  * Builds a complete test card with predictable defaults and optional field overrides.
  * Tests can describe only the card fields relevant to their scenario.
  */
-export const createCard = (overrides: Partial<Card> = {}): Card => ({
+export const createCard = (overrides: Partial<RemoteCard> = {}): RemoteCard => ({
   id: "card-id",
   deckId: "deck-id",
   uid: "user-id",
+  frontText: "front",
+  backText: "back",
+  tags: [],
+  uniqueKey: "unique-key",
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+  score: 0,
+  numberOfSeen: 0,
+  ...overrides,
+});
+
+export const createLocalCard = (overrides: Partial<LocalCard> = {}): LocalCard => ({
+  id: "local-card-id",
+  deckId: "local-deck-id",
   frontText: "front",
   backText: "back",
   tags: [],

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -4,7 +4,7 @@
  * "should update a card", and "should import cards".
  */
 
-import { mutateCards, type Card } from "@/entities/card";
+import { mutateCards, type Card, type RemoteCard } from "@/entities/card";
 import type { CardCreateInput } from "@/entities/card/model/types";
 
 import "@/test/initializeTestFirestore";
@@ -117,7 +117,7 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
   it("reports failed imported Cards while persisting valid Cards", async () => {
     const deckId = await initDeck();
     const valid = { ...newCard, deckId, id: uuid(), frontText: "valid" };
-    const invalid = { ...newCard, deckId, id: uuid(), frontText: 42 } as unknown as Card;
+    const invalid = { ...newCard, deckId, id: uuid(), frontText: 42 } as unknown as RemoteCard;
 
     await expect(
       mutateCards("uid", [


### PR DESCRIPTION
## Summary

- model local Decks and Cards without Firebase Authentication UIDs while keeping remote entities owner-bound
- keep local/remote routing inside the entity mutation APIs instead of exposing persistence decisions to features and pages
- keep local persistence at version 1 and normalize persisted UIDs through the existing schema parse during hydration
- keep remote import and Firestore contracts restricted to authenticated remote entity types

## Why

Local and remote entities previously shared create schemas that required a UID. This made browser-local data depend on Firebase Authentication and prevented `Local only` behavior from standing on its own.

## Impact

Local Decks and their Cards can now be created, edited, deleted, and hydrated without an authenticated UID. Existing version 1 local data remains readable; obsolete UID fields are dropped as unknown schema keys during hydration. Login and logout continue to clear only remote collections. Remote writes still require a non-empty authenticated UID and preserve owner validation.

## Validation

- `mise run check`
- 101 unit test files passed
- 520 unit tests passed

Closes #959