### PR TITLE
fix: verify missing study cards from server (#947)

### DIFF
--- a/src/entities/card/api/firestore.spec.ts
+++ b/src/entities/card/api/firestore.spec.ts
@@ -2,12 +2,34 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createCard as createCardFixture } from "@/test/factories";
 
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn((...parts: unknown[]) => parts),
+  getDocFromServer: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>();
+  return { ...actual, doc: mocks.doc, getDocFromServer: mocks.getDocFromServer };
+});
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 
-import { createCard, deleteCard, editCard } from "./firestore";
+import { createCard, deleteCard, editCard, fetchCardFromServer } from "./firestore";
 
 describe("Card Firestore persistence", () => {
   const card = createCardFixture({ id: "card", uid: "uid-a" });
+
+  it("reads only the requested Card from the server", async () => {
+    mocks.getDocFromServer.mockResolvedValueOnce({ exists: () => true, id: card.id, data: () => card });
+
+    await expect(fetchCardFromServer(card.id)).resolves.toEqual(card);
+    expect(mocks.doc).toHaveBeenCalledWith({}, "card", card.id);
+  });
+
+  it("returns undefined when the server Card is missing", async () => {
+    mocks.getDocFromServer.mockResolvedValueOnce({ exists: () => false });
+
+    await expect(fetchCardFromServer(card.id)).resolves.toBeUndefined();
+  });
 
   it("rejects create requests without a confirmed matching owner", async () => {
     await expect(createCard("", card)).rejects.toThrow("confirmed user");

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -8,7 +8,17 @@ import type {
   EditCardInput,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  onSnapshot,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 
 import { db } from "@/shared/firebase";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
@@ -65,6 +75,11 @@ export const fetchCards = async (uid: string): Promise<Card[]> => {
   return snapshot.docs
     .map((document) => convertCardDocumentToCard(document.id, document.data()))
     .filter((card) => card.deletedAt === null);
+};
+
+export const fetchCardFromServer = async (id: CardId): Promise<Card | undefined> => {
+  const snapshot = await getDocFromServer(doc(db, CARD_COLLECTION, id));
+  return snapshot.exists() ? convertCardDocumentToCard(snapshot.id, snapshot.data()) : undefined;
 };
 
 const createCardDocument = async (card: CardCreate): Promise<void> => {

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,4 @@
-export { createCard, deleteCard, editCard, fetchCards, subscribeCards } from "./api/firestore";
+export { createCard, deleteCard, editCard, fetchCardFromServer, fetchCards, subscribeCards } from "./api/firestore";
 export { generateCardId } from "./model/id";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";

--- a/src/features/study/components/StudyWorkflow.spec.tsx
+++ b/src/features/study/components/StudyWorkflow.spec.tsx
@@ -16,9 +16,14 @@ const mocks = vi.hoisted(() => ({
   touchStudySession: vi.fn(),
   toggleShowHeader: vi.fn(),
   toggleShowSwipeButtonList: vi.fn(),
+  fetchCardFromServer: vi.fn(),
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return { ...actual, fetchCardFromServer: mocks.fetchCardFromServer };
+});
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => {
     if (mocks.preferences == null) throw new Error("Preferences not initialized");
@@ -59,6 +64,13 @@ const createCard = (id: string): Card => ({
 const cards = [createCard("card-1"), createCard("card-2"), createCard("card-3")];
 
 const WorkflowView = ({ state }: { state: StudyWorkflowState }) => {
+  if (state.status === "error") {
+    return (
+      <button type="button" onClick={state.retry}>
+        retry
+      </button>
+    );
+  }
   if (state.status !== "ready") return <div>{state.status}</div>;
   return (
     <div>
@@ -82,7 +94,7 @@ const WorkflowView = ({ state }: { state: StudyWorkflowState }) => {
 
 const renderWorkflow = (currentCards: readonly Card[] = cards) =>
   render(
-    <StudyWorkflow cards={currentCards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
+    <StudyWorkflow cards={currentCards} deckId={deckId} uid="user-id" onUnavailable={mocks.onUnavailable}>
       {(state) => <WorkflowView state={state} />}
     </StudyWorkflow>
   );
@@ -93,6 +105,7 @@ describe("StudyWorkflow", () => {
     vi.clearAllMocks();
     mocks.hydrated = true;
     mocks.update.mockResolvedValue(undefined);
+    mocks.fetchCardFromServer.mockReturnValue(new Promise(() => undefined));
     mocks.preferences = createPreferences({
       cardInterval: 1,
       defaultAutoPlay: false,
@@ -116,6 +129,7 @@ describe("StudyWorkflow", () => {
     renderWorkflow();
 
     expect(screen.getByText("card-1")).toBeVisible();
+    expect(mocks.fetchCardFromServer).not.toHaveBeenCalled();
     expect(mocks.touchStudySession).toHaveBeenCalledWith(deckId);
     fireEvent.keyDown(window, { key: "Enter" });
     expect(screen.getByTestId("back")).toHaveTextContent("true");
@@ -143,12 +157,57 @@ describe("StudyWorkflow", () => {
 
     mocks.hydrated = true;
     view.rerender(
-      <StudyWorkflow cards={cards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
+      <StudyWorkflow cards={cards} deckId={deckId} uid="user-id" onUnavailable={mocks.onUnavailable}>
         {(state) => <WorkflowView state={state} />}
       </StudyWorkflow>
     );
     await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
     expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+  });
+
+  it("uses an active remote target without resetting the session", async () => {
+    mocks.fetchCardFromServer.mockResolvedValueOnce(cards[0]);
+    renderWorkflow([]);
+
+    expect(await screen.findByText("card-1")).toBeVisible();
+    expect(mocks.fetchCardFromServer).toHaveBeenCalledOnce();
+    expect(mocks.onUnavailable).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "swipe right" }));
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledOnce());
+  });
+
+  it("cleans up a missing remote target", async () => {
+    mocks.fetchCardFromServer.mockResolvedValueOnce(undefined);
+    renderWorkflow([]);
+
+    await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+  });
+
+  it.each([
+    ["deleted", { deletedAt: 1 }],
+    ["another Deck", { deckId: "other-deck" }],
+    ["another user", { uid: "other-user" }],
+  ])("cleans up a remote target belonging to %s", async (_label, overrides) => {
+    mocks.fetchCardFromServer.mockResolvedValueOnce({ ...cards[0], ...overrides });
+    renderWorkflow([]);
+
+    await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeUndefined();
+  });
+
+  it("keeps the session and offers retry when the server read fails", async () => {
+    mocks.fetchCardFromServer.mockRejectedValueOnce(new Error("offline"));
+    renderWorkflow([]);
+
+    const retry = await screen.findByRole("button", { name: "retry" });
+    expect(mocks.onUnavailable).not.toHaveBeenCalled();
+    expect(studyStore.getState().sessionsByDeckId[deckId]).toBeDefined();
+
+    mocks.fetchCardFromServer.mockResolvedValueOnce(cards[0]);
+    fireEvent.click(retry);
+    expect(await screen.findByText("card-1")).toBeVisible();
+    expect(mocks.fetchCardFromServer).toHaveBeenCalledTimes(2);
   });
 
   it("restarts repeated swipe feedback timing", async () => {

--- a/src/features/study/components/StudyWorkflow.tsx
+++ b/src/features/study/components/StudyWorkflow.tsx
@@ -21,6 +21,7 @@ type PresentationActions = Pick<
 
 export type StudyWorkflowState =
   | { status: "loading" | "unavailable" }
+  | { status: "error"; retry: () => void }
   | {
       status: "ready";
       card: Card;
@@ -37,16 +38,20 @@ export type StudyWorkflowState =
 interface StudyWorkflowProps {
   cards: readonly Card[];
   deckId: DeckId;
+  uid: string;
   onUnavailable: () => void;
   children: (state: StudyWorkflowState) => React.ReactNode;
 }
 
-export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyWorkflowProps) => {
+export const StudyWorkflow = ({ cards, deckId, uid, onUnavailable, children }: StudyWorkflowProps) => {
   const display = useStudyDisplayState();
   const feedback = useSwipeFeedback(display.preferences.appearance.showSwipeFeedback);
   const cardMutation = useEditStudyProgress();
+  const session = useActiveStudySession(deckId, uid, cards);
+  const workflowCards =
+    session.status === "ready" && !cards.some(({ id }) => id === session.card.id) ? [...cards, session.card] : cards;
   const actions = useStudyActions(deckId, {
-    cards,
+    cards: workflowCards,
     cardMutation: { update: cardMutation.update },
     onSwipe: feedback.showSwipe,
     showBackText: display.showBackText,
@@ -55,7 +60,6 @@ export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyW
     onRestoreBackText: display.restoreBackText,
     onToggleAutoPlay: display.toggleAutoPlay,
   });
-  const session = useActiveStudySession(deckId, cards);
   useStudySessionLifecycle({ deckId, session, resetStudy: actions.resetStudy, onUnavailable });
   useStudyShortcuts(actions);
 

--- a/src/features/study/hooks/useActiveStudySession.ts
+++ b/src/features/study/hooks/useActiveStudySession.ts
@@ -1,4 +1,4 @@
-import type { Card } from "@/entities/card";
+import { fetchCardFromServer, type Card, type CardId } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 
 import * as React from "react";
@@ -10,6 +10,7 @@ import { useStudyStore } from "./useStudyStore";
 
 export type ActiveStudySession =
   | { status: "loading" | "unavailable" }
+  | { status: "error"; retry: () => void }
   | {
       status: "ready";
       card: Card;
@@ -17,17 +18,66 @@ export type ActiveStudySession =
       numberOfCards: number;
     };
 
-export const useActiveStudySession = (deckId: DeckId, cards: readonly Card[]): ActiveStudySession => {
+type RemoteCardResult =
+  | { cardId?: undefined; status: "idle" }
+  | { cardId: CardId; attempt: number; status: "missing" | "error" }
+  | { cardId: CardId; attempt: number; status: "found"; card: Card };
+
+const useRemoteStudyCard = (cardId: CardId | undefined, enabled: boolean) => {
+  const [attempt, setAttempt] = React.useState(0);
+  const [result, setResult] = React.useState<RemoteCardResult>({ status: "idle" });
+
+  React.useEffect(() => {
+    if (!enabled || cardId == null) return;
+
+    let cancelled = false;
+    void fetchCardFromServer(cardId).then(
+      (card) => {
+        if (!cancelled) {
+          setResult(card == null ? { cardId, attempt, status: "missing" } : { cardId, attempt, status: "found", card });
+        }
+      },
+      () => {
+        if (!cancelled) setResult({ cardId, attempt, status: "error" });
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt, cardId, enabled]);
+
+  const retry = React.useCallback(() => setAttempt((value) => value + 1), []);
+  return { attempt, result, retry };
+};
+
+export const useActiveStudySession = (deckId: DeckId, uid: string, cards: readonly Card[]): ActiveStudySession => {
   const session = useStudyStore(selectStudySessionForRoute(deckId));
+  const hydrated = useStudyHydrated();
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
   const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
   const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
+  const remote = useRemoteStudyCard(cardId, hydrated && sessionHasTargetCard && card == null);
 
   if (card != null && sessionHasTargetCard) {
     return { status: "ready", card, index, numberOfCards: session.cardOrderIds.length };
   }
-  if (sessionHasTargetCard && cards.length === 0) return { status: "loading" };
+  if (!sessionHasTargetCard) return { status: "unavailable" };
+  if (
+    !hydrated ||
+    remote.result.cardId !== cardId ||
+    !("attempt" in remote.result) ||
+    remote.result.attempt !== remote.attempt
+  ) {
+    return { status: "loading" };
+  }
+  if (remote.result.status === "error") return { status: "error", retry: remote.retry };
+  if (remote.result.status === "found") {
+    const remoteCard = remote.result.card;
+    if (remoteCard.deletedAt === null && remoteCard.deckId === deckId && remoteCard.uid === uid) {
+      return { status: "ready", card: remoteCard, index, numberOfCards: session.cardOrderIds.length };
+    }
+  }
   return { status: "unavailable" };
 };
 
@@ -51,11 +101,11 @@ export const useStudySessionLifecycle = ({
   }, [deckId, session.status]);
 
   React.useEffect(() => {
-    if (session.status === "ready") {
+    if (session.status !== "unavailable") {
       exitingDeck.current = undefined;
       return;
     }
-    if (!hydrated || session.status === "loading" || exitingDeck.current === deckId) return;
+    if (!hydrated || exitingDeck.current === deckId) return;
 
     exitingDeck.current = deckId;
     resetStudy();

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { StudyWorkflowState } from "@/features/study";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,7 +13,9 @@ const mocks = vi.hoisted(() => ({
   cards: [] as Card[],
   navigate: vi.fn(),
   workflowState: { status: "unavailable" } as StudyWorkflowState,
-  workflowProps: undefined as { cards: readonly Card[]; deckId: string; onUnavailable: () => void } | undefined,
+  workflowProps: undefined as
+    | { cards: readonly Card[]; deckId: string; uid: string; onUnavailable: () => void }
+    | undefined,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -36,6 +38,7 @@ vi.mock("@/features/study", async (importOriginal) => {
     }: { children: (state: StudyWorkflowState) => React.ReactNode } & {
       cards: readonly Card[];
       deckId: string;
+      uid: string;
       onUnavailable: () => void;
     }) => {
       mocks.workflowProps = props;
@@ -115,7 +118,7 @@ describe("DeckSwiperPage", () => {
   it("passes Entity reads to StudyWorkflow and composes the application shell", () => {
     render(<DeckSwiperPage />);
 
-    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, cards: [card] });
+    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, uid: deck.uid, cards: [card] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     expect(screen.getByText(card.frontText)).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
@@ -128,6 +131,16 @@ describe("DeckSwiperPage", () => {
     mocks.workflowState = { status };
     render(<DeckSwiperPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
+  });
+
+  it("renders retryable feedback when target verification fails", () => {
+    const retry = vi.fn();
+    mocks.workflowState = { status: "error", retry };
+    render(<DeckSwiperPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to verify study session.");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(retry).toHaveBeenCalledOnce();
   });
 
   it("converts unavailable intent into current route navigation", () => {

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -35,11 +35,18 @@ const useStudyHistoryGuard = (deckId: string, navigate: ReturnType<typeof useNav
 
 const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
   if (state.status !== "ready") {
-    return state.status === "loading" ? (
-      <RouteFeedback title="Loading…" tone="loading" />
-    ) : (
-      <RouteFeedback title="Study session unavailable." tone="not-found" />
-    );
+    if (state.status === "loading") return <RouteFeedback title="Loading…" tone="loading" />;
+    if (state.status === "error") {
+      return (
+        <RouteFeedback
+          title="Unable to verify study session."
+          description="Check your connection and try again."
+          tone="error"
+          primaryAction={{ label: "Retry", onClick: state.retry }}
+        />
+      );
+    }
+    return <RouteFeedback title="Study session unavailable." tone="not-found" />;
   }
 
   const category = getCategory(deck.category, state.card.tags);
@@ -82,7 +89,7 @@ const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   }, [navigate]);
 
   return (
-    <StudyWorkflow key={deck.id} cards={cards} deckId={deck.id} onUnavailable={handleUnavailable}>
+    <StudyWorkflow key={deck.id} cards={cards} deckId={deck.id} uid={deck.uid} onUnavailable={handleUnavailable}>
       {(state) => renderStudyScreen(deck, state)}
     </StudyWorkflow>
   );


### PR DESCRIPTION
## Summary

- add a Card Entity API that reads one target Card directly from the Firestore server
- verify a hydrated study session's missing local target before deciding whether to clean it up
- preserve active sessions on read failures and expose a retry action
- validate remote Card existence, soft-delete state, deck ownership, and user ownership

## Why

The study workflow used `cards.length === 0` as a proxy for Card subscription readiness. That could not distinguish an initial snapshot that had not arrived from a persisted session pointing to a Card that was actually missing, leaving the route on `Loading…` indefinitely.

The scoped read now runs only when the hydrated session target is absent from the local entity store. A confirmed active Card can be used temporarily until the subscription catches up; confirmed invalid targets are cleaned up, while read failures remain non-destructive.

## User impact

Persisted study sessions referencing deleted or inaccessible Cards now exit cleanly. Temporary subscription delays and network failures no longer delete otherwise valid sessions.

## Validation

- `mise run check`
- 102 unit test files passed
- 516 unit tests passed

Closes #947