### PR TITLE
fix(#386): Guard global shortcuts on interactive targets

### DIFF
--- a/src/features/study/components/StudyWorkflow.spec.tsx
+++ b/src/features/study/components/StudyWorkflow.spec.tsx
@@ -76,6 +76,7 @@ const WorkflowView = ({ state }: { state: StudyWorkflowState }) => {
       <button type="button" onClick={state.actions.swipeRight}>
         swipe right
       </button>
+      <input type="range" aria-label="Study position" />
     </div>
   );
 };
@@ -127,6 +128,22 @@ describe("StudyWorkflow", () => {
     fireEvent.keyDown(window, { key: "ArrowRight" });
     await waitFor(() => expect(screen.getByText("card-2")).toBeVisible());
     expect(mocks.update).toHaveBeenCalledOnce();
+  });
+
+  it("leaves keyboard interaction to focused Study controls", () => {
+    renderWorkflow();
+
+    const toggleBackButton = screen.getByRole("button", { name: "toggle back" });
+    fireEvent.keyDown(toggleBackButton, { key: "Enter" });
+    fireEvent.keyDown(toggleBackButton, { key: " " });
+    fireEvent.keyDown(toggleBackButton, { key: "h" });
+    expect(screen.getByTestId("back")).toHaveTextContent("false");
+    expect(screen.getByTestId("autoplay")).toHaveTextContent("false");
+    expect(mocks.toggleShowHeader).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByRole("slider", { name: "Study position" }), { key: "ArrowRight" });
+    expect(screen.getByTestId("index")).toHaveTextContent("0");
+    expect(mocks.update).not.toHaveBeenCalled();
   });
 
   it("waits for Card readiness and exits only after hydration confirms unavailability", async () => {

--- a/src/features/study/hooks/useStudyShortcuts.ts
+++ b/src/features/study/hooks/useStudyShortcuts.ts
@@ -2,15 +2,41 @@ import { toggleShowHeader, toggleShowSwipeButtonList } from "@/entities/preferen
 
 import { useKey } from "react-use";
 
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
+
 import type { StudyActions } from "./useStudyActions";
 
 export const useStudyShortcuts = (actions: StudyActions) => {
-  useKey("ArrowUp", actions.swipeUp);
-  useKey("ArrowDown", actions.swipeDown);
-  useKey("ArrowLeft", actions.swipeLeft);
-  useKey("ArrowRight", actions.swipeRight);
-  useKey("Enter", actions.toggleShowBackText);
-  useKey("h", toggleShowHeader);
-  useKey("b", toggleShowSwipeButtonList);
-  useKey(" ", actions.toggleAutoPlay);
+  useKey("ArrowUp", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void actions.swipeUp();
+  });
+  useKey("ArrowDown", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void actions.swipeDown();
+  });
+  useKey("ArrowLeft", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void actions.swipeLeft();
+  });
+  useKey("ArrowRight", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void actions.swipeRight();
+  });
+  useKey("Enter", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    actions.toggleShowBackText();
+  });
+  useKey("h", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    toggleShowHeader();
+  });
+  useKey("b", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    toggleShowSwipeButtonList();
+  });
+  useKey(" ", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    actions.toggleAutoPlay();
+  });
 };

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -113,6 +113,12 @@ describe("CardListPage", () => {
     fireEvent.keyDown(window, { key: "s" });
     expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/settings");
+
+    mocks.navigate.mockClear();
+    const editButton = screen.getByRole("button", { name: "Edit card" });
+    fireEvent.keyDown(editButton, { key: "t" });
+    fireEvent.keyDown(editButton, { key: "s" });
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it("renders not-found feedback with route navigation", async () => {

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -9,6 +9,7 @@ import { CardList } from "@/features/card-list";
 import { BackText } from "@/features/card-view";
 import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
 import { useEditStudyProgress, useStudyCards } from "@/features/study";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -51,8 +52,14 @@ export const CardListPage: React.FC = () => {
   const { cards: deckCards, tags } = useCardsByDeckId(deckId);
   const cards = useStudyCards(deck, deckCards, preferences);
 
-  useKey("t", () => void navigate("/"));
-  useKey("s", () => void navigate("/settings"));
+  useKey("t", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/");
+  });
+  useKey("s", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/settings");
+  });
 
   if (deck == null) {
     return (

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -136,6 +136,12 @@ describe("DeckImportPage", () => {
 
     expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/settings");
+
+    mocks.navigate.mockClear();
+    const fileInput = screen.getByLabelText("Upload a csv file");
+    fireEvent.keyDown(fileInput, { key: "t" });
+    fireEvent.keyDown(fileInput, { key: "s" });
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it("adds the bundled sample without navigating automatically", async () => {

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -6,6 +6,7 @@ import { createDeck, useDecks } from "@/entities/deck";
 import { createCard, editCard, generateCardId, useCards } from "@/entities/card";
 import { usePreferences } from "@/entities/preferences";
 import { downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/deck-import";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckImportView } from "./DeckImportView";
@@ -23,8 +24,14 @@ export const DeckImportPage: React.FC = () => {
     editCard,
     generateCardId,
   });
-  useKey("t", () => void navigate("/"));
-  useKey("s", () => void navigate("/settings"));
+  useKey("t", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/");
+  });
+  useKey("s", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/settings");
+  });
 
   return (
     <AppLayout showHeader>

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -71,6 +71,14 @@ vi.mock("@/features/deck-list", () => ({
         <button type="button" onClick={() => void props.onDeleteDeck(deck)}>
           Delete deck
         </button>
+        <div role="menu">
+          <button type="button" role="menuitem">
+            Menu action
+          </button>
+        </div>
+        <div role="alertdialog" aria-label="Delete deck dialog">
+          <button type="button">Cancel delete</button>
+        </div>
       </section>
     );
   },
@@ -120,6 +128,11 @@ describe("DeckListPage", () => {
     expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/settings");
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
     expect(mocks.sampleBootstrap).toHaveBeenCalledWith(expect.objectContaining({ decks: [deck], cards: [card] }));
+
+    mocks.navigate.mockClear();
+    fireEvent.keyDown(screen.getByRole("menuitem", { name: "Menu action" }), { key: "s" });
+    fireEvent.keyDown(screen.getByRole("button", { name: "Cancel delete" }), { key: "i" });
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it("renders empty list when no decks exist", () => {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -8,6 +8,7 @@ import { createDeck, deleteDeck, useDecks } from "@/entities/deck";
 import { useSampleDeckBootstrap } from "@/features/deck-import";
 import { DeckList } from "@/features/deck-list";
 import { removeStudySession, touchStudySession, useStudyHydrated, useStudySessions } from "@/features/study";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { AppLayout } from "@/widgets/app-layout";
 
 export const DeckListPage: React.FC = () => {
@@ -26,8 +27,14 @@ export const DeckListPage: React.FC = () => {
     editCard,
     generateCardId,
   });
-  useKey("s", () => void navigate("/settings"));
-  useKey("i", () => void navigate("/import"));
+  useKey("s", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/settings");
+  });
+  useKey("i", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/import");
+  });
 
   if (!hydrated) {
     return (

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -10,13 +10,11 @@ import { useCardsByDeckId } from "@/entities/card";
 import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
 import { useStudyActions, useStudyCards } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 import { DeckStartView } from "./DeckStartView";
-
-const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
-  target instanceof Element && target.closest("a[href], button, input, select, textarea") != null;
 
 const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
   const { deck, cards, preferences, tags } = props;
@@ -27,7 +25,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Prefe
   const deckStartForm = useDeckFilterState({ deck, tags });
   const start = () => studyActions.start(cards);
   const startFromEnter = (event: KeyboardEvent) => {
-    if (cards.length === 0 || hasInteractiveShortcutTarget(event.target)) return;
+    if (cards.length === 0 || isInteractiveShortcutTarget(event.target)) return;
     start();
   };
   useKey("Enter", startFromEnter, {}, [startFromEnter]);

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -38,8 +38,11 @@ describe("SettingsPage", () => {
 
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     fireEvent.keyDown(window, { key: "t" });
-
     expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith("/");
+
+    mocks.navigate.mockClear();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Login" }), { key: "t" });
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it("displays an alert when sign-out fails and allows retrying sign-out", async () => {

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { updatePreferences, usePreferences } from "@/entities/preferences";
 import { SettingsForm, usePreferencesFormState } from "@/features/settings";
 import { useSignIn } from "@/features/sign-in";
 import { useSignOut } from "@/features/sign-out";
+import { isInteractiveShortcutTarget } from "@/shared/lib/isInteractiveShortcutTarget";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -33,7 +34,10 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
     preferences,
     onSubmit: updatePreferences,
   });
-  useKey("t", () => void navigate("/"));
+  useKey("t", (event) => {
+    if (isInteractiveShortcutTarget(event.target)) return;
+    void navigate("/");
+  });
 
   return (
     <AppLayout showHeader>

--- a/src/shared/lib/isInteractiveShortcutTarget.spec.ts
+++ b/src/shared/lib/isInteractiveShortcutTarget.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { isInteractiveShortcutTarget } from "./isInteractiveShortcutTarget";
+
+describe("isInteractiveShortcutTarget", () => {
+  it.each([document, window, document.createElement("div")])("rejects a non-interactive target", (target) => {
+    expect(isInteractiveShortcutTarget(target)).toBe(false);
+  });
+
+  it.each([
+    ["link", "a", '<a href="/settings">Settings</a>'],
+    ["button", "button", "<button>Save</button>"],
+    ["input", "input", "<input>"],
+    ["select", "select", "<select></select>"],
+    ["summary", "summary", "<details><summary>Advanced</summary></details>"],
+    ["textarea", "textarea", "<textarea></textarea>"],
+  ])("accepts a %s", (_name, selector, html) => {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+
+    expect(isInteractiveShortcutTarget(container.querySelector(selector))).toBe(true);
+  });
+
+  it("accepts a descendant of an interactive element", () => {
+    const button = document.createElement("button");
+    const icon = document.createElement("span");
+    button.append(icon);
+
+    expect(isInteractiveShortcutTarget(icon)).toBe(true);
+  });
+
+  it.each(["", "true", "plaintext-only"])("accepts contenteditable=%s", (value) => {
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", value);
+
+    expect(isInteractiveShortcutTarget(editable)).toBe(true);
+  });
+
+  it('rejects contenteditable="false"', () => {
+    const element = document.createElement("div");
+    element.setAttribute("contenteditable", "false");
+
+    expect(isInteractiveShortcutTarget(element)).toBe(false);
+  });
+});

--- a/src/shared/lib/isInteractiveShortcutTarget.ts
+++ b/src/shared/lib/isInteractiveShortcutTarget.ts
@@ -1,0 +1,12 @@
+const interactiveShortcutTargetSelector = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "summary",
+  "textarea",
+  '[contenteditable]:not([contenteditable="false"])',
+].join(",");
+
+export const isInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element && target.closest(interactiveShortcutTargetSelector) != null;


### PR DESCRIPTION
## Related issue

Fixes #386

## Root cause

Page and Study shortcuts were registered directly with `react-use` without consistently checking the keyboard event target. DeckStart had a local guard, but it was not reusable and did not cover editable content.

## Summary

- add one shared predicate for native interactive and contenteditable shortcut targets
- apply the guard to navigation, DeckStart, and Study shortcut registrations
- preserve native button, input, slider, menu, dialog, and editable keyboard behavior
- add focused-control and background-target regression coverage

## Impact

Global shortcuts continue to work from page backgrounds, while focused interactive controls retain ownership of their native keyboard interactions.

## Validation

- `mise run check`
- 103 test files passed
- 522 tests passed