### PR TITLE
[No issue] Move DeckImportView ownership to deck import feature

### DIFF
--- a/src/features/deck-import/index.ts
+++ b/src/features/deck-import/index.ts
@@ -1,4 +1,4 @@
-export type { DeckImportPreview, DeckImportResult } from "./model/deckImportTypes";
 export { useDeckImport } from "./hooks/useDeckImport";
 export { useSampleDeckBootstrap } from "./hooks/useSampleDeckBootstrap";
 export { downloadSampleCsv, SAMPLE_CSV_TEXT } from "./sampleCsv";
+export { DeckImportView } from "./ui/DeckImportView";

--- a/src/features/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/features/deck-import/ui/DeckImportView.spec.tsx
@@ -10,7 +10,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
-import type { DeckImportPreview, DeckImportResult } from "@/features/deck-import";
+import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTypes";
 
 import { DeckImportView } from "./DeckImportView";
 

--- a/src/features/deck-import/ui/DeckImportView.stories.tsx
+++ b/src/features/deck-import/ui/DeckImportView.stories.tsx
@@ -6,10 +6,10 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { SAMPLE_CSV_TEXT } from "@/features/deck-import";
-import type { DeckImportPreview } from "@/features/deck-import";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
+import type { DeckImportPreview } from "../model/deckImportTypes";
+import { SAMPLE_CSV_TEXT } from "../sampleCsv";
 import { DeckImportView as Template } from "./DeckImportView";
 
 const preview = {
@@ -50,7 +50,7 @@ const preview = {
 } satisfies DeckImportPreview;
 
 const meta = {
-  title: "Pages/Deck Import",
+  title: "Features/Deck Import/DeckImportView",
   component: Template,
   tags: ["autodocs"],
   parameters: {

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -9,7 +9,7 @@ import { AiOutlineCloudDownload } from "react-icons/ai";
 import { Button } from "@/shared/ui/button";
 import { Code, Description } from "@/shared/ui/content";
 import { Upload } from "@/shared/ui/forms";
-import type { DeckImportPreview, DeckImportResult } from "@/features/deck-import";
+import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTypes";
 
 interface DeckImportViewProps {
   onChange?: (file: File) => void;

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -6,12 +6,18 @@
  * page when importing fails".
  */
 
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { DeckImportPreview, DeckImportResult } from "@/features/deck-import";
+import type { DeckImportView } from "@/features/deck-import";
+
+type DeckImportViewProps = ComponentProps<typeof DeckImportView>;
+type DeckImportPreview = NonNullable<DeckImportViewProps["preview"]>;
+type DeckImportResult = NonNullable<DeckImportViewProps["result"]>;
 
 const mocks = vi.hoisted(() => ({
   selectFile: vi.fn(),
@@ -38,7 +44,8 @@ vi.mock("@/entities/card", () => ({
   generateCardId: vi.fn(),
   useCards: () => [],
 }));
-vi.mock("@/features/deck-import", () => ({
+vi.mock("@/features/deck-import", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/features/deck-import")>()),
   SAMPLE_CSV_TEXT: "sample csv",
   downloadSampleCsv: mocks.downloadSampleCsv,
   useDeckImport: () => ({

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -5,10 +5,8 @@ import { useKey } from "react-use";
 import { createDeck, useDecks } from "@/entities/deck";
 import { createCard, editCard, generateCardId, useCards } from "@/entities/card";
 import { usePreferences } from "@/entities/preferences";
-import { downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/deck-import";
+import { DeckImportView, downloadSampleCsv, SAMPLE_CSV_TEXT, useDeckImport } from "@/features/deck-import";
 import { AppLayout } from "@/widgets/app-layout";
-
-import { DeckImportView } from "./DeckImportView";
 
 export const DeckImportPage: React.FC = () => {
   const preferences = usePreferences();


### PR DESCRIPTION
## Related issue

None

## Summary

- Move DeckImportView, its tests, and its stories from the page layer to the deck-import feature.
- Export DeckImportView through the feature public API and keep the page focused on route composition.
- Remove the now-unused public preview and result type exports.

## Testing

- mise run check