### PR TITLE
refactor(#948): Separate Card and StudyProgress read models

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -42,7 +42,6 @@ const cloneDeck = (deck: Deck): Deck => ({
 const cloneCard = (card: Card): Card => ({
   ...card,
   tags: [...card.tags],
-  ...(card.nextSeeingAt === undefined ? {} : { nextSeeingAt: new Date(card.nextSeeingAt.getTime()) }),
 });
 
 const cloneSessions = (sessionsByDeckId: StudyState["sessionsByDeckId"]): StudyState["sessionsByDeckId"] => {

--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   authState: { status: "initializing" } as AuthSessionState,
   subscribeCards: vi.fn(),
   subscribeDecks: vi.fn(),
+  subscribeStudyProgresses: vi.fn(),
   operations: [] as string[],
 }));
 
@@ -20,6 +21,10 @@ vi.mock("@/entities/card", () => ({
 vi.mock("@/entities/deck", () => ({
   clearRemoteDecks: () => mocks.operations.push("clear remote Decks"),
   subscribeDecks: mocks.subscribeDecks,
+}));
+vi.mock("@/entities/study-progress", () => ({
+  clearRemoteStudyProgresses: () => mocks.operations.push("clear remote StudyProgresses"),
+  subscribeStudyProgresses: mocks.subscribeStudyProgresses,
 }));
 
 import { FirestoreSubscriptionsProvider } from ".";
@@ -35,6 +40,10 @@ describe("FirestoreSubscriptionsProvider", () => {
       mocks.operations.push(`start Decks ${uid}`);
       return () => mocks.operations.push(`stop Decks ${uid}`);
     });
+    mocks.subscribeStudyProgresses.mockImplementation((uid: string) => {
+      mocks.operations.push(`start StudyProgresses ${uid}`);
+      return () => mocks.operations.push(`stop StudyProgresses ${uid}`);
+    });
     mocks.operations.length = 0;
     mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
   });
@@ -42,7 +51,11 @@ describe("FirestoreSubscriptionsProvider", () => {
   it("starts subscriptions for the authenticated UID and cleans them up on unmount", () => {
     const view = render(<FirestoreSubscriptionsProvider>content</FirestoreSubscriptionsProvider>);
 
-    expect(mocks.operations).toEqual(["start Cards test-user", "start Decks test-user"]);
+    expect(mocks.operations).toEqual([
+      "start Cards test-user",
+      "start Decks test-user",
+      "start StudyProgresses test-user",
+    ]);
     expect(screen.getByText("content")).toBeDefined();
 
     view.unmount();
@@ -50,10 +63,13 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(mocks.operations).toEqual([
       "start Cards test-user",
       "start Decks test-user",
+      "start StudyProgresses test-user",
       "stop Cards test-user",
       "stop Decks test-user",
+      "stop StudyProgresses test-user",
       "clear remote Cards",
       "clear remote Decks",
+      "clear remote StudyProgresses",
     ]);
   });
 
@@ -67,10 +83,13 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(mocks.operations).toEqual([
       "stop Cards test-user",
       "stop Decks test-user",
+      "stop StudyProgresses test-user",
       "clear remote Cards",
       "clear remote Decks",
+      "clear remote StudyProgresses",
       "start Cards next-user",
       "start Decks next-user",
+      "start StudyProgresses next-user",
     ]);
   });
 
@@ -84,6 +103,7 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(mocks.operations).toEqual([]);
     expect(mocks.subscribeCards).toHaveBeenCalledOnce();
     expect(mocks.subscribeDecks).toHaveBeenCalledOnce();
+    expect(mocks.subscribeStudyProgresses).toHaveBeenCalledOnce();
   });
 
   it("stops subscriptions and clears related state on logout", () => {
@@ -96,8 +116,10 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(mocks.operations).toEqual([
       "stop Cards test-user",
       "stop Decks test-user",
+      "stop StudyProgresses test-user",
       "clear remote Cards",
       "clear remote Decks",
+      "clear remote StudyProgresses",
     ]);
   });
 });

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useAuthSession } from "@/entities/auth";
 import { clearRemoteCards, subscribeCards } from "@/entities/card";
 import { clearRemoteDecks, subscribeDecks } from "@/entities/deck";
+import { clearRemoteStudyProgresses, subscribeStudyProgresses } from "@/entities/study-progress";
 
 export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const authState = useAuthSession();
@@ -11,12 +12,16 @@ export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> =
   React.useEffect(() => {
     const stopCards = authenticatedUid == null ? undefined : subscribeCards(authenticatedUid, console.error);
     const stopDecks = authenticatedUid == null ? undefined : subscribeDecks(authenticatedUid, console.error);
+    const stopStudyProgresses =
+      authenticatedUid == null ? undefined : subscribeStudyProgresses(authenticatedUid, console.error);
 
     return () => {
       stopCards?.();
       stopDecks?.();
+      stopStudyProgresses?.();
       clearRemoteCards();
       clearRemoteDecks();
+      clearRemoteStudyProgresses();
     };
   }, [authenticatedUid]);
 

--- a/src/entities/card/@x/study-progress.ts
+++ b/src/entities/card/@x/study-progress.ts
@@ -1,1 +1,2 @@
 export type { CardId } from "../model/types";
+export { parseCardDocument } from "../api/document";

--- a/src/entities/card/api/document.spec.ts
+++ b/src/entities/card/api/document.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseCardDocument } from "./document";
+import { mapCardDocument, parseCardDocument } from "./document";
 
 const requiredDocument = {
   frontText: "Front",
@@ -40,6 +40,30 @@ describe("Card document", () => {
     const nextSeeingAt = { seconds: 0, nanoseconds: 60_000_000, toDate: () => date };
 
     expect(parseCardDocument("card-a", { ...requiredDocument, nextSeeingAt }).nextSeeingAt).toBe(date);
+  });
+
+  it("maps Card content without StudyProgress fields", () => {
+    const card = mapCardDocument("card-a", {
+      ...requiredDocument,
+      lastSeenAt: 5,
+      nextSeeingAt: new Date(6),
+      interval: 7,
+    });
+
+    expect(card).toEqual({
+      id: "card-a",
+      frontText: "Front",
+      backText: "Back",
+      tags: ["science"],
+      uniqueKey: "key-card-a",
+      deckId: "deck-a",
+      uid: "uid-a",
+      createdAt: 1,
+      updatedAt: 2,
+      deletedAt: null,
+    });
+    expect(card).not.toHaveProperty("score");
+    expect(card).not.toHaveProperty("numberOfSeen");
   });
 
   it.each([

--- a/src/entities/card/api/document.ts
+++ b/src/entities/card/api/document.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 import { firestoreTimestampDateSchema, parseFirestoreDocument } from "@/shared/api";
+import { omitUndefined } from "@/shared/lib/omitUndefined";
+import type { Card, CardCreate, CardId } from "../model/types";
 
 const cardDocumentSchema = z.object({
   id: z.string().optional(),
@@ -27,3 +29,34 @@ export type CardDocument = z.infer<typeof cardDocumentSchema>;
 
 export const parseCardDocument = (id: string, value: unknown): CardDocument =>
   parseFirestoreDocument(cardDocumentSchema, "card", id, value);
+
+export const buildCardCreateDocument = (card: CardCreate, createdAt: number): CardDocument =>
+  cardDocumentSchema.parse(
+    omitUndefined({
+      ...card,
+      createdAt,
+      updatedAt: createdAt,
+      score: 0,
+      numberOfSeen: 0,
+    })
+  );
+
+export const mapCardDocument = (id: CardId, value: unknown): Card => {
+  const document = parseCardDocument(id, value);
+  const card: Card = {
+    id,
+    frontText: document.frontText,
+    backText: document.backText,
+    tags: document.tags,
+    uniqueKey: document.uniqueKey,
+    deckId: document.deckId,
+    uid: document.uid,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+    deletedAt: document.deletedAt,
+  };
+  if (document.url !== undefined) card.url = document.url;
+  if (document.startLine !== undefined) card.startLine = document.startLine;
+  if (document.endLine !== undefined) card.endLine = document.endLine;
+  return card;
+};

--- a/src/entities/card/api/firestore.spec.ts
+++ b/src/entities/card/api/firestore.spec.ts
@@ -2,12 +2,32 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createCard as createCardFixture } from "@/test/factories";
 
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn((...parts: unknown[]) => parts),
+  setDoc: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>();
+  return { ...actual, doc: mocks.doc, setDoc: mocks.setDoc };
+});
 vi.mock("@/shared/firebase", () => ({ db: {} }));
+vi.mock("@/shared/lib/currentTime", () => ({ getCurrentTimeMillis: () => 10 }));
 
 import { createCard, deleteCard, editCard } from "./firestore";
 
 describe("Card Firestore persistence", () => {
   const card = createCardFixture({ id: "card", uid: "uid-a" });
+
+  it("persists initial StudyProgress fields without adding them to Card", async () => {
+    await createCard("uid-a", card);
+
+    expect(card).not.toHaveProperty("score");
+    expect(mocks.setDoc).toHaveBeenCalledWith(
+      [{}, "card", card.id],
+      expect.objectContaining({ id: card.id, score: 0, numberOfSeen: 0, createdAt: 10, updatedAt: 10 })
+    );
+  });
 
   it("rejects create requests without a confirmed matching owner", async () => {
     await expect(createCard("", card)).rejects.toThrow("confirmed user");

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -1,12 +1,4 @@
-import type {
-  Card,
-  CardCreate,
-  CardCreateInput,
-  CardEdit,
-  CardId,
-  DeleteCardInput,
-  EditCardInput,
-} from "../model/types";
+import type { Card, CardCreate, CardCreateInput, CardEdit, DeleteCardInput, EditCardInput } from "../model/types";
 
 import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
 
@@ -15,34 +7,9 @@ import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { createCardSchema, deleteCardSchema, editCardSchema } from "../model/schema";
 import { replaceRemoteCards } from "../model/store";
-import { parseCardDocument } from "./document";
+import { buildCardCreateDocument, mapCardDocument } from "./document";
 
 const CARD_COLLECTION = "card";
-
-const convertCardDocumentToCard = (id: CardId, value: unknown): Card => {
-  const document = parseCardDocument(id, value);
-  const card: Card = {
-    id,
-    frontText: document.frontText,
-    backText: document.backText,
-    tags: document.tags,
-    uniqueKey: document.uniqueKey,
-    deckId: document.deckId,
-    uid: document.uid,
-    createdAt: document.createdAt,
-    updatedAt: document.updatedAt,
-    deletedAt: document.deletedAt,
-    score: document.score,
-    numberOfSeen: document.numberOfSeen,
-  };
-  if (document.lastSeenAt !== undefined) card.lastSeenAt = document.lastSeenAt;
-  if (document.nextSeeingAt !== undefined) card.nextSeeingAt = document.nextSeeingAt;
-  if (document.interval !== undefined) card.interval = document.interval;
-  if (document.url !== undefined) card.url = document.url;
-  if (document.startLine !== undefined) card.startLine = document.startLine;
-  if (document.endLine !== undefined) card.endLine = document.endLine;
-  return card;
-};
 
 export const subscribeCards = (uid: string, onError: (error: Error) => void): (() => void) =>
   onSnapshot(
@@ -50,7 +17,7 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
     (snapshot) => {
       try {
         const cards = snapshot.docs
-          .map((document) => convertCardDocumentToCard(document.id, document.data()))
+          .map((document) => mapCardDocument(document.id, document.data()))
           .filter((card) => card.deletedAt === null);
         replaceRemoteCards(cards);
       } catch (cause) {
@@ -63,13 +30,13 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
 export const fetchCards = async (uid: string): Promise<Card[]> => {
   const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return snapshot.docs
-    .map((document) => convertCardDocumentToCard(document.id, document.data()))
+    .map((document) => mapCardDocument(document.id, document.data()))
     .filter((card) => card.deletedAt === null);
 };
 
 const createCardDocument = async (card: CardCreate): Promise<void> => {
   const createdAt = getCurrentTimeMillis();
-  const document = omitUndefined({ ...card, createdAt, updatedAt: createdAt } satisfies Card);
+  const document = buildCardCreateDocument(card, createdAt);
   await setDoc(doc(db, CARD_COLLECTION, card.id), document);
 };
 

--- a/src/entities/card/api/subscription.spec.tsx
+++ b/src/entities/card/api/subscription.spec.tsx
@@ -86,15 +86,15 @@ describe("Card Firestore subscription", () => {
     expect(result.current).toEqual([
       expect.objectContaining({
         id: "active",
-        lastSeenAt: 50,
-        nextSeeingAt: new Date(60),
-        interval: 7,
         url: "https://example.com/card",
         startLine: 8,
         endLine: 9,
       }),
       localCard,
     ]);
+    expect(result.current[0]).not.toHaveProperty("score");
+    expect(result.current[0]).not.toHaveProperty("numberOfSeen");
+    expect(result.current[0]).not.toHaveProperty("lastSeenAt");
 
     act(() => getSnapshotHandler()({ docs: [cardDocument("replacement", { frontText: "Current" })] }));
     expect(result.current).toEqual([expect.objectContaining({ id: "replacement", frontText: "Current" }), localCard]);

--- a/src/entities/card/model/schema.spec.ts
+++ b/src/entities/card/model/schema.spec.ts
@@ -32,8 +32,6 @@ describe("Card operation schemas", () => {
         tags: ["tag"],
         uniqueKey: "key",
         deletedAt: null,
-        score: 0,
-        numberOfSeen: 0,
       },
     });
   });

--- a/src/entities/card/model/schema.ts
+++ b/src/entities/card/model/schema.ts
@@ -19,24 +19,12 @@ export const cardCreateSchema = editableCardFieldsSchema.extend({
   deckId: z.string().min(1, "Card deck is required"),
   uid: cardUidSchema,
   deletedAt: z.number().nullable().default(null),
-  score: z.number().default(0),
-  numberOfSeen: z.number().default(0),
-  lastSeenAt: z.number().optional(),
-  nextSeeingAt: z.date().optional(),
-  interval: z.number().optional(),
 });
 
 export const cardSchema = cardCreateSchema.extend({
   createdAt: z.number(),
   updatedAt: z.number(),
 });
-
-const persistedDateSchema = z.preprocess(
-  (value) => (typeof value === "string" ? new Date(value) : value),
-  z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date")
-);
-
-export const persistedCardSchema = cardSchema.extend({ nextSeeingAt: persistedDateSchema.optional() });
 
 export const cardEditSchema = editableCardFieldsSchema.partial().extend({ id: cardIdSchema, uid: cardUidSchema });
 const cardIdentitySchema = z.object({ id: cardIdSchema, uid: cardUidSchema });

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -81,15 +81,15 @@ describe("Card store", () => {
     });
   });
 
-  it("persists only local Cards and restores dates after hydration", async () => {
+  it("persists only local Cards", async () => {
     const storage = useMemoryStorage();
     const remoteCard = createCard({ id: "remote" });
-    const localCard = createCard({ id: "local", nextSeeingAt: new Date(1_000) });
+    const localCard = createCard({ id: "local" });
     cardStore.setState({ remoteCards: [remoteCard], localCards: [localCard] });
 
     const persistedValue = (await storage.getItem("tango-local-cards")) ?? "{}";
     expect(JSON.parse(persistedValue)).toEqual({
-      state: { localCards: [{ ...localCard, nextSeeingAt: new Date(1_000).toISOString() }] },
+      state: { localCards: [localCard] },
       version: 1,
     });
 
@@ -102,7 +102,7 @@ describe("Card store", () => {
   it("rejects invalid persisted Cards", async () => {
     useMemoryStorage({
       "tango-local-cards": JSON.stringify({
-        state: { localCards: [{ ...createCard(), nextSeeingAt: "invalid" }] },
+        state: { localCards: [{ ...createCard(), frontText: 42 }] },
         version: 1,
       }),
     });

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -2,7 +2,7 @@ import { createJSONStorage, persist, type StateStorage } from "zustand/middlewar
 import { createStore } from "zustand/vanilla";
 import { z } from "zod";
 
-import { cardCreateSchema, cardEditSchema, cardIdSchema, cardSchema, persistedCardSchema } from "./schema";
+import { cardCreateSchema, cardEditSchema, cardIdSchema, cardSchema } from "./schema";
 import type { Card, CardCreateInput, CardEdit, CardId } from "./types";
 
 interface CardState {
@@ -19,7 +19,7 @@ interface CreateCardStoreOptions {
   skipHydration?: boolean;
 }
 
-const persistedCardStateSchema = z.object({ localCards: z.array(persistedCardSchema) });
+const persistedCardStateSchema = z.object({ localCards: z.array(cardSchema) });
 
 const parsePersistedCardState = (value: unknown): PersistedCardState => {
   const result = persistedCardStateSchema.safeParse(value);

--- a/src/entities/study-progress/api/document.spec.ts
+++ b/src/entities/study-progress/api/document.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { mapStudyProgressDocument } from "./document";
+
+describe("StudyProgress document", () => {
+  it("maps progress without Card content", () => {
+    const progress = mapStudyProgressDocument("card-a", {
+      frontText: "Front",
+      backText: "Back",
+      tags: ["science"],
+      uniqueKey: "key-card-a",
+      deckId: "deck-a",
+      uid: "uid-a",
+      createdAt: 1,
+      updatedAt: 2,
+      deletedAt: null,
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 5,
+      nextSeeingAt: new Date(6),
+      interval: 7,
+    });
+
+    expect(progress).toEqual({
+      cardId: "card-a",
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 5,
+      nextSeeingAt: new Date(6),
+      interval: 7,
+    });
+    expect(progress).not.toHaveProperty("frontText");
+    expect(progress).not.toHaveProperty("deckId");
+  });
+});

--- a/src/entities/study-progress/api/document.ts
+++ b/src/entities/study-progress/api/document.ts
@@ -1,0 +1,15 @@
+import { parseCardDocument } from "@/entities/card/@x/study-progress";
+import type { StudyProgress } from "../model/types";
+
+export const mapStudyProgressDocument = (cardId: string, value: unknown): StudyProgress => {
+  const document = parseCardDocument(cardId, value);
+  const progress: StudyProgress = {
+    cardId,
+    score: document.score,
+    numberOfSeen: document.numberOfSeen,
+  };
+  if (document.lastSeenAt !== undefined) progress.lastSeenAt = document.lastSeenAt;
+  if (document.nextSeeingAt !== undefined) progress.nextSeeingAt = document.nextSeeingAt;
+  if (document.interval !== undefined) progress.interval = document.interval;
+  return progress;
+};

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -1,11 +1,30 @@
 import type { EditStudyProgressInput } from "../model/types";
 
-import { doc, updateDoc } from "firebase/firestore";
+import { collection, doc, onSnapshot, query, updateDoc, where } from "firebase/firestore";
 
+import { parseCardDocument } from "@/entities/card/@x/study-progress";
 import { db } from "@/shared/firebase";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { editStudyProgressSchema } from "../model/schema";
+import { replaceRemoteStudyProgresses } from "../model/store";
+import { mapStudyProgressDocument } from "./document";
+
+export const subscribeStudyProgresses = (uid: string, onError: (error: Error) => void): (() => void) =>
+  onSnapshot(
+    query(collection(db, "card"), where("uid", "==", uid)),
+    (snapshot) => {
+      try {
+        const progresses = snapshot.docs
+          .filter((document) => parseCardDocument(document.id, document.data()).deletedAt === null)
+          .map((document) => mapStudyProgressDocument(document.id, document.data()));
+        replaceRemoteStudyProgresses(progresses);
+      } catch (cause) {
+        onError(cause instanceof Error ? cause : new Error(String(cause)));
+      }
+    },
+    onError
+  );
 
 export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,9 +1,11 @@
-export { editStudyProgress } from "./api/firestore";
+export { editStudyProgress, subscribeStudyProgresses } from "./api/firestore";
+export { createStudyProgress } from "./model/defaults";
+export { useStudyProgress, useStudyProgresses } from "./model/hooks";
 export {
   compareStudyProgress,
-  createStudyProgressFromCard,
   getNextStudyAvailabilityAt,
   isStudyProgressEligible,
   recordStudyProgress,
 } from "./model/rules";
+export { clearRemoteStudyProgresses } from "./model/store";
 export type { StudyProgress, StudyProgressEdit, StudyRating } from "./model/types";

--- a/src/entities/study-progress/model/hooks.ts
+++ b/src/entities/study-progress/model/hooks.ts
@@ -1,0 +1,10 @@
+import { useStore } from "zustand";
+
+import { studyProgressStore } from "./store";
+import type { StudyProgress } from "./types";
+
+export const useStudyProgresses = (): StudyProgress[] =>
+  useStore(studyProgressStore, (state) => state.remoteProgresses);
+
+export const useStudyProgress = (cardId: string | undefined): StudyProgress | undefined =>
+  useStore(studyProgressStore, (state) => state.remoteProgresses.find((progress) => progress.cardId === cardId));

--- a/src/entities/study-progress/model/rules.spec.ts
+++ b/src/entities/study-progress/model/rules.spec.ts
@@ -2,53 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   compareStudyProgress,
-  createStudyProgressFromCard,
   getNextStudyAvailabilityAt,
   isStudyProgressEligible,
   recordStudyProgress,
 } from "./rules";
-import type { StudyProgress, StudyProgressEdit, StudyRating } from "./types";
+import type { StudyProgress, StudyRating } from "./types";
 
 const initialStudyProgress = (cardId: string): StudyProgress => ({ cardId, score: 0, numberOfSeen: 0 });
-
-describe("createStudyProgressFromCard", () => {
-  it("allows editing selected progress fields while retaining the card id", () => {
-    const edit: StudyProgressEdit = {
-      cardId: "card-id",
-      score: 3,
-      lastSeenAt: 1_786_512_000_000,
-    };
-
-    expect(edit).toEqual({
-      cardId: "card-id",
-      score: 3,
-      lastSeenAt: 1_786_512_000_000,
-    });
-  });
-
-  it("restores progress from a Card without copying Card content", () => {
-    const card = {
-      id: "card-id",
-      score: 3,
-      numberOfSeen: 4,
-      lastSeenAt: 1_786_512_000_000,
-      nextSeeingAt: new Date(1_786_598_400_000),
-      interval: 86_400,
-      frontText: "not part of progress",
-    };
-    const progress = createStudyProgressFromCard(card);
-
-    expect(progress).toEqual({
-      cardId: "card-id",
-      score: 3,
-      numberOfSeen: 4,
-      lastSeenAt: 1_786_512_000_000,
-      nextSeeingAt: new Date(1_786_598_400_000),
-      interval: 86_400,
-    });
-    expect(progress).not.toHaveProperty("frontText");
-  });
-});
 
 describe("recordStudyProgress", () => {
   it.each<[number, StudyRating, number]>([

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -1,15 +1,4 @@
-import { createStudyProgress } from "./defaults";
-import type { CardProgressFields, StudyProgress, StudyProgressEdit, StudyProgressFilter, StudyRating } from "./types";
-
-export const createStudyProgressFromCard = (card: CardProgressFields): StudyProgress => {
-  const progress = createStudyProgress(card.id);
-  progress.score = card.score;
-  progress.numberOfSeen = card.numberOfSeen;
-  if (card.lastSeenAt !== undefined) progress.lastSeenAt = card.lastSeenAt;
-  if (card.nextSeeingAt !== undefined) progress.nextSeeingAt = card.nextSeeingAt;
-  if (card.interval !== undefined) progress.interval = card.interval;
-  return progress;
-};
+import type { StudyProgress, StudyProgressEdit, StudyProgressFilter, StudyRating } from "./types";
 
 const calculateScore = (score: number, rating: StudyRating): number => {
   if (rating === "mastered") return score >= 0 ? score + 1 : 0;

--- a/src/entities/study-progress/model/store.ts
+++ b/src/entities/study-progress/model/store.ts
@@ -1,0 +1,17 @@
+import { createStore } from "zustand/vanilla";
+
+import type { StudyProgress } from "./types";
+
+interface StudyProgressState {
+  remoteProgresses: StudyProgress[];
+}
+
+export const studyProgressStore = createStore<StudyProgressState>(() => ({ remoteProgresses: [] }));
+
+export const replaceRemoteStudyProgresses = (remoteProgresses: StudyProgress[]): void => {
+  studyProgressStore.setState({ remoteProgresses });
+};
+
+export const clearRemoteStudyProgresses = (): void => {
+  studyProgressStore.setState({ remoteProgresses: [] });
+};

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -22,13 +22,4 @@ export interface StudyProgressFilter {
   respectNextSeeingAt: boolean;
 }
 
-export interface CardProgressFields {
-  id: CardId;
-  score: number;
-  numberOfSeen: number;
-  lastSeenAt?: number;
-  nextSeeingAt?: Date;
-  interval?: number;
-}
-
 export type EditStudyProgressInput = z.infer<typeof editStudyProgressSchema>;

--- a/src/features/card-edit/ui/CardEditForm.tsx
+++ b/src/features/card-edit/ui/CardEditForm.tsx
@@ -1,4 +1,5 @@
 import type { Card } from "@/entities/card";
+import type { StudyProgress } from "@/entities/study-progress";
 
 import type * as React from "react";
 import { AiOutlineArrowLeft } from "react-icons/ai";
@@ -11,11 +12,12 @@ import { CardForm } from "./CardForm";
 
 export interface CardEditFormProps {
   card: Card;
+  progress?: StudyProgress | undefined;
   onCancel: () => void;
   onSaved: () => void;
 }
 
-export const CardEditForm: React.FC<CardEditFormProps> = ({ card, onCancel, onSaved }) => {
+export const CardEditForm: React.FC<CardEditFormProps> = ({ card, progress, onCancel, onSaved }) => {
   const editAction = useCardEditAction({ onSaved });
   const cardForm = useCardFormState({
     card,
@@ -40,7 +42,7 @@ export const CardEditForm: React.FC<CardEditFormProps> = ({ card, onCancel, onSa
         <p className="mt-2 text-body text-ink-muted">Update the prompt, answer, and organization for this card.</p>
       </header>
       <Feedback tone="error">{editAction.error == null ? null : "Unable to save changes. Try again."}</Feedback>
-      <CardForm {...cardForm} />
+      <CardForm {...cardForm} progress={progress} />
     </section>
   );
 };

--- a/src/features/card-edit/ui/CardForm.tsx
+++ b/src/features/card-edit/ui/CardForm.tsx
@@ -1,4 +1,5 @@
 import type { Card } from "@/entities/card";
+import type { StudyProgress } from "@/entities/study-progress";
 
 import type * as React from "react";
 import { useId } from "react";
@@ -19,6 +20,7 @@ interface CardFormFields {
 
 export interface CardFormProps {
   card: Card;
+  progress?: StudyProgress | undefined;
   fields: CardFormFields;
   errors?: {
     frontText?: string;
@@ -128,10 +130,10 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
               <dd className="text-ink">{new Date(props.card.createdAt).toLocaleDateString()}</dd>
             </div>
           )}
-          {props.card.lastSeenAt != null && (
+          {props.progress?.lastSeenAt != null && (
             <div>
               <dt className="font-medium text-ink-muted">Last seen</dt>
-              <dd className="text-ink">{new Date(props.card.lastSeenAt).toLocaleDateString()}</dd>
+              <dd className="text-ink">{new Date(props.progress.lastSeenAt).toLocaleDateString()}</dd>
             </div>
           )}
         </dl>

--- a/src/features/card-list/ui/Card.spec.tsx
+++ b/src/features/card-list/ui/Card.spec.tsx
@@ -13,14 +13,19 @@ import { describe, expect, it, vi } from "vitest";
 import type { Card as CardEntity } from "@/entities/card";
 import { Card } from "./Card";
 
-const card = {
+const card: CardEntity = {
   id: "card-id",
+  deckId: "deck-id",
+  uid: "user-id",
   frontText: "A long front",
   backText: "Back",
-  score: 3,
-  numberOfSeen: 7,
   tags: ["one", "two"],
-} as CardEntity;
+  uniqueKey: "card-id",
+  createdAt: 0,
+  updatedAt: 0,
+  deletedAt: null,
+};
+const progress = { cardId: card.id, score: 3, numberOfSeen: 7 };
 
 /**
  * Renders the test-only Controlled Card component with controlled state or providers.
@@ -74,7 +79,7 @@ describe("Card", () => {
       onSwipedRight: vi.fn(),
       onToggleMenu: vi.fn(),
     };
-    render(<ControlledCard card={card} {...actions} />);
+    render(<ControlledCard card={card} progress={progress} {...actions} />);
     const article = screen.getByRole("article");
 
     expect(screen.getByLabelText("Score 3, positive")).toBeInTheDocument();
@@ -99,15 +104,15 @@ describe("Card", () => {
   });
 
   it("uses explicit copy for unstudied and singular study counts", () => {
-    const view = render(<Card card={{ ...card, numberOfSeen: 0 }} />);
+    const view = render(<Card card={card} progress={{ ...progress, numberOfSeen: 0 }} />);
     expect(screen.getByText("not studied yet")).toBeInTheDocument();
 
-    view.rerender(<Card card={{ ...card, numberOfSeen: 1 }} />);
+    view.rerender(<Card card={card} progress={{ ...progress, numberOfSeen: 1 }} />);
     expect(screen.getByText("studied 1 time")).toBeInTheDocument();
   });
 
   it("keeps study and tag metadata outside the View button", () => {
-    render(<Card card={card} />);
+    render(<Card card={card} progress={progress} />);
     const viewButton = screen.getByRole("button", { name: "View A long front" });
     const studyText = screen.getByText("studied 7 times");
     const tags = screen.getByLabelText("Tags: one, two");
@@ -117,7 +122,7 @@ describe("Card", () => {
   });
 
   it("renders card tags as compact read-only markers", () => {
-    render(<Card card={card} />);
+    render(<Card card={card} progress={progress} />);
     const metadata = screen.getByLabelText("Tags: one, two");
 
     expect(within(metadata).queryByRole("button")).not.toBeInTheDocument();
@@ -125,7 +130,7 @@ describe("Card", () => {
   });
 
   it("covers the complete central region with View without owning its metadata", () => {
-    render(<Card card={card} />);
+    render(<Card card={card} progress={progress} />);
     const viewButton = screen.getByRole("button", { name: "View A long front" });
 
     expect(viewButton).toHaveClass("absolute", "inset-0");
@@ -136,7 +141,7 @@ describe("Card", () => {
     vi.useFakeTimers();
     const goToView = vi.fn();
     const onSwipedLeft = vi.fn();
-    render(<Card card={card} goToView={goToView} onSwipedLeft={onSwipedLeft} />);
+    render(<Card card={card} progress={progress} goToView={goToView} onSwipedLeft={onSwipedLeft} />);
     const viewButton = screen.getByRole("button", { name: "View A long front" });
 
     swipe(viewButton, 100, 0);
@@ -152,7 +157,7 @@ describe("Card", () => {
 
   it("does not start swipe tracking from the actions menu trigger", () => {
     const onSwipedLeft = vi.fn();
-    render(<ControlledCard card={card} onSwipedLeft={onSwipedLeft} />);
+    render(<ControlledCard card={card} progress={progress} onSwipedLeft={onSwipedLeft} />);
     const trigger = screen.getByRole("button", { name: "Open actions for A long front" });
 
     swipe(trigger, 100, 0);
@@ -165,7 +170,9 @@ describe("Card", () => {
   it("isolates complete touch sequences on the actions trigger while preserving its click", () => {
     const onSwipedLeft = vi.fn();
     const onSwipedRight = vi.fn();
-    render(<ControlledCard card={card} onSwipedLeft={onSwipedLeft} onSwipedRight={onSwipedRight} />);
+    render(
+      <ControlledCard card={card} progress={progress} onSwipedLeft={onSwipedLeft} onSwipedRight={onSwipedRight} />
+    );
     const trigger = screen.getByRole("button", { name: "Open actions for A long front" });
 
     touchGesture(trigger, 240, 80);
@@ -188,7 +195,7 @@ describe("Card", () => {
       onSwipedRight: vi.fn(),
       onToggleMenu: vi.fn(),
     };
-    render(<ControlledCard card={card} disabled {...actions} />);
+    render(<ControlledCard card={card} progress={progress} disabled {...actions} />);
     const article = screen.getByRole("article");
 
     expect(article).toHaveAttribute("aria-busy", "true");

--- a/src/features/card-list/ui/Card.stories.tsx
+++ b/src/features/card-list/ui/Card.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Card as Template } from "./Card";
 import * as fixture from "@/storybook/fixture";
+import { createStudyProgress } from "@/test/factories";
 
 const meta = {
   title: "Features/Card List/Card",
@@ -15,6 +16,7 @@ const meta = {
   tags: ["autodocs"],
   args: {
     card: fixture.card.default,
+    progress: createStudyProgress({ cardId: fixture.card.default.id, score: 3, numberOfSeen: 5 }),
   },
 } satisfies Meta<typeof Template>;
 
@@ -24,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Unstudied: Story = {
-  args: { card: { ...fixture.card.default, numberOfSeen: 0, score: 0 } },
+  args: { progress: createStudyProgress({ cardId: fixture.card.default.id }) },
 };
 
 export const LongText: Story = { args: { card: fixture.card.long } };

--- a/src/features/card-list/ui/Card.tsx
+++ b/src/features/card-list/ui/Card.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import { useSwipeable } from "react-swipeable";
 
 import type { Card as CardEntity, CardId } from "@/entities/card";
+import type { StudyProgress } from "@/entities/study-progress";
 import { CardActionsMenu } from "./CardActionsMenu";
 import { Score, TagLabel } from "@/shared/ui/content";
 
@@ -42,9 +43,9 @@ const studiedText = (count: number) => {
  * Renders the Card user interface.
  * Presents one study card's front, back, score, and tags according to its current reveal state.
  */
-export const Card: React.FC<{ className?: string; card: CardEntity } & CardActionsProps & CardRowMenuProps> = (
-  props
-) => {
+export const Card: React.FC<
+  { className?: string; card: CardEntity; progress?: StudyProgress } & CardActionsProps & CardRowMenuProps
+> = (props) => {
   const id = props.card.id;
   const disabled = Boolean(props.disabled);
   const suppressViewClick = React.useRef(false);
@@ -105,7 +106,8 @@ export const Card: React.FC<{ className?: string; card: CardEntity } & CardActio
     onSwipedRight: withSwipeId(props.onSwipedRight),
     trackMouse: true,
   });
-  const seenCount = props.card.numberOfSeen ?? 0;
+  const progress = props.progress ?? { cardId: props.card.id, score: 0, numberOfSeen: 0 };
+  const seenCount = progress.numberOfSeen;
 
   return (
     <article
@@ -118,7 +120,7 @@ export const Card: React.FC<{ className?: string; card: CardEntity } & CardActio
         props.className
       )}
     >
-      <Score className="shrink-0" score={props.card.score} />
+      <Score className="shrink-0" score={progress.score} />
       <div className="relative flex min-h-touch min-w-0 flex-1 flex-col justify-center rounded-control">
         <button
           type="button"

--- a/src/features/card-list/ui/CardList.spec.tsx
+++ b/src/features/card-list/ui/CardList.spec.tsx
@@ -150,7 +150,7 @@ describe("CardList", () => {
     swipe(article, 0, 100);
 
     await waitFor(() => expect(onChangeScore).toHaveBeenCalledTimes(2));
-    expect(onChangeScore).toHaveBeenLastCalledWith(card, 1);
+    expect(onChangeScore).toHaveBeenLastCalledWith({ cardId: card.id, score: 0, numberOfSeen: 0 }, 1);
     await waitFor(() => expect(screen.queryByText("Unable to save changes. Try again.")).not.toBeInTheDocument());
   });
 });

--- a/src/features/card-list/ui/CardList.tsx
+++ b/src/features/card-list/ui/CardList.tsx
@@ -4,6 +4,7 @@ import { useAuthUid } from "@/entities/auth";
 import { deleteCard, type Card, type CardId } from "@/entities/card";
 import { getCategory, isHighlightLanguage, type Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
+import type { StudyProgress } from "@/entities/study-progress";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
 
@@ -26,12 +27,12 @@ interface CardListBackTextProps {
 
 export interface CardListProps {
   deck: Deck;
-  cards: Card[];
+  cards: (Card | { card: Card; progress: StudyProgress })[];
   preferences: Preferences;
   filter: CardListFilter;
   renderBackText: (props: CardListBackTextProps) => React.ReactNode;
   onEditCard: (id: CardId) => void;
-  onChangeScore: (card: Card, score: number) => Promise<void>;
+  onChangeScore: (progress: StudyProgress, score: number) => Promise<void>;
 }
 
 export const CardList: React.FC<CardListProps> = (props) => {
@@ -42,23 +43,27 @@ export const CardList: React.FC<CardListProps> = (props) => {
   const [mutationError, setMutationError] = React.useState<unknown>(null);
   const [successMessage, setSuccessMessage] = React.useState<string>();
 
-  const findCard = (id: CardId) => props.cards.find((card) => card.id === id);
+  const findStudyCard = (id: CardId) => {
+    const item = props.cards.find((candidate) => ("card" in candidate ? candidate.card.id : candidate.id) === id);
+    if (item == null) return undefined;
+    return "card" in item ? item : { card: item, progress: { cardId: item.id, score: 0, numberOfSeen: 0 } };
+  };
 
   const changeScore = (id: CardId, offset: number) => {
-    const card = findCard(id);
-    if (card == null) return;
+    const studyCard = findStudyCard(id);
+    if (studyCard == null) return;
     void props
-      .onChangeScore(card, card.score + offset)
+      .onChangeScore(studyCard.progress, studyCard.progress.score + offset)
       .then(() => setMutationError(null))
       .catch(setMutationError);
   };
 
   const requestDeletion = (id: CardId) => {
-    const card = findCard(id);
-    if (card == null) return;
+    const studyCard = findStudyCard(id);
+    if (studyCard == null) return;
     setSuccessMessage(undefined);
     setDeletionErrorCardId(undefined);
-    setDeletionTarget(card);
+    setDeletionTarget(studyCard.card);
   };
 
   const confirmDeletion = async () => {

--- a/src/features/card-list/ui/CardListView.tsx
+++ b/src/features/card-list/ui/CardListView.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { AiOutlineDown } from "react-icons/ai";
 
 import type { Card as CardEntity, CardId } from "@/entities/card";
+import type { StudyProgress } from "@/entities/study-progress";
 import { RemovableTag } from "@/shared/ui/content";
 import { Overlay } from "@/shared/ui/feedback";
 
@@ -24,7 +25,7 @@ interface CardListFilterState {
 }
 
 export interface CardListViewProps {
-  cards: CardEntity[];
+  cards: (CardEntity | { card: CardEntity; progress: StudyProgress })[];
   filter?: CardListFilterState;
   filterSlot?: React.ReactNode;
   card?: CardProps;
@@ -66,6 +67,9 @@ const filterLabel = (filter: CardListFilterState) => {
 
 const emptyFilter: CardListFilterState = { scoreMax: null, scoreMin: null, selectedTags: [] };
 
+const splitCardListItem = (item: CardListViewProps["cards"][number]) =>
+  "card" in item ? item : { card: item, progress: undefined };
+
 /**
  * Composes the complete Card List Rows screen from reusable UI components.
  * All data and callbacks arrive through props, allowing the same screen to run in tests and
@@ -76,23 +80,27 @@ const CardListRows: React.FC<Pick<CardListViewProps, "cards" | "card" | "onShowC
 
   return (
     <div className="overflow-visible rounded-surface border border-border bg-surface shadow-surface dark:border-black">
-      {props.cards.map((card) => (
-        <Card
-          key={card.id}
-          card={card}
-          menuOpen={openMenuCardId === card.id}
-          onToggleMenu={(id) => setOpenMenuCardId((value) => (value === id ? undefined : id))}
-          onCloseMenu={() => setOpenMenuCardId(undefined)}
-          {...(props.card?.onSwipedLeft !== undefined ? { onSwipedLeft: props.card.onSwipedLeft } : {})}
-          {...(props.card?.onSwipedRight !== undefined ? { onSwipedRight: props.card.onSwipedRight } : {})}
-          {...(props.card?.onDelete !== undefined ? { onDelete: props.card.onDelete } : {})}
-          {...(props.card?.goToEdit !== undefined ? { goToEdit: props.card.goToEdit } : {})}
-          goToView={() => {
-            setOpenMenuCardId(undefined);
-            props.onShowCard?.(card);
-          }}
-        />
-      ))}
+      {props.cards.map((item) => {
+        const { card, progress } = splitCardListItem(item);
+        return (
+          <Card
+            key={card.id}
+            card={card}
+            {...(progress !== undefined ? { progress } : {})}
+            menuOpen={openMenuCardId === card.id}
+            onToggleMenu={(id) => setOpenMenuCardId((value) => (value === id ? undefined : id))}
+            onCloseMenu={() => setOpenMenuCardId(undefined)}
+            {...(props.card?.onSwipedLeft !== undefined ? { onSwipedLeft: props.card.onSwipedLeft } : {})}
+            {...(props.card?.onSwipedRight !== undefined ? { onSwipedRight: props.card.onSwipedRight } : {})}
+            {...(props.card?.onDelete !== undefined ? { onDelete: props.card.onDelete } : {})}
+            {...(props.card?.goToEdit !== undefined ? { goToEdit: props.card.goToEdit } : {})}
+            goToView={() => {
+              setOpenMenuCardId(undefined);
+              props.onShowCard?.(card);
+            }}
+          />
+        );
+      })}
     </div>
   );
 };
@@ -151,7 +159,7 @@ export const CardListView: React.FC<CardListViewProps> = (props) => {
 
       {props.cards.length > 0 && (
         <CardListRows
-          key={JSON.stringify(props.cards.map((card) => card.id))}
+          key={JSON.stringify(props.cards.map((item) => splitCardListItem(item).card.id))}
           cards={props.cards}
           {...(props.card !== undefined ? { card: props.card } : {})}
           {...(props.onShowCard !== undefined ? { onShowCard: props.onShowCard } : {})}

--- a/src/features/card-view/ui/CardOverlay.spec.tsx
+++ b/src/features/card-view/ui/CardOverlay.spec.tsx
@@ -8,11 +8,16 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 import { CardOverlay } from "./CardOverlay";
-import { createCard } from "@/test/factories";
+import { createCard, createStudyProgress } from "@/test/factories";
 
 describe("CardOverlay", () => {
   it("preserves score and seen metadata", () => {
-    render(<CardOverlay card={createCard({ score: -2, numberOfSeen: 4, lastSeenAt: Date.UTC(2024, 0, 2) })} />);
+    render(
+      <CardOverlay
+        card={createCard()}
+        progress={createStudyProgress({ score: -2, numberOfSeen: 4, lastSeenAt: Date.UTC(2024, 0, 2) })}
+      />
+    );
     expect(screen.getByLabelText("Score -2, negative")).toBeInTheDocument();
     expect(screen.getByText(/4 times/)).toBeInTheDocument();
     expect(screen.getByText(/4 times/)).toBeVisible();

--- a/src/features/card-view/ui/CardOverlay.tsx
+++ b/src/features/card-view/ui/CardOverlay.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Card } from "@/entities/card";
+import type { StudyProgress } from "@/entities/study-progress";
 
 import type * as React from "react";
 import { Description, Score } from "@/shared/ui/content";
@@ -15,15 +16,15 @@ import { Overlay } from "@/shared/ui/feedback";
  * Shows the active card's score and tags in a compact overlay, falling back to neutral values
  * before a card is available.
  */
-export const CardOverlay: React.FC<{ card?: Card }> = (props) => {
-  const card = props.card;
+export const CardOverlay: React.FC<{ card?: Card; progress?: StudyProgress }> = (props) => {
+  const progress = props.progress;
   return (
     <Overlay position="top">
       <div className="mx-auto flex max-w-reading flex-row items-center gap-2 bg-surface-elevated p-2 text-ink">
-        <Score score={card?.score ?? 0} />
+        <Score score={progress?.score ?? 0} />
         <Description>
-          {card?.numberOfSeen != null && `${card.numberOfSeen} times`}
-          {card?.lastSeenAt != null && ` since ${new Date(card.lastSeenAt).toLocaleDateString()}`}
+          {progress != null && `${progress.numberOfSeen} times`}
+          {progress?.lastSeenAt != null && ` since ${new Date(progress.lastSeenAt).toLocaleDateString()}`}
         </Description>
       </div>
     </Overlay>

--- a/src/features/study/components/StudyWorkflow.spec.tsx
+++ b/src/features/study/components/StudyWorkflow.spec.tsx
@@ -1,4 +1,3 @@
-import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
@@ -38,23 +37,25 @@ vi.mock("../commands/studySessionCommands", () => ({
 }));
 
 import { StudyWorkflow, type StudyWorkflowState } from "./StudyWorkflow";
+import type { StudyCard } from "../model/studyCard";
 import { studyStore } from "../state/studyStoreInstance";
 
 const deckId: DeckId = "deck-id";
-const createCard = (id: string): Card => ({
+const createCard = (id: string): StudyCard & { id: string } => ({
   id,
-  deckId,
-  uid: "user-id",
-  frontText: id,
-  backText: `${id}-back`,
-  tags: [],
-  uniqueKey: id,
-  score: 0,
-  numberOfSeen: 0,
-  createdAt: 0,
-  updatedAt: 0,
-  deletedAt: null,
-  lastSeenAt: 0,
+  card: {
+    id,
+    deckId,
+    uid: "user-id",
+    frontText: id,
+    backText: `${id}-back`,
+    tags: [],
+    uniqueKey: id,
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+  },
+  progress: { cardId: id, score: 0, numberOfSeen: 0, lastSeenAt: 0 },
 });
 const cards = [createCard("card-1"), createCard("card-2"), createCard("card-3")];
 
@@ -80,7 +81,7 @@ const WorkflowView = ({ state }: { state: StudyWorkflowState }) => {
   );
 };
 
-const renderWorkflow = (currentCards: readonly Card[] = cards) =>
+const renderWorkflow = (currentCards: readonly StudyCard[] = cards) =>
   render(
     <StudyWorkflow cards={currentCards} deckId={deckId} onUnavailable={mocks.onUnavailable}>
       {(state) => <WorkflowView state={state} />}

--- a/src/features/study/components/StudyWorkflow.tsx
+++ b/src/features/study/components/StudyWorkflow.tsx
@@ -1,6 +1,7 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { SwipeDirection } from "@/entities/preferences";
+import type { StudyProgress } from "@/entities/study-progress";
 
 import type * as React from "react";
 
@@ -13,6 +14,7 @@ import { useStudyControllerState } from "../hooks/useStudyControllerState";
 import { useStudyDisplayState } from "../hooks/useStudyDisplayState";
 import { useStudyShortcuts } from "../hooks/useStudyShortcuts";
 import { useSwipeFeedback } from "../hooks/useSwipeFeedback";
+import type { StudyCard } from "../model/studyCard";
 
 type PresentationActions = Pick<
   StudyActions,
@@ -24,6 +26,7 @@ export type StudyWorkflowState =
   | {
       status: "ready";
       card: Card;
+      progress: StudyProgress;
       showHeader: boolean;
       showBackText: boolean;
       showController: boolean;
@@ -35,7 +38,7 @@ export type StudyWorkflowState =
     };
 
 interface StudyWorkflowProps {
-  cards: readonly Card[];
+  cards: readonly StudyCard[];
   deckId: DeckId;
   onUnavailable: () => void;
   children: (state: StudyWorkflowState) => React.ReactNode;
@@ -81,6 +84,7 @@ export const StudyWorkflow = ({ cards, deckId, onUnavailable, children }: StudyW
   const state: StudyWorkflowState = {
     status: "ready",
     card: session.card,
+    progress: session.progress,
     showHeader: display.preferences.appearance.showHeader && !display.showBackText,
     showBackText: display.showBackText,
     showController: display.preferences.study.cardInterval > 0,

--- a/src/features/study/hooks/useActiveStudySession.ts
+++ b/src/features/study/hooks/useActiveStudySession.ts
@@ -1,5 +1,6 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
+import type { StudyProgress } from "@/entities/study-progress";
 
 import * as React from "react";
 
@@ -7,25 +8,33 @@ import { touchStudySession } from "../commands/studySessionCommands";
 import { selectStudySessionForRoute } from "../state/studyStore";
 import { useStudyHydrated } from "./useStudyHydrated";
 import { useStudyStore } from "./useStudyStore";
+import type { StudyCard } from "../model/studyCard";
 
 export type ActiveStudySession =
   | { status: "loading" | "unavailable" }
   | {
       status: "ready";
       card: Card;
+      progress: StudyProgress;
       index: number;
       numberOfCards: number;
     };
 
-export const useActiveStudySession = (deckId: DeckId, cards: readonly Card[]): ActiveStudySession => {
+export const useActiveStudySession = (deckId: DeckId, cards: readonly StudyCard[]): ActiveStudySession => {
   const session = useStudyStore(selectStudySessionForRoute(deckId));
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
+  const studyCard = cardId == null ? undefined : cards.find(({ card }) => card.id === cardId);
   const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
 
-  if (card != null && sessionHasTargetCard) {
-    return { status: "ready", card, index, numberOfCards: session.cardOrderIds.length };
+  if (studyCard != null && sessionHasTargetCard) {
+    return {
+      status: "ready",
+      card: studyCard.card,
+      progress: studyCard.progress,
+      index,
+      numberOfCards: session.cardOrderIds.length,
+    };
   }
   if (sessionHasTargetCard && cards.length === 0) return { status: "loading" };
   return { status: "unavailable" };

--- a/src/features/study/hooks/useEditStudyProgress.ts
+++ b/src/features/study/hooks/useEditStudyProgress.ts
@@ -1,17 +1,10 @@
-import type { Card } from "@/entities/card";
 import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 
 import { useAuthUid } from "@/entities/auth";
-
-export type StudyProgressPatch = Omit<StudyProgressEdit, "cardId">;
 
 export const useEditStudyProgress = () => {
   const uid = useAuthUid();
   const update = (progress: StudyProgressEdit) => editStudyProgress(uid, progress);
 
-  return {
-    update,
-    updateBy: (card: Card, buildPatch: (card: Card) => StudyProgressPatch) =>
-      update({ ...buildPatch(card), cardId: card.id }),
-  };
+  return { update };
 };

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -4,7 +4,7 @@
  * cards before notifying its owner" and "rejects a route and session mismatch before writing a card".
  */
 
-import type { Card, CardId } from "@/entities/card";
+import type { CardId } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
@@ -16,12 +16,13 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 import { useStudyActions } from "./useStudyActions";
 import { studyStore } from "../state/studyStoreInstance";
 import { actAsync } from "@/test/act";
+import type { StudyCard } from "../model/studyCard";
 
 const mocks = vi.hoisted(() => {
   const cardUpdate = vi.fn();
 
   return {
-    state: null as { cards: Card[]; preferences: Preferences } | null,
+    state: null as { cards: (StudyCard & { id: CardId })[]; preferences: Preferences } | null,
     cardUpdate,
     cardMutations: {
       update: cardUpdate,
@@ -57,19 +58,21 @@ const deck: Deck = {
  * Provides the create card test helper used by this file.
  * Keeping this setup in one function lets each test focus on the behavior it is proving.
  */
-const createCard = (id: CardId, numberOfSeen: number): Card => ({
+const createCard = (id: CardId, numberOfSeen: number): StudyCard & { id: CardId } => ({
   id,
-  deckId: deck.id,
-  uid: "user-1",
-  frontText: id,
-  backText: `${id}-back`,
-  tags: [],
-  uniqueKey: id,
-  score: 0,
-  numberOfSeen,
-  createdAt: 0,
-  updatedAt: 0,
-  deletedAt: null,
+  card: {
+    id,
+    deckId: deck.id,
+    uid: "user-1",
+    frontText: id,
+    backText: `${id}-back`,
+    tags: [],
+    uniqueKey: id,
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+  },
+  progress: { cardId: id, score: 0, numberOfSeen },
 });
 
 const card1 = createCard("card-1", 0);

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -4,7 +4,6 @@
  * coordinate services themselves.
  */
 
-import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { StudyProgressEdit } from "@/entities/study-progress";
 import type { Preferences, SwipeDirection } from "@/entities/preferences";
@@ -12,13 +11,13 @@ import type { Preferences, SwipeDirection } from "@/entities/preferences";
 import React from "react";
 
 import { buildStudySession, calculateNextIndex } from "../model/session";
-import { createStudyCard } from "../model/studyCard";
+import type { StudyCard } from "../model/studyCard";
 import { buildStudyPatch, resolveSwipeAction } from "../model/swipe";
 import { studyStore } from "../state/studyStoreInstance";
 import { usePreferences } from "@/entities/preferences";
 
 export interface StudyActions {
-  start: (cards: Card[]) => void;
+  start: (cards: StudyCard[]) => void;
   swipeUp: () => Promise<void>;
   swipeDown: () => Promise<void>;
   swipeLeft: () => Promise<void>;
@@ -36,7 +35,7 @@ interface StudyCardMutation {
 type SwipeRollback = () => void;
 
 interface UseStudyActionsOptions {
-  cards?: readonly Card[] | undefined;
+  cards?: readonly StudyCard[] | undefined;
   cardMutation?: StudyCardMutation | undefined;
   onStarted?: (() => void) | undefined;
   onSwipe?: ((direction: SwipeDirection) => SwipeRollback | undefined) | undefined;
@@ -51,7 +50,7 @@ interface StudySwipeDependencies {
   mutationTokenRef: { current: symbol | undefined };
   deckId: DeckId;
   preferences: Preferences;
-  cards: readonly Card[];
+  cards: readonly StudyCard[];
   update: (progress: StudyProgressEdit) => Promise<void>;
   onSwipe?: ((direction: SwipeDirection) => SwipeRollback | undefined) | undefined;
   showBackText?: boolean | undefined;
@@ -125,8 +124,8 @@ const runStudySwipe = async (
   }
 
   const cardId = session.cardOrderIds[session.currentIndex];
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  if (card == null) return;
+  const studyCard = cardId == null ? undefined : cards.find(({ card }) => card.id === cardId);
+  if (studyCard == null) return;
 
   const previous = {
     session: { ...session },
@@ -138,7 +137,7 @@ const runStudySwipe = async (
     onHideBackText?.();
   }
 
-  const patch = buildStudyPatch(createStudyCard(card), swipeAction, Date.now());
+  const patch = buildStudyPatch(studyCard, swipeAction, Date.now());
   const nextIndex = calculateNextIndex(session.currentIndex, session.cardOrderIds.length, swipeAction);
   const mutationToken = Symbol();
   mutationTokenRef.current = mutationToken;
@@ -187,8 +186,11 @@ export const useStudyActions = (
    * Creates a new study session from the currently filtered cards.
    * The saved UI preferences are applied before the Page is notified that the session is ready.
    */
-  const start = (cards: Card[]) => {
-    const cardOrderIds = buildStudySession(cards, preferences.study);
+  const start = (cards: StudyCard[]) => {
+    const cardOrderIds = buildStudySession(
+      cards.map(({ card }) => card),
+      preferences.study
+    );
     const state = studyStore.getState();
     state.startStudy(deckId, cardOrderIds);
     onHideBackText?.();

--- a/src/features/study/hooks/useStudyCards.spec.tsx
+++ b/src/features/study/hooks/useStudyCards.spec.tsx
@@ -4,11 +4,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { createCard, createPreferences, createDeck } from "@/test/factories";
+import { createStudyProgress } from "@/test/factories";
+import type { StudyProgress } from "@/entities/study-progress";
+
+const mocks = vi.hoisted(() => ({ progresses: [] as StudyProgress[] }));
+
+vi.mock("@/entities/study-progress", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/study-progress")>();
+  return { ...actual, useStudyProgresses: () => mocks.progresses };
+});
 
 import { useStudyCards } from "./useStudyCards";
 
 describe("useStudyCards", () => {
-  beforeEach(() => vi.restoreAllMocks());
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.progresses = [];
+  });
 
   afterEach(() => {
     vi.useRealTimers();
@@ -18,13 +30,16 @@ describe("useStudyCards", () => {
     const now = Date.UTC(2026, 6, 19);
     vi.spyOn(Date, "now").mockReturnValue(now);
     const deck = createDeck({ id: "deck" });
-    const available = createCard({ id: "available", deckId: deck.id, nextSeeingAt: new Date(now) });
-    const future = createCard({ id: "future", deckId: deck.id, nextSeeingAt: new Date(now + 1) });
+    const available = createCard({ id: "available", deckId: deck.id });
+    const future = createCard({ id: "future", deckId: deck.id });
+    const availableProgress = createStudyProgress({ cardId: available.id, nextSeeingAt: new Date(now) });
+    const futureProgress = createStudyProgress({ cardId: future.id, nextSeeingAt: new Date(now + 1) });
+    mocks.progresses = [availableProgress, futureProgress];
     const cards = [available, future];
 
     const { result } = renderHook(() => useStudyCards(deck, cards, createPreferences({ useCardInterval: true })));
 
-    expect(result.current).toEqual([available]);
+    expect(result.current).toEqual([{ card: available, progress: availableProgress }]);
   });
 
   it("returns no Cards when the Deck is unavailable", () => {
@@ -39,7 +54,9 @@ describe("useStudyCards", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const deck = createDeck({ id: "scheduled" });
-    const card = createCard({ id: "scheduled-card", deckId: deck.id, nextSeeingAt: new Date(1_500) });
+    const card = createCard({ id: "scheduled-card", deckId: deck.id });
+    const progress = createStudyProgress({ cardId: card.id, nextSeeingAt: new Date(1_500) });
+    mocks.progresses = [progress];
     const cards = [card];
     const enabled = createPreferences({ useCardInterval: true });
     const disabled = createPreferences({ useCardInterval: false });
@@ -49,13 +66,13 @@ describe("useStudyCards", () => {
     }));
 
     expect(result.current.enabled).toEqual([]);
-    expect(result.current.disabled).toEqual([card]);
+    expect(result.current.disabled).toEqual([{ card, progress }]);
 
     act(() => vi.advanceTimersByTime(499));
     expect(result.current.enabled).toEqual([]);
 
     act(() => vi.advanceTimersByTime(1));
-    expect(result.current.enabled).toEqual([card]);
+    expect(result.current.enabled).toEqual([{ card, progress }]);
   });
 
   it("reschedules review times beyond the browser timeout limit", () => {
@@ -66,8 +83,12 @@ describe("useStudyCards", () => {
     const card = createCard({
       id: "scheduled-card",
       deckId: deck.id,
+    });
+    const progress = createStudyProgress({
+      cardId: card.id,
       nextSeeingAt: new Date(1_000 + maxTimeout + 500),
     });
+    mocks.progresses = [progress];
     const config = createPreferences({ useCardInterval: true });
     const { result } = renderHook(() => useStudyCards(deck, [card], config));
 
@@ -77,6 +98,6 @@ describe("useStudyCards", () => {
     expect(result.current).toEqual([]);
 
     act(() => vi.advanceTimersByTime(500));
-    expect(result.current).toEqual([card]);
+    expect(result.current).toEqual([{ card, progress }]);
   });
 });

--- a/src/features/study/hooks/useStudyCards.ts
+++ b/src/features/study/hooks/useStudyCards.ts
@@ -2,22 +2,34 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
-import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
+import { createStudyProgress, getNextStudyAvailabilityAt, useStudyProgresses } from "@/entities/study-progress";
 import { filterCardsForDeck } from "../model/cardSelection";
-import { createStudyCard } from "../model/studyCard";
+import { createStudyCard, type StudyCard } from "../model/studyCard";
 import type { Preferences } from "@/entities/preferences";
 
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
-export const useStudyCards = (deck: Deck | undefined, cards: Card[], preferences: Preferences): Card[] => {
+export const useStudyCardItems = (cards: Card[]): StudyCard[] => {
+  const progresses = useStudyProgresses();
+  const progressesByCardId = useMemo(
+    () => new Map(progresses.map((progress) => [progress.cardId, progress])),
+    [progresses]
+  );
+  return useMemo(
+    () => cards.map((card) => createStudyCard(card, progressesByCardId.get(card.id) ?? createStudyProgress(card.id))),
+    [cards, progressesByCardId]
+  );
+};
+
+export const useStudyCards = (deck: Deck | undefined, cards: Card[], preferences: Preferences): StudyCard[] => {
   const [scheduleClock, setScheduleClock] = useState(() => Date.now());
-  const studyCards = useMemo(() => cards.map(createStudyCard), [cards]);
+  const studyCards = useStudyCardItems(cards);
 
   useEffect(() => {
     const current = Date.now();
     const refresh = window.setTimeout(() => setScheduleClock(current), 0);
     return () => window.clearTimeout(refresh);
-  }, [cards]);
+  }, [studyCards]);
 
   useEffect(() => {
     const current = Date.now();
@@ -34,7 +46,5 @@ export const useStudyCards = (deck: Deck | undefined, cards: Card[], preferences
     };
   }, [scheduleClock, studyCards]);
 
-  return deck == null
-    ? []
-    : filterCardsForDeck(studyCards, deck, preferences.study, scheduleClock).map(({ card }) => card);
+  return deck == null ? [] : filterCardsForDeck(studyCards, deck, preferences.study, scheduleClock);
 };

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -4,7 +4,8 @@ export { SwipeButtonList, type SwipeButtonListProps } from "./components/SwipeBu
 export { removeStudySession, touchStudySession } from "./commands/studySessionCommands";
 export { useStudyHydrated } from "./hooks/useStudyHydrated";
 export { useStudyActions } from "./hooks/useStudyActions";
-export { useStudyCards } from "./hooks/useStudyCards";
+export { useStudyCardItems, useStudyCards } from "./hooks/useStudyCards";
+export type { StudyCard } from "./model/studyCard";
 export { useStudySessions } from "./hooks/useStudySessions";
 export { clearStudyStore } from "./state/studyStoreInstance";
 export { useEditStudyProgress } from "./hooks/useEditStudyProgress";

--- a/src/features/study/model/studyCard.ts
+++ b/src/features/study/model/studyCard.ts
@@ -1,21 +1,12 @@
 import type { Card } from "@/entities/card";
-import { createStudyProgressFromCard, type StudyProgress } from "@/entities/study-progress";
+import type { StudyProgress } from "@/entities/study-progress";
 
-type StudyCardContent = Omit<Card, keyof Omit<StudyProgress, "cardId">>;
-
-export interface StudyCard<TCard extends StudyCardContent = StudyCardContent> {
+export interface StudyCard<TCard extends Card = Card> {
   card: TCard;
   progress: StudyProgress;
 }
 
-export const createStudyCard = <TCard extends Card>(card: TCard): StudyCard<TCard> => ({
+export const createStudyCard = <TCard extends Card>(card: TCard, progress: StudyProgress): StudyCard<TCard> => ({
   card,
-  progress: createStudyProgressFromCard({
-    id: card.id,
-    score: card.score,
-    numberOfSeen: card.numberOfSeen,
-    ...(card.lastSeenAt === undefined ? {} : { lastSeenAt: card.lastSeenAt }),
-    ...(card.nextSeeingAt === undefined ? {} : { nextSeeingAt: card.nextSeeingAt }),
-    ...(card.interval === undefined ? {} : { interval: card.interval }),
-  }),
+  progress,
 });

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -2,18 +2,19 @@ import type * as React from "react";
 import { useNavigate } from "react-router-dom";
 
 import { type Card, useCard } from "@/entities/card";
+import { type StudyProgress, useStudyProgress } from "@/entities/study-progress";
 import { CardEditForm } from "@/features/card-edit";
 import { useRequiredRouteParam } from "@/shared/router";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
-const CardFormContent = ({ card }: { card: Card }) => {
+const CardFormContent = ({ card, progress }: { card: Card; progress?: StudyProgress | undefined }) => {
   const navigate = useNavigate();
   const goBack = () => void navigate(-1);
 
   return (
     <AppLayout showHeader>
-      <CardEditForm card={card} onSaved={goBack} onCancel={goBack} />
+      <CardEditForm card={card} progress={progress} onSaved={goBack} onCancel={goBack} />
     </AppLayout>
   );
 };
@@ -22,6 +23,7 @@ export const CardFormPage: React.FC = () => {
   const navigate = useNavigate();
   const cardId = useRequiredRouteParam("id");
   const card = useCard(cardId);
+  const progress = useStudyProgress(cardId);
 
   if (card == null) {
     return (
@@ -35,5 +37,5 @@ export const CardFormPage: React.FC = () => {
     );
   }
 
-  return <CardFormContent card={card} />;
+  return <CardFormContent card={card} progress={progress} />;
 };

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -1,6 +1,7 @@
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
+import type { StudyProgress } from "@/entities/study-progress";
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -16,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   cards: [] as Card[],
   navigate: vi.fn(),
   onClickTag: vi.fn(),
-  updateBy: vi.fn(),
+  update: vi.fn(),
   cardListProps: null as null | Record<string, unknown>,
 }));
 
@@ -31,19 +32,25 @@ vi.mock("@/entities/card", () => ({
 vi.mock("@/entities/deck", () => ({ useDeck: () => mocks.deck ?? undefined }));
 vi.mock("@/features/card-list", () => ({
   CardList: (props: {
-    cards: Card[];
+    cards: { card: Card; progress: StudyProgress }[];
     filter: { selectedTags: string[]; onChangeSelectedTags: (tags: string[]) => void };
     onEditCard: (id: string) => void;
-    onChangeScore: (card: Card, score: number) => Promise<void>;
+    onChangeScore: (progress: StudyProgress, score: number) => Promise<void>;
   }) => {
     mocks.cardListProps = props as unknown as Record<string, unknown>;
     return (
       <div>
         <span>Card list feature</span>
-        <button type="button" onClick={() => props.onEditCard(props.cards[0]?.id ?? "missing")}>
+        <button type="button" onClick={() => props.onEditCard(props.cards[0]?.card.id ?? "missing")}>
           Edit card
         </button>
-        <button type="button" onClick={() => void props.onChangeScore(props.cards[0] as Card, 3)}>
+        <button
+          type="button"
+          onClick={() => {
+            const progress = props.cards[0]?.progress;
+            if (progress !== undefined) void props.onChangeScore(progress, 3);
+          }}
+        >
           Change score
         </button>
         <button type="button" onClick={() => props.filter.onChangeSelectedTags(["react"])}>
@@ -62,8 +69,9 @@ vi.mock("@/features/deck-start", () => ({
   }),
 }));
 vi.mock("@/features/study", () => ({
-  useEditStudyProgress: () => ({ updateBy: mocks.updateBy }),
-  useStudyCards: (deck: Deck | undefined, cards: Card[]) => (deck == null ? [] : cards),
+  useEditStudyProgress: () => ({ update: mocks.update }),
+  useStudyCards: (deck: Deck | undefined, cards: Card[]) =>
+    deck == null ? [] : cards.map((card) => ({ card, progress: { cardId: card.id, score: 0, numberOfSeen: 0 } })),
 }));
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
@@ -84,7 +92,7 @@ describe("CardListPage", () => {
     mocks.preferences = createPreferences();
     mocks.navigate.mockReset();
     mocks.onClickTag.mockReset();
-    mocks.updateBy.mockReset().mockResolvedValue(undefined);
+    mocks.update.mockReset().mockResolvedValue(undefined);
     mocks.cardListProps = null;
   });
 
@@ -98,9 +106,7 @@ describe("CardListPage", () => {
     expect(mocks.navigate).toHaveBeenCalledWith(`/card/${card.id}/edit`);
 
     await userEvent.click(screen.getByRole("button", { name: "Change score" }));
-    const buildPatch = mocks.updateBy.mock.calls[0]?.[1] as (card: Card) => object;
-    expect(mocks.updateBy.mock.calls[0]?.[0]).toEqual(card);
-    expect(buildPatch(card)).toEqual({ score: 3 });
+    expect(mocks.update).toHaveBeenCalledWith({ cardId: card.id, score: 3 });
 
     await userEvent.click(screen.getByRole("button", { name: "Change tags" }));
     expect(mocks.onClickTag).toHaveBeenCalledExactlyOnceWith(["react"]);

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -2,19 +2,19 @@ import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { type Card, type CardId, useCardsByDeckId } from "@/entities/card";
+import { type CardId, useCardsByDeckId } from "@/entities/card";
 import { type Deck, useDeck } from "@/entities/deck";
 import { type Preferences, usePreferences } from "@/entities/preferences";
 import { CardList } from "@/features/card-list";
 import { BackText } from "@/features/card-view";
 import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
-import { useEditStudyProgress, useStudyCards } from "@/features/study";
+import { useEditStudyProgress, useStudyCards, type StudyCard } from "@/features/study";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 const CardListComposition = (props: {
   deck: Deck;
-  cards: Card[];
+  cards: StudyCard[];
   tags: string[];
   preferences: Preferences;
   onEditCard: (id: CardId) => void;
@@ -36,7 +36,7 @@ const CardListComposition = (props: {
       }}
       renderBackText={(backText) => <BackText {...backText} />}
       onEditCard={props.onEditCard}
-      onChangeScore={(card, score) => editMutation.updateBy(card, () => ({ score }))}
+      onChangeScore={(progress, score) => editMutation.update({ cardId: progress.cardId, score })}
     />
   );
 };

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -1,4 +1,3 @@
-import type { Card } from "@/entities/card";
 import { type Deck, useDeck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
@@ -8,7 +7,7 @@ import { useKey } from "react-use";
 
 import { useCardsByDeckId } from "@/entities/card";
 import { DeckStartForm, useDeckFilterState } from "@/features/deck-start";
-import { useStudyActions, useStudyCards } from "@/features/study";
+import { useStudyActions, useStudyCards, type StudyCard } from "@/features/study";
 import { usePreferences } from "@/entities/preferences";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
@@ -18,7 +17,7 @@ import { DeckStartView } from "./DeckStartView";
 const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
   target instanceof Element && target.closest("a[href], button, input, select, textarea") != null;
 
-const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
+const DeckStartContent = (props: { deck: Deck; cards: StudyCard[]; preferences: Preferences; tags: string[] }) => {
   const { deck, cards, preferences, tags } = props;
   const navigate = useNavigate();
   const studyActions = useStudyActions(deck.id, {

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx
@@ -1,6 +1,6 @@
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
-import type { StudyWorkflowState } from "@/features/study";
+import type { StudyCard, StudyWorkflowState } from "@/features/study";
 
 import { act, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   cards: [] as Card[],
   navigate: vi.fn(),
   workflowState: { status: "unavailable" } as StudyWorkflowState,
-  workflowProps: undefined as { cards: readonly Card[]; deckId: string; onUnavailable: () => void } | undefined,
+  workflowProps: undefined as { cards: readonly StudyCard[]; deckId: string; onUnavailable: () => void } | undefined,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -21,7 +21,11 @@ vi.mock("@/entities/deck", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/deck")>();
   return { ...actual, useDeck: () => mocks.deck };
 });
-vi.mock("@/entities/card", () => ({ useCards: () => mocks.cards }));
+vi.mock("@/entities/card", () => ({ useCardsByDeckId: () => ({ cards: mocks.cards, tags: [] }) }));
+vi.mock("@/entities/preferences", () => ({
+  setDarkMode: vi.fn(),
+  usePreferences: () => ({ appearance: { darkMode: false } }),
+}));
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
   useParams: () => mocks.params,
@@ -30,11 +34,16 @@ vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
   return {
     ...actual,
+    useStudyCardItems: (cards: Card[]) =>
+      cards.map((card) => ({
+        card,
+        progress: { cardId: card.id, score: 2, numberOfSeen: 3, lastSeenAt: 1 },
+      })),
     StudyWorkflow: ({
       children,
       ...props
     }: { children: (state: StudyWorkflowState) => React.ReactNode } & {
-      cards: readonly Card[];
+      cards: readonly StudyCard[];
       deckId: string;
       onUnavailable: () => void;
     }) => {
@@ -70,17 +79,16 @@ const card: Card = {
   backText: "const answer = 42;",
   tags: ["typescript"],
   uniqueKey: "unique-key",
-  score: 2,
-  numberOfSeen: 3,
   createdAt: 0,
   updatedAt: 0,
   deletedAt: null,
-  lastSeenAt: 1,
 };
+const progress = { cardId: card.id, score: 2, numberOfSeen: 3, lastSeenAt: 1 };
 const noop = vi.fn();
 const readyState = (): StudyWorkflowState => ({
   status: "ready",
   card,
+  progress,
   showHeader: true,
   showBackText: false,
   showController: true,
@@ -115,7 +123,7 @@ describe("DeckSwiperPage", () => {
   it("passes Entity reads to StudyWorkflow and composes the application shell", () => {
     render(<DeckSwiperPage />);
 
-    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, cards: [card] });
+    expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, cards: [{ card, progress }] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     expect(screen.getByText(card.frontText)).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();

--- a/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
+++ b/src/pages/deck-swiper/ui/DeckSwiperPage.tsx
@@ -3,9 +3,9 @@ import { getCategory, type Deck, useDeck } from "@/entities/deck";
 import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { type Card, useCards } from "@/entities/card";
+import { useCardsByDeckId } from "@/entities/card";
 import { CardOverlay, CardView, FrontText } from "@/features/card-view";
-import { StudyWorkflow, type StudyWorkflowState } from "@/features/study";
+import { StudyWorkflow, type StudyCard, type StudyWorkflowState, useStudyCardItems } from "@/features/study";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -62,7 +62,7 @@ const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
             onClick={state.actions.toggleShowBackText}
           />
         }
-        cardOverlaySlot={<CardOverlay card={state.card} />}
+        cardOverlaySlot={<CardOverlay card={state.card} progress={state.progress} />}
         backTextSlot={
           <CardView card={state.card} deck={deck} onClick={state.actions.toggleShowBackText} variant="bare" />
         }
@@ -74,7 +74,7 @@ const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
   );
 };
 
-const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
+const DeckSwiperContent = ({ cards, deck }: { cards: StudyCard[]; deck: Deck }) => {
   const navigate = useNavigate();
   useStudyHistoryGuard(deck.id, navigate);
   const handleUnavailable = React.useCallback(() => {
@@ -93,8 +93,9 @@ export const DeckSwiperPage: React.FC = () => {
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
 
-  const cards = useCards();
   const deck = useDeck(deckId);
+  const { cards: deckCards } = useCardsByDeckId(deckId);
+  const cards = useStudyCardItems(deckCards);
 
   if (deck == null) {
     return <RouteFeedback title="Study session unavailable." tone="not-found" />;

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -7,6 +7,7 @@
 import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { Preferences, StudyPreferences, SwipeAction } from "@/entities/preferences";
+import type { StudyProgress } from "@/entities/study-progress";
 
 type AppearancePreferences = Preferences["appearance"];
 type ControlPreferences = Preferences["controls"];
@@ -37,7 +38,7 @@ export const createDeck = (overrides: Partial<Deck> = {}): Deck => ({
  * Builds a complete test card with predictable defaults and optional field overrides.
  * Tests can describe only the card fields relevant to their scenario.
  */
-export const createCard = (overrides: Partial<Card> = {}): Card => ({
+export const createCard = (overrides: Partial<Card> & Partial<Omit<StudyProgress, "cardId">> = {}): Card => ({
   id: "card-id",
   deckId: "deck-id",
   uid: "user-id",
@@ -48,6 +49,11 @@ export const createCard = (overrides: Partial<Card> = {}): Card => ({
   createdAt: 0,
   updatedAt: 0,
   deletedAt: null,
+  ...overrides,
+});
+
+export const createStudyProgress = (overrides: Partial<StudyProgress> = {}): StudyProgress => ({
+  cardId: "card-id",
   score: 0,
   numberOfSeen: 0,
   ...overrides,


### PR DESCRIPTION
## Related issue

Fixes #948

## Summary

- Separate the physical Firestore card document contract from the Card domain schema.
- Map the same stored document independently into Card and StudyProgress read models.
- Add StudyProgress subscription state and compose `{ card, progress }` explicitly in study, card list, card overlay, and card edit flows.
- Remove StudyProgress fields and transitional helpers from the Card model while preserving the stored Firestore shape and initial progress values.
- Keep remote/local Card state separation and default missing progress for local Cards without adding `localMode` to Card.

## Why

Card content and study progress were represented as one Card object even though they have different owners and persistence responsibilities. That coupling made study workflows depend on `Card.score`, `Card.numberOfSeen`, and scheduling fields, and blurred the boundary between the physical Firestore document and application models.

## Impact

User-visible study, filtering, score editing, overlay, and card information behavior is preserved. Firestore still stores Card and StudyProgress fields in the existing `card` document format; no collection split or data migration is introduced.

## Validation

- `npm run lint:fsd`
- `mise run check` (508 unit tests plus TypeScript, ESLint, Biome, FSD, Knip, Markdown, sample formatting, and Dockerfile lint)