### PR TITLE
feat(#968): Add required entity lookup helpers

### DIFF
--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -16,4 +16,4 @@ export type {
   CardId,
   CardRaw,
 } from "./model/types";
-export { filterCardsByDeckId } from "./model/rules";
+export { filterCardsByDeckId, mustFindCardById } from "./model/rules";

--- a/src/entities/card/model/rules.spec.ts
+++ b/src/entities/card/model/rules.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createCard } from "@/test/factories";
-import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
+import { filterCardsByDeckId, filterTagsByDeckId, mustFindCardById } from "./rules";
 
 describe("filterCardsByDeckId", () => {
   it("returns cards matching the specified deckId", () => {
@@ -20,5 +20,17 @@ describe("filterTagsByDeckId", () => {
     const card3 = createCard({ id: "card-3", deckId: "deck-b", tags: ["other"] });
 
     expect(filterTagsByDeckId([card1, card2, card3], "deck-a")).toEqual(["kanji", "n5", "verb"]);
+  });
+});
+
+describe("mustFindCardById", () => {
+  it("returns the card matching the specified id", () => {
+    const target = createCard({ id: "target" });
+
+    expect(mustFindCardById([createCard({ id: "other" }), target], target.id)).toBe(target);
+  });
+
+  it("throws when no card matches the specified id", () => {
+    expect(() => mustFindCardById([], "missing")).toThrow("Card not found: missing");
   });
 });

--- a/src/entities/card/model/rules.ts
+++ b/src/entities/card/model/rules.ts
@@ -1,7 +1,15 @@
-import type { Card } from "./types";
+import type { Card, CardId } from "./types";
 
 export const filterCardsByDeckId = (cards: Card[], deckId: string): Card[] =>
   cards.filter((card) => card.deckId === deckId);
 
 export const filterTagsByDeckId = (cards: Card[], deckId: string): string[] =>
   [...new Set(filterCardsByDeckId(cards, deckId).flatMap((card) => card.tags))].sort();
+
+export const mustFindCardById = (cards: readonly Card[], id: CardId): Card => {
+  const card = cards.find((card) => card.id === id);
+
+  if (card == null) throw new Error(`Card not found: ${id}`);
+
+  return card;
+};

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,6 +1,6 @@
 export { createDeck, deleteDeck, editDeck, fetchDecks, subscribeDecks } from "./api/firestore";
 export { generateDeckId } from "./model/id";
-export { CATEGORY, getCategory, isHighlightLanguage } from "./model/rules";
+export { CATEGORY, getCategory, isHighlightLanguage, mustFindDeckById } from "./model/rules";
 export { useDeck, useDecks } from "./model/hooks";
 export { clearRemoteDecks } from "./model/store";
 /** @public */

--- a/src/entities/deck/model/rules.spec.ts
+++ b/src/entities/deck/model/rules.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { CATEGORY, getCategory, isHighlightLanguage } from "./rules";
+import { createDeck } from "@/test/factories";
+import { CATEGORY, getCategory, isHighlightLanguage, mustFindDeckById } from "./rules";
 
 describe("category", () => {
   it("defines supported categories including application categories and major languages", () => {
@@ -32,5 +33,17 @@ describe("category", () => {
 
   it("falls back to the deck category when no supported tag exists", () => {
     expect(getCategory("markdown", ["unknown"])).toBe("markdown");
+  });
+});
+
+describe("mustFindDeckById", () => {
+  it("returns the deck matching the specified id", () => {
+    const target = createDeck({ id: "target" });
+
+    expect(mustFindDeckById([createDeck({ id: "other" }), target], target.id)).toBe(target);
+  });
+
+  it("throws when no deck matches the specified id", () => {
+    expect(() => mustFindDeckById([], "missing")).toThrow("Deck not found: missing");
   });
 });

--- a/src/entities/deck/model/rules.ts
+++ b/src/entities/deck/model/rules.ts
@@ -1,4 +1,4 @@
-import type { Category } from "./types";
+import type { Category, Deck, DeckId } from "./types";
 
 const APPLICATION_CATEGORIES: Category[] = ["raw", "math"];
 
@@ -47,4 +47,12 @@ export const getCategory = (category: Category, tags: string[]): Category => {
   const tagCategory = tags.find((tag) => APPLICATION_CATEGORIES.includes(tag) || isHighlightLanguage(tag));
 
   return tagCategory ?? category;
+};
+
+export const mustFindDeckById = (decks: readonly Deck[], id: DeckId): Deck => {
+  const deck = decks.find((deck) => deck.id === id);
+
+  if (deck == null) throw new Error(`Deck not found: ${id}`);
+
+  return deck;
 };

--- a/src/features/card-list/ui/CardList.tsx
+++ b/src/features/card-list/ui/CardList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { deleteCard, type Card, type CardId } from "@/entities/card";
+import { deleteCard, mustFindCardById, type Card, type CardId } from "@/entities/card";
 import { getCategory, isHighlightLanguage, type Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
@@ -42,11 +42,8 @@ export const CardList: React.FC<CardListProps> = (props) => {
   const [mutationError, setMutationError] = React.useState<unknown>(null);
   const [successMessage, setSuccessMessage] = React.useState<string>();
 
-  const findCard = (id: CardId) => props.cards.find((card) => card.id === id);
-
   const changeScore = (id: CardId, offset: number) => {
-    const card = findCard(id);
-    if (card == null) return;
+    const card = mustFindCardById(props.cards, id);
     void props
       .onChangeScore(card, card.score + offset)
       .then(() => setMutationError(null))
@@ -54,8 +51,7 @@ export const CardList: React.FC<CardListProps> = (props) => {
   };
 
   const requestDeletion = (id: CardId) => {
-    const card = findCard(id);
-    if (card == null) return;
+    const card = mustFindCardById(props.cards, id);
     setSuccessMessage(undefined);
     setDeletionErrorCardId(undefined);
     setDeletionTarget(card);

--- a/src/features/deck-list/ui/DeckList.tsx
+++ b/src/features/deck-list/ui/DeckList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { filterCardsByDeckId, type Card } from "@/entities/card";
-import type { Deck, DeckId } from "@/entities/deck";
+import { mustFindDeckById, type Deck, type DeckId } from "@/entities/deck";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
 
@@ -38,12 +38,10 @@ export const DeckList: React.FC<DeckListProps> = (props) => {
     []
   );
 
-  const findDeck = (id: DeckId) => props.decks.find((deck) => deck.id === id);
   const cardsForDeck = (id: DeckId) => filterCardsByDeckId(props.cards, id);
 
   const requestDeletion = (id: DeckId) => {
-    const deck = findDeck(id);
-    if (deck == null) return;
+    const deck = mustFindDeckById(props.decks, id);
     setSuccessMessage(undefined);
     setDeletionErrorDeckId(undefined);
     setDeletionTarget({ deck, cardCount: cardsForDeck(id).length });
@@ -100,8 +98,8 @@ export const DeckList: React.FC<DeckListProps> = (props) => {
           onClickRestart: props.onStartDeck,
           onClickStudy: props.onStartDeck,
           onClickDownload: (id) => {
-            const deck = findDeck(id);
-            if (deck != null) downloadDeckCsv(deck, cardsForDeck(id));
+            const deck = mustFindDeckById(props.decks, id);
+            downloadDeckCsv(deck, cardsForDeck(id));
           },
           onClickDelete: requestDeletion,
         }}

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -4,7 +4,7 @@
  * coordinate services themselves.
  */
 
-import type { Card } from "@/entities/card";
+import { mustFindCardById, type Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { StudyProgressEdit } from "@/entities/study-progress";
 import type { Preferences, SwipeDirection } from "@/entities/preferences";
@@ -125,8 +125,8 @@ const runStudySwipe = async (
   }
 
   const cardId = session.cardOrderIds[session.currentIndex];
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  if (card == null) return;
+  if (cardId == null) return;
+  const card = mustFindCardById(cards, cardId);
 
   const previous = {
     session: { ...session },


### PR DESCRIPTION
## Related issue

Fixes #968

## Summary

- add `mustFindDeckById` and `mustFindCardById` to the entity public APIs
- throw descriptive errors when required entities are missing
- replace duplicated required lookups in deck list, card list, and study swipe flows

## Testing

- `mise run check`