### PR TITLE
refactor(#722): Hide local Card mutation internals

### DIFF
--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -3,13 +3,6 @@ export { createCard, deleteCard, editCard } from "./api/mutations";
 export { generateCardId } from "./model/id";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { clearRemoteCards } from "./model/store";
-/** @public */
-export {
-  createLocalCard,
-  deleteLocalCard,
-  deleteLocalCardsByDeckId,
-  editLocalCard,
-} from "./model/store";
 export type {
   Card,
   CardCreateInput,

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -60,7 +60,6 @@ export const findCardById = (id: CardId): Card | undefined => {
   return state.remoteCards.find((card) => card.id === cardId) ?? state.localCards.find((card) => card.id === cardId);
 };
 
-/** @public */
 export const createLocalCard = (input: CardCreateInput): Card => {
   const card = cardCreateSchema.parse(input);
   const timestamp = Date.now();
@@ -70,7 +69,6 @@ export const createLocalCard = (input: CardCreateInput): Card => {
   return createdCard;
 };
 
-/** @public */
 export const editLocalCard = (input: CardEdit): Card => {
   const edit = cardEditSchema.parse(input);
   const localCards = cardStore.getState().localCards;
@@ -82,13 +80,11 @@ export const editLocalCard = (input: CardEdit): Card => {
   return updatedCard;
 };
 
-/** @public */
 export const deleteLocalCard = (input: CardId): void => {
   const cardId = cardIdSchema.parse(input);
   cardStore.setState({ localCards: cardStore.getState().localCards.filter(({ id }) => id !== cardId) });
 };
 
-/** @public */
 export const deleteLocalCardsByDeckId = (deckId: string): void => {
   const parsedDeckId = z.string().min(1, "Card deck is required").parse(deckId);
   cardStore.setState({ localCards: cardStore.getState().localCards.filter((card) => card.deckId !== parsedDeckId) });


### PR DESCRIPTION
## Related issue

Related to #722

## Summary

- remove direct local Card mutation functions from the Card slice Public API
- keep local mutation routing internal to `api/mutations.ts` and the deck-only cleanup contract in `@x/deck.ts`
- remove transitional `@public` markers from the internal store mutations

This is the cleanup that can be finalized against the current Card boundary. It intentionally does not close #722 while #603 and #604 remain open.

## Testing

- `env CHOKIDAR_USEPOLLING=1 npm run lint:fsd`
- `env CHOKIDAR_USEPOLLING=1 mise run check`