### PR TITLE
[No issue] Clarify Pages responsibilities

### DIFF
--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,5 +1,5 @@
 # Pages Instructions
 
 - Keep URL routes and Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
-- Keep Pages UI-only. Import containers or components from `src/features` and only compose their layout.
-- Keep Page components concise. Do not add business logic, state management, data fetching, or workflow orchestration.
+- Keep Pages UI-only. Import containers or components from lower layers and compose them into the Page layout.
+- Keep Page components concise. Limit them to simple UI composition, and move complex business logic, state coordination, data fetching, and workflows to the appropriate lower layers.

--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,7 +1,5 @@
 # Pages Instructions
 
-- Treat `src/pages` as route adapters: read route state, compose lower layers, and handle route-level navigation and feedback.
-- Routing hooks such as `useParams` and `useNavigate` may be used directly. Do not call business or application hooks from pages.
-- Own route- and screen-level keyboard shortcut mappings and registration in `src/pages`, using `useKey` directly by default.
-- Lower layers must not register global listeners for Page shortcuts. They expose actions or callbacks that Page shortcut handlers call without adding business or workflow logic.
-- Keep business logic, mutations, workflows, store coordination, view-model construction, and non-route effects in lower FSD layers.
+- Keep URL routes and Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
+- Keep Pages UI-only. Import containers or components from `src/features` and only compose their layout.
+- Keep Page components concise. Do not add business logic, state management, data fetching, or workflow orchestration.

--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -3,3 +3,5 @@
 - Keep URL routes and Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
 - Keep Pages UI-only. Import containers or components from lower layers and compose them into the Page layout.
 - Keep Page components concise. Limit them to simple UI composition, and move complex business logic, state coordination, data fetching, and workflows to the appropriate lower layers.
+- Do not define custom hooks in `src/pages`. Use framework or library hooks such as `useParams`, `useNavigate`, and `useKey`, or existing hooks exposed by lower layers.
+- Own screen-level keyboard shortcut mappings and registration in `src/pages`. Use `useKey` directly and delegate shortcut actions to lower layers.


### PR DESCRIPTION
## Related issue
None

## Summary
- Define a one-to-one mapping between URL routes and Page components.
- Keep Pages limited to simple UI composition using containers, components, and existing hooks from lower layers.
- Prohibit custom hook definitions in Pages while allowing framework and library hooks such as useParams, useNavigate, and useKey.
- Assign screen-level keyboard shortcut mapping and registration to Pages and delegate shortcut actions to lower layers.

## Testing
- Not run (documentation-only change).