### PR TITLE
#986 Separate Settings account workflow

### DIFF
--- a/src/features/settings/ui/components/SettingsForm.spec.tsx
+++ b/src/features/settings/ui/components/SettingsForm.spec.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -28,7 +28,6 @@ function createProps(overrides: Partial<SettingsFormProps> = {}): SettingsFormPr
     fields: createFields(),
     maxNumberOfCardsToLearn: 24,
     cardInterval: 7,
-    version: "1.2.3",
     ...overrides,
   };
 }
@@ -38,26 +37,20 @@ describe("SettingsForm", () => {
     render(<SettingsForm {...createProps()} />);
 
     expect(screen.queryByRole("form")).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 1, name: "Settings" })).toHaveClass("text-title");
-    expect(screen.getByText("Changes are saved automatically")).toHaveClass("text-ink-muted");
-    for (const name of ["Account", "Appearance", "Study"]) {
+    for (const name of ["Appearance", "Study"]) {
       expect(screen.getByRole("region", { name })).toBeInTheDocument();
     }
-    expect(screen.getByRole("group", { name: "Advanced" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Account" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Advanced" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 2, name: "Layout" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 2, name: "Autoplay" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 2, name: "Metadata" })).not.toBeInTheDocument();
-    expect(screen.getByRole("region", { name: "Account" })).toHaveClass("rounded-surface", "border", "bg-surface");
     expect(screen.getByText("Show header")).toBeInTheDocument();
     expect(screen.queryByText("Show Heaer")).not.toBeInTheDocument();
   });
 
-  it("preserves all switch, slider, and metadata values", () => {
-    render(
-      <SettingsForm
-        {...createProps({ identity: { uid: "user-123", displayName: "Settings User" }, isLoggedIn: true })}
-      />
-    );
+  it("preserves all switch and slider values", () => {
+    render(<SettingsForm {...createProps()} />);
 
     expect(screen.getAllByRole("checkbox")).toHaveLength(7);
     expect(screen.getByRole("checkbox", { name: "Show header" })).toBeChecked();
@@ -67,12 +60,6 @@ describe("SettingsForm", () => {
     expect(screen.getByRole("slider", { name: "Autoplay interval" })).toHaveAttribute("aria-valuetext", "7 seconds");
     expect(screen.getByText("24")).toBeInTheDocument();
     expect(screen.getByText("7s")).toBeInTheDocument();
-
-    const details = screen.getByRole("group", { name: "Advanced" });
-    expect(details).not.toHaveAttribute("open");
-    expect(details).not.toHaveTextContent("Github Access Token");
-    expect(details).toHaveTextContent("1.2.3");
-    expect(details).toHaveTextContent("user-123");
   });
 
   it("describes review scheduling independently from autoplay", () => {
@@ -116,58 +103,9 @@ describe("SettingsForm", () => {
         <SettingsForm {...createProps()} />
       </>
     );
-    for (const name of ["Account", "Appearance", "Study"]) {
+    for (const name of ["Appearance", "Study"]) {
       expect(screen.getAllByRole("region", { name })).toHaveLength(2);
       expect(screen.getAllByRole("heading", { level: 2, name })).toHaveLength(2);
     }
-    expect(screen.getAllByRole("group", { name: "Advanced" })).toHaveLength(2);
-  });
-
-  it("preserves logged-out login and logged-in logout behavior", async () => {
-    const onLogin = vi.fn();
-    const onLogout = vi.fn();
-    const view = render(<SettingsForm {...createProps({ onLogin })} />);
-
-    expect(screen.getByText("Google Login")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Login" }));
-    expect(onLogin).toHaveBeenCalledOnce();
-
-    view.rerender(
-      <SettingsForm
-        {...createProps({
-          isLoggedIn: true,
-          identity: { uid: "user-123", displayName: "Settings User" },
-          onLogout,
-        })}
-      />
-    );
-    expect(screen.getByText("Settings User")).toBeInTheDocument();
-    expect(screen.getByText("Signed in with Google")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Logout" }));
-    expect(onLogout).toHaveBeenCalledOnce();
-  });
-
-  it("shows account feedback and disables the active account action while pending", () => {
-    const feedback = <p>Signing in…</p>;
-    const view = render(<SettingsForm {...createProps({ accountPending: true, accountFeedback: feedback })} />);
-
-    const login = screen.getByRole("button", { name: "Login" });
-    expect(login).toBeDisabled();
-    expect(login).toHaveAttribute("aria-busy", "true");
-    expect(within(screen.getByRole("region", { name: "Account" })).getByText("Signing in…")).toBeVisible();
-
-    view.rerender(
-      <SettingsForm
-        {...createProps({
-          isLoggedIn: true,
-          identity: { uid: "user-123", displayName: "Settings User" },
-          accountPending: true,
-        })}
-      />
-    );
-
-    const logout = screen.getByRole("button", { name: "Logout" });
-    expect(logout).toBeDisabled();
-    expect(logout).toHaveAttribute("aria-busy", "true");
   });
 });

--- a/src/features/settings/ui/components/SettingsForm.stories.tsx
+++ b/src/features/settings/ui/components/SettingsForm.stories.tsx
@@ -34,7 +34,6 @@ const settingsFormProps = {
   fields,
   maxNumberOfCardsToLearn: fixture.preferences.default.study.maxNumberOfCardsToLearn,
   cardInterval: fixture.preferences.default.study.cardInterval,
-  version: "1.2.3",
 };
 
 const meta = {
@@ -48,24 +47,6 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const LoggedOut: Story = {};
-export const LoggedIn: Story = {
-  args: {
-    ...settingsFormProps,
-    isLoggedIn: true,
-    identity: { uid: "settings-user", displayName: "Settings User" },
-  },
-};
-export const LongContent: Story = {
-  args: {
-    ...settingsFormProps,
-    isLoggedIn: true,
-    identity: {
-      uid: "settings-user-with-an-intentionally-long-identifier-for-responsive-review-1234567890",
-      displayName: "A settings user with an intentionally long display name for responsive review",
-    },
-    version: "2026.07.16-calm-focus-settings-presentation-long-metadata",
-  },
-};
-export const Dark: Story = { ...LoggedIn, globals: { theme: "dark" } };
-export const Mobile: Story = { ...LongContent, parameters: { viewport: { defaultViewport: "iphonex" } } };
+export const Default: Story = {};
+export const Dark: Story = { globals: { theme: "dark" } };
+export const Mobile: Story = { parameters: { viewport: { defaultViewport: "iphonex" } } };

--- a/src/features/settings/ui/components/SettingsForm.tsx
+++ b/src/features/settings/ui/components/SettingsForm.tsx
@@ -1,9 +1,8 @@
 import type * as React from "react";
 import { useId } from "react";
-import { AiOutlineDown, AiOutlineEye, AiOutlinePlayCircle, AiOutlineTool, AiOutlineUser } from "react-icons/ai";
+import { AiOutlineEye, AiOutlinePlayCircle } from "react-icons/ai";
 
 import { SettingsRow, SettingsSection } from "./SettingsSection";
-import { Button } from "@/shared/ui/button";
 import { Slider, Switch } from "@/shared/ui/forms";
 
 interface SettingsFields {
@@ -19,16 +18,9 @@ interface SettingsFields {
 }
 
 export interface SettingsFormProps {
-  isLoggedIn?: boolean;
-  identity?: { uid: string; displayName: string | null };
   fields: SettingsFields;
   maxNumberOfCardsToLearn: number;
   cardInterval: number;
-  onLogin?: () => void;
-  onLogout?: () => void;
-  accountPending?: boolean;
-  accountFeedback?: React.ReactNode;
-  version?: string;
 }
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
@@ -44,7 +36,6 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
     defaultAutoPlay: `${idPrefix}-start-autoplay`,
     cardInterval: `${idPrefix}-autoplay-interval`,
   };
-  const advancedHeadingId = `${idPrefix}-advanced-heading`;
   /**
    * Builds the stable HTML identifier used by a field's explanatory text.
    * Inputs can reference this identifier with `aria-describedby` so assistive technology reads the
@@ -53,194 +44,111 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
   const descriptionId = (inputId: string) => `${inputId}-description`;
 
   return (
-    <section className="mx-auto flex w-full max-w-reading flex-col gap-4 text-ink">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
-        <h1 className="break-words text-title font-bold text-ink">Settings</h1>
-        <p className="text-caption text-ink-muted">Changes are saved automatically</p>
-      </div>
-      <div className="space-y-4">
-        <SettingsSection title="Account" description="Profile and sign-in" icon={<AiOutlineUser />}>
-          <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <span
-                aria-hidden="true"
-                className="flex size-9 shrink-0 items-center justify-center rounded-full bg-accent-primary text-ink-inverse"
-              >
-                <AiOutlineUser />
-              </span>
-              <div className="min-w-0">
-                <p className="break-words text-body font-medium text-ink">
-                  {props.isLoggedIn ? (props.identity?.displayName ?? "No name") : "Google Login"}
-                </p>
-                <p className="text-caption text-ink-muted">
-                  {props.isLoggedIn ? "Signed in with Google" : "Sync your decks across devices"}
-                </p>
-              </div>
-            </div>
-            {props.isLoggedIn ? (
-              <Button
-                variant="quiet"
-                size="sm"
-                {...(props.accountPending !== undefined ? { loading: props.accountPending } : {})}
-                {...(props.onLogout !== undefined ? { onClick: props.onLogout } : {})}
-              >
-                Logout
-              </Button>
-            ) : (
-              <Button
-                variant="primary"
-                size="sm"
-                {...(props.accountPending !== undefined ? { loading: props.accountPending } : {})}
-                {...(props.onLogin !== undefined ? { onClick: props.onLogin } : {})}
-              >
-                Login
-              </Button>
-            )}
-          </div>
-          {props.accountFeedback}
-        </SettingsSection>
-
-        <SettingsSection title="Appearance" description="Navigation and visual feedback" icon={<AiOutlineEye />}>
-          <SettingsRow inputId={inputIds.showHeader} label="Show header" description="Keep app navigation visible">
-            <Switch
-              {...props.fields.showHeader}
-              id={inputIds.showHeader}
-              aria-describedby={descriptionId(inputIds.showHeader)}
-            />
-          </SettingsRow>
-          <SettingsRow
-            inputId={inputIds.showSwipeButtonList}
-            label="Show study buttons"
-            description="Display study action controls"
-          >
-            <Switch
-              {...props.fields.showSwipeButtonList}
-              id={inputIds.showSwipeButtonList}
-              aria-describedby={descriptionId(inputIds.showSwipeButtonList)}
-            />
-          </SettingsRow>
-          <SettingsRow
-            inputId={inputIds.showSwipeFeedback}
-            label="Show swipe feedback"
-            description="Confirm each study action on screen"
-          >
-            <Switch
-              {...props.fields.showSwipeFeedback}
-              id={inputIds.showSwipeFeedback}
-              aria-describedby={descriptionId(inputIds.showSwipeFeedback)}
-            />
-          </SettingsRow>
-          <SettingsRow inputId={inputIds.darkMode} label="Dark mode" description="Use the darker Calm Focus palette">
-            <Switch
-              {...props.fields.darkMode}
-              id={inputIds.darkMode}
-              aria-describedby={descriptionId(inputIds.darkMode)}
-            />
-          </SettingsRow>
-        </SettingsSection>
-
-        <SettingsSection
-          title="Study"
-          description="Card order, session size, and autoplay"
-          icon={<AiOutlinePlayCircle />}
+    <div className="space-y-4">
+      <SettingsSection title="Appearance" description="Navigation and visual feedback" icon={<AiOutlineEye />}>
+        <SettingsRow inputId={inputIds.showHeader} label="Show header" description="Keep app navigation visible">
+          <Switch
+            {...props.fields.showHeader}
+            id={inputIds.showHeader}
+            aria-describedby={descriptionId(inputIds.showHeader)}
+          />
+        </SettingsRow>
+        <SettingsRow
+          inputId={inputIds.showSwipeButtonList}
+          label="Show study buttons"
+          description="Display study action controls"
         >
-          <SettingsRow inputId={inputIds.shuffled} label="Shuffle cards" description="Randomize each study session">
-            <Switch
-              {...props.fields.shuffled}
-              id={inputIds.shuffled}
-              aria-describedby={descriptionId(inputIds.shuffled)}
-            />
-          </SettingsRow>
-          <SettingsRow
-            inputId={inputIds.maxNumberOfCardsToLearn}
-            label="Maximum cards"
-            description="Limit the size of a study session"
-          >
-            <div className="flex w-32 items-center gap-2 sm:w-52">
-              <Slider
-                {...props.fields.maxNumberOfCardsToLearn}
-                id={inputIds.maxNumberOfCardsToLearn}
-                aria-describedby={descriptionId(inputIds.maxNumberOfCardsToLearn)}
-                aria-valuetext={`${props.maxNumberOfCardsToLearn} cards`}
-              />
-              <span className="min-w-10 rounded-control bg-surface-muted px-2 py-1 text-center text-caption font-bold text-accent-primary">
-                {props.maxNumberOfCardsToLearn}
-              </span>
-            </div>
-          </SettingsRow>
-          <SettingsRow
-            inputId={inputIds.useCardInterval}
-            label="Respect review schedule"
-            description="Hide cards until their next review time"
-          >
-            <Switch
-              {...props.fields.useCardInterval}
-              id={inputIds.useCardInterval}
-              aria-describedby={descriptionId(inputIds.useCardInterval)}
-            />
-          </SettingsRow>
-          <SettingsRow
-            inputId={inputIds.defaultAutoPlay}
-            label="Start autoplay"
-            description="Begin playback when study opens"
-          >
-            <Switch
-              {...props.fields.defaultAutoPlay}
-              id={inputIds.defaultAutoPlay}
-              aria-describedby={descriptionId(inputIds.defaultAutoPlay)}
-            />
-          </SettingsRow>
-          <SettingsRow inputId={inputIds.cardInterval} label="Autoplay interval" description="Seconds between cards">
-            <div className="flex w-32 items-center gap-2 sm:w-52">
-              <Slider
-                {...props.fields.cardInterval}
-                id={inputIds.cardInterval}
-                aria-describedby={descriptionId(inputIds.cardInterval)}
-                aria-valuetext={`${props.cardInterval} seconds`}
-              />
-              <span className="min-w-10 rounded-control bg-surface-muted px-2 py-1 text-center text-caption font-bold text-accent-primary">
-                {props.cardInterval}s
-              </span>
-            </div>
-          </SettingsRow>
-        </SettingsSection>
-
-        <details
-          aria-labelledby={advancedHeadingId}
-          className="group overflow-hidden rounded-surface border border-border bg-surface shadow-surface"
+          <Switch
+            {...props.fields.showSwipeButtonList}
+            id={inputIds.showSwipeButtonList}
+            aria-describedby={descriptionId(inputIds.showSwipeButtonList)}
+          />
+        </SettingsRow>
+        <SettingsRow
+          inputId={inputIds.showSwipeFeedback}
+          label="Show swipe feedback"
+          description="Confirm each study action on screen"
         >
-          <summary className="flex min-h-touch cursor-pointer list-none items-center gap-3 px-4 py-3 [&::-webkit-details-marker]:hidden">
-            <span
-              aria-hidden="true"
-              className="flex size-8 shrink-0 items-center justify-center rounded-control bg-surface-muted text-accent-primary"
-            >
-              <AiOutlineTool />
-            </span>
-            <span className="min-w-0 flex-1">
-              <h2 id={advancedHeadingId} className="text-body font-bold text-ink">
-                Advanced
-              </h2>
-              <span className="block text-caption text-ink-muted">Version and user ID</span>
-            </span>
-            <AiOutlineDown
-              aria-hidden="true"
-              className="shrink-0 text-ink-muted transition-transform duration-normal ease-calm group-open:rotate-180"
+          <Switch
+            {...props.fields.showSwipeFeedback}
+            id={inputIds.showSwipeFeedback}
+            aria-describedby={descriptionId(inputIds.showSwipeFeedback)}
+          />
+        </SettingsRow>
+        <SettingsRow inputId={inputIds.darkMode} label="Dark mode" description="Use the darker Calm Focus palette">
+          <Switch
+            {...props.fields.darkMode}
+            id={inputIds.darkMode}
+            aria-describedby={descriptionId(inputIds.darkMode)}
+          />
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Study"
+        description="Card order, session size, and autoplay"
+        icon={<AiOutlinePlayCircle />}
+      >
+        <SettingsRow inputId={inputIds.shuffled} label="Shuffle cards" description="Randomize each study session">
+          <Switch
+            {...props.fields.shuffled}
+            id={inputIds.shuffled}
+            aria-describedby={descriptionId(inputIds.shuffled)}
+          />
+        </SettingsRow>
+        <SettingsRow
+          inputId={inputIds.maxNumberOfCardsToLearn}
+          label="Maximum cards"
+          description="Limit the size of a study session"
+        >
+          <div className="flex w-32 items-center gap-2 sm:w-52">
+            <Slider
+              {...props.fields.maxNumberOfCardsToLearn}
+              id={inputIds.maxNumberOfCardsToLearn}
+              aria-describedby={descriptionId(inputIds.maxNumberOfCardsToLearn)}
+              aria-valuetext={`${props.maxNumberOfCardsToLearn} cards`}
             />
-          </summary>
-          <div className="divide-y divide-border border-t border-border">
-            <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
-              <span className="text-body font-medium text-ink">Version</span>
-              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{props.version}</span>
-            </div>
-            <div className="flex min-h-touch items-start justify-between gap-4 px-4 py-3">
-              <span className="shrink-0 text-body font-medium text-ink">User ID</span>
-              <span className="min-w-0 break-all text-right text-caption text-ink-muted">
-                {props.identity?.uid ?? ""}
-              </span>
-            </div>
+            <span className="min-w-10 rounded-control bg-surface-muted px-2 py-1 text-center text-caption font-bold text-accent-primary">
+              {props.maxNumberOfCardsToLearn}
+            </span>
           </div>
-        </details>
-      </div>
-    </section>
+        </SettingsRow>
+        <SettingsRow
+          inputId={inputIds.useCardInterval}
+          label="Respect review schedule"
+          description="Hide cards until their next review time"
+        >
+          <Switch
+            {...props.fields.useCardInterval}
+            id={inputIds.useCardInterval}
+            aria-describedby={descriptionId(inputIds.useCardInterval)}
+          />
+        </SettingsRow>
+        <SettingsRow
+          inputId={inputIds.defaultAutoPlay}
+          label="Start autoplay"
+          description="Begin playback when study opens"
+        >
+          <Switch
+            {...props.fields.defaultAutoPlay}
+            id={inputIds.defaultAutoPlay}
+            aria-describedby={descriptionId(inputIds.defaultAutoPlay)}
+          />
+        </SettingsRow>
+        <SettingsRow inputId={inputIds.cardInterval} label="Autoplay interval" description="Seconds between cards">
+          <div className="flex w-32 items-center gap-2 sm:w-52">
+            <Slider
+              {...props.fields.cardInterval}
+              id={inputIds.cardInterval}
+              aria-describedby={descriptionId(inputIds.cardInterval)}
+              aria-valuetext={`${props.cardInterval} seconds`}
+            />
+            <span className="min-w-10 rounded-control bg-surface-muted px-2 py-1 text-center text-caption font-bold text-accent-primary">
+              {props.cardInterval}s
+            </span>
+          </div>
+        </SettingsRow>
+      </SettingsSection>
+    </div>
   );
 };

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -16,7 +16,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authSession }));
+vi.mock("@/entities/auth", () => ({
+  useAuthSession: () => mocks.authSession,
+  useAuthUid: () => (mocks.authSession.status === "authenticated" ? mocks.authSession.uid : ""),
+}));
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
@@ -42,26 +45,18 @@ describe("SettingsPage", () => {
     expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith("/");
   });
 
-  it("displays an alert when sign-out fails and allows retrying sign-out", async () => {
+  it("composes account, preferences, and page metadata", () => {
     mocks.authSession = {
       status: "authenticated",
       uid: "retry-uid-a",
       isAnonymous: false,
       displayName: "Test User",
     };
-    const signOutError = new Error("sign out failed");
-    const logout = vi.fn().mockRejectedValueOnce(signOutError).mockResolvedValueOnce(undefined);
+    render(<SettingsPage login={vi.fn()} logout={vi.fn()} />);
 
-    render(<SettingsPage login={vi.fn()} logout={logout} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
-
-    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
-    expect(logout).toHaveBeenCalledOnce();
-
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
-    expect(logout).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("region", { name: "Account" })).toBeVisible();
+    expect(screen.getByRole("region", { name: "Appearance" })).toBeVisible();
+    expect(screen.getByRole("region", { name: "Study" })).toBeVisible();
+    expect(screen.getByRole("group", { name: "Advanced" })).toHaveTextContent("retry-uid-a");
   });
 });

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,14 +1,14 @@
 import type * as React from "react";
+import { useId } from "react";
+import { AiOutlineDown, AiOutlineTool } from "react-icons/ai";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { updatePreferences, usePreferences } from "@/entities/preferences";
 import { SettingsForm, usePreferencesFormState } from "@/features/settings";
-import { useSignIn } from "@/features/sign-in";
-import { useSignOut } from "@/features/sign-out";
-import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { AppLayout } from "@/widgets/app-layout";
+import { SettingsAccount } from "@/widgets/settings-account";
 
 interface SettingsPageProps {
   login: () => Promise<void>;
@@ -17,35 +17,9 @@ interface SettingsPageProps {
 
 export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => {
   const preferences = usePreferences();
-  const authState = useAuthSession();
+  const authUid = useAuthUid();
   const navigate = useNavigate();
-
-  const authenticatedUser = authState.status === "authenticated" ? authState : undefined;
-  const linkedUser = authenticatedUser != null && !authenticatedUser.isAnonymous ? authenticatedUser : undefined;
-  const isLoggedIn = linkedUser != null;
-  const identity = {
-    uid: authenticatedUser?.uid ?? "",
-    displayName: authenticatedUser?.displayName ?? null,
-  };
-
-  const signIn = useSignIn(login);
-  const signOut = useSignOut(isLoggedIn ? logout : undefined);
-  const accountOperation = isLoggedIn
-    ? {
-        run: signOut.signOut,
-        pending: signOut.pending,
-        error: signOut.error,
-        pendingLabel: "Signing out…",
-        errorLabel: "Unable to sign out.",
-      }
-    : {
-        run: signIn.signIn,
-        pending: signIn.pending,
-        error: signIn.error,
-        pendingLabel: "Signing in…",
-        errorLabel: "Unable to sign in.",
-      };
-  const runAccountOperation = () => void accountOperation.run().catch(() => undefined);
+  const advancedHeadingId = useId();
 
   const formState = usePreferencesFormState({
     preferences,
@@ -55,24 +29,47 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
 
   return (
     <AppLayout showHeader>
-      <SettingsForm
-        {...formState}
-        identity={identity}
-        version={__APP_VERSION__}
-        isLoggedIn={isLoggedIn}
-        onLogin={runAccountOperation}
-        {...(isLoggedIn ? { onLogout: runAccountOperation } : {})}
-        accountPending={accountOperation.pending}
-        accountFeedback={
-          <RemoteMutationNotice
-            pending={accountOperation.pending}
-            error={accountOperation.error}
-            onRetry={runAccountOperation}
-            pendingLabel={accountOperation.pendingLabel}
-            errorLabel={accountOperation.errorLabel}
-          />
-        }
-      />
+      <section className="mx-auto flex w-full max-w-reading flex-col gap-4 text-ink">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+          <h1 className="break-words text-title font-bold text-ink">Settings</h1>
+          <p className="text-caption text-ink-muted">Changes are saved automatically</p>
+        </div>
+        <SettingsAccount login={login} logout={logout} />
+        <SettingsForm {...formState} />
+        <details
+          aria-labelledby={advancedHeadingId}
+          className="group overflow-hidden rounded-surface border border-border bg-surface shadow-surface"
+        >
+          <summary className="flex min-h-touch cursor-pointer list-none items-center gap-3 px-4 py-3 [&::-webkit-details-marker]:hidden">
+            <span
+              aria-hidden="true"
+              className="flex size-8 shrink-0 items-center justify-center rounded-control bg-surface-muted text-accent-primary"
+            >
+              <AiOutlineTool />
+            </span>
+            <span className="min-w-0 flex-1">
+              <h2 id={advancedHeadingId} className="text-body font-bold text-ink">
+                Advanced
+              </h2>
+              <span className="block text-caption text-ink-muted">Version and user ID</span>
+            </span>
+            <AiOutlineDown
+              aria-hidden="true"
+              className="shrink-0 text-ink-muted transition-transform duration-normal ease-calm group-open:rotate-180"
+            />
+          </summary>
+          <div className="divide-y divide-border border-t border-border">
+            <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
+              <span className="text-body font-medium text-ink">Version</span>
+              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{__APP_VERSION__}</span>
+            </div>
+            <div className="flex min-h-touch items-start justify-between gap-4 px-4 py-3">
+              <span className="shrink-0 text-body font-medium text-ink">User ID</span>
+              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{authUid}</span>
+            </div>
+          </div>
+        </details>
+      </section>
     </AppLayout>
   );
 };

--- a/src/widgets/settings-account/index.ts
+++ b/src/widgets/settings-account/index.ts
@@ -1,0 +1,1 @@
+export { SettingsAccount } from "./ui/SettingsAccount";

--- a/src/widgets/settings-account/ui/SettingsAccount.spec.tsx
+++ b/src/widgets/settings-account/ui/SettingsAccount.spec.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { useAuthSession } from "@/entities/auth";
+
+type AuthSessionState = ReturnType<typeof useAuthSession>;
+
+const mocks = vi.hoisted(() => ({
+  authSession: { status: "initializing" } as AuthSessionState,
+}));
+
+vi.mock("@/shared/firebase", () => ({ auth: {} }));
+vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authSession }));
+
+import { SettingsAccount } from "./SettingsAccount";
+
+describe("SettingsAccount", () => {
+  beforeEach(() => {
+    mocks.authSession = { status: "initializing" };
+  });
+
+  it("signs in when the current user is not linked", async () => {
+    const login = vi.fn().mockResolvedValue(undefined);
+
+    render(<SettingsAccount login={login} logout={vi.fn()} />);
+
+    expect(screen.getByText("Google Login")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Login" }));
+    expect(login).toHaveBeenCalledOnce();
+  });
+
+  it("signs out when the current user is linked", async () => {
+    mocks.authSession = {
+      status: "authenticated",
+      uid: "linked-user",
+      isAnonymous: false,
+      displayName: "Settings User",
+    };
+    const logout = vi.fn().mockResolvedValue(undefined);
+
+    render(<SettingsAccount login={vi.fn()} logout={logout} />);
+
+    expect(screen.getByText("Settings User")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Logout" }));
+    expect(logout).toHaveBeenCalledOnce();
+  });
+
+  it("shows pending feedback while the account operation is running", async () => {
+    let resolveLogin: (() => void) | undefined;
+    const login = vi.fn(() => new Promise<void>((resolve) => (resolveLogin = resolve)));
+
+    render(<SettingsAccount login={login} logout={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    expect(await screen.findByText("Signing in…")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Login" })).toBeDisabled();
+    resolveLogin?.();
+    await waitFor(() => expect(screen.queryByText("Signing in…")).not.toBeInTheDocument());
+  });
+
+  it("displays an error and retries the active operation", async () => {
+    const login = vi.fn().mockRejectedValueOnce(new Error("sign in failed")).mockResolvedValueOnce(undefined);
+
+    render(<SettingsAccount login={login} logout={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign in.");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(login).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/widgets/settings-account/ui/SettingsAccount.tsx
+++ b/src/widgets/settings-account/ui/SettingsAccount.tsx
@@ -1,0 +1,77 @@
+import { useId } from "react";
+import { AiOutlineUser } from "react-icons/ai";
+
+import { useAuthSession } from "@/entities/auth";
+import { useSignIn } from "@/features/sign-in";
+import { useSignOut } from "@/features/sign-out";
+import { Button } from "@/shared/ui/button";
+import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
+
+interface SettingsAccountProps {
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const SettingsAccount = ({ login, logout }: SettingsAccountProps) => {
+  const headingId = useId();
+  const authState = useAuthSession();
+  const linkedUser = authState.status === "authenticated" && !authState.isAnonymous ? authState : undefined;
+  const signIn = useSignIn(login);
+  const signOut = useSignOut(linkedUser == null ? undefined : logout);
+  const operation = linkedUser == null ? signIn.signIn : signOut.signOut;
+  const pending = linkedUser == null ? signIn.pending : signOut.pending;
+  const error = linkedUser == null ? signIn.error : signOut.error;
+  const runOperation = () => void operation().catch(() => undefined);
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="overflow-hidden rounded-surface border border-border bg-surface shadow-surface"
+    >
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span
+          aria-hidden="true"
+          className="flex size-8 shrink-0 items-center justify-center rounded-control bg-surface-muted text-accent-primary"
+        >
+          <AiOutlineUser />
+        </span>
+        <div className="min-w-0">
+          <h2 id={headingId} className="text-body font-bold text-ink">
+            Account
+          </h2>
+          <p className="text-caption text-ink-muted">Profile and sign-in</p>
+        </div>
+      </div>
+      <div className="divide-y divide-border border-t border-border">
+        <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <span
+              aria-hidden="true"
+              className="flex size-9 shrink-0 items-center justify-center rounded-full bg-accent-primary text-ink-inverse"
+            >
+              <AiOutlineUser />
+            </span>
+            <div className="min-w-0">
+              <p className="break-words text-body font-medium text-ink">
+                {linkedUser == null ? "Google Login" : (linkedUser.displayName ?? "No name")}
+              </p>
+              <p className="text-caption text-ink-muted">
+                {linkedUser == null ? "Sync your decks across devices" : "Signed in with Google"}
+              </p>
+            </div>
+          </div>
+          <Button variant={linkedUser == null ? "primary" : "quiet"} size="sm" loading={pending} onClick={runOperation}>
+            {linkedUser == null ? "Login" : "Logout"}
+          </Button>
+        </div>
+        <RemoteMutationNotice
+          pending={pending}
+          error={error}
+          onRetry={runOperation}
+          pendingLabel={linkedUser == null ? "Signing in…" : "Signing out…"}
+          errorLabel={linkedUser == null ? "Unable to sign in." : "Unable to sign out."}
+        />
+      </div>
+    </section>
+  );
+};

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -40,6 +40,13 @@ export default defineConfig([
     },
   },
   {
+    files: ["./src/widgets/settings-account/**"],
+    rules: {
+      // The route-specific widget keeps sign-in and sign-out features independent while composing the account workflow.
+      "fsd/insignificant-slice": "off",
+    },
+  },
+  {
     files: ["./src/entities/preferences/**"],
     rules: {
       // Preferences is the domain concept's established name, not a plural collection of entities.


### PR DESCRIPTION
## Summary

- move Account UI and authentication operation composition into a dedicated `settings-account` widget
- limit `SettingsForm` to preference controls
- keep `SettingsPage` focused on layout, routing, metadata, and composing the Account and Preferences UI
- move Login, Logout, pending, error, and retry behavior tests to the Account widget

## Why

`SettingsPage` and `SettingsForm` previously owned account-specific authentication branching and feedback in addition to their page and preferences responsibilities. This separates those concerns without adding feature-to-feature dependencies or changing authentication behavior.

## Validation

- `mise run check`
- 103 unit test files passed (519 tests)
- TypeScript, ESLint, Biome, FSD, Knip, Markdown, and Docker lint passed

Closes #986