### PR TITLE
[No issue] Define widgets layer scope

### DIFF
--- a/src/widgets/AGENTS.md
+++ b/src/widgets/AGENTS.md
@@ -1,0 +1,4 @@
+# Widgets Instructions
+
+- Only place UI compositions shared by multiple Pages in `src/widgets`, such as `AppLayout`.
+- Do not place Page-specific or single-use components in `src/widgets`.


### PR DESCRIPTION
## Related issue

None

## Summary

- Add instructions for the widgets layer.
- Limit `src/widgets` to UI compositions shared by multiple Pages, such as `AppLayout`.
- Prohibit Page-specific and single-use components.