### PR TITLE
[No issue] Expose linked account from auth entity

### DIFF
--- a/src/entities/auth/index.ts
+++ b/src/entities/auth/index.ts
@@ -1,2 +1,2 @@
-export { useAuthSession, useAuthUid } from "./model/hooks";
+export { useAuthAccount, useAuthSession, useAuthUid } from "./model/hooks";
 export { getAuthSession, replaceAuthSession } from "./model/store";

--- a/src/entities/auth/model/hooks.spec.ts
+++ b/src/entities/auth/model/hooks.spec.ts
@@ -61,7 +61,7 @@ describe("useAuthUid", () => {
 describe("useAuthAccount", () => {
   beforeEach(() => replaceAuthSession({ status: "initializing" }));
 
-  it("exposes identity and linked status for a linked account", () => {
+  it("returns a linked account", () => {
     replaceAuthSession({
       status: "authenticated",
       uid: "uid-a",
@@ -71,13 +71,10 @@ describe("useAuthAccount", () => {
 
     const { result } = renderHook(useAuthAccount);
 
-    expect(result.current).toEqual({
-      identity: { uid: "uid-a", displayName: "Test User" },
-      isLinked: true,
-    });
+    expect(result.current).toEqual({ uid: "uid-a", displayName: "Test User" });
   });
 
-  it("keeps anonymous identity without treating it as a linked account", () => {
+  it("does not return an anonymous user as an account", () => {
     replaceAuthSession({
       status: "authenticated",
       uid: "anonymous-uid",
@@ -87,18 +84,12 @@ describe("useAuthAccount", () => {
 
     const { result } = renderHook(useAuthAccount);
 
-    expect(result.current).toEqual({
-      identity: { uid: "anonymous-uid", displayName: null },
-      isLinked: false,
-    });
+    expect(result.current).toBeUndefined();
   });
 
-  it("returns an empty identity before authentication", () => {
+  it("returns no account before authentication", () => {
     const { result } = renderHook(useAuthAccount);
 
-    expect(result.current).toEqual({
-      identity: { uid: "", displayName: null },
-      isLinked: false,
-    });
+    expect(result.current).toBeUndefined();
   });
 });

--- a/src/entities/auth/model/hooks.spec.ts
+++ b/src/entities/auth/model/hooks.spec.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { useAuthSession, useAuthUid } from "./hooks";
+import { useAuthAccount, useAuthSession, useAuthUid } from "./hooks";
 import { replaceAuthSession } from "./store";
 
 describe("useAuthSession", () => {
@@ -55,5 +55,50 @@ describe("useAuthUid", () => {
     const { result } = renderHook(useAuthUid);
 
     expect(result.current).toBe("");
+  });
+});
+
+describe("useAuthAccount", () => {
+  beforeEach(() => replaceAuthSession({ status: "initializing" }));
+
+  it("exposes identity and linked status for a linked account", () => {
+    replaceAuthSession({
+      status: "authenticated",
+      uid: "uid-a",
+      isAnonymous: false,
+      displayName: "Test User",
+    });
+
+    const { result } = renderHook(useAuthAccount);
+
+    expect(result.current).toEqual({
+      identity: { uid: "uid-a", displayName: "Test User" },
+      isLinked: true,
+    });
+  });
+
+  it("keeps anonymous identity without treating it as a linked account", () => {
+    replaceAuthSession({
+      status: "authenticated",
+      uid: "anonymous-uid",
+      isAnonymous: true,
+      displayName: null,
+    });
+
+    const { result } = renderHook(useAuthAccount);
+
+    expect(result.current).toEqual({
+      identity: { uid: "anonymous-uid", displayName: null },
+      isLinked: false,
+    });
+  });
+
+  it("returns an empty identity before authentication", () => {
+    const { result } = renderHook(useAuthAccount);
+
+    expect(result.current).toEqual({
+      identity: { uid: "", displayName: null },
+      isLinked: false,
+    });
   });
 });

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useStore } from "zustand";
 
 import { authSessionStore } from "./store";
@@ -7,3 +8,19 @@ export const useAuthSession = (): AuthSessionState => useStore(authSessionStore)
 
 export const useAuthUid = (): string =>
   useStore(authSessionStore, (auth) => (auth.status === "authenticated" ? auth.uid : ""));
+
+export const useAuthAccount = () => {
+  const auth = useAuthSession();
+
+  return useMemo(() => {
+    const authenticatedUser = auth.status === "authenticated" ? auth : undefined;
+
+    return {
+      identity: {
+        uid: authenticatedUser?.uid ?? "",
+        displayName: authenticatedUser?.displayName ?? null,
+      },
+      isLinked: authenticatedUser != null && !authenticatedUser.isAnonymous,
+    };
+  }, [auth]);
+};

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -2,25 +2,21 @@ import { useMemo } from "react";
 import { useStore } from "zustand";
 
 import { authSessionStore } from "./store";
-import type { AuthSessionState } from "./types";
+import type { AuthAccount, AuthSessionState } from "./types";
 
 export const useAuthSession = (): AuthSessionState => useStore(authSessionStore);
 
 export const useAuthUid = (): string =>
   useStore(authSessionStore, (auth) => (auth.status === "authenticated" ? auth.uid : ""));
 
-export const useAuthAccount = () => {
+export const useAuthAccount = (): AuthAccount | undefined => {
   const auth = useAuthSession();
 
-  return useMemo(() => {
-    const authenticatedUser = auth.status === "authenticated" ? auth : undefined;
-
-    return {
-      identity: {
-        uid: authenticatedUser?.uid ?? "",
-        displayName: authenticatedUser?.displayName ?? null,
-      },
-      isLinked: authenticatedUser != null && !authenticatedUser.isAnonymous,
-    };
-  }, [auth]);
+  return useMemo(
+    () =>
+      auth.status === "authenticated" && !auth.isAnonymous
+        ? { uid: auth.uid, displayName: auth.displayName }
+        : undefined,
+    [auth]
+  );
 };

--- a/src/entities/auth/model/types.ts
+++ b/src/entities/auth/model/types.ts
@@ -1,7 +1,10 @@
-interface AuthenticatedSession {
+export interface AuthAccount {
   uid: string;
-  isAnonymous: boolean;
   displayName: string | null;
+}
+
+interface AuthenticatedSession extends AuthAccount {
+  isAnonymous: boolean;
 }
 
 /**

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -9,14 +9,18 @@ import { createPreferences } from "@/test/factories";
 type AuthAccount = ReturnType<typeof useAuthAccount>;
 
 const mocks = vi.hoisted(() => ({
-  authAccount: { identity: { uid: "", displayName: null }, isLinked: false } as AuthAccount,
+  authAccount: undefined as AuthAccount,
+  authUid: "",
   preferences: null as unknown as Preferences,
   navigate: vi.fn(),
   setDarkMode: vi.fn(),
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/auth", () => ({ useAuthAccount: () => mocks.authAccount }));
+vi.mock("@/entities/auth", () => ({
+  useAuthAccount: () => mocks.authAccount,
+  useAuthUid: () => mocks.authUid,
+}));
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
@@ -29,7 +33,8 @@ import { SettingsPage } from "./SettingsPage";
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.authAccount = { identity: { uid: "", displayName: null }, isLinked: false };
+    mocks.authAccount = undefined;
+    mocks.authUid = "";
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
   });
 
@@ -43,10 +48,8 @@ describe("SettingsPage", () => {
   });
 
   it("displays an alert when sign-out fails and allows retrying sign-out", async () => {
-    mocks.authAccount = {
-      identity: { uid: "retry-uid-a", displayName: "Test User" },
-      isLinked: true,
-    };
+    mocks.authAccount = { uid: "retry-uid-a", displayName: "Test User" };
+    mocks.authUid = "retry-uid-a";
     const signOutError = new Error("sign out failed");
     const logout = vi.fn().mockRejectedValueOnce(signOutError).mockResolvedValueOnce(undefined);
 

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -2,21 +2,21 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import type { useAuthSession } from "@/entities/auth";
+import type { useAuthAccount } from "@/entities/auth";
 import type { Preferences } from "@/entities/preferences";
 import { createPreferences } from "@/test/factories";
 
-type AuthSessionState = ReturnType<typeof useAuthSession>;
+type AuthAccount = ReturnType<typeof useAuthAccount>;
 
 const mocks = vi.hoisted(() => ({
-  authSession: { status: "initializing" } as AuthSessionState,
+  authAccount: { identity: { uid: "", displayName: null }, isLinked: false } as AuthAccount,
   preferences: null as unknown as Preferences,
   navigate: vi.fn(),
   setDarkMode: vi.fn(),
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authSession }));
+vi.mock("@/entities/auth", () => ({ useAuthAccount: () => mocks.authAccount }));
 vi.mock("@/entities/preferences", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
@@ -29,7 +29,7 @@ import { SettingsPage } from "./SettingsPage";
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.authSession = { status: "initializing" };
+    mocks.authAccount = { identity: { uid: "", displayName: null }, isLinked: false };
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
   });
 
@@ -43,11 +43,9 @@ describe("SettingsPage", () => {
   });
 
   it("displays an alert when sign-out fails and allows retrying sign-out", async () => {
-    mocks.authSession = {
-      status: "authenticated",
-      uid: "retry-uid-a",
-      isAnonymous: false,
-      displayName: "Test User",
+    mocks.authAccount = {
+      identity: { uid: "retry-uid-a", displayName: "Test User" },
+      isLinked: true,
     };
     const signOutError = new Error("sign out failed");
     const logout = vi.fn().mockRejectedValueOnce(signOutError).mockResolvedValueOnce(undefined);

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -2,7 +2,7 @@ import type * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthAccount } from "@/entities/auth";
 import { updatePreferences, usePreferences } from "@/entities/preferences";
 import { SettingsForm, usePreferencesFormState } from "@/features/settings";
 import { useSignIn } from "@/features/sign-in";
@@ -17,16 +17,10 @@ interface SettingsPageProps {
 
 export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => {
   const preferences = usePreferences();
-  const authState = useAuthSession();
+  const authAccount = useAuthAccount();
   const navigate = useNavigate();
 
-  const authenticatedUser = authState.status === "authenticated" ? authState : undefined;
-  const linkedUser = authenticatedUser != null && !authenticatedUser.isAnonymous ? authenticatedUser : undefined;
-  const isLoggedIn = linkedUser != null;
-  const identity = {
-    uid: authenticatedUser?.uid ?? "",
-    displayName: authenticatedUser?.displayName ?? null,
-  };
+  const isLoggedIn = authAccount.isLinked;
 
   const signIn = useSignIn(login);
   const signOut = useSignOut(isLoggedIn ? logout : undefined);
@@ -57,7 +51,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
     <AppLayout showHeader>
       <SettingsForm
         {...formState}
-        identity={identity}
+        identity={authAccount.identity}
         version={__APP_VERSION__}
         isLoggedIn={isLoggedIn}
         onLogin={runAccountOperation}

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -2,7 +2,7 @@ import type * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { useAuthAccount } from "@/entities/auth";
+import { useAuthAccount, useAuthUid } from "@/entities/auth";
 import { updatePreferences, usePreferences } from "@/entities/preferences";
 import { SettingsForm, usePreferencesFormState } from "@/features/settings";
 import { useSignIn } from "@/features/sign-in";
@@ -18,9 +18,10 @@ interface SettingsPageProps {
 export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => {
   const preferences = usePreferences();
   const authAccount = useAuthAccount();
+  const authUid = useAuthUid();
   const navigate = useNavigate();
 
-  const isLoggedIn = authAccount.isLinked;
+  const isLoggedIn = authAccount != null;
 
   const signIn = useSignIn(login);
   const signOut = useSignOut(isLoggedIn ? logout : undefined);
@@ -51,7 +52,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
     <AppLayout showHeader>
       <SettingsForm
         {...formState}
-        identity={authAccount.identity}
+        identity={{ uid: authUid, displayName: authAccount?.displayName ?? null }}
         version={__APP_VERSION__}
         isLoggedIn={isLoggedIn}
         onLogin={runAccountOperation}


### PR DESCRIPTION
## Related issue

None

## Summary

- Make useAuthAccount return the linked AuthAccount entity or undefined.
- Keep anonymous UID access in useAuthUid and remove UI-specific identity and isLinked fields from the entity API.
- Let SettingsPage derive its presentation state from the auth entity hooks.

## Testing

- mise run check