### PR TITLE
[No issue] Clarify store compatibility policy

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,7 @@
+# Source Instructions
+
+## Store Compatibility
+
+- The product is under active development. Do not preserve backward compatibility for store state unless explicitly requested.
+- Breaking changes to store state shape and behavior are allowed. Prefer the simplest current design over compatibility layers.
+- In particular, do not add migrations or retain legacy state formats for Zustand `persist`. Invalidate or discard incompatible persisted state instead.


### PR DESCRIPTION
## Related issue

None

## Summary

- Allow breaking store state changes while the product is under active development.
- Direct Zustand persist changes to discard incompatible persisted state instead of adding migrations or retaining legacy formats.

## Testing

- mise run check