### PR TITLE
[No issue] Simplify study session entity

### DIFF
--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -7,7 +7,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { clearStudySessions, getStudySession, startStudySession, studySessionStore } from "./store";
+import {
+  clearStudySessions,
+  getStudySession,
+  removeStudySession,
+  setStudySessionIndex,
+  startStudySession,
+  studySessionStore,
+  touchStudySession,
+} from "./store";
 
 const STUDY_STORAGE_KEY = "tango-study";
 
@@ -31,7 +39,7 @@ describe("study store", () => {
   it("starts at index zero with a copied card order", () => {
     const cardOrderIds = ["card-1", "card-2"];
 
-    store.getState().start("deck-1", cardOrderIds);
+    startStudySession("deck-1", cardOrderIds);
     cardOrderIds.pop();
 
     expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({
@@ -44,9 +52,9 @@ describe("study store", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
 
-    store.getState().start("deck-1", ["card-1", "card-2"]);
+    startStudySession("deck-1", ["card-1", "card-2"]);
     vi.setSystemTime(2000);
-    store.getState().start("deck-2", ["card-3"]);
+    startStudySession("deck-2", ["card-3"]);
 
     expect(store.getState().sessionsByDeckId).toEqual({
       "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 0, lastStudiedAt: 1000 },
@@ -57,11 +65,11 @@ describe("study store", () => {
   it("updates only the requested session and its last studied time", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    store.getState().start("deck-1", ["card-1", "card-2"]);
-    store.getState().start("deck-2", ["card-3", "card-4"]);
+    startStudySession("deck-1", ["card-1", "card-2"]);
+    startStudySession("deck-2", ["card-3", "card-4"]);
 
     vi.setSystemTime(3000);
-    store.getState().setIndex("deck-1", 1);
+    setStudySessionIndex("deck-1", 1);
 
     expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({ currentIndex: 1, lastStudiedAt: 3000 });
     expect(store.getState().sessionsByDeckId["deck-2"]).toMatchObject({ currentIndex: 0, lastStudiedAt: 1000 });
@@ -70,10 +78,10 @@ describe("study store", () => {
   it.each([-1, 2, 0.5])("does not persist an invalid session index: %s", (currentIndex) => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    store.getState().start("deck-1", ["card-1", "card-2"]);
+    startStudySession("deck-1", ["card-1", "card-2"]);
 
     vi.setSystemTime(3000);
-    store.getState().setIndex("deck-1", currentIndex);
+    setStudySessionIndex("deck-1", currentIndex);
 
     expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({ currentIndex: 0, lastStudiedAt: 1000 });
   });
@@ -81,21 +89,21 @@ describe("study store", () => {
   it("touches only an existing requested session", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    store.getState().start("deck-1", ["card-1"]);
+    startStudySession("deck-1", ["card-1"]);
 
     vi.setSystemTime(4000);
-    store.getState().touch("deck-1");
-    store.getState().touch("missing-deck");
+    touchStudySession("deck-1");
+    touchStudySession("missing-deck");
 
     expect(store.getState().sessionsByDeckId["deck-1"]?.lastStudiedAt).toBe(4000);
     expect(store.getState().sessionsByDeckId).not.toHaveProperty("missing-deck");
   });
 
   it("removes only the requested session", () => {
-    store.getState().start("deck-1", ["card-1"]);
-    store.getState().start("deck-2", ["card-2"]);
+    startStudySession("deck-1", ["card-1"]);
+    startStudySession("deck-2", ["card-2"]);
 
-    store.getState().remove("deck-1");
+    removeStudySession("deck-1");
 
     expect(store.getState().sessionsByDeckId).toEqual({
       "deck-2": expect.objectContaining({ deckId: "deck-2" }),
@@ -118,7 +126,7 @@ describe("study store", () => {
   it("persists exactly the session map in a v3 envelope", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    store.getState().start("deck-1", ["card-1"]);
+    startStudySession("deck-1", ["card-1"]);
 
     const persistedSession = localStorage.getItem(STUDY_STORAGE_KEY);
     expect(JSON.parse(persistedSession ?? "{}")).toEqual({

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -173,38 +173,4 @@ describe("study store", () => {
     });
     expect(store.getState()).not.toHaveProperty("unknownRootMetadata");
   });
-
-  it.each([1, 2])("migrates a valid v%s session into the v3 map", async (version) => {
-    setVersionedStorage(
-      { session: { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1 } },
-      version
-    );
-
-    await store.persist.rehydrate();
-
-    expect(store.getState().sessionsByDeckId).toEqual({
-      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 0 },
-    });
-    expect(JSON.parse(localStorage.getItem(STUDY_STORAGE_KEY) ?? "{}")).toEqual({
-      state: {
-        sessionsByDeckId: {
-          "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 0 },
-        },
-      },
-      version: 3,
-    });
-  });
-
-  it.each([
-    ["a missing session", {}],
-    ["an empty card order", { session: { deckId: "deck-1", cardOrderIds: [], currentIndex: 0 } }],
-    ["a negative index", { session: { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: -1 } }],
-    ["a terminal index", { session: { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 1 } }],
-  ])("drops invalid legacy state with %s", async (_label, state) => {
-    setVersionedStorage(state, 2);
-
-    await store.persist.rehydrate();
-
-    expect(store.getState().sessionsByDeckId).toEqual({});
-  });
 });

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -1,7 +1,8 @@
 import type { CardId } from "@/entities/card/@x/study-session";
 import type { DeckId } from "@/entities/deck/@x/study-session";
 
-import { createJSONStorage, persist } from "zustand/middleware";
+import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
 import type { StudySession, StudySessions } from "./types";
@@ -9,20 +10,8 @@ import type { StudySession, StudySessions } from "./types";
 const STUDY_STORAGE_KEY = "tango-study";
 const STUDY_STORAGE_VERSION = 3;
 
-interface PersistedStudySessionState {
+interface StudySessionState {
   sessionsByDeckId: StudySessions;
-}
-
-interface StudySessionStoreState extends PersistedStudySessionState {
-  start: (deckId: DeckId, cardOrderIds: CardId[]) => void;
-  touch: (deckId: DeckId) => void;
-  setIndex: (deckId: DeckId, currentIndex: number) => void;
-  remove: (deckId: DeckId) => void;
-  restoreIfCurrent: (
-    deckId: DeckId,
-    expectedSession: StudySession | undefined,
-    previousSession: StudySession
-  ) => boolean;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -51,7 +40,7 @@ const sanitizeStudySession = (value: unknown, fallbackLastStudiedAt?: number): S
   return { deckId, cardOrderIds: [...cardOrderIds], currentIndex, lastStudiedAt };
 };
 
-const sanitizePersistedState = (persistedState: unknown): PersistedStudySessionState => {
+const sanitizePersistedState = (persistedState: unknown): StudySessionState => {
   if (!isRecord(persistedState) || !isRecord(persistedState.sessionsByDeckId)) {
     return { sessionsByDeckId: {} };
   }
@@ -64,108 +53,81 @@ const sanitizePersistedState = (persistedState: unknown): PersistedStudySessionS
   return { sessionsByDeckId };
 };
 
-const migratePersistedState = (persistedState: unknown, version: number): PersistedStudySessionState => {
-  if (version !== 1 && version !== 2) return { sessionsByDeckId: {} };
-  if (!isRecord(persistedState)) return { sessionsByDeckId: {} };
+const migratePersistedState = (persistedState: unknown, version: number): StudySessionState => {
+  if ((version !== 1 && version !== 2) || !isRecord(persistedState)) return { sessionsByDeckId: {} };
   const session = sanitizeStudySession(persistedState.session, 0);
   return session == null ? { sessionsByDeckId: {} } : { sessionsByDeckId: { [session.deckId]: session } };
 };
 
-const createStudySessionStore = () => {
-  const persistStorage = createJSONStorage<PersistedStudySessionState>(() => localStorage);
-  return createStore<StudySessionStoreState>()(
-    persist<StudySessionStoreState, [], [], PersistedStudySessionState>(
-      (set, get) => ({
-        sessionsByDeckId: {},
-        start: (deckId, cardOrderIds) =>
-          set((state) => ({
-            sessionsByDeckId: {
-              ...state.sessionsByDeckId,
-              [deckId]: {
-                deckId,
-                cardOrderIds: [...cardOrderIds],
-                currentIndex: 0,
-                lastStudiedAt: Date.now(),
-              },
-            },
-          })),
-        touch: (deckId) =>
-          set((state) => {
-            const session = state.sessionsByDeckId[deckId];
-            if (session == null) return state;
-            return {
-              sessionsByDeckId: {
-                ...state.sessionsByDeckId,
-                [deckId]: { ...session, lastStudiedAt: Date.now() },
-              },
-            };
-          }),
-        setIndex: (deckId, currentIndex) =>
-          set((state) => {
-            const session = state.sessionsByDeckId[deckId];
-            if (
-              session == null ||
-              !Number.isInteger(currentIndex) ||
-              currentIndex < 0 ||
-              currentIndex >= session.cardOrderIds.length
-            ) {
-              return state;
-            }
-            return {
-              sessionsByDeckId: {
-                ...state.sessionsByDeckId,
-                [deckId]: { ...session, currentIndex, lastStudiedAt: Date.now() },
-              },
-            };
-          }),
-        remove: (deckId) =>
-          set((state) => {
-            const { [deckId]: _removed, ...sessionsByDeckId } = state.sessionsByDeckId;
-            return { sessionsByDeckId };
-          }),
-        restoreIfCurrent: (deckId, expectedSession, previousSession) => {
-          if (get().sessionsByDeckId[deckId] !== expectedSession) return false;
-          set((state) => ({
-            sessionsByDeckId: { ...state.sessionsByDeckId, [deckId]: previousSession },
-          }));
-          return true;
-        },
+export const studySessionStore = createStore<StudySessionState>()(
+  persist(
+    immer(() => ({ sessionsByDeckId: {} })),
+    {
+      name: STUDY_STORAGE_KEY,
+      version: STUDY_STORAGE_VERSION,
+      migrate: migratePersistedState,
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...sanitizePersistedState(persistedState),
       }),
-      {
-        name: STUDY_STORAGE_KEY,
-        version: STUDY_STORAGE_VERSION,
-        storage: persistStorage,
-        migrate: migratePersistedState,
-        merge: (persistedState, currentState) => ({
-          ...currentState,
-          ...sanitizePersistedState(persistedState),
-        }),
-        partialize: ({ sessionsByDeckId }) => ({ sessionsByDeckId }),
-      }
-    )
-  );
-};
-
-export const studySessionStore = createStudySessionStore();
+    }
+  )
+);
 
 export const getStudySession = (deckId: DeckId): StudySession | undefined =>
   studySessionStore.getState().sessionsByDeckId[deckId];
 
-export const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void =>
-  studySessionStore.getState().start(deckId, cardOrderIds);
+export const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
+  studySessionStore.setState((state) => {
+    state.sessionsByDeckId[deckId] = {
+      deckId,
+      cardOrderIds: [...cardOrderIds],
+      currentIndex: 0,
+      lastStudiedAt: Date.now(),
+    };
+  });
+};
 
-export const touchStudySession = (deckId: DeckId): void => studySessionStore.getState().touch(deckId);
+export const touchStudySession = (deckId: DeckId): void => {
+  studySessionStore.setState((state) => {
+    const session = state.sessionsByDeckId[deckId];
+    if (session != null) session.lastStudiedAt = Date.now();
+  });
+};
 
-export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): void =>
-  studySessionStore.getState().setIndex(deckId, currentIndex);
+export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): void => {
+  studySessionStore.setState((state) => {
+    const session = state.sessionsByDeckId[deckId];
+    if (
+      session == null ||
+      !Number.isInteger(currentIndex) ||
+      currentIndex < 0 ||
+      currentIndex >= session.cardOrderIds.length
+    ) {
+      return;
+    }
+    session.currentIndex = currentIndex;
+    session.lastStudiedAt = Date.now();
+  });
+};
 
-export const removeStudySession = (deckId: DeckId): void => studySessionStore.getState().remove(deckId);
+export const removeStudySession = (deckId: DeckId): void => {
+  studySessionStore.setState((state) => {
+    delete state.sessionsByDeckId[deckId];
+  });
+};
 
 export const restoreStudySession = (
   deckId: DeckId,
   expectedSession: StudySession | undefined,
   previousSession: StudySession
-): boolean => studySessionStore.getState().restoreIfCurrent(deckId, expectedSession, previousSession);
+): boolean => {
+  if (getStudySession(deckId) !== expectedSession) return false;
+  studySessionStore.setState((state) => {
+    state.sessionsByDeckId[deckId] = previousSession;
+  });
+  return true;
+};
 
 export const clearStudySessions = async (): Promise<void> => {
   studySessionStore.setState({ sessionsByDeckId: {} });

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -17,10 +17,9 @@ interface StudySessionState {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value != null && !Array.isArray(value);
 
-const sanitizeStudySession = (value: unknown, fallbackLastStudiedAt?: number): StudySession | undefined => {
+const sanitizeStudySession = (value: unknown): StudySession | undefined => {
   if (!isRecord(value)) return undefined;
-  const { deckId, cardOrderIds, currentIndex } = value;
-  const lastStudiedAt = value.lastStudiedAt ?? fallbackLastStudiedAt;
+  const { deckId, cardOrderIds, currentIndex, lastStudiedAt } = value;
   if (
     typeof deckId !== "string" ||
     !Array.isArray(cardOrderIds) ||
@@ -53,19 +52,12 @@ const sanitizePersistedState = (persistedState: unknown): StudySessionState => {
   return { sessionsByDeckId };
 };
 
-const migratePersistedState = (persistedState: unknown, version: number): StudySessionState => {
-  if ((version !== 1 && version !== 2) || !isRecord(persistedState)) return { sessionsByDeckId: {} };
-  const session = sanitizeStudySession(persistedState.session, 0);
-  return session == null ? { sessionsByDeckId: {} } : { sessionsByDeckId: { [session.deckId]: session } };
-};
-
 export const studySessionStore = createStore<StudySessionState>()(
   persist(
     immer(() => ({ sessionsByDeckId: {} })),
     {
       name: STUDY_STORAGE_KEY,
       version: STUDY_STORAGE_VERSION,
-      migrate: migratePersistedState,
       merge: (persistedState, currentState) => ({
         ...currentState,
         ...sanitizePersistedState(persistedState),

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -1,11 +1,28 @@
 import type { CardId } from "@/entities/card/@x/study-session";
 import type { DeckId } from "@/entities/deck/@x/study-session";
 
+/**
+ * Persisted progress for one deck's active study run.
+ *
+ * Starting the same deck again replaces its existing session. A session keeps
+ * the original card order so resuming does not reshuffle cards midway through
+ * the run.
+ */
 export interface StudySession {
+  /** Deck that owns the session and also keys it in {@link StudySessions}. */
   deckId: DeckId;
+  /** Card identifiers in the exact order presented during this run. */
   cardOrderIds: CardId[];
+  /** Zero-based position of the active card within {@link cardOrderIds}. */
   currentIndex: number;
+  /** Unix time in milliseconds when this session was last started or used. */
   lastStudiedAt: number;
 }
 
+/**
+ * Active study sessions indexed by deck identifier.
+ *
+ * A deck is absent until study starts and after its session is completed,
+ * reset, or removed with the deck.
+ */
 export type StudySessions = Partial<Record<DeckId, StudySession>>;


### PR DESCRIPTION
## Related issue

None.

## Summary

- simplify the study session store by removing duplicated internal actions and using Immer state updates
- preserve persistence validation, legacy migration, and rollback behavior
- document the study session lifecycle and fields, and test mutations through the public API

## Testing

- mise run check