### PR TITLE
[No issue] Simplify Firestore subscription lifecycle

### DIFF
--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -1,18 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { useAuthSession } from "@/entities/auth";
-
-type AuthSessionState = ReturnType<typeof useAuthSession>;
-
 const mocks = vi.hoisted(() => ({
-  authState: { status: "initializing" } as AuthSessionState,
+  authUid: "",
   subscribeCards: vi.fn(),
   subscribeDecks: vi.fn(),
   operations: [] as string[],
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthSession: () => mocks.authState }));
+vi.mock("@/entities/auth", () => ({ useAuthUid: () => mocks.authUid }));
 vi.mock("@/entities/card", () => ({
   clearRemoteCards: () => mocks.operations.push("clear remote Cards"),
   subscribeCards: mocks.subscribeCards,
@@ -36,7 +32,7 @@ describe("FirestoreSubscriptionsProvider", () => {
       return () => mocks.operations.push(`stop Decks ${uid}`);
     });
     mocks.operations.length = 0;
-    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
+    mocks.authUid = "test-user";
   });
 
   it("starts subscriptions for the authenticated UID and cleans them up on unmount", () => {
@@ -58,7 +54,7 @@ describe("FirestoreSubscriptionsProvider", () => {
   });
 
   it("does not subscribe or clear remote state before authentication", () => {
-    mocks.authState = { status: "initializing" };
+    mocks.authUid = "";
 
     const view = render(<FirestoreSubscriptionsProvider />);
     view.unmount();
@@ -70,7 +66,7 @@ describe("FirestoreSubscriptionsProvider", () => {
     const view = render(<FirestoreSubscriptionsProvider />);
     mocks.operations.length = 0;
 
-    mocks.authState = { status: "authenticated", uid: "next-user", isAnonymous: false, displayName: "Ada" };
+    mocks.authUid = "next-user";
     view.rerender(<FirestoreSubscriptionsProvider />);
 
     expect(mocks.operations).toEqual([
@@ -83,11 +79,10 @@ describe("FirestoreSubscriptionsProvider", () => {
     ]);
   });
 
-  it("keeps subscriptions when authentication metadata changes for the same UID", () => {
+  it("keeps subscriptions when the authenticated UID is unchanged", () => {
     const view = render(<FirestoreSubscriptionsProvider />);
     mocks.operations.length = 0;
 
-    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: false, displayName: "Ada" };
     view.rerender(<FirestoreSubscriptionsProvider />);
 
     expect(mocks.operations).toEqual([]);
@@ -99,7 +94,7 @@ describe("FirestoreSubscriptionsProvider", () => {
     const view = render(<FirestoreSubscriptionsProvider />);
     mocks.operations.length = 0;
 
-    mocks.authState = { status: "unauthenticated" };
+    mocks.authUid = "";
     view.rerender(<FirestoreSubscriptionsProvider />);
 
     expect(mocks.operations).toEqual([

--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -57,6 +57,15 @@ describe("FirestoreSubscriptionsProvider", () => {
     ]);
   });
 
+  it("does not subscribe or clear remote state before authentication", () => {
+    mocks.authState = { status: "initializing" };
+
+    const view = render(<FirestoreSubscriptionsProvider />);
+    view.unmount();
+
+    expect(mocks.operations).toEqual([]);
+  });
+
   it("replaces subscriptions when the authenticated UID changes", () => {
     const view = render(<FirestoreSubscriptionsProvider />);
     mocks.operations.length = 0;

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -9,12 +9,16 @@ export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> =
   const authenticatedUid = authState.status === "authenticated" ? authState.uid : null;
 
   React.useEffect(() => {
-    const stopCards = authenticatedUid == null ? undefined : subscribeCards(authenticatedUid, console.error);
-    const stopDecks = authenticatedUid == null ? undefined : subscribeDecks(authenticatedUid, console.error);
+    if (authenticatedUid === null) {
+      return;
+    }
+
+    const stopCards = subscribeCards(authenticatedUid, console.error);
+    const stopDecks = subscribeDecks(authenticatedUid, console.error);
 
     return () => {
-      stopCards?.();
-      stopDecks?.();
+      stopCards();
+      stopDecks();
       clearRemoteCards();
       clearRemoteDecks();
     };

--- a/src/app/providers/firestore-subscriptions/index.tsx
+++ b/src/app/providers/firestore-subscriptions/index.tsx
@@ -1,20 +1,19 @@
 import React from "react";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuthUid } from "@/entities/auth";
 import { clearRemoteCards, subscribeCards } from "@/entities/card";
 import { clearRemoteDecks, subscribeDecks } from "@/entities/deck";
 
 export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const authState = useAuthSession();
-  const authenticatedUid = authState.status === "authenticated" ? authState.uid : null;
+  const uid = useAuthUid();
 
   React.useEffect(() => {
-    if (authenticatedUid === null) {
+    if (uid === "") {
       return;
     }
 
-    const stopCards = subscribeCards(authenticatedUid, console.error);
-    const stopDecks = subscribeDecks(authenticatedUid, console.error);
+    const stopCards = subscribeCards(uid, console.error);
+    const stopDecks = subscribeDecks(uid, console.error);
 
     return () => {
       stopCards();
@@ -22,7 +21,7 @@ export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> =
       clearRemoteCards();
       clearRemoteDecks();
     };
-  }, [authenticatedUid]);
+  }, [uid]);
 
   return children;
 };


### PR DESCRIPTION
## Related issue

None.

## Summary

- Skip Firestore subscription setup until an authenticated UID is available.
- Run unsubscribe and remote-state cleanup only for subscriptions that were started.
- Cover the unauthenticated lifecycle with a provider test.

## Testing

- mise run check