### PR TITLE
test(#981): update StudySession E2E fixture

### DIFF
--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -54,13 +54,16 @@ const e2eCards = [
 
 const persistedStudy = {
   state: {
-    session: {
-      deckId: e2eDeck.id,
-      cardOrderIds: e2eCards.map((card) => card.id),
-      currentIndex: 0,
+    sessionsByDeckId: {
+      [e2eDeck.id]: {
+        deckId: e2eDeck.id,
+        cardOrderIds: e2eCards.map((card) => card.id),
+        currentIndex: 0,
+        lastStudiedAt: 0,
+      },
     },
   },
-  version: 2,
+  version: 3,
 };
 
 const seedSwipeSession = async (page: Page) => {


### PR DESCRIPTION
## Related issue

Follow-up to #981

## Summary

- update the swipe E2E fixture to the current version 3 StudySession envelope
- seed the session under sessionsByDeckId with the required lastStudiedAt field
- prevent the study route from discarding the fixture and redirecting to the deck list

## Testing

- targeted swipe E2E: 2 passed
- CHOKIDAR_USEPOLLING=1 mise run check