### PR TITLE
#982 Finalize the Study public API cleanup

### DIFF
--- a/src/features/study/components/Controller.tsx
+++ b/src/features/study/components/Controller.tsx
@@ -1,9 +1,3 @@
-/**
- * @file Defines the study feature's Controller presentation component.
- * The component renders props and reports user intent through callbacks while data access stays
- * outside the view.
- */
-
 import type * as React from "react";
 import { IconContext } from "react-icons";
 import { AiOutlinePause, AiOutlineCaretRight } from "react-icons/ai";
@@ -19,11 +13,6 @@ export interface ControllerProps {
   onChange?: (index: number) => void;
 }
 
-/**
- * Renders the Controller user interface.
- * Shows study progress and controls for reveal, navigation, and autoplay based on the current card
- * index.
- */
 export const Controller: React.FC<ControllerProps> = (props) => {
   const numberOfCards = props.numberOfCards ?? 0;
   const index = props.index ?? 0;

--- a/src/features/study/components/DeckSwiperView.tsx
+++ b/src/features/study/components/DeckSwiperView.tsx
@@ -1,8 +1,3 @@
-/**
- * @file Composes the Deck Swiper Page's presentation.
- * Data and callbacks arrive through props, which keeps this presentation usable in Storybook.
- */
-
 import type { SwipeDirection } from "@/entities/preferences";
 
 import cx from "classnames";
@@ -112,11 +107,6 @@ const Controls: React.FC<{
   );
 };
 
-/**
- * Composes the Deck Swiper screen from reusable UI components.
- * All data and callbacks arrive through props, allowing the same screen to run in tests and
- * Storybook.
- */
 export const DeckSwiperView: React.FC<DeckSwiperViewProps> = (props) => (
   <>
     {props.feedbackSlot}

--- a/src/features/study/components/SwipeButtonList.tsx
+++ b/src/features/study/components/SwipeButtonList.tsx
@@ -1,9 +1,3 @@
-/**
- * @file Defines the study feature's Swipe Button List presentation component.
- * The component renders props and reports user intent through callbacks while data access stays
- * outside the view.
- */
-
 import type { SwipeDirection } from "@/entities/preferences";
 
 import type * as React from "react";
@@ -31,11 +25,6 @@ export interface SwipeButtonListProps {
   onClickRight?: () => void;
 }
 
-/**
- * Renders the Swipe Button List user interface.
- * Displays one grading button per swipe direction and reports the chosen direction unless controls
- * are disabled.
- */
 export const SwipeButtonList: React.FC<SwipeButtonListProps> = (props) => {
   return (
     <div className="flex">

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -1,9 +1,3 @@
-/**
- * @file Provides the study feature's Use Study Actions React hook.
- * The hook combines state and operations behind one interface so components do not need to
- * coordinate services themselves.
- */
-
 import { mustFindCardById, type Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { Preferences, SwipeDirection } from "@/entities/preferences";
@@ -85,10 +79,8 @@ const revertOptimisticUpdate = (
   return true;
 };
 
-/**
- * Runs the study swipe workflow for the study feature.
- * The sequence and its cleanup remain together so partial failures can be handled consistently.
- */
+// Keep the transition, mutation, and rollback in one sequence so a failed write cannot leave the
+// persisted session and transient feedback describing different cards.
 const runStudySwipe = async (
   direction: SwipeDirection,
   {
@@ -152,11 +144,6 @@ const runStudySwipe = async (
   }
 };
 
-/**
- * Provides the study actions values and operations needed by React components.
- * Callers receive one focused interface without coordinating the study feature's stores and
- * services themselves.
- */
 export const useStudyActions = (
   deckId: DeckId,
   {
@@ -173,11 +160,6 @@ export const useStudyActions = (
   const preferences = usePreferences();
   const mutationTokenRef = React.useRef<symbol | undefined>(undefined);
 
-  /**
-   * Runs the study workflow for one swipe direction.
-   * Direction-specific callbacks reuse this function so pending checks, optimistic state, and
-   * persistence stay identical.
-   */
   const swipe = (direction: SwipeDirection) => {
     if (cardMutation == null) return Promise.resolve();
     return runStudySwipe(direction, {

--- a/src/features/study/hooks/useStudyControllerState.ts
+++ b/src/features/study/hooks/useStudyControllerState.ts
@@ -1,9 +1,3 @@
-/**
- * @file Provides the study feature's Use Study Controller State React hook.
- * The hook combines state and operations behind one interface so components do not need to
- * coordinate services themselves.
- */
-
 import * as React from "react";
 import type { ControllerProps } from "../components/Controller";
 
@@ -16,11 +10,6 @@ export type StudyControllerState = ControllerProps & {
   onToggleAutoPlay: () => void;
 };
 
-/**
- * Provides the study controller state values and operations needed by React components.
- * Callers receive one focused interface without coordinating the study feature's stores and
- * services themselves.
- */
 export const useStudyControllerState = (props: UseStudyControllerStateOptions): StudyControllerState => {
   const cardInterval = props.cardInterval ?? 10;
   const numberOfCards = props.numberOfCards ?? 0;

--- a/src/features/study/index.ts
+++ b/src/features/study/index.ts
@@ -1,2 +1,4 @@
-export { DeckSwiperView } from "./components/DeckSwiperView";
+// Keep setup and persisted session APIs behind their owning slices; this entry point is only for
+// the active Study workflow and its props-driven presentation.
 export { StudyWorkflow, type StudyWorkflowState } from "./components/StudyWorkflow";
+export { DeckSwiperView } from "./components/DeckSwiperView";


### PR DESCRIPTION
## Summary

- document that the Study entry point is limited to the active workflow and props-driven presentation
- keep the public surface at the three symbols used by `pages/deck-swiper`
- remove stale and boilerplate comments that described Page ownership or narrated implementation details
- preserve the intent comment for the mutation/rollback ordering invariant

## Why

The prerequisite ownership moves already removed persisted session, setup, hydration, and generic mutation APIs from `features/study`. The remaining cleanup was to make that final boundary explicit and remove stale commentary without changing active Study behavior.

## Impact

Application behavior and the presentation prop contracts are unchanged. Consumers continue to use only `StudyWorkflow`, `StudyWorkflowState`, and `DeckSwiperView` from the Study public API.

Closes #982

## Validation

- `npm run lint:fsd`
- `npm run lint:knip`
- `npx vitest run --project=unit src/features/study src/pages/deck-swiper/ui/DeckSwiperPage.spec.tsx` (42 tests)
- `mise run check` (105 test files, 521 tests)