### PR TITLE
[No issue] Rename deck swiper page to deck study

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -30,7 +30,7 @@ vi.mock("@/pages/deck-form", () => ({ DeckFormPage: () => null }));
 vi.mock("@/pages/deck-import", () => ({ DeckImportPage: () => null }));
 vi.mock("@/pages/deck-list", () => ({ DeckListPage: () => <div>Deck list</div> }));
 vi.mock("@/pages/deck-start", () => ({ DeckStartPage: () => null }));
-vi.mock("@/pages/deck-swiper", () => ({ DeckSwiperPage: () => null }));
+vi.mock("@/pages/deck-study", () => ({ DeckStudyPage: () => null }));
 vi.mock("@/pages/settings", () => ({ SettingsPage: () => null }));
 
 import App from "./App";

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -16,7 +16,7 @@ import { DeckFormPage } from "@/pages/deck-form";
 import { DeckImportPage } from "@/pages/deck-import";
 import { DeckListPage } from "@/pages/deck-list";
 import { DeckStartPage } from "@/pages/deck-start";
-import { DeckSwiperPage } from "@/pages/deck-swiper";
+import { DeckStudyPage } from "@/pages/deck-study";
 import { SettingsPage } from "@/pages/settings";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 
@@ -51,7 +51,7 @@ export const AppRoutes: React.FC = () => (
     <Route path="/deck/:id" element={<CardListPage />} />
     <Route path="/deck/:id/edit" element={<DeckFormPage />} />
     <Route path="/deck/:id/start" element={<DeckStartPage />} />
-    <Route path="/deck/:id/study" element={<DeckSwiperPage />} />
+    <Route path="/deck/:id/study" element={<DeckStudyPage />} />
     <Route path="/card/:id" element={<CardViewPage />} />
     <Route path="/card/:id/edit" element={<CardFormPage />} />
     <Route path="/settings" element={<SettingsPage login={login} logout={signOutCurrentUser} />} />

--- a/src/features/study/components/DeckSwiperView.tsx
+++ b/src/features/study/components/DeckSwiperView.tsx
@@ -1,5 +1,5 @@
 /**
- * @file Composes the Deck Swiper Page's presentation.
+ * @file Composes the deck study screen's swipe-based presentation.
  * Data and callbacks arrive through props, which keeps this presentation usable in Storybook.
  */
 

--- a/src/pages/deck-study/index.ts
+++ b/src/pages/deck-study/index.ts
@@ -1,0 +1,1 @@
+export { DeckStudyPage } from "./ui/DeckStudyPage";

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -44,7 +44,7 @@ vi.mock("@/features/study", async (importOriginal) => {
   };
 });
 
-import { DeckSwiperPage } from "./DeckSwiperPage";
+import { DeckStudyPage } from "./DeckStudyPage";
 
 const deck: Deck = {
   id: "deck-id",
@@ -104,7 +104,7 @@ const readyState = (): StudyWorkflowState => ({
   swipeActions: { disabled: false },
 });
 
-describe("DeckSwiperPage", () => {
+describe("DeckStudyPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.params.id = deck.id;
@@ -117,11 +117,11 @@ describe("DeckSwiperPage", () => {
 
   it("validates the route parameter", () => {
     mocks.params.id = undefined;
-    expect(() => render(<DeckSwiperPage />)).toThrow("invalid deck id");
+    expect(() => render(<DeckStudyPage />)).toThrow("invalid deck id");
   });
 
   it("passes Entity reads to StudyWorkflow and composes the application shell", () => {
-    render(<DeckSwiperPage />);
+    render(<DeckStudyPage />);
 
     expect(mocks.workflowProps).toMatchObject({ deckId: deck.id, cards: [card] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
@@ -134,18 +134,18 @@ describe("DeckSwiperPage", () => {
     ["unavailable", "Study session unavailable."],
   ] as const)("renders route feedback for %s workflow state", (status, title) => {
     mocks.workflowState = { status, shortcutActions: readyState().shortcutActions };
-    render(<DeckSwiperPage />);
+    render(<DeckStudyPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
   });
 
   it("converts unavailable intent into current route navigation", () => {
-    render(<DeckSwiperPage />);
+    render(<DeckStudyPage />);
     act(() => mocks.workflowProps?.onUnavailable());
     expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
   });
 
   it("delegates a representative Study shortcut to the workflow action", () => {
-    render(<DeckSwiperPage />);
+    render(<DeckStudyPage />);
     const state = mocks.workflowState;
     if (state.status !== "ready") throw new Error("expected ready workflow state");
 
@@ -156,7 +156,7 @@ describe("DeckSwiperPage", () => {
 
   it("shows route feedback when the Deck Entity is unavailable", () => {
     mocks.deck = undefined;
-    render(<DeckSwiperPage />);
+    render(<DeckStudyPage />);
     expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
   });
 
@@ -164,7 +164,7 @@ describe("DeckSwiperPage", () => {
     const pushState = vi.spyOn(window.history, "pushState");
     const view = render(
       <React.StrictMode>
-        <DeckSwiperPage />
+        <DeckStudyPage />
       </React.StrictMode>
     );
 

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -74,7 +74,7 @@ const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
   );
 };
 
-const DeckSwiperScreen = ({ deck, state }: { deck: Deck; state: StudyWorkflowState }) => {
+const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyWorkflowState }) => {
   useKey("ArrowUp", state.shortcutActions.swipeUp);
   useKey("ArrowDown", state.shortcutActions.swipeDown);
   useKey("ArrowLeft", state.shortcutActions.swipeLeft);
@@ -87,7 +87,7 @@ const DeckSwiperScreen = ({ deck, state }: { deck: Deck; state: StudyWorkflowSta
   return renderStudyScreen(deck, state);
 };
 
-const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
+const DeckStudyContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const navigate = useNavigate();
   useStudyHistoryGuard(deck.id, navigate);
   const handleUnavailable = React.useCallback(() => {
@@ -96,12 +96,12 @@ const DeckSwiperContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
 
   return (
     <StudyWorkflow key={deck.id} cards={cards} deckId={deck.id} onUnavailable={handleUnavailable}>
-      {(state) => <DeckSwiperScreen deck={deck} state={state} />}
+      {(state) => <DeckStudyScreen deck={deck} state={state} />}
     </StudyWorkflow>
   );
 };
 
-export const DeckSwiperPage: React.FC = () => {
+export const DeckStudyPage: React.FC = () => {
   const params = useParams();
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
@@ -113,5 +113,5 @@ export const DeckSwiperPage: React.FC = () => {
     return <RouteFeedback title="Study session unavailable." tone="not-found" />;
   }
 
-  return <DeckSwiperContent key={deck.id} cards={cards} deck={deck} />;
+  return <DeckStudyContent key={deck.id} cards={cards} deck={deck} />;
 };

--- a/src/pages/deck-swiper/index.ts
+++ b/src/pages/deck-swiper/index.ts
@@ -1,1 +1,0 @@
-export { DeckSwiperPage } from "./ui/DeckSwiperPage";


### PR DESCRIPTION
## Related issue

None

## Summary

- Rename the deck swiper page slice to deck study
- Update the page component, route wiring, and tests to match the study route
- Keep DeckSwiperView named for its swipe-based presentation role

## Testing

- mise run check