### PR TITLE
[No issue] Refactor useSignOut interface

### DIFF
--- a/src/features/sign-out/model/useSignOut.ts
+++ b/src/features/sign-out/model/useSignOut.ts
@@ -1,12 +1,10 @@
 import { useState } from "react";
 
-export const useSignOut = (signOut?: () => Promise<void>) => {
+export const useSignOut = (signOut: () => Promise<void>) => {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<unknown>(null);
 
   const run = async () => {
-    if (signOut == null) return;
-
     setPending(true);
     setError(null);
     try {

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -24,7 +24,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => 
   const isLoggedIn = authAccount != null;
 
   const signIn = useSignIn(login);
-  const signOut = useSignOut(isLoggedIn ? logout : undefined);
+  const signOut = useSignOut(logout);
   const accountOperation = isLoggedIn
     ? {
         run: signOut.signOut,


### PR DESCRIPTION
## Related issue

None

## Summary

- Require the useSignOut callback instead of accepting undefined.
- Pass logout directly from SettingsPage and remove silent no-op behavior.

## Testing

- mise run check (105 test files, 521 tests passed)