### PR TITLE
refactor(#968): Reuse required entity lookup helpers

### DIFF
--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -9,6 +9,7 @@ import {
   localCardSchema,
   persistedCardSchema,
 } from "./schema";
+import { mustFindCardById } from "./rules";
 import type { Card, CardId, LocalCard, LocalCardCreateInput, LocalCardEdit, RemoteCard } from "./types";
 
 interface CardState {
@@ -77,8 +78,7 @@ export const createLocalCard = (input: LocalCardCreateInput): LocalCard => {
 export const editLocalCard = (input: LocalCardEdit): LocalCard => {
   const edit = localCardEditSchema.parse(input);
   const localCards = cardStore.getState().localCards;
-  const currentCard = localCards.find(({ id }) => id === edit.id);
-  if (currentCard === undefined) throw new Error(`Local Card "${edit.id}" was not found`);
+  const currentCard = mustFindCardById(localCards, edit.id);
 
   const updatedCard = localCardSchema.parse({ ...currentCard, ...edit, updatedAt: Date.now() });
   cardStore.setState({ localCards: localCards.map((card) => (card.id === updatedCard.id ? updatedCard : card)) });

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -2,6 +2,7 @@ import { createJSONStorage, persist, type StateStorage } from "zustand/middlewar
 import { createStore } from "zustand/vanilla";
 import { z } from "zod";
 
+import { mustFindDeckById } from "./rules";
 import { deckEditSchema, deckIdSchema, localDeckCreateSchema, localDeckSchema } from "./schema";
 import type { Deck, DeckEdit, DeckId, LocalDeck, LocalDeckCreateInput, RemoteDeck } from "./types";
 
@@ -71,8 +72,7 @@ export const createLocalDeck = (input: LocalDeckCreateInput): LocalDeck => {
 export const editLocalDeck = (input: DeckEdit): LocalDeck => {
   const edit = deckEditSchema.parse(input);
   const localDecks = deckStore.getState().localDecks;
-  const currentDeck = localDecks.find(({ id }) => id === edit.id);
-  if (currentDeck === undefined) throw new Error(`Local Deck "${edit.id}" was not found`);
+  const currentDeck = mustFindDeckById(localDecks, edit.id);
 
   const updatedDeck = localDeckSchema.parse({ ...currentDeck, ...edit, updatedAt: Date.now() });
   deckStore.setState({ localDecks: localDecks.map((deck) => (deck.id === updatedDeck.id ? updatedDeck : deck)) });


### PR DESCRIPTION
## Related issue

Related to #968

## Summary

- reuse `mustFindCardById` when editing a required local Card
- reuse `mustFindDeckById` when editing a required local Deck
- retain optional lookup behavior for selectors, study loading, and Deck import flows

## Testing

- `mise run check`