### PR TITLE
refactor(#1025): Move card list coordination to container

### DIFF
--- a/src/features/card-list/index.ts
+++ b/src/features/card-list/index.ts
@@ -1,2 +1,1 @@
-export { useEditCardScore } from "./model/useEditCardScore";
-export { CardList } from "./ui/CardList";
+export { CardListContainer } from "./ui/CardListContainer";

--- a/src/features/card-list/ui/CardListContainer.spec.tsx
+++ b/src/features/card-list/ui/CardListContainer.spec.tsx
@@ -1,0 +1,123 @@
+import type { Card } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import type { Preferences } from "@/entities/preferences";
+import type { ReactNode } from "react";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCard, createDeck, createPreferences } from "@/test/factories";
+
+const mocks = vi.hoisted(() => ({
+  preferences: null as unknown as Preferences,
+  deckCards: [] as Card[],
+  filteredCards: [] as Card[],
+  tags: [] as string[],
+  requestedDeckId: undefined as string | undefined,
+  filterOptions: undefined as { deck: Deck; tags: string[] } | undefined,
+  onClickTag: vi.fn(),
+  updateScore: vi.fn(),
+}));
+
+vi.mock("@/entities/preferences", () => ({ usePreferences: () => mocks.preferences }));
+vi.mock("@/entities/card", () => ({
+  useCardsByDeckId: (deckId: string) => {
+    mocks.requestedDeckId = deckId;
+    return { cards: mocks.deckCards, tags: mocks.tags };
+  },
+}));
+vi.mock("@/features/deck-filter", () => ({
+  DeckFilterForm: () => <div>Filter controls</div>,
+  useFilteredStudyCards: () => mocks.filteredCards,
+  useDeckFilterState: (options: { deck: Deck; tags: string[] }) => {
+    mocks.filterOptions = options;
+    return {
+      scoreMax: 4,
+      scoreMin: -2,
+      tagFilterProps: { selectedTags: ["typescript"], onClickTag: mocks.onClickTag },
+    };
+  },
+}));
+vi.mock("../model/useEditCardScore", () => ({
+  useEditCardScore: () => ({ updateScore: mocks.updateScore }),
+}));
+vi.mock("./CardList", () => ({
+  CardList: (props: {
+    cards: Card[];
+    preferences: Preferences;
+    filter: {
+      scoreMax: number;
+      scoreMin: number;
+      selectedTags: string[];
+      controls: ReactNode;
+      onChangeSelectedTags: (tags: string[]) => void;
+    };
+    renderBackText: (props: { text: string }) => ReactNode;
+    onEditCard: (id: string) => void;
+    onChangeScore: (card: Card, score: number) => Promise<void>;
+  }) => (
+    <section>
+      <div>{props.filter.controls}</div>
+      <span>{props.cards.map((card) => card.id).join(",")}</span>
+      <span>{`${props.filter.scoreMin}:${props.filter.scoreMax}:${props.filter.selectedTags.join(",")}`}</span>
+      <span>{String(props.preferences.appearance.darkMode)}</span>
+      {props.renderBackText({ text: "Back text" })}
+      <button type="button" onClick={() => props.onEditCard(props.cards[0]?.id ?? "missing")}>
+        Edit card
+      </button>
+      <button type="button" onClick={() => void props.onChangeScore(props.cards[0] as Card, 3)}>
+        Change score
+      </button>
+      <button type="button" onClick={() => props.filter.onChangeSelectedTags(["react"])}>
+        Change tags
+      </button>
+    </section>
+  ),
+}));
+
+import { CardListContainer } from "./CardListContainer";
+
+describe("CardListContainer", () => {
+  const deck = createDeck({ id: "deck-id" });
+  const deckCard = createCard({ id: "deck-card", deckId: deck.id });
+  const filteredCard = createCard({ id: "filtered-card", deckId: deck.id });
+  const onEditCard = vi.fn();
+  const renderBackText = ({ text }: { text: string }) => <div>{text}</div>;
+
+  beforeEach(() => {
+    mocks.preferences = createPreferences({ appearance: { darkMode: true } });
+    mocks.deckCards = [deckCard];
+    mocks.filteredCards = [filteredCard];
+    mocks.tags = ["typescript"];
+    mocks.requestedDeckId = undefined;
+    mocks.filterOptions = undefined;
+    vi.clearAllMocks();
+    mocks.updateScore.mockResolvedValue(undefined);
+  });
+
+  it("coordinates card data, filtering, and presentation state", () => {
+    render(<CardListContainer deck={deck} renderBackText={renderBackText} onEditCard={onEditCard} />);
+
+    expect(mocks.requestedDeckId).toBe(deck.id);
+    expect(mocks.filterOptions).toEqual({ deck, tags: ["typescript"] });
+    expect(screen.getByText("Filter controls")).toBeVisible();
+    expect(screen.getByText(filteredCard.id)).toBeVisible();
+    expect(screen.getByText("-2:4:typescript")).toBeVisible();
+    expect(screen.getByText("true")).toBeVisible();
+    expect(screen.getByText("Back text")).toBeVisible();
+  });
+
+  it("connects edit, score, and filter actions", async () => {
+    render(<CardListContainer deck={deck} renderBackText={renderBackText} onEditCard={onEditCard} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit card" }));
+    await userEvent.click(screen.getByRole("button", { name: "Change score" }));
+    await userEvent.click(screen.getByRole("button", { name: "Change tags" }));
+
+    expect(onEditCard).toHaveBeenCalledExactlyOnceWith(filteredCard.id);
+    expect(mocks.updateScore).toHaveBeenCalledExactlyOnceWith(filteredCard.id, 3);
+    expect(mocks.onClickTag).toHaveBeenCalledExactlyOnceWith(["react"]);
+  });
+});

--- a/src/features/card-list/ui/CardListContainer.tsx
+++ b/src/features/card-list/ui/CardListContainer.tsx
@@ -1,0 +1,41 @@
+import type * as React from "react";
+
+import { type CardId, useCardsByDeckId } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import { usePreferences } from "@/entities/preferences";
+import { DeckFilterForm, useDeckFilterState, useFilteredStudyCards } from "@/features/deck-filter";
+
+import { useEditCardScore } from "../model/useEditCardScore";
+import { CardList, type CardListProps } from "./CardList";
+
+export interface CardListContainerProps {
+  deck: Deck;
+  renderBackText: CardListProps["renderBackText"];
+  onEditCard: (id: CardId) => void;
+}
+
+export const CardListContainer: React.FC<CardListContainerProps> = (props) => {
+  const preferences = usePreferences();
+  const { cards: deckCards, tags } = useCardsByDeckId(props.deck.id);
+  const cards = useFilteredStudyCards(props.deck, deckCards, preferences);
+  const deckFilterForm = useDeckFilterState({ deck: props.deck, tags });
+  const editCardScore = useEditCardScore();
+
+  return (
+    <CardList
+      deck={props.deck}
+      cards={cards}
+      preferences={preferences}
+      filter={{
+        scoreMax: deckFilterForm.scoreMax,
+        scoreMin: deckFilterForm.scoreMin,
+        selectedTags: deckFilterForm.tagFilterProps.selectedTags ?? [],
+        controls: <DeckFilterForm {...deckFilterForm} />,
+        onChangeSelectedTags: (selectedTags) => deckFilterForm.tagFilterProps.onClickTag?.(selectedTags),
+      }}
+      renderBackText={props.renderBackText}
+      onEditCard={props.onEditCard}
+      onChangeScore={(card, score) => editCardScore.updateScore(card.id, score)}
+    />
+  );
+};

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -1,68 +1,39 @@
-import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
-import type { Preferences } from "@/entities/preferences";
+import type { ReactNode } from "react";
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createCard, createDeck, createPreferences } from "@/test/factories";
+import { createDeck } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   params: { id: "deck-id" as string | undefined },
-  preferences: null as unknown as Preferences,
   deck: null as Deck | null,
-  cards: [] as Card[],
   navigate: vi.fn(),
-  onClickTag: vi.fn(),
-  updateScore: vi.fn(),
-  cardListProps: null as null | Record<string, unknown>,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/preferences", () => ({ usePreferences: () => mocks.preferences, setDarkMode: vi.fn() }));
-vi.mock("@/entities/card", () => ({
-  useCardsByDeckId: (id: string) => {
-    const cards = mocks.cards.filter((card) => card.deckId === id);
-    return { cards, tags: [...new Set(cards.flatMap((card) => card.tags))] };
-  },
-}));
 vi.mock("@/entities/deck", () => ({ useDeck: () => mocks.deck ?? undefined }));
 vi.mock("@/features/card-list", () => ({
-  useEditCardScore: () => ({ updateScore: mocks.updateScore }),
-  CardList: (props: {
-    cards: Card[];
-    filter: { selectedTags: string[]; onChangeSelectedTags: (tags: string[]) => void };
+  CardListContainer: (props: {
+    deck: Deck;
+    renderBackText: (props: { text: string }) => ReactNode;
     onEditCard: (id: string) => void;
-    onChangeScore: (card: Card, score: number) => Promise<void>;
   }) => {
-    mocks.cardListProps = props as unknown as Record<string, unknown>;
     return (
       <div>
-        <span>Card list feature</span>
-        <button type="button" onClick={() => props.onEditCard(props.cards[0]?.id ?? "missing")}>
+        <span>{`Card list: ${props.deck.id}`}</span>
+        {props.renderBackText({ text: "Back text" })}
+        <button type="button" onClick={() => props.onEditCard("card-id")}>
           Edit card
-        </button>
-        <button type="button" onClick={() => void props.onChangeScore(props.cards[0] as Card, 3)}>
-          Change score
-        </button>
-        <button type="button" onClick={() => props.filter.onChangeSelectedTags(["react"])}>
-          Change tags
         </button>
       </div>
     );
   },
 }));
-vi.mock("@/features/deck-filter", () => ({
-  DeckFilterForm: () => <div>Filter controls</div>,
-  useFilteredStudyCards: (deck: Deck | undefined, cards: Card[]) => (deck == null ? [] : cards),
-  useDeckFilterState: () => ({
-    scoreMax: 4,
-    scoreMin: -2,
-    tagFilterProps: { selectedTags: ["typescript"], onClickTag: mocks.onClickTag },
-  }),
-}));
+vi.mock("@/features/card-view", () => ({ BackText: ({ text }: { text: string }) => <div>{text}</div> }));
 vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
   useNavigate: () => mocks.navigate,
@@ -72,34 +43,21 @@ import { CardListPage } from "./CardListPage";
 
 describe("CardListPage", () => {
   const deck = createDeck({ id: "deck-id" });
-  const card = createCard({ id: "card-id", deckId: deck.id, tags: ["typescript"] });
-  const otherCard = createCard({ id: "other-card", deckId: "other-deck" });
 
   beforeEach(() => {
     mocks.params.id = deck.id;
     mocks.deck = deck;
-    mocks.cards = [card, otherCard];
-    mocks.preferences = createPreferences();
     mocks.navigate.mockReset();
-    mocks.onClickTag.mockReset();
-    mocks.updateScore.mockReset().mockResolvedValue(undefined);
-    mocks.cardListProps = null;
   });
 
-  it("composes the feature from the resolved route data and route callbacks", async () => {
+  it("composes the resolved deck container and route navigation", async () => {
     render(<CardListPage />);
 
-    expect(screen.getByText("Card list feature")).toBeInTheDocument();
+    expect(screen.getByText(`Card list: ${deck.id}`)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
 
     await userEvent.click(screen.getByRole("button", { name: "Edit card" }));
-    expect(mocks.navigate).toHaveBeenCalledWith(`/card/${card.id}/edit`);
-
-    await userEvent.click(screen.getByRole("button", { name: "Change score" }));
-    expect(mocks.updateScore).toHaveBeenCalledExactlyOnceWith(card.id, 3);
-
-    await userEvent.click(screen.getByRole("button", { name: "Change tags" }));
-    expect(mocks.onClickTag).toHaveBeenCalledExactlyOnceWith(["react"]);
+    expect(mocks.navigate).toHaveBeenCalledWith("/card/card-id/edit");
   });
 
   it("keeps route shortcuts in the page adapter", () => {
@@ -116,7 +74,7 @@ describe("CardListPage", () => {
     render(<CardListPage />);
 
     expect(screen.getByRole("heading", { name: "Deck not found" })).toBeInTheDocument();
-    expect(screen.queryByText("Card list feature")).not.toBeInTheDocument();
+    expect(screen.queryByText(`Card list: ${deck.id}`)).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Go home" }));
     await userEvent.click(screen.getByRole("button", { name: "Go back" }));
     expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/");

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -2,53 +2,18 @@ import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { type Card, type CardId, useCardsByDeckId } from "@/entities/card";
-import { type Deck, useDeck } from "@/entities/deck";
-import { type Preferences, usePreferences } from "@/entities/preferences";
-import { CardList, useEditCardScore } from "@/features/card-list";
+import { useDeck } from "@/entities/deck";
+import { CardListContainer } from "@/features/card-list";
 import { BackText } from "@/features/card-view";
-import { DeckFilterForm, useDeckFilterState, useFilteredStudyCards } from "@/features/deck-filter";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
-
-const CardListComposition = (props: {
-  deck: Deck;
-  cards: Card[];
-  tags: string[];
-  preferences: Preferences;
-  onEditCard: (id: CardId) => void;
-}) => {
-  const deckFilterForm = useDeckFilterState({ deck: props.deck, tags: props.tags });
-  const editCardScore = useEditCardScore();
-
-  return (
-    <CardList
-      deck={props.deck}
-      cards={props.cards}
-      preferences={props.preferences}
-      filter={{
-        scoreMax: deckFilterForm.scoreMax,
-        scoreMin: deckFilterForm.scoreMin,
-        selectedTags: deckFilterForm.tagFilterProps.selectedTags ?? [],
-        controls: <DeckFilterForm {...deckFilterForm} />,
-        onChangeSelectedTags: (selectedTags) => deckFilterForm.tagFilterProps.onClickTag?.(selectedTags),
-      }}
-      renderBackText={(backText) => <BackText {...backText} />}
-      onEditCard={props.onEditCard}
-      onChangeScore={(card, score) => editCardScore.updateScore(card.id, score)}
-    />
-  );
-};
 
 export const CardListPage: React.FC = () => {
   const params = useParams();
   const navigate = useNavigate();
   const deckId = params.id;
   if (deckId == null) throw Error("invalid deck id");
-  const preferences = usePreferences();
   const deck = useDeck(deckId);
-  const { cards: deckCards, tags } = useCardsByDeckId(deckId);
-  const cards = useFilteredStudyCards(deck, deckCards, preferences);
 
   useKey("t", () => void navigate("/"));
   useKey("s", () => void navigate("/settings"));
@@ -67,11 +32,9 @@ export const CardListPage: React.FC = () => {
 
   return (
     <AppLayout showHeader>
-      <CardListComposition
+      <CardListContainer
         deck={deck}
-        cards={cards}
-        tags={tags}
-        preferences={preferences}
+        renderBackText={(backText) => <BackText {...backText} />}
         onEditCard={(id) => void navigate(`/card/${id}/edit`)}
       />
     </AppLayout>

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -28,6 +28,20 @@ export default defineConfig([
     },
   },
   {
+    files: ["./src/features/card-list/ui/CardListContainer.tsx"],
+    rules: {
+      // The route container must own filter coordination while consuming only deck-filter's public contract.
+      "fsd/forbidden-imports": "off",
+    },
+  },
+  {
+    files: ["./src/features/deck-filter/**"],
+    rules: {
+      // Card list consumes this contract at the same layer, which does not count as a higher-layer reference.
+      "fsd/insignificant-slice": "off",
+    },
+  },
+  {
     files: [
       "./src/features/card-edit/**",
       "./src/features/card-list/**",


### PR DESCRIPTION
## Related issue

Fixes #1025

## Summary

- move card data, filter state, score editing, and CardList prop mapping into CardListContainer
- keep route resolution, not-found handling, card edit navigation, layout, and screen shortcuts in CardListPage
- add container behavior tests and narrow the card-list public API to the screen container

## Testing

- mise run check (106 test files, 525 tests)