### PR TITLE
refactor: limit SettingsPage to UI composition (#1022)

### DIFF
--- a/src/pages/settings/ui/SettingsContainer.spec.tsx
+++ b/src/pages/settings/ui/SettingsContainer.spec.tsx
@@ -1,0 +1,74 @@
+import type { useAuthAccount } from "@/entities/auth";
+import type { Preferences } from "@/entities/preferences";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { createPreferences } from "@/test/factories";
+
+type AuthAccount = ReturnType<typeof useAuthAccount>;
+
+const mocks = vi.hoisted(() => ({
+  authAccount: undefined as AuthAccount,
+  authUid: "",
+  preferences: null as unknown as Preferences,
+  updatePreferences: vi.fn(),
+}));
+
+vi.mock("@/shared/firebase", () => ({ auth: {} }));
+vi.mock("@/entities/auth", () => ({
+  useAuthAccount: () => mocks.authAccount,
+  useAuthUid: () => mocks.authUid,
+}));
+vi.mock("@/entities/preferences", () => ({
+  usePreferences: () => mocks.preferences,
+  updatePreferences: mocks.updatePreferences,
+}));
+
+import { SettingsContainer } from "./SettingsContainer";
+
+describe("SettingsContainer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authAccount = undefined;
+    mocks.authUid = "";
+    mocks.preferences = createPreferences({ appearance: { darkMode: false } });
+  });
+
+  it("connects account sign-in and preference updates", async () => {
+    const login = vi.fn().mockResolvedValue(undefined);
+    render(<SettingsContainer login={login} logout={vi.fn()} version="1.2.3" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Login" }));
+    expect(login).toHaveBeenCalledOnce();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "Show header" }));
+    await waitFor(() => {
+      expect(mocks.updatePreferences).toHaveBeenLastCalledWith({
+        ...mocks.preferences,
+        appearance: { ...mocks.preferences.appearance, showHeader: !mocks.preferences.appearance.showHeader },
+      });
+    });
+  });
+
+  it("displays an alert when sign-out fails and allows retrying sign-out", async () => {
+    mocks.authAccount = { uid: "retry-uid-a", displayName: "Test User" };
+    mocks.authUid = "retry-uid-a";
+    const signOutError = new Error("sign out failed");
+    const logout = vi.fn().mockRejectedValueOnce(signOutError).mockResolvedValueOnce(undefined);
+
+    render(<SettingsContainer login={vi.fn()} logout={logout} version="1.2.3" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+    expect(logout).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(logout).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/pages/settings/ui/SettingsContainer.tsx
+++ b/src/pages/settings/ui/SettingsContainer.tsx
@@ -1,0 +1,67 @@
+import type * as React from "react";
+
+import { useAuthAccount, useAuthUid } from "@/entities/auth";
+import { updatePreferences, usePreferences } from "@/entities/preferences";
+import { SettingsForm, usePreferencesFormState } from "@/features/preferences-edit";
+import { useSignIn } from "@/features/sign-in";
+import { useSignOut } from "@/features/sign-out";
+import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
+
+interface SettingsContainerProps {
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+  version: string;
+}
+
+export const SettingsContainer: React.FC<SettingsContainerProps> = ({ login, logout, version }) => {
+  const preferences = usePreferences();
+  const authAccount = useAuthAccount();
+  const authUid = useAuthUid();
+  const isLoggedIn = authAccount != null;
+
+  const signIn = useSignIn(login);
+  const signOut = useSignOut(logout);
+  const accountOperation = isLoggedIn
+    ? {
+        run: signOut.signOut,
+        pending: signOut.pending,
+        error: signOut.error,
+        pendingLabel: "Signing out…",
+        errorLabel: "Unable to sign out.",
+      }
+    : {
+        run: signIn.signIn,
+        pending: signIn.pending,
+        error: signIn.error,
+        pendingLabel: "Signing in…",
+        errorLabel: "Unable to sign in.",
+      };
+  // Mutation hooks retain rejected operations for feedback, so UI events consume the handled promise.
+  const runAccountOperation = () => void accountOperation.run().catch(() => undefined);
+
+  const formState = usePreferencesFormState({
+    preferences,
+    onSubmit: updatePreferences,
+  });
+
+  return (
+    <SettingsForm
+      {...formState}
+      identity={{ uid: authUid, displayName: authAccount?.displayName ?? null }}
+      version={version}
+      isLoggedIn={isLoggedIn}
+      onLogin={runAccountOperation}
+      {...(isLoggedIn ? { onLogout: runAccountOperation } : {})}
+      accountPending={accountOperation.pending}
+      accountFeedback={
+        <RemoteMutationNotice
+          pending={accountOperation.pending}
+          error={accountOperation.error}
+          onRetry={runAccountOperation}
+          pendingLabel={accountOperation.pendingLabel}
+          errorLabel={accountOperation.errorLabel}
+        />
+      }
+    />
+  );
+};

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -45,24 +45,5 @@ describe("SettingsPage", () => {
     fireEvent.keyDown(window, { key: "t" });
 
     expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith("/");
-  });
-
-  it("displays an alert when sign-out fails and allows retrying sign-out", async () => {
-    mocks.authAccount = { uid: "retry-uid-a", displayName: "Test User" };
-    mocks.authUid = "retry-uid-a";
-    const signOutError = new Error("sign out failed");
-    const logout = vi.fn().mockRejectedValueOnce(signOutError).mockResolvedValueOnce(undefined);
-
-    render(<SettingsPage login={vi.fn()} logout={logout} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
-
-    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
-    expect(logout).toHaveBeenCalledOnce();
-
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
-    expect(logout).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -2,13 +2,9 @@ import type * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { useAuthAccount, useAuthUid } from "@/entities/auth";
-import { updatePreferences, usePreferences } from "@/entities/preferences";
-import { SettingsForm, usePreferencesFormState } from "@/features/preferences-edit";
-import { useSignIn } from "@/features/sign-in";
-import { useSignOut } from "@/features/sign-out";
-import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { AppLayout } from "@/widgets/app-layout";
+
+import { SettingsContainer } from "./SettingsContainer";
 
 interface SettingsPageProps {
   login: () => Promise<void>;
@@ -16,58 +12,12 @@ interface SettingsPageProps {
 }
 
 export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => {
-  const preferences = usePreferences();
-  const authAccount = useAuthAccount();
-  const authUid = useAuthUid();
   const navigate = useNavigate();
-
-  const isLoggedIn = authAccount != null;
-
-  const signIn = useSignIn(login);
-  const signOut = useSignOut(logout);
-  const accountOperation = isLoggedIn
-    ? {
-        run: signOut.signOut,
-        pending: signOut.pending,
-        error: signOut.error,
-        pendingLabel: "Signing out…",
-        errorLabel: "Unable to sign out.",
-      }
-    : {
-        run: signIn.signIn,
-        pending: signIn.pending,
-        error: signIn.error,
-        pendingLabel: "Signing in…",
-        errorLabel: "Unable to sign in.",
-      };
-  const runAccountOperation = () => void accountOperation.run().catch(() => undefined);
-
-  const formState = usePreferencesFormState({
-    preferences,
-    onSubmit: updatePreferences,
-  });
   useKey("t", () => void navigate("/"));
 
   return (
     <AppLayout showHeader>
-      <SettingsForm
-        {...formState}
-        identity={{ uid: authUid, displayName: authAccount?.displayName ?? null }}
-        version={__APP_VERSION__}
-        isLoggedIn={isLoggedIn}
-        onLogin={runAccountOperation}
-        {...(isLoggedIn ? { onLogout: runAccountOperation } : {})}
-        accountPending={accountOperation.pending}
-        accountFeedback={
-          <RemoteMutationNotice
-            pending={accountOperation.pending}
-            error={accountOperation.error}
-            onRetry={runAccountOperation}
-            pendingLabel={accountOperation.pendingLabel}
-            errorLabel={accountOperation.errorLabel}
-          />
-        }
-      />
+      <SettingsContainer login={login} logout={logout} version={__APP_VERSION__} />
     </AppLayout>
   );
 };


### PR DESCRIPTION
## Summary

- move authentication operation selection, feedback, and retry coordination into `SettingsContainer`
- move preferences form state and mutation wiring out of `SettingsPage`
- keep route-level keyboard shortcut registration and application layout in `SettingsPage`
- relocate behavior coverage to the container boundary

## Why

`SettingsPage` coordinated authentication and preferences workflows in addition to composing the route UI. This exceeded the page-layer policy that Pages remain concise and UI-focused.

## Impact

The settings screen keeps the existing sign-in, sign-out, retry, pending/error feedback, and automatic preferences update behavior. The Page now owns only route navigation, the screen shortcut, layout, and container placement.

Closes #1022

## Checks

- `mise run check`
- 106 unit-test files passed (524 tests)