### PR TITLE
[#1004] Restrict React memo hook imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,5 @@
 import tseslint from "@typescript-eslint/eslint-plugin";
 import * as tsParser from "@typescript-eslint/parser";
-import eslintReact from "@eslint-react/eslint-plugin";
 import {
   createConfig as createBoundariesConfig,
   recommended as boundariesRecommended,
@@ -12,6 +11,13 @@ const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
 const sliceLayers = ["entities", "features", "pages", "widgets"];
 const nonSliceLayers = ["app", "shared"];
+// React Compiler owns routine memoization; React-qualified calls keep exceptional manual memoization explicit.
+const restrictedReactMemoImports = {
+  name: "react",
+  importNames: ["useCallback", "useMemo"],
+  allowTypeImports: true,
+  message: "Use React.useMemo or React.useCallback when manual memoization is necessary.",
+};
 
 export default [
   {
@@ -37,13 +43,13 @@ export default [
   },
   {
     files: sourceFiles,
-    plugins: {
-      "@eslint-react": eslintReact,
-    },
     rules: {
-      // React Compiler owns routine memoization; manual memoization must have an observable reason to remain.
-      "@eslint-react/no-unnecessary-use-callback": "error",
-      "@eslint-react/no-unnecessary-use-memo": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [restrictedReactMemoImports],
+        },
+      ],
     },
   },
   createBoundariesConfig({
@@ -108,6 +114,7 @@ export default [
       "no-restricted-imports": [
         "error",
         {
+          paths: [restrictedReactMemoImports],
           patterns: [
             {
               group: ["@/features/*/*", "@/features/*/*/**"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@biomejs/biome": "2.5.7",
-        "@eslint-react/eslint-plugin": "^2.13.0",
         "@feature-sliced/steiger-plugin": "^0.7.0",
         "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/test": "^1.61.1",
@@ -2649,133 +2648,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint-react/ast": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-2.13.0.tgz",
-      "integrity": "sha512-43+5gmqV3MpatTzKnu/V2i/jXjmepvwhrb9MaGQvnXHQgq9J7/C7VVCCcwp6Rvp2QHAFquAAdvQDSL8IueTpeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/typescript-estree": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "string-ts": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-m62XDzkf1hpzW4sBc7uh7CT+8rBG2xz/itSADuEntlsg4YA7Jhb8hjU6VHf3wRFDwyfx5VnbV209sbJ7Azey0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/eff": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-2.13.0.tgz",
-      "integrity": "sha512-rEH2R8FQnUAblUW+v3ZHDU1wEhatbL1+U2B1WVuBXwSKqzF7BGaLqCPIU7o9vofumz5MerVfaCtJgI8jYe2Btg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@eslint-react/eslint-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
-      "integrity": "sha512-iaMXpqnJCTW7317hg8L4wx7u5aIiPzZ+d1p59X8wXFgMHzFX4hNu4IfV8oygyjmWKdLsjKE9sEpv/UYWczlb+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "eslint-plugin-react-dom": "2.13.0",
-        "eslint-plugin-react-hooks-extra": "2.13.0",
-        "eslint-plugin-react-naming-convention": "2.13.0",
-        "eslint-plugin-react-rsc": "2.13.0",
-        "eslint-plugin-react-web-api": "2.13.0",
-        "eslint-plugin-react-x": "2.13.0",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/shared": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.13.0.tgz",
-      "integrity": "sha512-IOloCqrZ7gGBT4lFf9+0/wn7TfzU7JBRjYwTSyb9SDngsbeRrtW95ZpgUpS8/jen1wUEm6F08duAooTZ2FtsWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0",
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/var": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-2.13.0.tgz",
-      "integrity": "sha512-dM+QaeiHR16qPQoJYg205MkdHYSWVa2B7ore5OFpOPlSwqDV3tLW7I+475WjbK7potq5QNPTxRa7VLp9FGeQqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@eslint/config-array": {
@@ -9830,13 +9702,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/birecord": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.2.tgz",
-      "integrity": "sha512-5PAPTTmMpMEb+GuMb5DebfBkipRGyIW9+gtwEBSoDA9xkhHILm04+hZQ702pMksu3d8YAuGkmgTzQWcKqTPScA==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)"
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -10701,13 +10566,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/compare-versions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
@@ -12280,32 +12138,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/eslint-plugin-react-dom": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-2.13.0.tgz",
-      "integrity": "sha512-+2IZzQ1WEFYOWatW+xvNUqmZn55YBCufzKA7hX3XQ/8eu85Mp4vnlOyNvdVHEOGhUnGuC6+9+zLK+IlEHKdKLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
@@ -12324,137 +12156,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-hooks-extra": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-2.13.0.tgz",
-      "integrity": "sha512-qIbha1nzuyhXM9SbEfrcGVqmyvQu7GAOB2sy9Y4Qo5S8nCqw4fSBxq+8lSce5Tk5Y7XzIkgHOhNyXEvUHRWFMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-naming-convention": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-2.13.0.tgz",
-      "integrity": "sha512-uSd25JzSg2R4p81s3Wqck0AdwRlO9Yc+cZqTEXv7vW8exGGAM3mWnF6hgrgdqVJqBEGJIbS/Vx1r5BdKcY/MHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "string-ts": "^2.3.1",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-rsc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-2.13.0.tgz",
-      "integrity": "sha512-RaftgITDLQm1zIgYyvR51sBdy4FlVaXFts5VISBaKbSUB0oqXyzOPxMHasfr9BCSjPLKus9zYe+G/Hr6rjFLXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-web-api": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-2.13.0.tgz",
-      "integrity": "sha512-nmJbzIAte7PeAkp22CwcKEASkKi49MshSdiDGO1XuN3f4N4/8sBfDcWbQuLPde6JiuzDT/0+l7Gi8wwTHtR1kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "birecord": "^0.1.1",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-x": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-2.13.0.tgz",
-      "integrity": "sha512-cMNX0+ws/fWTgVxn52qAQbaFF2rqvaDAtjrPUzY6XOzPjY0rJQdR2tSlWJttz43r2yBfqu+LGvHlGpWL2wfpTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "is-immutable-type": "^5.0.1",
-        "ts-api-utils": "^2.4.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -15463,32 +15164,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-immutable-type": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.4.tgz",
-      "integrity": "sha512-tDf0vB9dJJt/1USS2nvHJb8UsIAhs+pF6z8UZLNdhrzB+PKMrdcN45je9jhuFpaJOjJpoRhueFmFrRs5g/TNMA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "ko-fi",
-          "url": "https://ko-fi.com/rebeccastevens"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/is-immutable-type"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@typescript-eslint/type-utils": "^8.0.0",
-        "ts-api-utils": "^2.0.0",
-        "ts-declaration-location": "^1.0.4"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "typescript": ">=4.7.4"
       }
     },
     "node_modules/is-inside-container": {
@@ -22901,13 +22576,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-ts": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
-      "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -23842,42 +23510,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-declaration-location": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
-      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "ko-fi",
-          "url": "https://ko-fi.com/rebeccastevens"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.0.0"
-      }
-    },
-    "node_modules/ts-declaration-location/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -23891,13 +23523,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
-    },
-    "node_modules/ts-pattern": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
-      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@biomejs/biome": "2.5.7",
-    "@eslint-react/eslint-plugin": "^2.13.0",
     "@feature-sliced/steiger-plugin": "^0.7.0",
     "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/test": "^1.61.1",

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React from "react";
 import { useStore } from "zustand";
 
 import { authSessionStore } from "./store";
@@ -12,7 +12,7 @@ export const useAuthUid = (): string =>
 export const useAuthAccount = (): AuthAccount | undefined => {
   const auth = useAuthSession();
 
-  return useMemo(
+  return React.useMemo(
     () =>
       auth.status === "authenticated" && !auth.isAnonymous
         ? { uid: auth.uid, displayName: auth.displayName }

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React from "react";
 import { useStore } from "zustand";
 
 import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
@@ -18,7 +18,7 @@ export const useCard = (id: CardId | undefined): Card | undefined =>
 
 export const useCardsByDeckId = (deckId: string): { cards: Card[]; tags: string[] } => {
   const allCards = useCards();
-  return useMemo(
+  return React.useMemo(
     () => ({
       cards: filterCardsByDeckId(allCards, deckId),
       tags: filterTagsByDeckId(allCards, deckId),

--- a/src/features/card-edit/model/useCardEditAction.ts
+++ b/src/features/card-edit/model/useCardEditAction.ts
@@ -1,6 +1,6 @@
 import type { CardEditInput } from "@/entities/card";
 
-import * as React from "react";
+import React from "react";
 
 import { useAuthUid } from "@/entities/auth";
 import { editCard } from "@/entities/card";

--- a/src/features/card-list/ui/Card.spec.tsx
+++ b/src/features/card-list/ui/Card.spec.tsx
@@ -5,7 +5,7 @@
  * singular study counts", "keeps study and tag metadata outside the View button".
  */
 
-import * as React from "react";
+import React from "react";
 import { fireEvent, render, within, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";

--- a/src/features/card-list/ui/Card.tsx
+++ b/src/features/card-list/ui/Card.tsx
@@ -5,7 +5,7 @@
  */
 
 import cx from "classnames";
-import * as React from "react";
+import React from "react";
 import { useSwipeable } from "react-swipeable";
 
 import type { Card as CardEntity, CardId } from "@/entities/card";

--- a/src/features/card-list/ui/CardActionsMenu.spec.tsx
+++ b/src/features/card-list/ui/CardActionsMenu.spec.tsx
@@ -4,7 +4,7 @@
  * actions", "disables the trigger and hides an open menu".
  */
 
-import * as React from "react";
+import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";

--- a/src/features/card-list/ui/CardList.tsx
+++ b/src/features/card-list/ui/CardList.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import { useAuthUid } from "@/entities/auth";
 import { deleteCard, mustFindCardById, type Card, type CardId } from "@/entities/card";

--- a/src/features/card-list/ui/CardListView.stories.tsx
+++ b/src/features/card-list/ui/CardListView.stories.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import * as React from "react";
+import React from "react";
 import { expect, fn } from "storybook/test";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";

--- a/src/features/card-list/ui/CardListView.tsx
+++ b/src/features/card-list/ui/CardListView.tsx
@@ -3,7 +3,7 @@
  * Data and callbacks arrive through props, which keeps this presentation usable in Storybook.
  */
 
-import * as React from "react";
+import React from "react";
 import { AiOutlineDown } from "react-icons/ai";
 
 import type { Card as CardEntity, CardId } from "@/entities/card";

--- a/src/features/deck-edit/model/useDeckEditAction.ts
+++ b/src/features/deck-edit/model/useDeckEditAction.ts
@@ -1,6 +1,6 @@
 import type { DeckEdit } from "@/entities/deck";
 
-import * as React from "react";
+import React from "react";
 
 import { useAuthUid } from "@/entities/auth";
 import { editDeck } from "@/entities/deck";

--- a/src/features/deck-filter/model/useDeckFilterState.ts
+++ b/src/features/deck-filter/model/useDeckFilterState.ts
@@ -6,7 +6,7 @@
 
 import type { Deck } from "@/entities/deck";
 
-import * as React from "react";
+import React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 import { useAuthUid } from "@/entities/auth";

--- a/src/features/deck-filter/model/useFilteredStudyCards.ts
+++ b/src/features/deck-filter/model/useFilteredStudyCards.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import React from "react";
 
 import type { Card } from "@/entities/card";
 import { createSelectableStudyCard, type Deck, filterCardsForDeck } from "@/entities/deck";
@@ -9,17 +9,17 @@ import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 export const useFilteredStudyCards = (deck: Deck | undefined, cards: Card[], preferences: Preferences): Card[] => {
-  const [scheduleClock, setScheduleClock] = useState(() => Date.now());
-  const studyCards = useMemo(() => cards.map(createSelectableStudyCard), [cards]);
+  const [scheduleClock, setScheduleClock] = React.useState(() => Date.now());
+  const studyCards = React.useMemo(() => cards.map(createSelectableStudyCard), [cards]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     // Refresh after rendering so a changed card list is filtered against current time, not the previous clock.
     const current = Date.now();
     const refresh = window.setTimeout(() => setScheduleClock(current), 0);
     return () => window.clearTimeout(refresh);
   }, [cards]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     const current = Date.now();
     const next = getNextStudyAvailabilityAt(
       studyCards.map((card) => card.progress),

--- a/src/features/deck-filter/ui/TagFilter.stories.tsx
+++ b/src/features/deck-filter/ui/TagFilter.stories.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import * as React from "react";
+import React from "react";
 import { expect, fn } from "storybook/test";
 
 import { TagFilter as Template } from "./TagFilter";

--- a/src/features/deck-list/ui/DeckActionsMenu.spec.tsx
+++ b/src/features/deck-list/ui/DeckActionsMenu.spec.tsx
@@ -5,7 +5,7 @@
  * returns focus to the trigger on Escape".
  */
 
-import * as React from "react";
+import React from "react";
 import { act, fireEvent, render, waitFor, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";

--- a/src/features/deck-list/ui/DeckActionsMenu.tsx
+++ b/src/features/deck-list/ui/DeckActionsMenu.tsx
@@ -4,7 +4,7 @@
  * outside the view.
  */
 
-import * as React from "react";
+import React from "react";
 import { AiOutlineCloudDownload, AiOutlineDelete, AiOutlineEdit, AiOutlineReload } from "react-icons/ai";
 import { ActionsMenu, type ActionsMenuItem } from "@/shared/ui/actions-menu";
 

--- a/src/features/deck-list/ui/DeckList.tsx
+++ b/src/features/deck-list/ui/DeckList.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import { filterCardsByDeckId, type Card } from "@/entities/card";
 import { mustFindDeckById, type Deck, type DeckId } from "@/entities/deck";

--- a/src/features/deck-list/ui/DeckListCard.spec.tsx
+++ b/src/features/deck-list/ui/DeckListCard.spec.tsx
@@ -11,7 +11,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import * as React from "react";
+import React from "react";
 
 import { DeckListCard, type DeckListCardProps } from "./DeckListCard";
 import { createDeck } from "@/test/factories";

--- a/src/features/deck-list/ui/DeckListCard.tsx
+++ b/src/features/deck-list/ui/DeckListCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import cx from "classnames";
-import * as React from "react";
+import React from "react";
 import { AiFillCaretRight, AiOutlineCloud } from "react-icons/ai";
 
 import type { Deck, DeckId } from "@/entities/deck";

--- a/src/features/deck-list/ui/DeckListView.spec.tsx
+++ b/src/features/deck-list/ui/DeckListView.spec.tsx
@@ -7,7 +7,7 @@
 import type { DeckId } from "@/entities/deck";
 import type { DeckListSections } from "../model/buildDeckListSections";
 
-import * as React from "react";
+import React from "react";
 import { fireEvent, render, within, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";

--- a/src/features/deck-list/ui/DeckListView.tsx
+++ b/src/features/deck-list/ui/DeckListView.tsx
@@ -2,7 +2,7 @@
  * @file Renders the Deck List presentation from prepared sections and callbacks.
  */
 
-import * as React from "react";
+import React from "react";
 
 import type { DeckListItem, DeckListSections } from "../model/buildDeckListSections";
 

--- a/src/features/preferences-edit/model/hooks/usePreferencesFormState.ts
+++ b/src/features/preferences-edit/model/hooks/usePreferencesFormState.ts
@@ -1,6 +1,6 @@
 import { studyPreferencesLimits, type Preferences } from "@/entities/preferences";
 
-import * as React from "react";
+import React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 export interface UsePreferencesFormStateOptions {

--- a/src/features/preferences-edit/ui/components/SettingsSection.tsx
+++ b/src/features/preferences-edit/ui/components/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface SettingsSectionProps {
   title: string;

--- a/src/features/study-session-start/model/useStartStudySession.ts
+++ b/src/features/study-session-start/model/useStartStudySession.ts
@@ -4,7 +4,7 @@ import { usePreferences } from "@/entities/preferences";
 import { startStudySession } from "@/entities/study-session";
 import { buildStudyCardOrder } from "@/entities/study-progress";
 
-import { useCallback } from "react";
+import React from "react";
 
 interface UseStartStudySessionOptions {
   onStarted?: (() => void) | undefined;
@@ -15,7 +15,7 @@ export const useStartStudySession = (
   { onStarted }: UseStartStudySessionOptions = {}
 ): ((cards: Card[]) => void) => {
   const preferences = usePreferences();
-  return useCallback(
+  return React.useCallback(
     (cards) => {
       startStudySession(deckId, buildStudyCardOrder(cards, preferences.study));
       onStarted?.();

--- a/src/features/study/hooks/useActiveStudySession.ts
+++ b/src/features/study/hooks/useActiveStudySession.ts
@@ -2,7 +2,7 @@ import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { touchStudySession, useStudySession } from "@/entities/study-session";
 
-import * as React from "react";
+import React from "react";
 
 export type ActiveStudySession =
   | { status: "loading" | "unavailable" }

--- a/src/features/study/hooks/useStudyControllerState.ts
+++ b/src/features/study/hooks/useStudyControllerState.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import type { ControllerProps } from "../components/Controller";
 
 export interface UseStudyControllerStateOptions extends ControllerProps {

--- a/src/features/study/hooks/useStudyDisplayState.ts
+++ b/src/features/study/hooks/useStudyDisplayState.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import { usePreferences } from "@/entities/preferences";
 

--- a/src/features/study/hooks/useSwipeFeedback.ts
+++ b/src/features/study/hooks/useSwipeFeedback.ts
@@ -1,6 +1,6 @@
 import type { SwipeDirection } from "@/entities/preferences";
 
-import * as React from "react";
+import React from "react";
 
 const SWIPE_FEEDBACK_DURATION_MS = 900;
 

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -1,7 +1,7 @@
 import { getCategory, type Deck, useDeck } from "@/entities/deck";
 import { toggleShowHeader, toggleShowSwipeButtonList } from "@/entities/preferences";
 
-import * as React from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
 

--- a/src/shared/ui/actions-menu/ActionsMenu.spec.tsx
+++ b/src/shared/ui/actions-menu/ActionsMenu.spec.tsx
@@ -5,7 +5,7 @@
  * menu items out of the Tab sequence and moves Tab to the next external control".
  */
 
-import * as React from "react";
+import React from "react";
 import { act, fireEvent, render, waitFor, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";

--- a/src/shared/ui/content/Code.tsx
+++ b/src/shared/ui/content/Code.tsx
@@ -5,7 +5,7 @@
  */
 
 import cx from "classnames";
-import * as React from "react";
+import React from "react";
 import { Style } from "@/shared/ui/content/Style";
 // biome-ignore lint/correctness/noUnresolvedImports: highlight.js exposes this default through its ESM export map.
 import hljs from "highlight.js";

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
-import * as React from "react";
+import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DestructiveActionDialog } from "./DestructiveActionDialog";

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
 import { Button } from "@/shared/ui/button";

--- a/src/shared/ui/forms/Slider.stories.tsx
+++ b/src/shared/ui/forms/Slider.stories.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import * as React from "react";
+import React from "react";
 import { expect, fireEvent, fn } from "storybook/test";
 
 import { Slider as Template } from "@/shared/ui/forms/Slider";


### PR DESCRIPTION
## Related issue

Related to #1004

## Summary

- Replace unnecessary-memoization plugin rules with `no-restricted-imports` for `useMemo` and `useCallback`.
- Keep exceptional manual memoization explicit through React-qualified calls.
- Remove the unused `@eslint-react/eslint-plugin` dependency.

## Testing

- `mise run check`