### PR TITLE
[No issue] Simplify deck filter state

### DIFF
--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -33,8 +33,8 @@ const DeckFilterHarness: React.FC<{
   deck: Deck;
   tags: string[];
 }> = ({ deck, tags }) => {
-  const deckFilterForm = useDeckFilterState({ deck, tags });
-  return <DeckFilterForm {...deckFilterForm} />;
+  const deckFilter = useDeckFilterState(deck);
+  return <DeckFilterForm {...deckFilter} tags={tags} />;
 };
 
 describe("DeckFilterForm with useDeckFilterState", () => {
@@ -62,12 +62,11 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: "Match all selected tags" }));
     await userEvent.click(screen.getByRole("button", { name: /all/i }));
 
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: 2, scoreMin: -2, tagAndFilter: true, selectedTags: tags })
-      );
-    });
+    await waitFor(() => expect(mocks.editDeck).toHaveBeenCalledTimes(4));
+    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, scoreMax: 2 });
+    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, scoreMin: -2 });
+    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, tagAndFilter: true });
+    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, selectedTags: tags });
   });
 
   it("persists score toggle and slider changes", async () => {
@@ -75,14 +74,11 @@ describe("DeckFilterForm with useDeckFilterState", () => {
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: 0, scoreMin: null })
-      );
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMax: 0 });
     });
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ scoreMax: 0, scoreMin: 0 }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMin: 0 });
     });
 
     fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
@@ -92,19 +88,13 @@ describe("DeckFilterForm with useDeckFilterState", () => {
       target: { value: -2 },
     });
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: 2, scoreMin: -2 })
-      );
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMin: -2 });
     });
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith(
-        "user-id",
-        expect.objectContaining({ scoreMax: null, scoreMin: null })
-      );
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMin: null });
     });
   });
 
@@ -113,17 +103,17 @@ describe("DeckFilterForm with useDeckFilterState", () => {
 
     await userEvent.click(screen.getByText("tag2"));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ selectedTags: ["tag2"] }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, selectedTags: ["tag2"] });
     });
 
     await userEvent.click(screen.getByRole("button", { name: /all/i }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ selectedTags: tags }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, selectedTags: tags });
     });
 
     await userEvent.click(screen.getByRole("button", { name: /clear/i }));
     await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", expect.objectContaining({ selectedTags: [] }));
+      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, selectedTags: [] });
     });
   });
 });

--- a/src/features/deck-filter/model/useDeckFilterState.ts
+++ b/src/features/deck-filter/model/useDeckFilterState.ts
@@ -1,103 +1,40 @@
-/**
- * @file Provides the deck-filter feature's Deck filter state hook.
- * The hook combines state and operations behind one interface so components do not need to
- * coordinate services themselves.
- */
-
-import type { Deck } from "@/entities/deck";
-
-import * as React from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { useState } from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { editDeck } from "@/entities/deck";
-import type { DeckFilterForm } from "../ui/DeckFilterForm";
+import { type Deck, editDeck } from "@/entities/deck";
 
-type DeckFilterFormProps = React.ComponentProps<typeof DeckFilterForm>;
-
-export interface UseDeckFilterStateOptions {
-  deck: Deck;
-  tags: string[];
+export interface DeckFilterState {
+  scoreMax: number | null;
+  scoreMin: number | null;
+  selectedTags: string[];
+  tagAndFilter: boolean;
+  setScoreMax: (value: number | null) => void;
+  setScoreMin: (value: number | null) => void;
+  setSelectedTags: (value: string[]) => void;
+  setTagAndFilter: (value: boolean) => void;
 }
 
-/**
- * Provides the form state and persistence callback used to edit a Deck's card filters.
- */
-export const useDeckFilterState = ({ deck, tags }: UseDeckFilterStateOptions): DeckFilterFormProps => {
+type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
+
+export const useDeckFilterState = (deck: Deck): DeckFilterState => {
   const uid = useAuthUid();
-  const [scoreMaxEnabled, setScoreMaxEnabled] = React.useState(deck.scoreMax != null);
-  const [scoreMinEnabled, setScoreMinEnabled] = React.useState(deck.scoreMin != null);
-  const { control, handleSubmit, register, setValue, subscribe } = useForm<Deck>({ defaultValues: deck });
-  const scoreMax = useWatch({ control, name: "scoreMax" });
-  const scoreMin = useWatch({ control, name: "scoreMin" });
-  const selectedTags = useWatch({ control, name: "selectedTags" });
-  const tagAndFilter = useWatch({ control, name: "tagAndFilter" });
+  const [filter, setFilter] = useState<DeckFilterValues>(() => ({
+    scoreMax: deck.scoreMax,
+    scoreMin: deck.scoreMin,
+    selectedTags: deck.selectedTags,
+    tagAndFilter: deck.tagAndFilter,
+  }));
 
-  React.useEffect(
-    () =>
-      subscribe({
-        formState: { values: true },
-        callback: () => void handleSubmit((data) => editDeck(uid, data).catch(() => undefined))(),
-      }),
-    [handleSubmit, subscribe, uid]
-  );
-
-  const onClickFilter = (value: boolean) => {
-    setValue("tagAndFilter", value);
-  };
-  const onClickAll = () => {
-    setValue("selectedTags", tags);
-  };
-  const onClickClear = () => {
-    setValue("selectedTags", []);
-  };
-  const onClickTag = (value: string[]) => {
-    setValue("selectedTags", value);
+  const updateFilter = <Key extends keyof DeckFilterValues>(key: Key, value: DeckFilterValues[Key]) => {
+    setFilter((current) => ({ ...current, [key]: value }));
+    void editDeck(uid, { id: deck.id, [key]: value }).catch(() => undefined);
   };
 
   return {
-    scoreMax,
-    scoreMin,
-    scoreMaxSwitchProps: {
-      name: "scoreMaxSwitch",
-      checked: scoreMaxEnabled,
-      onChange: (event) => {
-        const enabled = event.currentTarget.checked;
-        setValue("scoreMax", enabled ? 0 : null);
-        setScoreMaxEnabled(enabled);
-      },
-    },
-    scoreMinSwitchProps: {
-      name: "scoreMinSwitch",
-      checked: scoreMinEnabled,
-      onChange: (event) => {
-        const enabled = event.currentTarget.checked;
-        setValue("scoreMin", enabled ? 0 : null);
-        setScoreMinEnabled(enabled);
-      },
-    },
-    scoreMaxSliderProps: {
-      ...register("scoreMax", { valueAsNumber: true }),
-      step: 1,
-      max: 10,
-      min: -10,
-      disabled: !scoreMaxEnabled,
-    },
-    scoreMinSliderProps: {
-      ...register("scoreMin", { valueAsNumber: true }),
-      step: 1,
-      max: 10,
-      min: -10,
-      disabled: !scoreMinEnabled,
-    },
-    tagFilterProps: {
-      tags,
-      selectedTags: selectedTags ?? [],
-      tagAndFilter: tagAndFilter ?? false,
-      onClickFilter,
-      onClickAll,
-      onClickClear,
-      onClickTag,
-    },
+    ...filter,
+    setScoreMax: (value) => updateFilter("scoreMax", value),
+    setScoreMin: (value) => updateFilter("scoreMin", value),
+    setSelectedTags: (value) => updateFilter("selectedTags", value),
+    setTagAndFilter: (value) => updateFilter("tagAndFilter", value),
   };
 };

--- a/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
@@ -21,11 +21,13 @@ type DeckFilterFormProps = ComponentProps<typeof DeckFilterForm>;
 const createProps = (): DeckFilterFormProps => ({
   scoreMax: 4,
   scoreMin: -2,
-  scoreMaxSwitchProps: { name: "maximum-enabled", checked: true, onChange: vi.fn() },
-  scoreMinSwitchProps: { name: "minimum-enabled", checked: true, onChange: vi.fn() },
-  scoreMaxSliderProps: { name: "maximum", value: "4", min: -10, max: 10, onChange: vi.fn() },
-  scoreMinSliderProps: { name: "minimum", value: "-2", min: -10, max: 10, onChange: vi.fn() },
-  tagFilterProps: { tags: ["one", "two"], selectedTags: ["one"], tagAndFilter: true },
+  tags: ["one", "two"],
+  selectedTags: ["one"],
+  tagAndFilter: true,
+  setScoreMax: vi.fn(),
+  setScoreMin: vi.fn(),
+  setSelectedTags: vi.fn(),
+  setTagAndFilter: vi.fn(),
 });
 
 describe("DeckFilterForm", () => {
@@ -50,10 +52,10 @@ describe("DeckFilterForm", () => {
     fireEvent.change(maxSlider, { target: { value: "5" } });
     fireEvent.change(minSlider, { target: { value: "-3" } });
 
-    expect(props.scoreMaxSwitchProps.onChange).toHaveBeenCalledOnce();
-    expect(props.scoreMinSwitchProps.onChange).toHaveBeenCalledOnce();
-    expect(props.scoreMaxSliderProps.onChange).toHaveBeenCalledOnce();
-    expect(props.scoreMinSliderProps.onChange).toHaveBeenCalledOnce();
+    expect(props.setScoreMax).toHaveBeenNthCalledWith(1, null);
+    expect(props.setScoreMin).toHaveBeenNthCalledWith(1, null);
+    expect(props.setScoreMax).toHaveBeenNthCalledWith(2, 5);
+    expect(props.setScoreMin).toHaveBeenNthCalledWith(2, -3);
   });
 
   it("shows unrestricted disabled limits", () => {

--- a/src/features/deck-filter/ui/DeckFilterForm.stories.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.stories.tsx
@@ -15,19 +15,13 @@ type DeckFilterFormProps = ComponentProps<typeof Template>;
 const args: DeckFilterFormProps = {
   scoreMax: 1,
   scoreMin: -1,
-  scoreMaxSwitchProps: { name: "scoreMaxSwitch", checked: true, onChange: () => undefined },
-  scoreMinSwitchProps: { name: "scoreMinSwitch", checked: true, onChange: () => undefined },
-  scoreMaxSliderProps: { name: "scoreMax", value: "1", min: -10, max: 10, onChange: () => undefined },
-  scoreMinSliderProps: { name: "scoreMin", value: "-1", min: -10, max: 10, onChange: () => undefined },
-  tagFilterProps: {
-    tags: [...fixture.tags.default],
-    selectedTags: [],
-    tagAndFilter: false,
-    onClickFilter: () => undefined,
-    onClickAll: () => undefined,
-    onClickClear: () => undefined,
-    onClickTag: () => undefined,
-  },
+  tags: [...fixture.tags.default],
+  selectedTags: [],
+  tagAndFilter: false,
+  setScoreMax: () => undefined,
+  setScoreMin: () => undefined,
+  setSelectedTags: () => undefined,
+  setTagAndFilter: () => undefined,
 };
 
 const meta = {
@@ -44,18 +38,16 @@ export const Default: Story = {};
 
 export const ManyTagsSelected: Story = {
   args: {
-    tagFilterProps: {
-      ...args.tagFilterProps,
-      tags: Array.from({ length: 40 }, (_, index) => `study-tag-${index + 1}`),
-      selectedTags: ["study-tag-2", "study-tag-17", "study-tag-31"],
-      tagAndFilter: true,
-    },
+    tags: Array.from({ length: 40 }, (_, index) => `study-tag-${index + 1}`),
+    selectedTags: ["study-tag-2", "study-tag-17", "study-tag-31"],
+    tagAndFilter: true,
   },
 };
 
 export const NoMatchCompatible: Story = {
   args: {
-    tagFilterProps: { ...args.tagFilterProps, selectedTags: ["advanced", "review"], tagAndFilter: true },
+    selectedTags: ["advanced", "review"],
+    tagAndFilter: true,
   },
 };
 

--- a/src/features/deck-filter/ui/DeckFilterForm.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.tsx
@@ -1,45 +1,25 @@
-/**
- * @file Defines the deck-filter feature's form presentation component.
- * The component renders props and reports user intent through callbacks while data access stays
- * outside the view.
- */
-
 import { useId } from "react";
 import type * as React from "react";
-import { Form, Slider, Switch } from "@/shared/ui/forms";
-import { TagFilter, type TagFilterProps } from "./TagFilter";
 
-interface DeckFilterFormProps {
-  scoreMax: number | null;
-  scoreMin: number | null;
-  scoreMaxSwitchProps: React.ComponentProps<typeof Switch>;
-  scoreMinSwitchProps: React.ComponentProps<typeof Switch>;
-  scoreMaxSliderProps: React.ComponentProps<typeof Slider>;
-  scoreMinSliderProps: React.ComponentProps<typeof Slider>;
-  tagFilterProps: TagFilterProps;
+import { Form, Slider, Switch } from "@/shared/ui/forms";
+import type { DeckFilterState } from "../model/useDeckFilterState";
+import { TagFilter } from "./TagFilter";
+
+interface DeckFilterFormProps extends DeckFilterState {
+  tags: string[];
 }
 
 interface ScoreLimitProps {
   label: "Maximum score" | "Minimum score";
-  enabledLabel: string;
   value: number | null;
   switchId: string;
   sliderId: string;
   descriptionId: string;
-  switchProps: React.ComponentProps<typeof Switch>;
-  sliderProps: React.ComponentProps<typeof Slider>;
+  onChange: (value: number | null) => void;
 }
 
-/**
- * Converts an optional score limit into the value displayed by the deck filter form.
- * Missing limits use the form's boundary value so the slider remains controlled.
- */
 const displayScore = (value: number): string => `${value}`.replace("-", "−");
 
-/**
- * Formats the score range label text shown to the user.
- * The helper keeps wording and singular or plural rules consistent across the screen.
- */
 const scoreRangeLabel = (min: number | null, max: number | null): string => {
   if (min != null && max != null) return `${displayScore(min)} to ${displayScore(max)}`;
   if (min != null) return `${displayScore(min)} and above`;
@@ -47,11 +27,6 @@ const scoreRangeLabel = (min: number | null, max: number | null): string => {
   return "Any score";
 };
 
-/**
- * Renders the Score Limit user interface.
- * Lets the user set an optional score threshold and reports a parsed numeric limit or an empty
- * value.
- */
 const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
   const boundary = props.label === "Maximum score" ? "upper" : "lower";
   return (
@@ -66,19 +41,27 @@ const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
           </p>
         </div>
         <Switch
-          {...props.switchProps}
           id={props.switchId}
-          aria-label={props.enabledLabel}
+          name={`${props.sliderId}-enabled`}
+          checked={props.value != null}
+          aria-label={`Enable ${props.label.toLowerCase()}`}
           aria-describedby={props.descriptionId}
+          onChange={(event) => props.onChange(event.currentTarget.checked ? 0 : null)}
         />
       </div>
       <div className="mt-3 flex items-center gap-3">
         <Slider
-          {...props.sliderProps}
           id={props.sliderId}
+          name={props.sliderId}
+          value={`${props.value ?? 0}`}
+          step={1}
+          max={10}
+          min={-10}
+          disabled={props.value == null}
           aria-label={`${props.label} value`}
           aria-describedby={props.descriptionId}
           aria-valuetext={props.value == null ? `${props.label} disabled` : displayScore(props.value)}
+          onChange={(event) => props.onChange(event.currentTarget.valueAsNumber)}
         />
         <span className="min-w-12 rounded-control bg-surface px-2 py-1 text-center text-caption font-bold text-accent-primary">
           {props.value == null ? "Any" : displayScore(props.value)}
@@ -88,10 +71,6 @@ const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
   );
 };
 
-/**
- * Renders the Deck Filter Form user interface.
- * Collects score and tag filters while persistence remains outside the presentation component.
- */
 export const DeckFilterForm: React.FC<DeckFilterFormProps> = (props) => {
   const idPrefix = useId();
   const headingId = `${idPrefix}-score-heading`;
@@ -122,27 +101,31 @@ export const DeckFilterForm: React.FC<DeckFilterFormProps> = (props) => {
         <div className="space-y-3">
           <ScoreLimit
             label="Maximum score"
-            enabledLabel="Enable maximum score"
             value={props.scoreMax}
             switchId={maximumSwitchId}
             sliderId={maximumSliderId}
             descriptionId={maximumDescriptionId}
-            switchProps={props.scoreMaxSwitchProps}
-            sliderProps={props.scoreMaxSliderProps}
+            onChange={props.setScoreMax}
           />
           <ScoreLimit
             label="Minimum score"
-            enabledLabel="Enable minimum score"
             value={props.scoreMin}
             switchId={minimumSwitchId}
             sliderId={minimumSliderId}
             descriptionId={minimumDescriptionId}
-            switchProps={props.scoreMinSwitchProps}
-            sliderProps={props.scoreMinSliderProps}
+            onChange={props.setScoreMin}
           />
         </div>
       </section>
-      <TagFilter {...props.tagFilterProps} />
+      <TagFilter
+        tags={props.tags}
+        selectedTags={props.selectedTags}
+        tagAndFilter={props.tagAndFilter}
+        onClickFilter={props.setTagAndFilter}
+        onClickAll={() => props.setSelectedTags(props.tags)}
+        onClickClear={() => props.setSelectedTags([])}
+        onClickTag={props.setSelectedTags}
+      />
     </Form>
   );
 };

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -60,7 +60,12 @@ vi.mock("@/features/deck-filter", () => ({
   useDeckFilterState: () => ({
     scoreMax: 4,
     scoreMin: -2,
-    tagFilterProps: { selectedTags: ["typescript"], onClickTag: mocks.onClickTag },
+    selectedTags: ["typescript"],
+    tagAndFilter: false,
+    setScoreMax: vi.fn(),
+    setScoreMin: vi.fn(),
+    setSelectedTags: mocks.onClickTag,
+    setTagAndFilter: vi.fn(),
   }),
 }));
 vi.mock("react-router-dom", () => ({

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -18,7 +18,7 @@ const CardListComposition = (props: {
   preferences: Preferences;
   onEditCard: (id: CardId) => void;
 }) => {
-  const deckFilterForm = useDeckFilterState({ deck: props.deck, tags: props.tags });
+  const deckFilter = useDeckFilterState(props.deck);
   const editCardScore = useEditCardScore();
 
   return (
@@ -27,11 +27,11 @@ const CardListComposition = (props: {
       cards={props.cards}
       preferences={props.preferences}
       filter={{
-        scoreMax: deckFilterForm.scoreMax,
-        scoreMin: deckFilterForm.scoreMin,
-        selectedTags: deckFilterForm.tagFilterProps.selectedTags ?? [],
-        controls: <DeckFilterForm {...deckFilterForm} />,
-        onChangeSelectedTags: (selectedTags) => deckFilterForm.tagFilterProps.onClickTag?.(selectedTags),
+        scoreMax: deckFilter.scoreMax,
+        scoreMin: deckFilter.scoreMin,
+        selectedTags: deckFilter.selectedTags,
+        controls: <DeckFilterForm {...deckFilter} tags={props.tags} />,
+        onChangeSelectedTags: deckFilter.setSelectedTags,
       }}
       renderBackText={(backText) => <BackText {...backText} />}
       onEditCard={props.onEditCard}

--- a/src/pages/deck-start/ui/DeckStartPage.spec.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.spec.tsx
@@ -32,11 +32,12 @@ vi.mock("@/features/deck-filter", async (importOriginal) => {
     useDeckFilterState: () => ({
       scoreMax: 4,
       scoreMin: -2,
-      scoreMaxSwitchProps: { name: "maximum-enabled", checked: true, onChange: vi.fn() },
-      scoreMinSwitchProps: { name: "minimum-enabled", checked: true, onChange: vi.fn() },
-      scoreMaxSliderProps: { name: "maximum", value: "4", min: -10, max: 10, onChange: vi.fn() },
-      scoreMinSliderProps: { name: "minimum", value: "-2", min: -10, max: 10, onChange: vi.fn() },
-      tagFilterProps: { tags: [], selectedTags: [], tagAndFilter: false },
+      selectedTags: [],
+      tagAndFilter: false,
+      setScoreMax: vi.fn(),
+      setScoreMin: vi.fn(),
+      setSelectedTags: vi.fn(),
+      setTagAndFilter: vi.fn(),
     }),
   };
 });

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -22,7 +22,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Prefe
   const startStudy = useStartStudySession(deck.id, {
     onStarted: () => void navigate(`/deck/${deck.id}/study`, { replace: true }),
   });
-  const deckFilterForm = useDeckFilterState({ deck, tags });
+  const deckFilter = useDeckFilterState(deck);
   const start = () => startStudy(cards);
   const startFromEnter = (event: KeyboardEvent) => {
     if (cards.length === 0 || hasInteractiveShortcutTarget(event.target)) return;
@@ -37,7 +37,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Prefe
         maxNumberOfCardsToLearn={preferences.study.maxNumberOfCardsToLearn}
         cardsLength={cards.length}
         onClickStart={start}
-        filterSlot={<DeckFilterForm {...deckFilterForm} />}
+        filterSlot={<DeckFilterForm {...deckFilter} tags={tags} />}
       />
     </AppLayout>
   );


### PR DESCRIPTION
## Summary

- replace react-hook-form prop assembly with focused deck filter state
- keep filter controls controlled and persist only changed fields
- update consumers, stories, and tests for the flat API

## Testing

- mise run check