### PR TITLE
refactor(#1043): Centralize study progress conversion

### DIFF
--- a/src/entities/deck/model/rules.ts
+++ b/src/entities/deck/model/rules.ts
@@ -63,14 +63,7 @@ export const getCategory = (category: Category, tags: string[]): Category => {
 
 export const createSelectableStudyCard = <TCard extends Card>(card: TCard): SelectableStudyCard<TCard> => ({
   card,
-  progress: createStudyProgressFromCard({
-    id: card.id,
-    score: card.score,
-    numberOfSeen: card.numberOfSeen,
-    ...(card.lastSeenAt === undefined ? {} : { lastSeenAt: card.lastSeenAt }),
-    ...(card.nextSeeingAt === undefined ? {} : { nextSeeingAt: card.nextSeeingAt }),
-    ...(card.interval === undefined ? {} : { interval: card.interval }),
-  }),
+  progress: createStudyProgressFromCard(card),
 });
 
 const isCardMatchingTags = (card: Card, deck: Pick<Deck, "selectedTags" | "tagAndFilter">) => {


### PR DESCRIPTION
## Related issue

Fixes #1043

## Summary

- Pass the complete Card directly to `createStudyProgressFromCard` when building a selectable study card.
- Remove the duplicate Card-to-StudyProgress field mapping from the Deck entity.
- Keep `createStudyProgressFromCard` as the single source of truth for this domain transformation without changing Study or Deck filtering behavior.

## Testing

- `mise run check`