### PR TITLE
[#1041] Centralize Card validation in entities

### DIFF
--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -12,4 +12,4 @@ export type {
   CardRaw,
   RemoteCard,
 } from "./model/types";
-export { filterCardsByDeckId, mustFindCardById } from "./model/rules";
+export { filterCardsByDeckId, getCardContentValidationErrors, mustFindCardById } from "./model/rules";

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -3,6 +3,7 @@ export { CardBulkMutationError, deleteCard, editCard, mutateCards } from "./api/
 export type { CardMutation } from "./api/mutations";
 export { generateCardId } from "./model/id";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
+export { cardContentSchema } from "./model/schema";
 export { clearRemoteCards } from "./model/store";
 export type {
   Card,

--- a/src/entities/card/model/rules.spec.ts
+++ b/src/entities/card/model/rules.spec.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from "vitest";
 
 import { createCard } from "@/test/factories";
-import { filterCardsByDeckId, filterTagsByDeckId, mustFindCardById } from "./rules";
+import { filterCardsByDeckId, filterTagsByDeckId, getCardContentValidationErrors, mustFindCardById } from "./rules";
+
+describe("getCardContentValidationErrors", () => {
+  it("returns field errors from the Card content schema", () => {
+    expect(getCardContentValidationErrors({ frontText: " ", backText: "\n", tags: [], uniqueKey: "\t" })).toEqual({
+      frontText: "Front text is required.",
+      backText: "Back text is required.",
+      uniqueKey: "Unique key is required.",
+    });
+  });
+
+  it("returns no errors for valid Card content", () => {
+    expect(
+      getCardContentValidationErrors({ frontText: "front", backText: "back", tags: [], uniqueKey: "key" })
+    ).toEqual({});
+  });
+});
 
 describe("filterCardsByDeckId", () => {
   it("returns cards matching the specified deckId", () => {

--- a/src/entities/card/model/rules.ts
+++ b/src/entities/card/model/rules.ts
@@ -1,4 +1,22 @@
-import type { Card, CardId } from "./types";
+import { cardContentSchema } from "./schema";
+import type { Card, CardId, CardRaw } from "./types";
+
+const cardContentFields: ReadonlySet<string> = new Set(["frontText", "backText", "tags", "uniqueKey"]);
+const isCardContentField = (field: PropertyKey | undefined): field is keyof CardRaw =>
+  typeof field === "string" && cardContentFields.has(field);
+
+export const getCardContentValidationErrors = (card: CardRaw): Partial<Record<keyof CardRaw, string>> => {
+  const validation = cardContentSchema.safeParse(card);
+  if (validation.success) return {};
+
+  // Keep Zod issue paths inside the Entity boundary so feature adapters only handle Card fields.
+  const errors: Partial<Record<keyof CardRaw, string>> = {};
+  for (const issue of validation.error.issues) {
+    const [field] = issue.path;
+    if (isCardContentField(field) && errors[field] === undefined) errors[field] = issue.message;
+  }
+  return errors;
+};
 
 export const filterCardsByDeckId = (cards: Card[], deckId: string): Card[] =>
   cards.filter((card) => card.deckId === deckId);

--- a/src/entities/card/model/schema.spec.ts
+++ b/src/entities/card/model/schema.spec.ts
@@ -2,7 +2,27 @@ import { describe, expect, it } from "vitest";
 
 import { createCard as createCardFixture } from "@/test/factories";
 
-import { createCardSchema, deleteCardSchema, editCardSchema } from "./schema";
+import { cardContentSchema, createCardSchema, deleteCardSchema, editCardSchema } from "./schema";
+
+describe("Card content schema", () => {
+  it.each(["", "   ", "\n\t"])("rejects blank front text: %j", (frontText) => {
+    expect(() => cardContentSchema.parse({ frontText, backText: "back", tags: [], uniqueKey: "key" })).toThrow(
+      "Front text is required."
+    );
+  });
+
+  it.each(["", "   ", "\n\t"])("rejects blank back text: %j", (backText) => {
+    expect(() => cardContentSchema.parse({ frontText: "front", backText, tags: [], uniqueKey: "key" })).toThrow(
+      "Back text is required."
+    );
+  });
+
+  it.each(["", "   ", "\n\t"])("rejects blank unique keys: %j", (uniqueKey) => {
+    expect(() => cardContentSchema.parse({ frontText: "front", backText: "back", tags: [], uniqueKey })).toThrow(
+      "Unique key is required."
+    );
+  });
+});
 
 describe("Card operation schemas", () => {
   const card = createCardFixture({ id: "card", deckId: "deck", uid: "uid-a" });
@@ -40,6 +60,15 @@ describe("Card operation schemas", () => {
 
   it("validates create ownership", () => {
     expect(() => createCardSchema.parse({ uid: "uid-b", card })).toThrow("owner does not match");
+  });
+
+  it("applies Card content validation to creates and edits", () => {
+    expect(() => createCardSchema.parse({ uid: "uid-a", card: { ...card, uniqueKey: " " } })).toThrow(
+      "Unique key is required."
+    );
+    expect(() => editCardSchema.parse({ uid: "uid-a", card: { id: card.id, uid: card.uid, frontText: " " } })).toThrow(
+      "Front text is required."
+    );
   });
 
   it("keeps ordinary edits within Card-owned editable fields", () => {

--- a/src/entities/card/model/schema.ts
+++ b/src/entities/card/model/schema.ts
@@ -1,14 +1,23 @@
 import { z } from "zod";
 
+import { isNonBlank } from "@/shared/lib/isNonBlank";
+
 const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote Card writes");
 export const cardIdSchema = z.string().min(1, "Card id is required");
 const cardUidSchema = z.string().min(1, "Card owner is required");
 
-const editableCardFieldsSchema = z.object({
-  frontText: z.string(),
-  backText: z.string(),
+const cardFrontTextSchema = z.string().refine(isNonBlank, { message: "Front text is required." });
+const cardBackTextSchema = z.string().refine(isNonBlank, { message: "Back text is required." });
+const cardUniqueKeySchema = z.string().refine(isNonBlank, { message: "Unique key is required." });
+
+export const cardContentSchema = z.object({
+  frontText: cardFrontTextSchema,
+  backText: cardBackTextSchema,
   tags: z.array(z.string()),
-  uniqueKey: z.string(),
+  uniqueKey: cardUniqueKeySchema,
+});
+
+const editableCardFieldsSchema = cardContentSchema.extend({
   url: z.string().optional(),
   startLine: z.number().optional(),
   endLine: z.number().optional(),

--- a/src/features/card-edit/model/cardFormSchema.ts
+++ b/src/features/card-edit/model/cardFormSchema.ts
@@ -1,13 +1,7 @@
-import * as z from "zod";
+import type * as z from "zod";
 
-import { isNonBlank } from "@/shared/lib/isNonBlank";
+import { cardContentSchema } from "@/entities/card";
 
-const requiredCardText = (message: string) => z.string().refine(isNonBlank, { message });
-
-export const cardFormSchema = z.object({
-  frontText: requiredCardText("Front text is required."),
-  backText: requiredCardText("Back text is required."),
-  tags: z.array(z.string()),
-});
+export const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
 
 export type CardFormValues = z.infer<typeof cardFormSchema>;

--- a/src/features/card-edit/ui/CardEditForm.spec.tsx
+++ b/src/features/card-edit/ui/CardEditForm.spec.tsx
@@ -14,7 +14,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/entities/auth", () => ({
   useAuthUid: () => "user-id",
 }));
-vi.mock("@/entities/card", () => ({ editCard: mocks.editCard }));
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+vi.mock("@/entities/card", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/entities/card")>()),
+  editCard: mocks.editCard,
+}));
 vi.mock("@/entities/deck", () => ({ CATEGORY: ["language", "math"] }));
 
 import { CardEditForm } from "./CardEditForm";

--- a/src/features/deck-import/lib/cardCsv.spec.ts
+++ b/src/features/deck-import/lib/cardCsv.spec.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { parseCsv } from "./cardCsv";
 
@@ -34,6 +36,16 @@ describe("card CSV import", () => {
           context: '["front"," ","","same"]',
         },
       ]);
+    });
+
+    it("rejects a blank Card unique key with CSV row context", async () => {
+      const analysis = await parseCsv('"front","back",""," "');
+
+      expect(analysis).toMatchObject({
+        rows: [],
+        invalidCount: 1,
+        issues: [{ rowNumber: 1, message: "uniqueKey is required.", context: '["front","back",""," "]' }],
+      });
     });
 
     it("rejects unsupported input at the parser boundary", async () => {

--- a/src/features/deck-import/lib/cardCsv.spec.ts
+++ b/src/features/deck-import/lib/cardCsv.spec.ts
@@ -28,8 +28,8 @@ describe("card CSV import", () => {
       expect(analysis.invalidCount).toBe(2);
       expect(analysis.rows).toEqual([]);
       expect(analysis.issues).toEqual([
-        { rowNumber: 1, message: "frontText is required.", context: '[" ","back",""," same "]' },
-        { rowNumber: 2, message: "backText is required.", context: '["front"," ","","same"]' },
+        { rowNumber: 1, message: "Front text is required.", context: '[" ","back",""," same "]' },
+        { rowNumber: 2, message: "Back text is required.", context: '["front"," ","","same"]' },
         {
           rowNumber: 2,
           message: 'uniqueKey "same" is duplicated in this file.',
@@ -44,7 +44,7 @@ describe("card CSV import", () => {
       expect(analysis).toMatchObject({
         rows: [],
         invalidCount: 1,
-        issues: [{ rowNumber: 1, message: "uniqueKey is required.", context: '["front","back",""," "]' }],
+        issues: [{ rowNumber: 1, message: "Unique key is required.", context: '["front","back",""," "]' }],
       });
     });
 

--- a/src/features/deck-import/lib/cardCsv.ts
+++ b/src/features/deck-import/lib/cardCsv.ts
@@ -1,4 +1,4 @@
-import { cardContentSchema, type CardRaw } from "@/entities/card";
+import { getCardContentValidationErrors, type CardRaw } from "@/entities/card";
 
 import * as Papa from "papaparse";
 
@@ -23,26 +23,17 @@ const fromRow = (row: string[]): CardRaw => ({
 
 const rowContext = (columns: string[]) => JSON.stringify(columns);
 
-const csvMessageByCardField: Record<string, string> = {
-  frontText: "frontText is required.",
-  backText: "backText is required.",
-  uniqueKey: "uniqueKey is required.",
-};
-
 const validateCard = (columns: string[], rowNumber: number, uniqueKeys: Set<string>) => {
   const card = fromRow(columns);
   const context = rowContext(columns);
-  const validation = cardContentSchema.safeParse(card);
-  const issues: DeckImportIssue[] = validation.success
-    ? []
-    : validation.error.issues.map((issue) => ({
-        rowNumber,
-        // CSV errors keep their field-oriented wording while Entity schema owns the validity rule.
-        message: csvMessageByCardField[String(issue.path[0])] ?? issue.message,
-        context,
-      }));
+  const validationErrors = getCardContentValidationErrors(card);
+  const issues: DeckImportIssue[] = Object.values(validationErrors).map((message) => ({
+    rowNumber,
+    message,
+    context,
+  }));
 
-  const uniqueKeyIsValid = cardContentSchema.shape.uniqueKey.safeParse(card.uniqueKey).success;
+  const uniqueKeyIsValid = validationErrors.uniqueKey === undefined;
   if (uniqueKeyIsValid && uniqueKeys.has(card.uniqueKey)) {
     issues.push({ rowNumber, message: `uniqueKey "${card.uniqueKey}" is duplicated in this file.`, context });
   } else if (uniqueKeyIsValid) {

--- a/src/features/deck-import/lib/cardCsv.ts
+++ b/src/features/deck-import/lib/cardCsv.ts
@@ -1,9 +1,8 @@
-import type { CardRaw } from "@/entities/card";
+import { cardContentSchema, type CardRaw } from "@/entities/card";
 
 import * as Papa from "papaparse";
 
 import type { DeckImportAnalysis, DeckImportIssue, DeckImportRow } from "../model/deckImportTypes";
-import { isNonBlank } from "@/shared/lib/isNonBlank";
 
 const fromRow = (row: string[]): CardRaw => ({
   frontText: row[0] || "",
@@ -24,21 +23,29 @@ const fromRow = (row: string[]): CardRaw => ({
 
 const rowContext = (columns: string[]) => JSON.stringify(columns);
 
+const csvMessageByCardField: Record<string, string> = {
+  frontText: "frontText is required.",
+  backText: "backText is required.",
+  uniqueKey: "uniqueKey is required.",
+};
+
 const validateCard = (columns: string[], rowNumber: number, uniqueKeys: Set<string>) => {
   const card = fromRow(columns);
   const context = rowContext(columns);
-  const issues: DeckImportIssue[] = [];
-  if (!isNonBlank(card.frontText)) {
-    issues.push({ rowNumber, message: "frontText is required.", context });
-  }
-  if (!isNonBlank(card.backText)) {
-    issues.push({ rowNumber, message: "backText is required.", context });
-  }
-  if (card.uniqueKey === "") {
-    issues.push({ rowNumber, message: "uniqueKey is required.", context });
-  } else if (uniqueKeys.has(card.uniqueKey)) {
+  const validation = cardContentSchema.safeParse(card);
+  const issues: DeckImportIssue[] = validation.success
+    ? []
+    : validation.error.issues.map((issue) => ({
+        rowNumber,
+        // CSV errors keep their field-oriented wording while Entity schema owns the validity rule.
+        message: csvMessageByCardField[String(issue.path[0])] ?? issue.message,
+        context,
+      }));
+
+  const uniqueKeyIsValid = cardContentSchema.shape.uniqueKey.safeParse(card.uniqueKey).success;
+  if (uniqueKeyIsValid && uniqueKeys.has(card.uniqueKey)) {
     issues.push({ rowNumber, message: `uniqueKey "${card.uniqueKey}" is duplicated in this file.`, context });
-  } else {
+  } else if (uniqueKeyIsValid) {
     uniqueKeys.add(card.uniqueKey);
   }
   return { card, issues };


### PR DESCRIPTION
## Related issue

Fixes #1041

## Summary

- define Card content validation in the Card entity schema
- derive card-edit form validation from the entity schema
- validate imported CSV cards with the same entity rules while preserving CSV-specific errors

## Testing

- mise run check