### PR TITLE
#1040 Move study session transition rule to entity

### DIFF
--- a/src/entities/preferences/@x/study-session.ts
+++ b/src/entities/preferences/@x/study-session.ts
@@ -1,0 +1,1 @@
+export type { SwipeAction } from "../model/types";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,4 +1,5 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
+export { calculateNextIndex } from "./model/rules";
 export {
   clearStudySessions,
   getStudySession,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { calculateNextIndex } from "./session";
+import { calculateNextIndex } from "./rules";
 
 describe("calculateNextIndex", () => {
   it("moves forward for non-prev actions", () => {

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -1,4 +1,4 @@
-import type { SwipeAction } from "@/entities/preferences";
+import type { SwipeAction } from "@/entities/preferences/@x/study-session";
 
 export const calculateNextIndex = (currentIndex: number, cardCount: number, swipeAction: SwipeAction): number => {
   let nextIndex = currentIndex;

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -4,6 +4,7 @@ import type { Preferences, SwipeDirection } from "@/entities/preferences";
 import { usePreferences } from "@/entities/preferences";
 import { createStudyProgressFromCard, type StudyProgressEdit } from "@/entities/study-progress";
 import {
+  calculateNextIndex,
   getStudySession,
   removeStudySession,
   restoreStudySession,
@@ -13,7 +14,6 @@ import {
 
 import React from "react";
 
-import { calculateNextIndex } from "../model/session";
 import { buildStudyPatch, resolveSwipeAction } from "../model/swipe";
 
 export interface StudyActions {


### PR DESCRIPTION
## Summary

- move `calculateNextIndex` from the study feature into the study-session entity rules
- expose the rule through the study-session public API
- use an explicit preferences cross-slice type contract for `SwipeAction`
- move the existing behavior tests alongside the entity rule

## Why

The next-index calculation is a pure study-session domain rule. Keeping it in the entity layer lets the study feature focus on workflow orchestration, mutations, rollback, and UI feedback.

## Impact

There is no intended user-visible behavior change. Study swipes continue to use the same transition logic through the entity public API.

## Validation

- `npm run test:unit -- src/entities/study-session/model/rules.spec.ts src/features/study/hooks/useStudyActions.spec.tsx`
- `mise run check` (103 test files, 522 tests)

Closes #1040