### PR TITLE
[No issue] Move study rating resolution to entity

### DIFF
--- a/src/entities/preferences/@x/study-progress.ts
+++ b/src/entities/preferences/@x/study-progress.ts
@@ -1,0 +1,1 @@
+export type { SwipeAction } from "../model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -6,4 +6,4 @@ export {
   recordStudyProgress,
   resolveStudyRating,
 } from "./model/rules";
-export type { StudyProgress, StudyProgressEdit, StudyRating } from "./model/types";
+export type { StudyProgress, StudyProgressEdit } from "./model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -4,5 +4,6 @@ export {
   createStudyProgressFromCard,
   getNextStudyAvailabilityAt,
   recordStudyProgress,
+  resolveStudyRating,
 } from "./model/rules";
 export type { StudyProgress, StudyProgressEdit, StudyRating } from "./model/types";

--- a/src/entities/study-progress/model/rules.spec.ts
+++ b/src/entities/study-progress/model/rules.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { SwipeAction } from "@/entities/preferences/@x/study-progress";
+
 const mocks = vi.hoisted(() => ({ shuffle: vi.fn((ids: string[]) => [...ids].reverse()) }));
 
 vi.mock("lodash", () => ({ shuffle: mocks.shuffle }));
@@ -10,6 +12,7 @@ import {
   getNextStudyAvailabilityAt,
   isStudyProgressEligible,
   recordStudyProgress,
+  resolveStudyRating,
 } from "./rules";
 import type { CardProgressFields, StudyProgress, StudyProgressEdit, StudyRating } from "./types";
 
@@ -19,6 +22,20 @@ const cardProgress = (id: string, numberOfSeen = 0): CardProgressFields => ({
   id,
   score: 0,
   numberOfSeen,
+});
+
+describe("resolveStudyRating", () => {
+  it.each<[SwipeAction, StudyRating]>([
+    ["GoToNextCardMastered", "mastered"],
+    ["GoToNextCardNotMastered", "not-mastered"],
+    ["GoToNextCardToggleMastered", "not-mastered"],
+    ["DoNothing", "unrated"],
+    ["GoBack", "unrated"],
+    ["GoToPrevCard", "unrated"],
+    ["GoToNextCard", "unrated"],
+  ])("maps %s to %s", (action, expectedRating) => {
+    expect(resolveStudyRating(action)).toBe(expectedRating);
+  });
 });
 
 describe("createStudyProgressFromCard", () => {

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -1,5 +1,7 @@
 import * as lodash from "lodash";
 
+import type { SwipeAction } from "@/entities/preferences/@x/study-progress";
+
 import { createStudyProgress } from "./defaults";
 import type {
   CardProgressFields,
@@ -9,6 +11,15 @@ import type {
   StudyProgressFilter,
   StudyRating,
 } from "./types";
+
+export const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
+  if (swipeAction === "GoToNextCardMastered") return "mastered";
+  // Toggle remains a negative rating because changing this mapping would alter the existing persisted-score behavior.
+  if (swipeAction === "GoToNextCardNotMastered" || swipeAction === "GoToNextCardToggleMastered") {
+    return "not-mastered";
+  }
+  return "unrated";
+};
 
 export const createStudyProgressFromCard = (card: CardProgressFields): StudyProgress => {
   const progress = createStudyProgress(card.id);

--- a/src/features/study/model/swipe.ts
+++ b/src/features/study/model/swipe.ts
@@ -1,16 +1,8 @@
-import { recordStudyProgress, type StudyRating } from "@/entities/study-progress";
+import { recordStudyProgress, resolveStudyRating } from "@/entities/study-progress";
 import type { StudyProgress, StudyProgressEdit } from "@/entities/study-progress";
 import type { SwipeAction, SwipeDirection, SwipeState } from "@/entities/preferences";
 
 export const resolveSwipeAction = (controls: SwipeState, direction: SwipeDirection): SwipeAction => controls[direction];
-
-const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
-  if (swipeAction === "GoToNextCardMastered") return "mastered";
-  if (swipeAction === "GoToNextCardNotMastered" || swipeAction === "GoToNextCardToggleMastered") {
-    return "not-mastered";
-  }
-  return "unrated";
-};
 
 export const buildStudyPatch = (progress: StudyProgress, swipeAction: SwipeAction, now: number): StudyProgressEdit =>
   recordStudyProgress(progress, resolveStudyRating(swipeAction), now);


### PR DESCRIPTION
## Related issue

None.

## Summary

- Move swipe-action rating resolution into the study-progress entity.
- Expose the preference action type through an explicit cross-slice contract.
- Cover every swipe-action mapping with entity rule tests.

## Testing

- mise run check