### PR TITLE
chore(#1018): Add Vitest ESLint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,9 +7,11 @@ import {
 } from "eslint-plugin-boundaries/config";
 import reactHooks from "eslint-plugin-react-hooks";
 import testingLibrary from "eslint-plugin-testing-library";
+import vitest from "@vitest/eslint-plugin";
 
 const sourceFiles = ["src/**/*.{ts,tsx}"];
 const testFiles = ["src/**/*.{spec,test,stories}.{ts,tsx}"];
+const vitestFiles = ["src/**/*.{spec,test}.{ts,tsx}"];
 const sliceLayers = ["entities", "features", "pages", "widgets"];
 const nonSliceLayers = ["app", "shared"];
 
@@ -135,6 +137,10 @@ export default [
   },
   {
     ...testingLibrary.configs["flat/react"],
-    files: ["src/**/*.spec.{ts,tsx}"],
+    files: vitestFiles,
+  },
+  {
+    ...vitest.configs.recommended,
+    files: vitestFiles,
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/browser-playwright": "^4.1.10",
         "@vitest/coverage-v8": "4.1.10",
+        "@vitest/eslint-plugin": "^1.6.27",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.8.1",
         "eslint-import-resolver-typescript": "^4.4.5",
@@ -8950,6 +8951,37 @@
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.27.tgz",
+      "integrity": "sha512-X1RCAfwbatG4GFbJ/1PIHP9MSZMt0JJThqbYID+vS4L783k6QGlLPe421wQE8dHXuGCcenVLsydiM4qzsYWxhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/browser-playwright": "^4.1.10",
     "@vitest/coverage-v8": "4.1.10",
+    "@vitest/eslint-plugin": "^1.6.27",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.8.1",
     "eslint-import-resolver-typescript": "^4.4.5",

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -104,8 +104,11 @@ describe("useDeckImport", () => {
     await actAsync(async () => {
       imported = await result.current.importPreview();
     });
-    expect(mocks.createDeck).toHaveBeenCalledOnce();
-    expect(mocks.createDeck).toHaveBeenCalledWith({ id: "deck", uid: "uid-a", name: "deck.csv" });
+    expect(mocks.createDeck).toHaveBeenCalledExactlyOnceWith({
+      id: "deck",
+      uid: "uid-a",
+      name: "deck.csv",
+    });
     expect(mocks.bulkUpsert).toHaveBeenCalledWith([
       {
         kind: "create",
@@ -476,12 +479,11 @@ describe("useDeckImport", () => {
     const { result, rerender } = renderHook(useTestDeckImport);
 
     const operation = result.current.importUrl("https://example.test/deck.csv");
-    const rejection = expect(operation).rejects.toThrow("user changed");
     mocks.uid = "uid-b";
     rerender();
     finishFetch(new Response('"front","back","","key"'));
 
-    await rejection;
+    await expect(operation).rejects.toThrow("user changed");
     expect(mocks.createDeck).not.toHaveBeenCalled();
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
     expect(result.current.pending).toBe(false);
@@ -500,14 +502,13 @@ describe("useDeckImport", () => {
     const { result, rerender } = renderHook(useTestDeckImport);
 
     const operation = result.current.importUrl("https://example.test/deck.csv");
-    const rejection = expect(operation).rejects.toThrow("user changed");
     await waitFor(() => expect(mocks.fetchDecks).toHaveBeenCalledWith("uid-a"));
 
     mocks.uid = "uid-b";
     rerender();
     finishServerRead([]);
 
-    await rejection;
+    await expect(operation).rejects.toThrow("user changed");
     expect(mocks.createDeck).not.toHaveBeenCalled();
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
     expect(result.current.pending).toBe(false);
@@ -531,7 +532,6 @@ describe("useDeckImport", () => {
     act(() => {
       selection = result.current.selectFile(file);
     });
-    const rejection = expect(selection).rejects.toThrow("user changed");
     await waitFor(() => expect(result.current.validating).toBe(true));
     mocks.uid = "uid-b";
     rerender();
@@ -549,7 +549,7 @@ describe("useDeckImport", () => {
         issues: [],
         invalidCount: 0,
       });
-      await rejection;
+      await expect(selection).rejects.toThrow("user changed");
     });
     expect(result.current.preview).toBeUndefined();
     expect(result.current.validating).toBe(false);

--- a/src/shared/ui/forms/SelectionControl.spec.tsx
+++ b/src/shared/ui/forms/SelectionControl.spec.tsx
@@ -144,8 +144,7 @@ describe("shared selection controls", () => {
     fireEvent.change(input, { target: { files: [file] } });
 
     expect(input?.files?.[0]).toBe(file);
-    expect(onChange).toHaveBeenCalledOnce();
-    expect(onChange).toHaveBeenCalledWith(file);
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(file);
   });
 
   it("presents the chosen file from controlled props without storing native file state", () => {


### PR DESCRIPTION
## Related issue

Fixes #1018

## Summary

- add @vitest/eslint-plugin and apply its recommended flat config to Vitest test files
- update existing tests to satisfy the enabled assertion rules
- share the Vitest file glob with Testing Library lint configuration

## Testing

- mise run check