### PR TITLE
[No issue] Remove study history guard

### DIFF
--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -4,7 +4,7 @@ import type { StudyWorkflowState } from "@/features/study";
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import React from "react";
+import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -158,23 +158,5 @@ describe("DeckStudyPage", () => {
     mocks.deck = undefined;
     render(<DeckStudyPage />);
     expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
-  });
-
-  it("installs one back-navigation guard when StrictMode replays the effect", () => {
-    const pushState = vi.spyOn(window.history, "pushState");
-    const view = render(
-      <React.StrictMode>
-        <DeckStudyPage />
-      </React.StrictMode>
-    );
-
-    expect(pushState).toHaveBeenCalledOnce();
-    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
-    expect(mocks.navigate).toHaveBeenCalledWith(1);
-
-    view.unmount();
-    mocks.navigate.mockClear();
-    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
-    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -11,28 +11,6 @@ import { DeckSwiperView, StudyWorkflow, type StudyWorkflowState } from "@/featur
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
-const STUDY_HISTORY_GUARD = "tangoStudyDeckId";
-const isHistoryState = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value != null && !Array.isArray(value);
-
-const useStudyHistoryGuard = (deckId: string, navigate: ReturnType<typeof useNavigate>) => {
-  // Keep the active study session on the route when browser history moves backward.
-  React.useEffect(() => {
-    const currentState: unknown = window.history.state;
-    const state = isHistoryState(currentState) ? currentState : {};
-    if (state[STUDY_HISTORY_GUARD] !== deckId) {
-      window.history.pushState({ ...state, [STUDY_HISTORY_GUARD]: deckId }, document.title, document.location.href);
-    }
-    const handlePopState = () => {
-      void navigate(1);
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
-  }, [deckId, navigate]);
-};
-
 const renderStudyScreen = (deck: Deck, state: StudyWorkflowState) => {
   if (state.status !== "ready") {
     return state.status === "loading" ? (
@@ -89,7 +67,6 @@ const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyWorkflowStat
 
 const DeckStudyContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const navigate = useNavigate();
-  useStudyHistoryGuard(deck.id, navigate);
   const handleUnavailable = React.useCallback(() => {
     void navigate("/", { replace: true });
   }, [navigate]);


### PR DESCRIPTION
## Related issue

None.

## Summary

- Remove the study route history mutation and popstate override.
- Restore standard browser back navigation while keeping persisted study sessions intact.

## Testing

- mise run check
- npm run test:unit -- src/pages/deck-study/ui/DeckStudyPage.spec.tsx