### PR TITLE
[No issue] Simplify filtered study card scheduling

### DIFF
--- a/src/features/deck-filter/model/useFilteredStudyCards.spec.tsx
+++ b/src/features/deck-filter/model/useFilteredStudyCards.spec.tsx
@@ -49,6 +49,24 @@ describe("useFilteredStudyCards", () => {
     expect(result.current.enabled).toEqual([card]);
   });
 
+  it("re-evaluates a changed card list against the current time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const deck = createDeck({ id: "scheduled" });
+    const initial = createCard({ id: "initial", deckId: deck.id, nextSeeingAt: new Date(2000) });
+    const current = createCard({ id: "current", deckId: deck.id, nextSeeingAt: new Date(1500) });
+    const preferences = createPreferences({ useCardInterval: true });
+    const { result, rerender } = renderHook(({ cards }) => useFilteredStudyCards(deck, cards, preferences), {
+      initialProps: { cards: [initial] },
+    });
+
+    vi.setSystemTime(1600);
+    rerender({ cards: [current] });
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current).toEqual([current]);
+  });
+
   it("reschedules review times beyond the browser timeout limit", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);

--- a/src/features/deck-filter/model/useFilteredStudyCards.ts
+++ b/src/features/deck-filter/model/useFilteredStudyCards.ts
@@ -13,25 +13,16 @@ export const useFilteredStudyCards = (deck: Deck | undefined, cards: Card[], pre
   const studyCards = useMemo(() => cards.map(createSelectableStudyCard), [cards]);
 
   useEffect(() => {
-    // Refresh after rendering so a changed card list is filtered against current time, not the previous clock.
-    const current = Date.now();
-    const refresh = window.setTimeout(() => setScheduleClock(current), 0);
-    return () => window.clearTimeout(refresh);
-  }, [cards]);
-
-  useEffect(() => {
-    const current = Date.now();
+    // Using the rendered clock makes an overdue review in a changed card list trigger an immediate refresh.
     const next = getNextStudyAvailabilityAt(
       studyCards.map((card) => card.progress),
-      current
+      scheduleClock
     );
-    const availability =
-      next === undefined
-        ? undefined
-        : window.setTimeout(() => setScheduleClock(Date.now()), Math.min(next - current, MAX_TIMEOUT_MS));
-    return () => {
-      if (availability !== undefined) window.clearTimeout(availability);
-    };
+    if (next === undefined) return;
+
+    const delay = Math.min(Math.max(next - Date.now(), 0), MAX_TIMEOUT_MS);
+    const availability = window.setTimeout(() => setScheduleClock(Date.now()), delay);
+    return () => window.clearTimeout(availability);
   }, [scheduleClock, studyCards]);
 
   return deck == null


### PR DESCRIPTION
## Related issue

None.

## Summary

- Consolidate study-card refresh scheduling into one effect.
- Preserve immediate refreshes for overdue cards after the card list changes.
- Add regression coverage for changed card lists.

## Testing

- `mise run check`