### PR TITLE
refactor(#1035): Separate local StudyProgress persistence

### DIFF
--- a/src/entities/card/@x/deck.ts
+++ b/src/entities/card/@x/deck.ts
@@ -1,2 +1,2 @@
-export { deleteLocalCardsByDeckId } from "../model/store";
+export { deleteLocalCardsByDeckId } from "../api/mutations";
 export type { Card } from "../model/types";

--- a/src/entities/card/@x/study-progress.ts
+++ b/src/entities/card/@x/study-progress.ts
@@ -1,1 +1,2 @@
+export { editLocalCardStudyProgress, findCardById } from "../model/store";
 export type { CardId } from "../model/types";

--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -7,7 +7,14 @@ import {
   createLocalDeck,
 } from "@/test/factories";
 
-import { type CardBulkMutationError, type CardMutation, deleteCard, editCard, mutateCards } from "./mutations";
+import {
+  type CardBulkMutationError,
+  type CardMutation,
+  deleteCard,
+  deleteLocalCardsByDeckId,
+  editCard,
+  mutateCards,
+} from "./mutations";
 import { cardStore, findCardById } from "../model/store";
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +22,9 @@ const mocks = vi.hoisted(() => ({
   deleteRemoteCard: vi.fn(),
   editRemoteCard: vi.fn(),
   findDeckById: vi.fn(),
+  createLocalStudyProgress: vi.fn(),
+  deleteLocalStudyProgress: vi.fn(),
+  deleteLocalStudyProgresses: vi.fn(),
 }));
 
 vi.mock("./firestore", () => ({
@@ -25,6 +35,16 @@ vi.mock("./firestore", () => ({
 
 vi.mock("@/entities/deck/@x/card", () => ({
   findDeckById: mocks.findDeckById,
+}));
+vi.mock("@/entities/study-progress/@x/card", () => ({
+  createLocalStudyProgress: mocks.createLocalStudyProgress,
+  createStudyProgressFromCard: (card: ReturnType<typeof createLocalCard>) => ({
+    cardId: card.id,
+    score: card.score,
+    numberOfSeen: card.numberOfSeen,
+  }),
+  deleteLocalStudyProgress: mocks.deleteLocalStudyProgress,
+  deleteLocalStudyProgresses: mocks.deleteLocalStudyProgresses,
 }));
 
 describe("Card mutations", () => {
@@ -42,13 +62,32 @@ describe("Card mutations", () => {
     await editCard("", { id: card.id, frontText: "Updated" });
 
     expect(findCardById(card.id)).toMatchObject({ id: card.id, frontText: "Updated" });
+    expect(mocks.createLocalStudyProgress).toHaveBeenCalledExactlyOnceWith({
+      cardId: card.id,
+      score: card.score,
+      numberOfSeen: card.numberOfSeen,
+    });
     expect(mocks.createRemoteCard).not.toHaveBeenCalled();
     expect(mocks.editRemoteCard).not.toHaveBeenCalled();
 
     await deleteCard("", card);
 
     expect(findCardById(card.id)).toBeUndefined();
+    expect(mocks.deleteLocalStudyProgress).toHaveBeenCalledExactlyOnceWith(card.id);
     expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
+  });
+
+  it("deletes progress for every local Card removed with its Deck", () => {
+    cardStore.setState({
+      localCards: [
+        createLocalCard({ id: "first", deckId: "local-deck" }),
+        createLocalCard({ id: "second", deckId: "local-deck" }),
+      ],
+    });
+
+    deleteLocalCardsByDeckId("local-deck");
+
+    expect(mocks.deleteLocalStudyProgresses).toHaveBeenCalledExactlyOnceWith(["first", "second"]);
   });
 
   it("preserves remote Card mutation behavior", async () => {

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -1,8 +1,20 @@
 import type { CardCreateInput, CardEditInput, CardId, LocalCardCreateInput, RemoteCard } from "../model/types";
 
 import { findDeckById } from "@/entities/deck/@x/card";
+import {
+  createLocalStudyProgress,
+  createStudyProgressFromCard,
+  deleteLocalStudyProgress,
+  deleteLocalStudyProgresses,
+} from "@/entities/study-progress/@x/card";
 import { cardCreateSchema } from "../model/schema";
-import { createLocalCard, deleteLocalCard, editLocalCard, findCardById } from "../model/store";
+import {
+  createLocalCard,
+  deleteLocalCard,
+  deleteLocalCardsByDeckId as deleteLocalCardRecordsByDeckId,
+  editLocalCard,
+  findCardById,
+} from "../model/store";
 import {
   createCard as createRemoteCard,
   deleteCard as deleteRemoteCard,
@@ -42,7 +54,8 @@ const requireRemoteCardCreate = (card: CardMutationCreateInput): CardCreateInput
 
 const createCard = async (uid: string, card: CardMutationCreateInput): Promise<void> => {
   if (isLocalDeck(card.deckId)) {
-    createLocalCard(card);
+    const createdCard = createLocalCard(card);
+    createLocalStudyProgress(createStudyProgressFromCard(createdCard));
     return;
   }
   await createRemoteCard(uid, requireRemoteCardCreate(card));
@@ -80,7 +93,13 @@ export const deleteCard = async (uid: string, card: { id: CardId }): Promise<voi
   const currentCard = requireCard(card.id);
   if (requireLocalMode(currentCard.deckId)) {
     deleteLocalCard(card.id);
+    deleteLocalStudyProgress(card.id);
     return;
   }
   await deleteRemoteCard(uid, { id: card.id, uid: requireRemoteCard(currentCard).uid });
+};
+
+export const deleteLocalCardsByDeckId = (deckId: string): void => {
+  const deletedCardIds = deleteLocalCardRecordsByDeckId(deckId);
+  deleteLocalStudyProgresses(deletedCardIds);
 };

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -11,6 +11,7 @@ import {
   deleteLocalCard,
   deleteLocalCardsByDeckId,
   editLocalCard,
+  editLocalCardStudyProgress,
   replaceRemoteCards,
 } from "./store";
 
@@ -139,6 +140,10 @@ describe("Card store", () => {
     const updatedCard = editLocalCard({ id: "local", frontText: "updated" });
     expect(updatedCard).toEqual(expect.objectContaining({ frontText: "updated", createdAt: 10, updatedAt: 20 }));
 
+    vi.mocked(Date.now).mockReturnValueOnce(30);
+    const updatedProgress = editLocalCardStudyProgress({ id: "local", score: 2, numberOfSeen: 3 });
+    expect(updatedProgress).toEqual(expect.objectContaining({ score: 2, numberOfSeen: 3, updatedAt: 30 }));
+
     deleteLocalCard("local");
     expect(cardStore.getState().localCards).toEqual([]);
   });
@@ -147,7 +152,7 @@ describe("Card store", () => {
     createLocalCard(cardInput("first", "deck-a"));
     createLocalCard(cardInput("second", "deck-b"));
 
-    deleteLocalCardsByDeckId("deck-a");
+    expect(deleteLocalCardsByDeckId("deck-a")).toEqual(["first"]);
 
     expect(cardStore.getState().localCards.map(({ id }) => id)).toEqual(["second"]);
   });

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -11,6 +11,9 @@ import {
 } from "./schema";
 import type { Card, CardId, LocalCard, LocalCardCreateInput, LocalCardEdit, RemoteCard } from "./types";
 
+type LocalCardStudyProgressEdit = Pick<LocalCard, "id"> &
+  Partial<Pick<LocalCard, "score" | "numberOfSeen" | "lastSeenAt" | "nextSeeingAt" | "interval">>;
+
 interface CardState {
   remoteCards: RemoteCard[];
   localCards: LocalCard[];
@@ -85,12 +88,28 @@ export const editLocalCard = (input: LocalCardEdit): LocalCard => {
   return updatedCard;
 };
 
+export const editLocalCardStudyProgress = (input: LocalCardStudyProgressEdit): LocalCard => {
+  const cardId = cardIdSchema.parse(input.id);
+  const { localCards } = cardStore.getState();
+  const currentCard = localCards.find(({ id }) => id === cardId);
+  if (currentCard === undefined) throw new Error(`Local Card "${cardId}" was not found`);
+
+  const updatedCard = localCardSchema.parse({ ...currentCard, ...input, updatedAt: Date.now() });
+  cardStore.setState({ localCards: localCards.map((card) => (card.id === cardId ? updatedCard : card)) });
+  return updatedCard;
+};
+
 export const deleteLocalCard = (input: CardId): void => {
   const cardId = cardIdSchema.parse(input);
   cardStore.setState({ localCards: cardStore.getState().localCards.filter(({ id }) => id !== cardId) });
 };
 
-export const deleteLocalCardsByDeckId = (deckId: string): void => {
+export const deleteLocalCardsByDeckId = (deckId: string): CardId[] => {
   const parsedDeckId = z.string().min(1, "Card deck is required").parse(deckId);
+  const deletedCardIds = cardStore
+    .getState()
+    .localCards.filter((card) => card.deckId === parsedDeckId)
+    .map((card) => card.id);
   cardStore.setState({ localCards: cardStore.getState().localCards.filter((card) => card.deckId !== parsedDeckId) });
+  return deletedCardIds;
 };

--- a/src/entities/study-progress/@x/card.ts
+++ b/src/entities/study-progress/@x/card.ts
@@ -1,0 +1,2 @@
+export { createLocalStudyProgress, deleteLocalStudyProgress, deleteLocalStudyProgresses } from "../model/store";
+export { createStudyProgressFromCard } from "../model/rules";

--- a/src/entities/study-progress/api/firestore.spec.ts
+++ b/src/entities/study-progress/api/firestore.spec.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 
-import { editStudyProgress } from "./firestore";
+import { editRemoteStudyProgress } from "./firestore";
 
 describe("StudyProgress Firestore persistence", () => {
   it("rejects edit requests without a confirmed user identity", async () => {
-    await expect(editStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
+    await expect(editRemoteStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
   });
 
   it("rejects edit requests without a card ID", async () => {
-    await expect(editStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
+    await expect(editRemoteStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
   });
 });

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -7,7 +7,10 @@ import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { editStudyProgressSchema } from "../model/schema";
 
-export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
+export const editRemoteStudyProgress = async (
+  uid: string,
+  progress: EditStudyProgressInput["progress"]
+): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });
   const { cardId, ...fields } = input.progress;
   const document = omitUndefined({ ...fields, updatedAt: getCurrentTimeMillis() });

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  editLocalCardStudyProgress: vi.fn(),
+  editLocalStudyProgress: vi.fn(),
+  editRemoteStudyProgress: vi.fn(),
+  findCardById: vi.fn(),
+}));
+
+vi.mock("@/entities/card/@x/study-progress", () => ({
+  editLocalCardStudyProgress: mocks.editLocalCardStudyProgress,
+  findCardById: mocks.findCardById,
+}));
+vi.mock("../model/store", () => ({ editLocalStudyProgress: mocks.editLocalStudyProgress }));
+vi.mock("./firestore", () => ({ editRemoteStudyProgress: mocks.editRemoteStudyProgress }));
+
+import { editStudyProgress } from "./mutations";
+
+describe("StudyProgress mutations", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("updates local state without writing to Firestore", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck" });
+    mocks.editLocalStudyProgress.mockReturnValue({ cardId: "local", score: 2, numberOfSeen: 3 });
+
+    await editStudyProgress("", { cardId: "local", score: 2 });
+
+    expect(mocks.editLocalStudyProgress).toHaveBeenCalledExactlyOnceWith({ cardId: "local", score: 2 });
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({
+      id: "local",
+      score: 2,
+      numberOfSeen: 3,
+    });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("preserves the remote Firestore write path", async () => {
+    mocks.findCardById.mockReturnValue({ id: "remote", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "remote", score: 2 });
+
+    expect(mocks.editRemoteStudyProgress).toHaveBeenCalledExactlyOnceWith("user", {
+      cardId: "remote",
+      score: 2,
+    });
+    expect(mocks.editLocalStudyProgress).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects progress for an unknown Card", async () => {
+    await expect(editStudyProgress("user", { cardId: "missing", score: 2 })).rejects.toThrow(
+      'Card "missing" was not found'
+    );
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+    expect(mocks.editLocalStudyProgress).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,0 +1,19 @@
+import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
+import { editLocalStudyProgress } from "../model/store";
+import type { StudyProgressEdit } from "../model/types";
+import { editRemoteStudyProgress } from "./firestore";
+
+export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
+  const card = findCardById(progress.cardId);
+  if (card === undefined) throw new Error(`Card "${progress.cardId}" was not found`);
+
+  if ("uid" in card) {
+    await editRemoteStudyProgress(uid, progress);
+    return;
+  }
+
+  const updatedProgress = editLocalStudyProgress(progress);
+  const { cardId: id, ...fields } = updatedProgress;
+  // Card consumers migrate in #604; keep their runtime view aligned without making Card persistence authoritative.
+  editLocalCardStudyProgress({ id, ...fields });
+};

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,4 +1,4 @@
-export { editStudyProgress } from "./api/firestore";
+export { editStudyProgress } from "./api/mutations";
 export {
   buildStudyCardOrder,
   createStudyProgressFromCard,

--- a/src/entities/study-progress/model/schema.ts
+++ b/src/entities/study-progress/model/schema.ts
@@ -2,13 +2,27 @@ import { z } from "zod";
 
 const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote StudyProgress writes");
 
-const studyProgressEditSchema = z.object({
+export const studyProgressEditSchema = z.object({
   cardId: z.string().min(1, "Card id is required"),
   score: z.number().optional(),
   numberOfSeen: z.number().optional(),
   lastSeenAt: z.number().optional(),
   nextSeeingAt: z.date().optional(),
   interval: z.number().optional(),
+});
+
+export const studyProgressSchema = studyProgressEditSchema.extend({
+  score: z.number(),
+  numberOfSeen: z.number(),
+});
+
+const persistedDateSchema = z.preprocess(
+  (value) => (typeof value === "string" ? new Date(value) : value),
+  z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date")
+);
+
+export const persistedStudyProgressSchema = studyProgressSchema.extend({
+  nextSeeingAt: persistedDateSchema.optional(),
 });
 
 export const editStudyProgressSchema = z.object({

--- a/src/entities/study-progress/model/store.spec.ts
+++ b/src/entities/study-progress/model/store.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStudyProgress } from "./defaults";
+
+const loadStore = () => {
+  vi.resetModules();
+  return import("./store");
+};
+
+describe("StudyProgress store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists local progress and restores scheduled dates", async () => {
+    const { createLocalStudyProgress } = await loadStore();
+    const local = { ...createStudyProgress("local"), nextSeeingAt: new Date(1000) };
+    createLocalStudyProgress(local);
+
+    expect(JSON.parse(localStorage.getItem("tango-local-study-progresses") ?? "null")).toEqual({
+      state: { localProgresses: [{ ...local, nextSeeingAt: new Date(1000).toISOString() }] },
+      version: 1,
+    });
+
+    const { editLocalStudyProgress } = await loadStore();
+    expect(editLocalStudyProgress({ cardId: local.cardId, score: 2 })).toEqual({ ...local, score: 2 });
+  });
+
+  it("migrates released local Card progress into its dedicated store once", async () => {
+    const nextSeeingAt = new Date(1000);
+    const legacyCard = {
+      id: "legacy-card",
+      frontText: "Legacy",
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 500,
+      nextSeeingAt: nextSeeingAt.toISOString(),
+      interval: 2,
+    };
+    localStorage.setItem("tango-local-cards", JSON.stringify({ state: { localCards: [legacyCard] }, version: 1 }));
+    const { editLocalStudyProgress } = await loadStore();
+
+    const migrated = {
+      cardId: legacyCard.id,
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 500,
+      nextSeeingAt,
+      interval: 2,
+    };
+    expect(editLocalStudyProgress({ cardId: legacyCard.id })).toEqual(migrated);
+    expect(JSON.parse(localStorage.getItem("tango-local-study-progresses") ?? "null")).toEqual({
+      state: { localProgresses: [{ ...migrated, nextSeeingAt: nextSeeingAt.toISOString() }] },
+      version: 1,
+    });
+
+    localStorage.setItem(
+      "tango-local-cards",
+      JSON.stringify({ state: { localCards: [{ ...legacyCard, score: 9 }] }, version: 1 })
+    );
+    const { editLocalStudyProgress: editReloadedProgress } = await loadStore();
+    expect(editReloadedProgress({ cardId: legacyCard.id })).toEqual(migrated);
+  });
+
+  it("creates, edits, and deletes local progress synchronously", async () => {
+    const { createLocalStudyProgress, deleteLocalStudyProgress, deleteLocalStudyProgresses, editLocalStudyProgress } =
+      await loadStore();
+    expect(createLocalStudyProgress(createStudyProgress("first"))).toEqual(createStudyProgress("first"));
+    createLocalStudyProgress(createStudyProgress("second"));
+
+    expect(editLocalStudyProgress({ cardId: "first", score: 3 })).toEqual({
+      ...createStudyProgress("first"),
+      score: 3,
+    });
+
+    deleteLocalStudyProgress("first");
+    deleteLocalStudyProgresses(["second"]);
+    expect(() => editLocalStudyProgress({ cardId: "first" })).toThrow('Local StudyProgress "first" was not found');
+    expect(() => editLocalStudyProgress({ cardId: "second" })).toThrow('Local StudyProgress "second" was not found');
+  });
+
+  it("fails when local progress is missing", async () => {
+    const { editLocalStudyProgress } = await loadStore();
+    expect(() => editLocalStudyProgress({ cardId: "missing", score: 1 })).toThrow(
+      'Local StudyProgress "missing" was not found'
+    );
+  });
+});

--- a/src/entities/study-progress/model/store.ts
+++ b/src/entities/study-progress/model/store.ts
@@ -1,0 +1,125 @@
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import { createStore } from "zustand/vanilla";
+import { z } from "zod";
+
+import { persistedStudyProgressSchema, studyProgressEditSchema, studyProgressSchema } from "./schema";
+import type { StudyProgress, StudyProgressEdit } from "./types";
+
+interface StudyProgressState {
+  remoteProgresses: StudyProgress[];
+  localProgresses: StudyProgress[];
+}
+
+interface PersistedStudyProgressState {
+  localProgresses: StudyProgress[];
+}
+
+interface CreateStudyProgressStoreOptions {
+  storage?: StateStorage;
+  skipHydration?: boolean;
+}
+
+const LOCAL_STUDY_PROGRESS_STORAGE_KEY = "tango-local-study-progresses";
+const LEGACY_LOCAL_CARD_STORAGE_KEY = "tango-local-cards";
+
+const persistedStudyProgressStateSchema = z.object({
+  localProgresses: z.array(persistedStudyProgressSchema),
+});
+
+const legacyLocalCardProgressSchema = persistedStudyProgressSchema.omit({ cardId: true }).extend({
+  id: studyProgressSchema.shape.cardId,
+});
+const legacyLocalCardStorageSchema = z.object({
+  state: z.object({ localCards: z.array(z.unknown()) }),
+  version: z.literal(1),
+});
+
+const parsePersistedStudyProgressState = (value: unknown): PersistedStudyProgressState => {
+  const result = persistedStudyProgressStateSchema.safeParse(value);
+  return result.success ? result.data : { localProgresses: [] };
+};
+
+const parseLegacyLocalCardProgresses = (value: string | null): StudyProgress[] | null => {
+  if (value === null) return null;
+  try {
+    const legacyStore = legacyLocalCardStorageSchema.safeParse(JSON.parse(value));
+    if (!legacyStore.success) return null;
+    return legacyStore.data.state.localCards.flatMap((card) => {
+      const result = legacyLocalCardProgressSchema.safeParse(card);
+      if (!result.success) return [];
+      const { id: cardId, ...progress } = result.data;
+      return [{ cardId, ...progress }];
+    });
+  } catch {
+    return null;
+  }
+};
+
+const migrateLegacyLocalCardProgresses = (storage: Storage): void => {
+  if (storage.getItem(LOCAL_STUDY_PROGRESS_STORAGE_KEY) !== null) return;
+  const localProgresses = parseLegacyLocalCardProgresses(storage.getItem(LEGACY_LOCAL_CARD_STORAGE_KEY));
+  if (localProgresses === null) return;
+  // Creating the dedicated key is the migration marker, so compatibility never enters the normal runtime path.
+  storage.setItem(LOCAL_STUDY_PROGRESS_STORAGE_KEY, JSON.stringify({ state: { localProgresses }, version: 1 }));
+};
+
+const createStudyProgressStore = ({ storage, skipHydration }: CreateStudyProgressStoreOptions = {}) => {
+  if (storage === undefined) migrateLegacyLocalCardProgresses(localStorage);
+  const persistStorage = createJSONStorage<PersistedStudyProgressState>(() => storage ?? localStorage);
+  return createStore<StudyProgressState>()(
+    persist<StudyProgressState, [], [], PersistedStudyProgressState>(
+      () => ({ remoteProgresses: [], localProgresses: [] }),
+      {
+        name: LOCAL_STUDY_PROGRESS_STORAGE_KEY,
+        version: 1,
+        ...(persistStorage !== undefined ? { storage: persistStorage } : {}),
+        ...(skipHydration !== undefined ? { skipHydration } : {}),
+        merge: (persistedState, currentState) => ({
+          ...currentState,
+          ...parsePersistedStudyProgressState(persistedState),
+        }),
+        partialize: ({ localProgresses }) => ({ localProgresses }),
+      }
+    )
+  );
+};
+
+const studyProgressStore = createStudyProgressStore();
+
+export const createLocalStudyProgress = (input: StudyProgress): StudyProgress => {
+  const progress = studyProgressSchema.parse(input);
+  const localProgresses = studyProgressStore
+    .getState()
+    .localProgresses.filter((item) => item.cardId !== progress.cardId);
+  studyProgressStore.setState({ localProgresses: [...localProgresses, progress] });
+  return progress;
+};
+
+export const editLocalStudyProgress = (input: StudyProgressEdit): StudyProgress => {
+  const edit = studyProgressEditSchema.parse(input);
+  const { localProgresses } = studyProgressStore.getState();
+  const currentProgress = localProgresses.find(({ cardId }) => cardId === edit.cardId);
+  if (currentProgress === undefined) throw new Error(`Local StudyProgress "${edit.cardId}" was not found`);
+
+  const updatedProgress = studyProgressSchema.parse({ ...currentProgress, ...edit });
+  studyProgressStore.setState({
+    localProgresses: localProgresses.map((progress) =>
+      progress.cardId === updatedProgress.cardId ? updatedProgress : progress
+    ),
+  });
+  return updatedProgress;
+};
+
+export const deleteLocalStudyProgress = (cardId: string): void => {
+  const id = studyProgressEditSchema.shape.cardId.parse(cardId);
+  studyProgressStore.setState({
+    localProgresses: studyProgressStore.getState().localProgresses.filter((progress) => progress.cardId !== id),
+  });
+};
+
+export const deleteLocalStudyProgresses = (cardIds: string[]): void => {
+  const ids = new Set(cardIds.map((cardId) => studyProgressEditSchema.shape.cardId.parse(cardId)));
+  studyProgressStore.setState({
+    localProgresses: studyProgressStore.getState().localProgresses.filter((progress) => !ids.has(progress.cardId)),
+  });
+};

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -7,9 +7,9 @@ export interface StudyProgress {
   cardId: CardId;
   score: number;
   numberOfSeen: number;
-  lastSeenAt?: number;
-  nextSeeingAt?: Date;
-  interval?: number;
+  lastSeenAt?: number | undefined;
+  nextSeeingAt?: Date | undefined;
+  interval?: number | undefined;
 }
 
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -14,7 +14,7 @@ import { createCard as createCardCommand, deleteCard, editCard } from "@/entitie
 import { createDeck as createDeckCommand } from "@/entities/deck/api/firestore";
 import { replaceRemoteCards } from "@/entities/card/model/store";
 import { replaceRemoteDecks } from "@/entities/deck/model/store";
-import { editStudyProgress } from "@/entities/study-progress";
+import { editRemoteStudyProgress } from "@/entities/study-progress/api/firestore";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as Uuid from "uuid";
 import { createCard, createDeck } from "@/test/factories";
@@ -98,9 +98,9 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
       deckId: "other-deck",
       uid: "other-user",
       deletedAt: 1,
-    } as unknown as Parameters<typeof editStudyProgress>[1];
+    } as unknown as Parameters<typeof editRemoteStudyProgress>[1];
 
-    await editStudyProgress("uid", untrustedProgress);
+    await editRemoteStudyProgress("uid", untrustedProgress);
 
     expect((await getDoc(doc(db, "card", card.id))).data()).toEqual({ ...card, score: 2, numberOfSeen: 3 });
   });


### PR DESCRIPTION
## Related issue

Fixes #1035

## Summary

- Add an explicit remote/local StudyProgress state boundary and persist only local progress under its own browser storage key.
- Validate persisted progress, restore scheduled dates, and migrate released tango-local-cards version 1 progress once when the new key is absent.
- Route local progress edits and Card lifecycle changes to local persistence while preserving the existing remote Firestore write path.

## Testing

- mise run check
- mise run test-integration