### PR TITLE
[No issue] Simplify filtered study cards

### DIFF
--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -3,7 +3,6 @@ export { createDeck, deleteDeck, editDeck } from "./api/mutations";
 export { generateDeckId } from "./model/id";
 export {
   CATEGORY,
-  createSelectableStudyCard,
   filterCardsForDeck,
   getCategory,
   isHighlightLanguage,

--- a/src/entities/deck/model/rules.spec.ts
+++ b/src/entities/deck/model/rules.spec.ts
@@ -3,14 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { createCard, createDeck } from "@/test/factories";
-import {
-  CATEGORY,
-  createSelectableStudyCard,
-  filterCardsForDeck,
-  getCategory,
-  isHighlightLanguage,
-  mustFindDeckById,
-} from "./rules";
+import { CATEGORY, filterCardsForDeck, getCategory, isHighlightLanguage, mustFindDeckById } from "./rules";
 
 describe("category", () => {
   it("defines supported categories including application categories and major languages", () => {
@@ -59,35 +52,34 @@ describe("mustFindDeckById", () => {
 
 describe("filterCardsForDeck", () => {
   const now = 1000;
-  const makeCard = (overrides: Parameters<typeof createCard>[0]) => createSelectableStudyCard(createCard(overrides));
   const baseDeck = createDeck({ selectedTags: [], tagAndFilter: false, scoreMax: null, scoreMin: null });
   const basePreferences = { useCardInterval: false };
 
   it("returns all cards when no filters are active", () => {
-    const cards = [makeCard({ id: "a" }), makeCard({ id: "b" })];
+    const cards = [createCard({ id: "a" }), createCard({ id: "b" })];
     expect(filterCardsForDeck(cards, baseDeck, basePreferences, now)).toHaveLength(2);
   });
 
   it("filters tags with OR semantics", () => {
-    const cards = [makeCard({ id: "a", tags: ["x"] }), makeCard({ id: "b", tags: ["y"] })];
+    const cards = [createCard({ id: "a", tags: ["x"] }), createCard({ id: "b", tags: ["y"] })];
     const deck = { ...baseDeck, selectedTags: ["x"], tagAndFilter: false };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map(({ card }) => card.id)).toEqual(["a"]);
+    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
   });
 
   it("filters tags with AND semantics", () => {
-    const cards = [makeCard({ id: "a", tags: ["x", "y"] }), makeCard({ id: "b", tags: ["x"] })];
+    const cards = [createCard({ id: "a", tags: ["x", "y"] }), createCard({ id: "b", tags: ["x"] })];
     const deck = { ...baseDeck, selectedTags: ["x", "y"], tagAndFilter: true };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map(({ card }) => card.id)).toEqual(["a"]);
+    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
   });
 
   it("includes the configured score boundaries", () => {
     const cards = [
-      makeCard({ id: "low", score: 1 }),
-      makeCard({ id: "middle", score: 2 }),
-      makeCard({ id: "high", score: 3 }),
+      createCard({ id: "low", score: 1 }),
+      createCard({ id: "middle", score: 2 }),
+      createCard({ id: "high", score: 3 }),
     ];
     const deck = { ...baseDeck, scoreMin: 1, scoreMax: 3 };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map(({ card }) => card.id)).toEqual([
+    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual([
       "low",
       "middle",
       "high",
@@ -96,26 +88,23 @@ describe("filterCardsForDeck", () => {
 
   it("excludes scores outside the configured range", () => {
     const cards = [
-      makeCard({ id: "low", score: 1 }),
-      makeCard({ id: "middle", score: 2 }),
-      makeCard({ id: "high", score: 3 }),
+      createCard({ id: "low", score: 1 }),
+      createCard({ id: "middle", score: 2 }),
+      createCard({ id: "high", score: 3 }),
     ];
     const deck = { ...baseDeck, scoreMin: 2, scoreMax: 2 };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map(({ card }) => card.id)).toEqual(["middle"]);
+    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["middle"]);
   });
 
   it("filters unavailable cards when intervals are enabled", () => {
-    const cards = [makeCard({ id: "future", nextSeeingAt: new Date(now + 1) }), makeCard({ id: "available" })];
-    expect(filterCardsForDeck(cards, baseDeck, { useCardInterval: true }, now).map(({ card }) => card.id)).toEqual([
+    const cards = [createCard({ id: "future", nextSeeingAt: new Date(now + 1) }), createCard({ id: "available" })];
+    expect(filterCardsForDeck(cards, baseDeck, { useCardInterval: true }, now).map((card) => card.id)).toEqual([
       "available",
     ]);
   });
 
   it("preserves input order while filtering", () => {
-    const cards = [makeCard({ id: "seen", numberOfSeen: 5 }), makeCard({ id: "new", numberOfSeen: 1 })];
-    expect(filterCardsForDeck(cards, baseDeck, basePreferences, now).map(({ card }) => card.id)).toEqual([
-      "seen",
-      "new",
-    ]);
+    const cards = [createCard({ id: "seen", numberOfSeen: 5 }), createCard({ id: "new", numberOfSeen: 1 })];
+    expect(filterCardsForDeck(cards, baseDeck, basePreferences, now).map((card) => card.id)).toEqual(["seen", "new"]);
   });
 });

--- a/src/entities/deck/model/rules.ts
+++ b/src/entities/deck/model/rules.ts
@@ -1,16 +1,7 @@
 import type { Card } from "@/entities/card/@x/deck";
-import {
-  createStudyProgressFromCard,
-  isStudyProgressEligible,
-  type StudyProgress,
-} from "@/entities/study-progress/@x/deck";
+import { createStudyProgressFromCard, isStudyProgressEligible } from "@/entities/study-progress/@x/deck";
 
 import type { Category, Deck, DeckId } from "./types";
-
-interface SelectableStudyCard<TCard extends Card = Card> {
-  card: TCard;
-  progress: StudyProgress;
-}
 
 const APPLICATION_CATEGORIES: Category[] = ["raw", "math"];
 
@@ -61,11 +52,6 @@ export const getCategory = (category: Category, tags: string[]): Category => {
   return tagCategory ?? category;
 };
 
-export const createSelectableStudyCard = <TCard extends Card>(card: TCard): SelectableStudyCard<TCard> => ({
-  card,
-  progress: createStudyProgressFromCard(card),
-});
-
 const isCardMatchingTags = (card: Card, deck: Pick<Deck, "selectedTags" | "tagAndFilter">) => {
   const tags = deck.selectedTags;
   if (tags.length === 0) return true;
@@ -74,15 +60,15 @@ const isCardMatchingTags = (card: Card, deck: Pick<Deck, "selectedTags" | "tagAn
 };
 
 export const filterCardsForDeck = <TCard extends Card>(
-  cards: SelectableStudyCard<TCard>[],
+  cards: TCard[],
   deck: Pick<Deck, "selectedTags" | "tagAndFilter" | "scoreMax" | "scoreMin">,
   study: { useCardInterval: boolean },
   now: number
-): SelectableStudyCard<TCard>[] =>
-  cards.filter(({ card, progress }) => {
+): TCard[] =>
+  cards.filter((card) => {
     if (!isCardMatchingTags(card, deck)) return false;
     return isStudyProgressEligible(
-      progress,
+      createStudyProgressFromCard(card),
       {
         maximumScore: deck.scoreMax,
         minimumScore: deck.scoreMin,

--- a/src/entities/study-progress/@x/deck.ts
+++ b/src/entities/study-progress/@x/deck.ts
@@ -1,2 +1,1 @@
 export { createStudyProgressFromCard, isStudyProgressEligible } from "../model/rules";
-export type { StudyProgress } from "../model/types";

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -74,10 +74,13 @@ export const buildStudyCardOrder = (
   return cardOrderIds;
 };
 
-export const getNextStudyAvailabilityAt = (progresses: StudyProgress[], now: number): number | undefined => {
+export const getNextStudyAvailabilityAt = (
+  scheduledItems: readonly { nextSeeingAt?: Date | undefined }[],
+  now: number
+): number | undefined => {
   let next: number | undefined;
-  for (const progress of progresses) {
-    const candidate = progress.nextSeeingAt?.getTime();
+  for (const item of scheduledItems) {
+    const candidate = item.nextSeeingAt?.getTime();
     if (candidate !== undefined && candidate > now && (next === undefined || candidate < next)) {
       next = candidate;
     }

--- a/src/features/deck-filter/model/useFilteredStudyCards.ts
+++ b/src/features/deck-filter/model/useFilteredStudyCards.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { Card } from "@/entities/card";
-import { createSelectableStudyCard, type Deck, filterCardsForDeck } from "@/entities/deck";
+import { type Deck, filterCardsForDeck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
 
@@ -9,23 +9,17 @@ import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 export const useFilteredStudyCards = (deck: Deck | undefined, cards: Card[], preferences: Preferences): Card[] => {
-  const [scheduleClock, setScheduleClock] = useState(() => Date.now());
-  const studyCards = useMemo(() => cards.map(createSelectableStudyCard), [cards]);
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    // Using the rendered clock makes an overdue review in a changed card list trigger an immediate refresh.
-    const next = getNextStudyAvailabilityAt(
-      studyCards.map((card) => card.progress),
-      scheduleClock
-    );
+    // Refreshing at the next due time keeps the visible selection current while the page remains open.
+    const next = getNextStudyAvailabilityAt(cards, now);
     if (next === undefined) return;
 
     const delay = Math.min(Math.max(next - Date.now(), 0), MAX_TIMEOUT_MS);
-    const availability = window.setTimeout(() => setScheduleClock(Date.now()), delay);
+    const availability = window.setTimeout(() => setNow(Date.now()), delay);
     return () => window.clearTimeout(availability);
-  }, [scheduleClock, studyCards]);
+  }, [cards, now]);
 
-  return deck == null
-    ? []
-    : filterCardsForDeck(studyCards, deck, preferences.study, scheduleClock).map(({ card }) => card);
+  return deck == null ? [] : filterCardsForDeck(cards, deck, preferences.study, now);
 };


### PR DESCRIPTION
## Summary

- let the Deck entity filter ordinary `Card[]` values directly
- remove the `SelectableStudyCard` wrapper, `useMemo`, and conversion maps from `useFilteredStudyCards`
- allow the Study Progress availability rule to inspect any scheduled item with `nextSeeingAt`

## Why

The feature hook was translating Cards into an entity-specific wrapper and back again even though the entity rules can interpret Cards themselves. Keeping that conversion in the hook obscured its only React responsibility: refreshing when the next card becomes due.

## Impact

Filtering behavior, input order, and automatic due-time refreshes are unchanged. The hook and cross-entity API are smaller.

## Validation

- `mise run check`
- 533 unit tests passed