### PR TITLE
No issue: inline card form schema

### DIFF
--- a/src/features/card-edit/model/cardFormSchema.ts
+++ b/src/features/card-edit/model/cardFormSchema.ts
@@ -1,7 +1,0 @@
-import type * as z from "zod";
-
-import { cardContentSchema } from "@/entities/card";
-
-export const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
-
-export type CardFormValues = z.infer<typeof cardFormSchema>;

--- a/src/features/card-edit/model/useCardFormState.ts
+++ b/src/features/card-edit/model/useCardFormState.ts
@@ -1,11 +1,14 @@
-import type { Card, CardEditInput } from "@/entities/card";
+import type * as z from "zod";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
+import { cardContentSchema, type Card, type CardEditInput } from "@/entities/card";
 import type { Option } from "@/shared/ui/forms";
 import type { CardFormProps } from "../ui/CardForm";
-import { cardFormSchema, type CardFormValues } from "./cardFormSchema";
+
+const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
+type CardFormValues = z.infer<typeof cardFormSchema>;
 
 interface UseCardFormStateOptions {
   card: Card;


### PR DESCRIPTION
## Summary

- inline the card edit form schema and inferred values type into `useCardFormState.ts`
- remove the redundant `cardFormSchema.ts` file

## Why

`cardFormSchema.ts` only wrapped `cardContentSchema.omit({ uniqueKey: true })` and exported its inferred type, while both were only used by `useCardFormState.ts`. Keeping that indirection adds a file without providing a meaningful separate responsibility.

## Impact

No behavior change is intended. Card edit validation still reuses `cardContentSchema` while excluding `uniqueKey` from the form.

## Validation

- reviewed the branch diff against `main`
- `mise run check` could not be run in the execution environment because the local environment could not resolve `github.com` to clone the repository