### PR TITLE
No issue: Simplify card form error state

### DIFF
--- a/src/features/card-edit/model/useCardFormState.ts
+++ b/src/features/card-edit/model/useCardFormState.ts
@@ -41,8 +41,8 @@ export const useCardFormState = ({
       })),
     },
     errors: {
-      ...(formState.errors.frontText?.message !== undefined ? { frontText: formState.errors.frontText.message } : {}),
-      ...(formState.errors.backText?.message !== undefined ? { backText: formState.errors.backText.message } : {}),
+      frontText: formState.errors.frontText?.message,
+      backText: formState.errors.backText?.message,
     },
     isSubmitting: formState.isSubmitting,
     onCancel,

--- a/src/features/card-edit/ui/CardForm.tsx
+++ b/src/features/card-edit/ui/CardForm.tsx
@@ -20,9 +20,9 @@ interface CardFormFields {
 export interface CardFormProps {
   card: Card;
   fields: CardFormFields;
-  errors?: {
-    frontText?: string;
-    backText?: string;
+  errors: {
+    frontText: string | undefined;
+    backText: string | undefined;
   };
   isSubmitting: boolean;
   onCancel: () => void;
@@ -56,14 +56,14 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
           label="Front text"
           inputId={frontInputId}
           errorId={frontErrorId}
-          {...(props.errors?.frontText !== undefined ? { error: props.errors.frontText } : {})}
+          {...(props.errors.frontText !== undefined ? { error: props.errors.frontText } : {})}
         >
           <Textarea
             rows={8}
             {...props.fields.frontText}
             id={frontInputId}
-            aria-invalid={props.errors?.frontText != null || undefined}
-            aria-describedby={props.errors?.frontText !== undefined ? frontErrorId : undefined}
+            aria-invalid={props.errors.frontText != null || undefined}
+            aria-describedby={props.errors.frontText !== undefined ? frontErrorId : undefined}
           />
         </FormItem>
       </section>
@@ -82,14 +82,14 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
           label="Back text"
           inputId={backInputId}
           errorId={backErrorId}
-          {...(props.errors?.backText !== undefined ? { error: props.errors.backText } : {})}
+          {...(props.errors.backText !== undefined ? { error: props.errors.backText } : {})}
         >
           <Textarea
             rows={8}
             {...props.fields.backText}
             id={backInputId}
-            aria-invalid={props.errors?.backText != null || undefined}
-            aria-describedby={props.errors?.backText !== undefined ? backErrorId : undefined}
+            aria-invalid={props.errors.backText != null || undefined}
+            aria-describedby={props.errors.backText !== undefined ? backErrorId : undefined}
           />
         </FormItem>
       </section>


### PR DESCRIPTION
## Summary

- make `CardFormProps.errors` match the form-state shape returned by `useCardFormState`
- remove conditional object spreads when mapping React Hook Form error messages
- simplify error access in `CardForm`

## Why

`useCardFormState` always returns an `errors` object, while each field can be absent. Expressing that directly in the props type makes the mapping shorter and easier to read without changing behavior.

## Validation

- reviewed the branch diff against `main`
- `mise run check` was not run locally because this environment has no repository checkout/toolchain access