### PR TITLE
[No issue] Make study session lifecycle explicit

### DIFF
--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -4,6 +4,7 @@ import { calculateStudySessionIndex } from "./rules";
 import type { StudySession } from "./types";
 
 const session: StudySession = {
+  status: "studying",
   deckId: "deck-1",
   cardOrderIds: ["card-1", "card-2", "card-3"],
   currentIndex: 1,

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -44,6 +44,7 @@ describe("study store", () => {
     cardOrderIds.pop();
 
     expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({
+      status: "studying",
       cardOrderIds: ["card-1", "card-2"],
       currentIndex: 0,
     });
@@ -58,8 +59,20 @@ describe("study store", () => {
     startStudySession("deck-2", ["card-3"]);
 
     expect(store.getState().sessionsByDeckId).toEqual({
-      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 0, lastStudiedAt: 1000 },
-      "deck-2": { deckId: "deck-2", cardOrderIds: ["card-3"], currentIndex: 0, lastStudiedAt: 2000 },
+      "deck-1": {
+        status: "studying",
+        deckId: "deck-1",
+        cardOrderIds: ["card-1", "card-2"],
+        currentIndex: 0,
+        lastStudiedAt: 1000,
+      },
+      "deck-2": {
+        status: "studying",
+        deckId: "deck-2",
+        cardOrderIds: ["card-3"],
+        currentIndex: 0,
+        lastStudiedAt: 2000,
+      },
     });
   });
 
@@ -76,14 +89,27 @@ describe("study store", () => {
     expect(store.getState().sessionsByDeckId["deck-2"]).toMatchObject({ currentIndex: 0, lastStudiedAt: 1000 });
   });
 
-  it("moves within a session and removes it when movement reaches an edge", () => {
+  it("moves within a session and marks it completed when movement reaches an edge", () => {
     startStudySession("deck-1", ["card-1", "card-2"]);
 
     moveStudySession("deck-1", "next");
     expect(getStudySession("deck-1")?.currentIndex).toBe(1);
 
     moveStudySession("deck-1", "next");
-    expect(getStudySession("deck-1")).toBeUndefined();
+    expect(getStudySession("deck-1")).toMatchObject({ status: "completed", currentIndex: 1 });
+  });
+
+  it("starts a new studying session over completed progress", () => {
+    startStudySession("deck-1", ["old-card"]);
+    moveStudySession("deck-1", "next");
+
+    startStudySession("deck-1", ["new-card"]);
+
+    expect(getStudySession("deck-1")).toMatchObject({
+      status: "studying",
+      cardOrderIds: ["new-card"],
+      currentIndex: 0,
+    });
   });
 
   it.each([-1, 2, 0.5])("does not persist an invalid session index: %s", (currentIndex) => {
@@ -134,7 +160,7 @@ describe("study store", () => {
     expect(localStorage.getItem(STUDY_STORAGE_KEY)).toBeNull();
   });
 
-  it("persists exactly the session map in a v3 envelope", async () => {
+  it("persists exactly the session map in a v4 envelope", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
     startStudySession("deck-1", ["card-1"]);
@@ -143,10 +169,16 @@ describe("study store", () => {
     expect(JSON.parse(persistedSession ?? "{}")).toEqual({
       state: {
         sessionsByDeckId: {
-          "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
+          "deck-1": {
+            status: "studying",
+            deckId: "deck-1",
+            cardOrderIds: ["card-1"],
+            currentIndex: 0,
+            lastStudiedAt: 1000,
+          },
         },
       },
-      version: 3,
+      version: 4,
     });
 
     store.setState({ sessionsByDeckId: {} });
@@ -154,33 +186,52 @@ describe("study store", () => {
     await store.persist.rehydrate();
     expect(store.getState()).toMatchObject({
       sessionsByDeckId: {
-        "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
+        "deck-1": {
+          status: "studying",
+          deckId: "deck-1",
+          cardOrderIds: ["card-1"],
+          currentIndex: 0,
+          lastStudiedAt: 1000,
+        },
       },
     });
     expect(store.getState()).not.toHaveProperty("session");
   });
 
-  it("hydrates valid v3 sessions independently and drops unknown metadata", async () => {
+  it("hydrates valid v4 sessions independently and drops unknown metadata", async () => {
     setVersionedStorage(
       {
         sessionsByDeckId: {
           "deck-1": {
+            status: "completed",
             deckId: "deck-1",
             cardOrderIds: ["card-1", "card-2"],
             currentIndex: 1,
             lastStudiedAt: 1000,
             unknownSessionMetadata: "drop",
           },
-          broken: { deckId: "broken", cardOrderIds: [], currentIndex: 0, lastStudiedAt: 2000 },
+          broken: {
+            status: "studying",
+            deckId: "broken",
+            cardOrderIds: [],
+            currentIndex: 0,
+            lastStudiedAt: 2000,
+          },
         },
         unknownRootMetadata: "drop",
       },
-      3
+      4
     );
     await store.persist.rehydrate();
 
     expect(store.getState().sessionsByDeckId).toEqual({
-      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 1000 },
+      "deck-1": {
+        status: "completed",
+        deckId: "deck-1",
+        cardOrderIds: ["card-1", "card-2"],
+        currentIndex: 1,
+        lastStudiedAt: 1000,
+      },
     });
     expect(store.getState()).not.toHaveProperty("unknownRootMetadata");
   });

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -10,7 +10,7 @@ import type { StudySession, StudySessions } from "./types";
 
 const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
-const STUDY_STORAGE_VERSION = 3;
+const STUDY_STORAGE_VERSION = 4;
 
 interface StudySessionState {
   sessionsByDeckId: StudySessions;
@@ -22,8 +22,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 // Rebuild canonical sessions from untrusted browser storage so malformed fields cannot break resume logic.
 const sanitizeStudySession = (value: unknown): StudySession | undefined => {
   if (!isRecord(value)) return;
-  const { deckId, cardOrderIds, currentIndex, lastStudiedAt } = value;
+  const { status, deckId, cardOrderIds, currentIndex, lastStudiedAt } = value;
   if (
+    (status !== "studying" && status !== "completed") ||
     typeof deckId !== "string" ||
     !Array.isArray(cardOrderIds) ||
     cardOrderIds.length === 0 ||
@@ -39,7 +40,7 @@ const sanitizeStudySession = (value: unknown): StudySession | undefined => {
     return;
   }
 
-  return { deckId, cardOrderIds: [...cardOrderIds], currentIndex, lastStudiedAt };
+  return { status, deckId, cardOrderIds: [...cardOrderIds], currentIndex, lastStudiedAt };
 };
 
 const sanitizePersistedState = (persistedState: unknown): StudySessionState => {
@@ -77,6 +78,7 @@ export const getStudySession = (deckId: DeckId): StudySession | undefined =>
 export const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
   studySessionStore.setState((state) => {
     state.sessionsByDeckId[deckId] = {
+      status: "studying",
       deckId,
       // The store owns this ordering snapshot even if the caller later reuses its array.
       cardOrderIds: [...cardOrderIds],
@@ -89,7 +91,7 @@ export const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void 
 export const touchStudySession = (deckId: DeckId): void => {
   studySessionStore.setState((state) => {
     const session = state.sessionsByDeckId[deckId];
-    if (session != null) session.lastStudiedAt = Date.now();
+    if (session?.status === "studying") session.lastStudiedAt = Date.now();
   });
 };
 
@@ -99,6 +101,7 @@ export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): void
     // Never persist a resume point that cannot identify an active card.
     if (
       session == null ||
+      session.status !== "studying" ||
       !Number.isInteger(currentIndex) ||
       currentIndex < 0 ||
       currentIndex >= session.cardOrderIds.length
@@ -113,11 +116,13 @@ export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): void
 export const moveStudySession = (deckId: DeckId, movement: StudySessionMovement): void => {
   studySessionStore.setState((state) => {
     const session = state.sessionsByDeckId[deckId];
-    if (session == null) return;
+    if (session?.status !== "studying") return;
 
     const nextIndex = calculateStudySessionIndex(session, movement);
     if (nextIndex === undefined) {
-      delete state.sessionsByDeckId[deckId];
+      // Keep completion observable so consumers do not infer lifecycle state from a missing session.
+      session.status = "completed";
+      session.lastStudiedAt = Date.now();
       return;
     }
     session.currentIndex = nextIndex;

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -2,7 +2,7 @@ import type { CardId } from "@/entities/card/@x/study-session";
 import type { DeckId } from "@/entities/deck/@x/study-session";
 
 /**
- * Persisted progress for one deck's active study run.
+ * Persisted progress for one deck's study run.
  *
  * Starting the same deck again replaces its existing session. A session keeps
  * the original card order so resuming does not reshuffle cards midway through
@@ -10,21 +10,23 @@ import type { DeckId } from "@/entities/deck/@x/study-session";
  * sessions that preserve the invariants documented below.
  */
 export interface StudySession {
+  /** Describes the study lifecycle without overloading missing card data as completion. */
+  status: "studying" | "completed";
   /** Must match its key in {@link StudySessions}; hydration drops mismatches. */
   deckId: DeckId;
   /** Snapshot fixed at start so later caller mutations cannot reorder the run. */
   cardOrderIds: CardId[];
-  /** Valid index into {@link cardOrderIds}; completed runs are removed instead of using a terminal index. */
+  /** Last valid index reached in {@link cardOrderIds}. */
   currentIndex: number;
   /** Drives recent-deck ordering and advances only when the session is started or used. */
   lastStudiedAt: number;
 }
 
 /**
- * Active study sessions indexed by deck identifier.
+ * Study sessions indexed by deck identifier.
  *
- * A deck is absent until study starts and after its session is completed,
- * reset, or removed with the deck. Persisted entries are validated independently
+ * A deck is absent until study starts and after its session is reset or removed
+ * with the deck. Completed sessions remain explicit until either event. Persisted entries are validated independently
  * so one corrupt session does not discard valid progress for other decks.
  */
 export type StudySessions = Partial<Record<DeckId, StudySession>>;

--- a/src/features/deck-list/model/buildDeckListSections.spec.ts
+++ b/src/features/deck-list/model/buildDeckListSections.spec.ts
@@ -21,18 +21,21 @@ describe("buildDeckListSections", () => {
     ];
     const sessionsByDeckId = {
       "active-old": {
+        status: "studying" as const,
         deckId: "active-old",
         cardOrderIds: ["old-1", "old-2"],
         currentIndex: 0,
         lastStudiedAt: 100,
       },
       "active-new": {
+        status: "studying" as const,
         deckId: "active-new",
         cardOrderIds: ["new-1", "new-2", "new-3"],
         currentIndex: 1,
         lastStudiedAt: 200,
       },
       missing: {
+        status: "studying" as const,
         deckId: "missing",
         cardOrderIds: ["missing-card"],
         currentIndex: 0,
@@ -55,6 +58,7 @@ describe("buildDeckListSections", () => {
   it("uses deck name as a stable tie breaker for equally recent sessions", () => {
     const decks = [createDeck({ id: "b", name: "Beta" }), createDeck({ id: "a", name: "Alpha" })];
     const session = (deckId: DeckId) => ({
+      status: "studying" as const,
       deckId,
       cardOrderIds: [`${deckId}-card`],
       currentIndex: 0,
@@ -65,5 +69,20 @@ describe("buildDeckListSections", () => {
 
     expect(sections.studying.map((item) => item.deck.name)).toEqual(["Alpha", "Beta"]);
     expect(sections.other).toEqual([]);
+  });
+
+  it("does not present completed sessions as in-progress study", () => {
+    const deck = createDeck({ id: "completed", name: "Completed" });
+    const sections = buildDeckListSections([deck], [], {
+      completed: {
+        status: "completed",
+        cardOrderIds: ["card-1"],
+        currentIndex: 0,
+        lastStudiedAt: 100,
+      },
+    });
+
+    expect(sections.studying).toEqual([]);
+    expect(sections.other).toEqual([{ deck, cardCount: 0 }]);
   });
 });

--- a/src/features/deck-list/model/buildDeckListSections.ts
+++ b/src/features/deck-list/model/buildDeckListSections.ts
@@ -2,6 +2,7 @@ import type { Card } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
 
 interface DeckListStudySession {
+  status: "studying" | "completed";
   cardOrderIds: string[];
   currentIndex: number;
   lastStudiedAt: number;
@@ -39,20 +40,21 @@ export const buildDeckListSections = (
 
   for (const deck of decks) {
     const session = sessionsByDeckId[deck.id];
+    const studyingSession = session?.status === "studying" ? session : undefined;
     const item: DeckListItem = {
       deck,
       cardCount: cardCounts.get(deck.id) ?? 0,
-      ...(session == null
+      ...(studyingSession == null
         ? {}
         : {
             studyProgress: {
-              currentIndex: session.currentIndex,
-              cardCount: session.cardOrderIds.length,
-              lastStudiedAt: session.lastStudiedAt,
+              currentIndex: studyingSession.currentIndex,
+              cardCount: studyingSession.cardOrderIds.length,
+              lastStudiedAt: studyingSession.lastStudiedAt,
             },
           }),
     };
-    if (session == null) other.push(item);
+    if (studyingSession == null) other.push(item);
     else studying.push(item);
   }
 

--- a/src/features/deck-list/ui/DeckList.spec.tsx
+++ b/src/features/deck-list/ui/DeckList.spec.tsx
@@ -23,11 +23,13 @@ const cards = [
 ];
 const sessionsByDeckId: DeckListProps["sessionsByDeckId"] = {
   [oldDeck.id]: {
+    status: "studying",
     cardOrderIds: ["old-1", "old-2"],
     currentIndex: 0,
     lastStudiedAt: 1000,
   },
   [recentDeck.id]: {
+    status: "studying",
     cardOrderIds: ["recent-1", "recent-2", "recent-3"],
     currentIndex: 1,
     lastStudiedAt: 2000,

--- a/src/features/study/hooks/useActiveStudySession.ts
+++ b/src/features/study/hooks/useActiveStudySession.ts
@@ -5,9 +5,9 @@ import { removeStudySession, touchStudySession, useStudySession } from "@/entiti
 import * as React from "react";
 
 export type ActiveStudySession =
-  | { status: "loading" | "unavailable" }
+  | { status: "loading" | "unavailable" | "completed" }
   | {
-      status: "ready";
+      status: "studying";
       card: Card;
       index: number;
       numberOfCards: number;
@@ -15,13 +15,15 @@ export type ActiveStudySession =
 
 export const useActiveStudySession = (deckId: DeckId, cards: readonly Card[]): ActiveStudySession => {
   const session = useStudySession(deckId);
+  if (session?.status === "completed") return { status: "completed" };
+
   const index = session?.currentIndex ?? -1;
   const cardId = index >= 0 ? session?.cardOrderIds[index] : undefined;
   const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
   const sessionHasTargetCard = session != null && index >= 0 && index < session.cardOrderIds.length;
 
   if (card != null && sessionHasTargetCard) {
-    return { status: "ready", card, index, numberOfCards: session.cardOrderIds.length };
+    return { status: "studying", card, index, numberOfCards: session.cardOrderIds.length };
   }
   if (sessionHasTargetCard && cards.length === 0) return { status: "loading" };
   return { status: "unavailable" };
@@ -39,19 +41,20 @@ export const useStudySessionLifecycle = ({
   const exitingDeck = React.useRef<DeckId>(undefined);
 
   React.useEffect(() => {
-    if (session.status !== "ready") return;
+    if (session.status !== "studying") return;
     touchStudySession(deckId);
   }, [deckId, session.status]);
 
   React.useEffect(() => {
-    if (session.status === "ready") {
+    if (session.status === "studying") {
       exitingDeck.current = undefined;
       return;
     }
     if (session.status === "loading" || exitingDeck.current === deckId) return;
 
     exitingDeck.current = deckId;
-    removeStudySession(deckId);
+    // Completed sessions remain persisted as lifecycle state; unavailable sessions are invalidated.
+    if (session.status === "unavailable") removeStudySession(deckId);
     onUnavailable();
   }, [deckId, onUnavailable, session.status]);
 };

--- a/src/features/study/hooks/useStudy.spec.tsx
+++ b/src/features/study/hooks/useStudy.spec.tsx
@@ -1,6 +1,6 @@
 import type { Card } from "@/entities/card";
 import type { Preferences } from "@/entities/preferences";
-import { clearStudySessions, startStudySession } from "@/entities/study-session";
+import { clearStudySessions, getStudySession, startStudySession } from "@/entities/study-session";
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -74,14 +74,14 @@ describe("useStudy", () => {
 
   it("coordinates display state, persistence, and session progression", async () => {
     const { result } = renderHook(() => useStudy(deckId, cards, mocks.onUnavailable));
-    expect(result.current).toMatchObject({ status: "ready", card: { id: "card-1" }, showBackText: false });
+    expect(result.current).toMatchObject({ status: "studying", card: { id: "card-1" }, showBackText: false });
     expect(mocks.touchStudySession).toHaveBeenCalledWith(deckId);
 
     act(() => result.current.toggleBackText());
-    expect(result.current).toMatchObject({ status: "ready", showBackText: true });
+    expect(result.current).toMatchObject({ status: "studying", showBackText: true });
     await actAsync(() => result.current.swipeRight());
 
-    await waitFor(() => expect(result.current).toMatchObject({ status: "ready", card: { id: "card-2" } }));
+    await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } }));
     expect(result.current).toMatchObject({ showBackText: false, swipeFeedback: "cardSwipeRight" });
     expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
   });
@@ -99,7 +99,18 @@ describe("useStudy", () => {
 
     act(() => vi.advanceTimersByTime(1000));
 
-    expect(result.current).toMatchObject({ status: "ready", card: { id: "card-2" } });
+    expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } });
+  });
+
+  it("reports completion without removing the completed session", async () => {
+    startStudySession(deckId, ["card-1"]);
+    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onUnavailable));
+
+    await actAsync(() => result.current.swipeRight());
+
+    await waitFor(() => expect(result.current.status).toBe("completed"));
+    await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
+    expect(getStudySession(deckId)).toMatchObject({ status: "completed", currentIndex: 0 });
   });
 
   it("reports and handles an unavailable session", async () => {

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -22,9 +22,9 @@ interface StudyCommands {
 
 export type StudyState = StudyCommands &
   (
-    | { status: "loading" | "unavailable" }
+    | { status: "loading" | "unavailable" | "completed" }
     | {
-        status: "ready";
+        status: "studying";
         card: Card;
         showHeader: boolean;
         showBackText: boolean;
@@ -57,7 +57,7 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
 
   React.useEffect(() => {
     if (
-      session.status !== "ready" ||
+      session.status !== "studying" ||
       !display.autoPlay ||
       display.preferences.study.cardInterval <= 0 ||
       session.index + 1 >= session.numberOfCards
@@ -79,10 +79,10 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
     toggleAutoPlay: display.toggleAutoPlay,
   };
 
-  if (session.status !== "ready") return { ...session, ...commands };
+  if (session.status !== "studying") return { ...session, ...commands };
 
   return {
-    status: "ready",
+    status: "studying",
     ...commands,
     card: session.card,
     showHeader: display.preferences.appearance.showHeader && !display.showBackText,

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -203,13 +203,13 @@ describe("useStudyActions", () => {
     expect(getStudySession(deckId)).toBeUndefined();
   });
 
-  it("removes the session after the final card is persisted", async () => {
+  it("completes the session after the final card is persisted", async () => {
     startStudySession(deckId, ["card-1"]);
     const { result } = renderActions();
 
     await actAsync(() => result.current.swipeRight());
 
     expect(saveProgress).toHaveBeenCalledOnce();
-    expect(getStudySession(deckId)).toBeUndefined();
+    expect(getStudySession(deckId)).toMatchObject({ status: "completed", currentIndex: 0 });
   });
 });

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -36,7 +36,7 @@ export const useStudyActions = (
     // biome-ignore lint/suspicious/noUnnecessaryConditions: The awaited write lets another event enter this closure.
     if (swipeState.current.inProgress) return;
     const session = getStudySession(deckId);
-    if (session == null) return;
+    if (session?.status !== "studying") return;
 
     const swipeAction = preferences.controls[direction];
     if (swipeAction === "DoNothing") return;
@@ -63,7 +63,8 @@ export const useStudyActions = (
     const currentSession = getStudySession(deckId);
     // Position changes during the write own the newer card, while timestamp-only touches still allow advancement.
     if (
-      currentSession?.currentIndex !== session.currentIndex ||
+      currentSession?.status !== "studying" ||
+      currentSession.currentIndex !== session.currentIndex ||
       currentSession.cardOrderIds[currentSession.currentIndex] !== cardId
     ) {
       return;
@@ -80,7 +81,7 @@ export const useStudyActions = (
     swipeLeft: () => swipe("cardSwipeLeft"),
     swipeRight: () => swipe("cardSwipeRight"),
     updateIndex: (currentIndex: number) => {
-      if (getStudySession(deckId) == null) return;
+      if (getStudySession(deckId)?.status !== "studying") return;
       onCardChanged?.();
       setStudySessionIndex(deckId, currentIndex);
     },

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -79,8 +79,8 @@ const commands = () => ({
   toggleBackText: vi.fn(),
   toggleAutoPlay: vi.fn(),
 });
-const readyState = (): StudyState => ({
-  status: "ready",
+const studyingState = (): StudyState => ({
+  status: "studying",
   ...commands(),
   card,
   showHeader: true,
@@ -99,7 +99,7 @@ describe("DeckStudyPage", () => {
     mocks.params.id = deck.id;
     mocks.deck = deck;
     mocks.cards = [card];
-    mocks.studyState = readyState();
+    mocks.studyState = studyingState();
     mocks.studyArgs = undefined;
     window.history.replaceState(null, document.title, document.location.href);
   });
@@ -136,7 +136,7 @@ describe("DeckStudyPage", () => {
   it("delegates a representative Study shortcut to the workflow action", () => {
     render(<DeckStudyPage />);
     const state = mocks.studyState;
-    if (state?.status !== "ready") throw new Error("expected ready workflow state");
+    if (state?.status !== "studying") throw new Error("expected studying workflow state");
 
     fireEvent.keyDown(window, { key: "ArrowLeft" });
 

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -12,7 +12,7 @@ import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 const renderStudyScreen = (deck: Deck, state: StudyState) => {
-  if (state.status !== "ready") {
+  if (state.status !== "studying") {
     return state.status === "loading" ? (
       <RouteFeedback title="Loading…" tone="loading" />
     ) : (

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -56,6 +56,7 @@ const persistedStudy = {
   state: {
     sessionsByDeckId: {
       [e2eDeck.id]: {
+        status: "studying",
         deckId: e2eDeck.id,
         cardOrderIds: e2eCards.map((card) => card.id),
         currentIndex: 0,
@@ -63,7 +64,7 @@ const persistedStudy = {
       },
     },
   },
-  version: 3,
+  version: 4,
 };
 
 const seedSwipeSession = async (page: Page) => {
@@ -142,13 +143,14 @@ test("updates study progress with a mastered deck swipe", async ({ page }) => {
       state: {
         sessionsByDeckId: {
           [e2eDeck.id]: {
+            status: "studying",
             deckId: e2eDeck.id,
             cardOrderIds: e2eCards.map((card) => card.id),
             currentIndex: 1,
           },
         },
       },
-      version: 3,
+      version: 4,
     });
   await expect
     .poll(async () => persistedStateBoundaries(page))


### PR DESCRIPTION
## Related issue

None.

## Summary

- add an explicit `studying | completed` status to persisted study sessions
- retain completed sessions instead of inferring completion from a missing session
- keep completed sessions out of active study controls and deck-list progress
- align the study workflow status name with the domain `studying` state

## Testing

- `mise run check`