### PR TITLE
[No issue] Enable no-implied-eval lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,7 +136,6 @@ export default [
       "@typescript-eslint/await-thenable": "off",
       "@typescript-eslint/no-base-to-string": "off",
       "@typescript-eslint/no-floating-promises": "off",
-      "@typescript-eslint/no-implied-eval": "off",
       "@typescript-eslint/no-misused-promises": "off",
       "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable @typescript-eslint/no-implied-eval by removing its explicit off override.
- Keep the strict type-checked ESLint configuration clean.

## Testing

- mise run check