### PR TITLE
[No issue] Simplify study session start hook

### DIFF
--- a/src/features/study-session-start/model/useStartStudySession.ts
+++ b/src/features/study-session-start/model/useStartStudySession.ts
@@ -4,22 +4,14 @@ import { usePreferences } from "@/entities/preferences";
 import { startStudySession } from "@/entities/study-session";
 import { buildStudyCardOrder } from "@/entities/study-progress";
 
-import { useCallback } from "react";
-
 interface UseStartStudySessionOptions {
   onStarted?: (() => void) | undefined;
 }
 
-export const useStartStudySession = (
-  deckId: DeckId,
-  { onStarted }: UseStartStudySessionOptions = {}
-): ((cards: Card[]) => void) => {
-  const preferences = usePreferences();
-  return useCallback(
-    (cards) => {
-      startStudySession(deckId, buildStudyCardOrder(cards, preferences.study));
-      onStarted?.();
-    },
-    [deckId, onStarted, preferences.study]
-  );
+export const useStartStudySession = (deckId: DeckId, { onStarted }: UseStartStudySessionOptions = {}) => {
+  const { study } = usePreferences();
+  return (cards: Card[]) => {
+    startStudySession(deckId, buildStudyCardOrder(cards, study));
+    onStarted?.();
+  };
 };


### PR DESCRIPTION
## Related issue

None

## Summary

- Remove manual useCallback memoization from the study session start hook
- Keep card ordering, session creation, and the onStarted notification sequence unchanged

## Testing

- mise run check