### PR TITLE
[No issue] Move study hook rules to entities

### DIFF
--- a/src/entities/preferences/@x/study-session.ts
+++ b/src/entities/preferences/@x/study-session.ts
@@ -1,0 +1,1 @@
+export type { SwipeAction } from "../model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,9 +1,7 @@
 export { editStudyProgress } from "./api/firestore";
 export {
   buildStudyCardOrder,
-  createStudyProgressFromCard,
   getNextStudyAvailabilityAt,
-  recordStudyProgress,
-  resolveStudyRating,
+  recordCardStudyProgress,
 } from "./model/rules";
 export type { StudyProgressEdit } from "./model/types";

--- a/src/entities/study-progress/model/rules.spec.ts
+++ b/src/entities/study-progress/model/rules.spec.ts
@@ -11,10 +11,9 @@ import {
   createStudyProgressFromCard,
   getNextStudyAvailabilityAt,
   isStudyProgressEligible,
-  recordStudyProgress,
-  resolveStudyRating,
+  recordCardStudyProgress,
 } from "./rules";
-import type { CardProgressFields, StudyProgress, StudyProgressEdit, StudyRating } from "./types";
+import type { CardProgressFields, StudyProgress, StudyProgressEdit } from "./types";
 
 const initialStudyProgress = (cardId: string): StudyProgress => ({ cardId, score: 0, numberOfSeen: 0 });
 
@@ -22,20 +21,6 @@ const cardProgress = (id: string, numberOfSeen = 0): CardProgressFields => ({
   id,
   score: 0,
   numberOfSeen,
-});
-
-describe("resolveStudyRating", () => {
-  it.each<[SwipeAction, StudyRating]>([
-    ["GoToNextCardMastered", "mastered"],
-    ["GoToNextCardNotMastered", "not-mastered"],
-    ["GoToNextCardToggleMastered", "not-mastered"],
-    ["DoNothing", "unrated"],
-    ["GoBack", "unrated"],
-    ["GoToPrevCard", "unrated"],
-    ["GoToNextCard", "unrated"],
-  ])("maps %s to %s", (action, expectedRating) => {
-    expect(resolveStudyRating(action)).toBe(expectedRating);
-  });
 });
 
 describe("createStudyProgressFromCard", () => {
@@ -77,19 +62,20 @@ describe("createStudyProgressFromCard", () => {
   });
 });
 
-describe("recordStudyProgress", () => {
-  it.each<[number, StudyRating, number]>([
-    [0, "mastered", 1],
-    [3, "mastered", 4],
-    [-1, "mastered", 0],
-    [0, "not-mastered", -1],
-    [-2, "not-mastered", -3],
-    [2, "not-mastered", 0],
-    [3, "unrated", 3],
-  ])("updates score %i for a %s rating", (score, rating, expectedScore) => {
-    const progress = { ...initialStudyProgress("card-id"), score, numberOfSeen: 2 };
+describe("recordCardStudyProgress", () => {
+  it.each<[number, SwipeAction, number]>([
+    [0, "GoToNextCardMastered", 1],
+    [3, "GoToNextCardMastered", 4],
+    [-1, "GoToNextCardMastered", 0],
+    [0, "GoToNextCardNotMastered", -1],
+    [-2, "GoToNextCardToggleMastered", -3],
+    [2, "GoToNextCardNotMastered", 0],
+    [3, "GoToNextCard", 3],
+    [3, "GoToPrevCard", 3],
+  ])("records score %i for %s as %i", (score, swipeAction, expectedScore) => {
+    const card = { ...cardProgress("card-id", 2), score };
 
-    expect(recordStudyProgress(progress, rating, 1_786_512_000_000)).toEqual({
+    expect(recordCardStudyProgress(card, swipeAction, 1_786_512_000_000)).toEqual({
       cardId: "card-id",
       score: expectedScore,
       numberOfSeen: 3,

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -12,7 +12,7 @@ import type {
   StudyRating,
 } from "./types";
 
-export const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
+const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
   if (swipeAction === "GoToNextCardMastered") return "mastered";
   // Toggle remains a negative rating because changing this mapping would alter the existing persisted-score behavior.
   if (swipeAction === "GoToNextCardNotMastered" || swipeAction === "GoToNextCardToggleMastered") {
@@ -37,16 +37,19 @@ const calculateScore = (score: number, rating: StudyRating): number => {
   return score;
 };
 
-export const recordStudyProgress = (
-  progress: StudyProgress,
-  rating: StudyRating,
-  studiedAt: number
-): StudyProgressEdit => ({
+const recordStudyProgress = (progress: StudyProgress, rating: StudyRating, studiedAt: number): StudyProgressEdit => ({
   cardId: progress.cardId,
   score: calculateScore(progress.score, rating),
   numberOfSeen: progress.numberOfSeen + 1,
   lastSeenAt: studiedAt,
 });
+
+export const recordCardStudyProgress = (
+  card: CardProgressFields,
+  swipeAction: SwipeAction,
+  studiedAt: number
+): StudyProgressEdit =>
+  recordStudyProgress(createStudyProgressFromCard(card), resolveStudyRating(swipeAction), studiedAt);
 
 export const isStudyProgressEligible = (progress: StudyProgress, filter: StudyProgressFilter, now: number): boolean => {
   if (filter.maximumScore != null && progress.score > filter.maximumScore) return false;

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,4 +1,11 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
+export {
+  calculateStudySessionIndex,
+  getCurrentStudySessionCardId,
+  isStudySessionPositionUnchanged,
+  resolveStudySession,
+  resolveStudySessionSwipeEffect,
+} from "./model/rules";
 export type { StudySession } from "./model/types";
 export {
   clearStudySessions,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { calculateStudySessionIndex } from "./rules";
+import {
+  calculateStudySessionIndex,
+  isStudySessionPositionUnchanged,
+  resolveStudySession,
+  resolveStudySessionSwipeEffect,
+} from "./rules";
 import type { StudySession } from "./types";
 
 const session: StudySession = {
@@ -19,5 +24,60 @@ describe("calculateStudySessionIndex", () => {
   it("returns no index when movement completes the session", () => {
     expect(calculateStudySessionIndex({ ...session, currentIndex: 0 }, "previous")).toBeUndefined();
     expect(calculateStudySessionIndex({ ...session, currentIndex: 2 }, "next")).toBeUndefined();
+  });
+});
+
+describe("resolveStudySession", () => {
+  const cards = [
+    { id: "card-1", label: "one" },
+    { id: "card-2", label: "two" },
+  ];
+
+  it("resolves the card at the persisted session position", () => {
+    expect(resolveStudySession(session, cards)).toEqual({
+      status: "ready",
+      session,
+      card: cards[1],
+    });
+  });
+
+  it("waits while cards for an active session are still loading", () => {
+    expect(resolveStudySession(session, [])).toEqual({ status: "loading" });
+  });
+
+  it("reports unavailable when the session or its active card is missing", () => {
+    expect(resolveStudySession(undefined, cards)).toEqual({ status: "unavailable" });
+    expect(resolveStudySession(session, cards.slice(0, 1))).toEqual({ status: "unavailable" });
+  });
+});
+
+describe("resolveStudySessionSwipeEffect", () => {
+  it.each([
+    ["DoNothing", "none"],
+    ["GoBack", "exit"],
+    ["GoToPrevCard", "previous"],
+    ["GoToNextCard", "next"],
+    ["GoToNextCardMastered", "next"],
+    ["GoToNextCardNotMastered", "next"],
+    ["GoToNextCardToggleMastered", "next"],
+  ] as const)("maps %s to the %s session effect", (swipeAction, effect) => {
+    expect(resolveStudySessionSwipeEffect(swipeAction)).toBe(effect);
+  });
+});
+
+describe("isStudySessionPositionUnchanged", () => {
+  it("ignores timestamp-only changes", () => {
+    expect(isStudySessionPositionUnchanged(session, { ...session, lastStudiedAt: 1 })).toBe(true);
+  });
+
+  it("detects a changed index, active card, or removed session", () => {
+    expect(isStudySessionPositionUnchanged(session, { ...session, currentIndex: 2 })).toBe(false);
+    expect(
+      isStudySessionPositionUnchanged(session, {
+        ...session,
+        cardOrderIds: ["card-1", "card-3", "card-2"],
+      })
+    ).toBe(false);
+    expect(isStudySessionPositionUnchanged(session, undefined)).toBe(false);
   });
 });

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -1,6 +1,42 @@
+import type { SwipeAction } from "@/entities/preferences/@x/study-session";
+
 import type { StudySession } from "./types";
 
 export type StudySessionMovement = "previous" | "next";
+export type StudySessionSwipeEffect = "none" | "exit" | StudySessionMovement;
+
+type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
+
+export type ResolvedStudySession<Card extends StudySessionCard> =
+  | { status: "loading" | "unavailable" }
+  | { status: "ready"; session: StudySession; card: Card };
+
+export const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
+  session.cardOrderIds[session.currentIndex];
+
+export const resolveStudySession = <Card extends StudySessionCard>(
+  session: StudySession | undefined,
+  cards: readonly Card[]
+): ResolvedStudySession<Card> => {
+  if (session == null) return { status: "unavailable" };
+
+  const cardId = getCurrentStudySessionCardId(session);
+  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
+  if (card != null) return { status: "ready", session, card };
+  // An empty collection can still be an in-flight read; a populated collection proves the persisted card is absent.
+  return { status: cardId != null && cards.length === 0 ? "loading" : "unavailable" };
+};
+
+export const resolveStudySessionSwipeEffect = (swipeAction: SwipeAction): StudySessionSwipeEffect => {
+  if (swipeAction === "DoNothing") return "none";
+  if (swipeAction === "GoBack") return "exit";
+  return swipeAction === "GoToPrevCard" ? "previous" : "next";
+};
+
+export const isStudySessionPositionUnchanged = (previous: StudySession, current: StudySession | undefined): boolean =>
+  // Persistence timestamps may change during a write, but a position change means another interaction owns the card.
+  current?.currentIndex === previous.currentIndex &&
+  getCurrentStudySessionCardId(current) === getCurrentStudySessionCardId(previous);
 
 export const calculateStudySessionIndex = (
   session: StudySession,

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -3,7 +3,14 @@ import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preferences";
 import { editStudyProgress } from "@/entities/study-progress";
-import { removeStudySession, type StudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+import {
+  calculateStudySessionIndex,
+  removeStudySession,
+  resolveStudySession,
+  type StudySession,
+  touchStudySession,
+  useStudySession,
+} from "@/entities/study-session";
 
 import * as React from "react";
 
@@ -56,46 +63,40 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
     onCardChanged: hideBackText,
   });
   const session = useStudySession(deckId);
-  const cardId = session?.cardOrderIds[session.currentIndex];
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  const status =
-    card != null ? "ready" : session != null && cardId != null && cards.length === 0 ? "loading" : "unavailable";
+  const resolvedSession = resolveStudySession(session, cards);
   const exitingDeck = React.useRef<DeckId>(undefined);
 
   React.useEffect(() => {
-    if (status !== "ready") return;
+    if (resolvedSession.status !== "ready") return;
     touchStudySession(deckId);
-  }, [deckId, status]);
+  }, [deckId, resolvedSession.status]);
 
   React.useEffect(() => {
-    if (status === "ready") {
+    if (resolvedSession.status === "ready") {
       exitingDeck.current = undefined;
       return;
     }
-    if (status === "loading" || exitingDeck.current === deckId) return;
+    if (resolvedSession.status === "loading" || exitingDeck.current === deckId) return;
 
     // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
     exitingDeck.current = deckId;
     removeStudySession(deckId);
     onUnavailable();
-  }, [deckId, onUnavailable, status]);
+  }, [deckId, onUnavailable, resolvedSession.status]);
 
   React.useEffect(() => {
+    const nextIndex = session == null ? undefined : calculateStudySessionIndex(session, "next");
     if (
-      status !== "ready" ||
-      session == null ||
+      resolvedSession.status !== "ready" ||
       !autoPlay ||
       preferences.study.cardInterval <= 0 ||
-      session.currentIndex + 1 >= session.cardOrderIds.length
+      nextIndex === undefined
     ) {
       return;
     }
-    const timeout = window.setTimeout(
-      () => actions.updateIndex(session.currentIndex + 1),
-      preferences.study.cardInterval * 1000
-    );
+    const timeout = window.setTimeout(() => actions.updateIndex(nextIndex), preferences.study.cardInterval * 1000);
     return () => window.clearTimeout(timeout);
-  }, [actions, autoPlay, preferences.study.cardInterval, session, status]);
+  }, [actions, autoPlay, preferences.study.cardInterval, resolvedSession.status, session]);
   const commands: StudyCommands = {
     swipeUp: actions.swipeUp,
     swipeDown: actions.swipeDown,
@@ -105,16 +106,13 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
     toggleAutoPlay,
   };
 
-  if (session == null || card == null) {
-    const inactiveStatus = session != null && cardId != null && cards.length === 0 ? "loading" : "unavailable";
-    return { status: inactiveStatus, ...commands };
-  }
+  if (resolvedSession.status !== "ready") return { status: resolvedSession.status, ...commands };
 
   return {
     status: "ready",
     ...commands,
-    session,
-    card,
+    session: resolvedSession.session,
+    card: resolvedSession.card,
     showHeader: preferences.appearance.showHeader && !showBackText,
     showBackText,
     showController: preferences.study.cardInterval > 0,

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -2,13 +2,16 @@ import { mustFindCardById, type Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { SwipeDirection } from "@/entities/preferences";
 import { usePreferences } from "@/entities/preferences";
+import { recordCardStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 import {
-  createStudyProgressFromCard,
-  recordStudyProgress,
-  resolveStudyRating,
-  type StudyProgressEdit,
-} from "@/entities/study-progress";
-import { getStudySession, moveStudySession, removeStudySession, setStudySessionIndex } from "@/entities/study-session";
+  getCurrentStudySessionCardId,
+  getStudySession,
+  isStudySessionPositionUnchanged,
+  moveStudySession,
+  removeStudySession,
+  resolveStudySessionSwipeEffect,
+  setStudySessionIndex,
+} from "@/entities/study-session";
 
 import React from "react";
 
@@ -42,17 +45,18 @@ export const useStudyActions = (
     if (session == null) return;
 
     const swipeAction = preferences.controls[direction];
-    if (swipeAction === "DoNothing") return;
-    if (swipeAction === "GoBack") {
+    const sessionEffect = resolveStudySessionSwipeEffect(swipeAction);
+    if (sessionEffect === "none") return;
+    if (sessionEffect === "exit") {
       onSwipe?.(direction);
       removeStudySession(deckId);
       return;
     }
 
-    const cardId = session.cardOrderIds[session.currentIndex];
+    const cardId = getCurrentStudySessionCardId(session);
     if (cardId == null) return;
     const card = mustFindCardById(cards, cardId);
-    const patch = recordStudyProgress(createStudyProgressFromCard(card), resolveStudyRating(swipeAction), Date.now());
+    const patch = recordCardStudyProgress(card, swipeAction, Date.now());
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
@@ -65,16 +69,11 @@ export const useStudyActions = (
 
     const currentSession = getStudySession(deckId);
     // Position changes during the write own the newer card, while timestamp-only touches still allow advancement.
-    if (
-      currentSession?.currentIndex !== session.currentIndex ||
-      currentSession.cardOrderIds[currentSession.currentIndex] !== cardId
-    ) {
-      return;
-    }
+    if (!isStudySessionPositionUnchanged(session, currentSession)) return;
 
     onSwipe?.(direction);
     if (preferences.appearance.hideBodyWhenCardChanged) onCardChanged?.();
-    moveStudySession(deckId, swipeAction === "GoToPrevCard" ? "previous" : "next");
+    moveStudySession(deckId, sessionEffect);
   };
 
   return {


### PR DESCRIPTION
## Related issue

None

## Summary

- move active card resolution, session availability, swipe effects, and position checks into StudySession rules
- centralize persisted progress edits in StudyProgress and narrow its public API
- keep study hooks focused on coordinating persistence, session updates, and UI callbacks

## Testing

- mise run check