### PR TITLE
No issue: Ban useMemo usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,5 @@
 import tseslint from "@typescript-eslint/eslint-plugin";
 import * as tsParser from "@typescript-eslint/parser";
-import eslintReact from "@eslint-react/eslint-plugin";
 import {
   createConfig as createBoundariesConfig,
   recommended as boundariesRecommended,
@@ -41,18 +40,17 @@ export default [
   },
   {
     files: sourceFiles,
-    plugins: {
-      "@eslint-react": eslintReact,
-    },
     rules: {
-      // React Compiler owns routine memoization; manual useMemo must have an observable reason to remain.
-      "@eslint-react/no-unnecessary-use-memo": "error",
       // Reserve this identifier so imports and React-qualified calls cannot bypass the compiler policy.
       "no-restricted-syntax": [
         "error",
         {
           selector: "Identifier[name='useCallback']",
           message: "Do not use useCallback; rely on React Compiler memoization.",
+        },
+        {
+          selector: "Identifier[name='useMemo']",
+          message: "Do not use useMemo; rely on React Compiler memoization.",
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@biomejs/biome": "2.5.7",
-        "@eslint-react/eslint-plugin": "^2.13.0",
         "@feature-sliced/steiger-plugin": "^0.7.0",
         "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/test": "^1.61.1",
@@ -2650,133 +2649,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint-react/ast": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-2.13.0.tgz",
-      "integrity": "sha512-43+5gmqV3MpatTzKnu/V2i/jXjmepvwhrb9MaGQvnXHQgq9J7/C7VVCCcwp6Rvp2QHAFquAAdvQDSL8IueTpeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/typescript-estree": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "string-ts": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-m62XDzkf1hpzW4sBc7uh7CT+8rBG2xz/itSADuEntlsg4YA7Jhb8hjU6VHf3wRFDwyfx5VnbV209sbJ7Azey0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/eff": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-2.13.0.tgz",
-      "integrity": "sha512-rEH2R8FQnUAblUW+v3ZHDU1wEhatbL1+U2B1WVuBXwSKqzF7BGaLqCPIU7o9vofumz5MerVfaCtJgI8jYe2Btg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@eslint-react/eslint-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
-      "integrity": "sha512-iaMXpqnJCTW7317hg8L4wx7u5aIiPzZ+d1p59X8wXFgMHzFX4hNu4IfV8oygyjmWKdLsjKE9sEpv/UYWczlb+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "eslint-plugin-react-dom": "2.13.0",
-        "eslint-plugin-react-hooks-extra": "2.13.0",
-        "eslint-plugin-react-naming-convention": "2.13.0",
-        "eslint-plugin-react-rsc": "2.13.0",
-        "eslint-plugin-react-web-api": "2.13.0",
-        "eslint-plugin-react-x": "2.13.0",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/shared": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.13.0.tgz",
-      "integrity": "sha512-IOloCqrZ7gGBT4lFf9+0/wn7TfzU7JBRjYwTSyb9SDngsbeRrtW95ZpgUpS8/jen1wUEm6F08duAooTZ2FtsWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0",
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/var": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-2.13.0.tgz",
-      "integrity": "sha512-dM+QaeiHR16qPQoJYg205MkdHYSWVa2B7ore5OFpOPlSwqDV3tLW7I+475WjbK7potq5QNPTxRa7VLp9FGeQqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@eslint/config-array": {
@@ -9862,13 +9734,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/birecord": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.2.tgz",
-      "integrity": "sha512-5PAPTTmMpMEb+GuMb5DebfBkipRGyIW9+gtwEBSoDA9xkhHILm04+hZQ702pMksu3d8YAuGkmgTzQWcKqTPScA==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)"
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -10733,13 +10598,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/compare-versions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
@@ -12312,32 +12170,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/eslint-plugin-react-dom": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-2.13.0.tgz",
-      "integrity": "sha512-+2IZzQ1WEFYOWatW+xvNUqmZn55YBCufzKA7hX3XQ/8eu85Mp4vnlOyNvdVHEOGhUnGuC6+9+zLK+IlEHKdKLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
@@ -12356,137 +12188,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-hooks-extra": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-2.13.0.tgz",
-      "integrity": "sha512-qIbha1nzuyhXM9SbEfrcGVqmyvQu7GAOB2sy9Y4Qo5S8nCqw4fSBxq+8lSce5Tk5Y7XzIkgHOhNyXEvUHRWFMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-naming-convention": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-2.13.0.tgz",
-      "integrity": "sha512-uSd25JzSg2R4p81s3Wqck0AdwRlO9Yc+cZqTEXv7vW8exGGAM3mWnF6hgrgdqVJqBEGJIbS/Vx1r5BdKcY/MHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "string-ts": "^2.3.1",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-rsc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-2.13.0.tgz",
-      "integrity": "sha512-RaftgITDLQm1zIgYyvR51sBdy4FlVaXFts5VISBaKbSUB0oqXyzOPxMHasfr9BCSjPLKus9zYe+G/Hr6rjFLXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-web-api": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-2.13.0.tgz",
-      "integrity": "sha512-nmJbzIAte7PeAkp22CwcKEASkKi49MshSdiDGO1XuN3f4N4/8sBfDcWbQuLPde6JiuzDT/0+l7Gi8wwTHtR1kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "birecord": "^0.1.1",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-x": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-2.13.0.tgz",
-      "integrity": "sha512-cMNX0+ws/fWTgVxn52qAQbaFF2rqvaDAtjrPUzY6XOzPjY0rJQdR2tSlWJttz43r2yBfqu+LGvHlGpWL2wfpTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "is-immutable-type": "^5.0.1",
-        "ts-api-utils": "^2.4.0",
-        "ts-pattern": "^5.9.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -15495,32 +15196,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-immutable-type": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.4.tgz",
-      "integrity": "sha512-tDf0vB9dJJt/1USS2nvHJb8UsIAhs+pF6z8UZLNdhrzB+PKMrdcN45je9jhuFpaJOjJpoRhueFmFrRs5g/TNMA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "ko-fi",
-          "url": "https://ko-fi.com/rebeccastevens"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/is-immutable-type"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@typescript-eslint/type-utils": "^8.0.0",
-        "ts-api-utils": "^2.0.0",
-        "ts-declaration-location": "^1.0.4"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "typescript": ">=4.7.4"
       }
     },
     "node_modules/is-inside-container": {
@@ -22933,13 +22608,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-ts": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
-      "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -23874,42 +23542,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-declaration-location": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
-      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "ko-fi",
-          "url": "https://ko-fi.com/rebeccastevens"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.0.0"
-      }
-    },
-    "node_modules/ts-declaration-location/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -23923,13 +23555,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
-    },
-    "node_modules/ts-pattern": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
-      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@biomejs/biome": "2.5.7",
-    "@eslint-react/eslint-plugin": "^2.13.0",
     "@feature-sliced/steiger-plugin": "^0.7.0",
     "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/test": "^1.61.1",

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useStore } from "zustand";
 
 import { authSessionStore } from "./store";
@@ -12,11 +11,7 @@ export const useAuthUid = (): string =>
 export const useAuthAccount = (): AuthAccount | undefined => {
   const auth = useAuthSession();
 
-  return useMemo(
-    () =>
-      auth.status === "authenticated" && !auth.isAnonymous
-        ? { uid: auth.uid, displayName: auth.displayName }
-        : undefined,
-    [auth]
-  );
+  return auth.status === "authenticated" && !auth.isAnonymous
+    ? { uid: auth.uid, displayName: auth.displayName }
+    : undefined;
 };

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useStore } from "zustand";
 
 import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
@@ -18,11 +17,8 @@ export const useCard = (id: CardId | undefined): Card | undefined =>
 
 export const useCardsByDeckId = (deckId: string): { cards: Card[]; tags: string[] } => {
   const allCards = useCards();
-  return useMemo(
-    () => ({
-      cards: filterCardsByDeckId(allCards, deckId),
-      tags: filterTagsByDeckId(allCards, deckId),
-    }),
-    [allCards, deckId]
-  );
+  return {
+    cards: filterCardsByDeckId(allCards, deckId),
+    tags: filterTagsByDeckId(allCards, deckId),
+  };
 };


### PR DESCRIPTION
## Summary

- ban `useMemo` identifiers with ESLint, matching the existing `useCallback` policy
- remove the two existing `useMemo` calls and rely on React Compiler memoization
- remove the now-unused `@eslint-react/eslint-plugin` dependency

## Why

React Compiler owns routine memoization in this project. Allowing manual `useMemo` usage creates an inconsistent policy and can bypass compiler-managed optimization.

## Impact

New imports, direct calls, and React-qualified `useMemo` calls fail ESLint. Existing derived values keep the same observable behavior without manual memoization.

## Validation

- `mise run check`
- 99 test files passed
- 536 tests passed