### PR TITLE
[No issue] Move study start logic to study session entity

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -16,7 +16,7 @@ import { replaceAuthSession } from "@/entities/auth";
 import type { Preferences } from "@/entities/preferences";
 import { preferencesSchema } from "@/entities/preferences/model/schema";
 import { preferencesStore } from "@/entities/preferences/model/store";
-import { clearStudySessions, setStudySessionIndex, startStudySession } from "@/entities/study-session";
+import { clearStudySessions, setStudySessionIndex, startStudy } from "@/entities/study-session";
 
 export const PAGE_STORY_UID = "storybook-user";
 
@@ -80,7 +80,11 @@ export const preparePageStory = async (parameters: PageStoryParameters): Promise
   });
   Object.entries(parameters.sessionsByDeckId ?? {}).forEach(([deckId, session]) => {
     if (session == null) return;
-    startStudySession(deckId, session.cardOrderIds);
+    startStudy(
+      deckId,
+      session.cardOrderIds.map((id, numberOfSeen) => ({ id, score: 0, numberOfSeen })),
+      { shuffled: false, maxNumberOfCardsToLearn: 0 }
+    );
     setStudySessionIndex(deckId, session.currentIndex);
   });
   replaceRemoteDecks(decks);

--- a/src/entities/study-progress/@x/study-session.ts
+++ b/src/entities/study-progress/@x/study-session.ts
@@ -1,0 +1,2 @@
+export { buildStudyCardOrder } from "../model/rules";
+export type { CardProgressFields, StudyCardOrderOptions } from "../model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,7 +1,3 @@
 export { editStudyProgress } from "./api/firestore";
-export {
-  buildStudyCardOrder,
-  getNextStudyAvailabilityAt,
-  recordCardStudyProgress,
-} from "./model/rules";
+export { getNextStudyAvailabilityAt, recordCardStudyProgress } from "./model/rules";
 export type { StudyProgressEdit } from "./model/types";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -13,6 +13,7 @@ export {
   moveStudySession,
   removeStudySession,
   setStudySessionIndex,
+  startStudy,
   startStudySession,
   touchStudySession,
 } from "./model/store";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -14,6 +14,5 @@ export {
   removeStudySession,
   setStudySessionIndex,
   startStudy,
-  startStudySession,
   touchStudySession,
 } from "./model/store";

--- a/src/entities/study-session/model/startStudy.spec.ts
+++ b/src/entities/study-session/model/startStudy.spec.ts
@@ -1,11 +1,9 @@
-import { clearStudySessions, getStudySession } from "@/entities/study-session";
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { createCard, createPreferences } from "@/test/factories";
-import { startStudy } from "./startStudy";
+import { clearStudySessions, getStudySession, startStudy } from "./store";
 
 describe("startStudy", () => {
   beforeEach(async () => {

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -12,12 +12,20 @@ import {
   moveStudySession,
   removeStudySession,
   setStudySessionIndex,
-  startStudySession,
+  startStudy,
   studySessionStore,
   touchStudySession,
 } from "./store";
 
 const STUDY_STORAGE_KEY = "tango-study";
+
+const startSession = (deckId: string, cardOrderIds: string[]): void => {
+  startStudy(
+    deckId,
+    cardOrderIds.map((id, numberOfSeen) => ({ id, score: 0, numberOfSeen })),
+    { shuffled: false, maxNumberOfCardsToLearn: 0 }
+  );
+};
 
 const setVersionedStorage = (state: unknown, version: number): void => {
   // Bypass store mutations so hydration tests model arbitrary browser payloads.
@@ -37,11 +45,8 @@ describe("study store", () => {
     await clearStudySessions();
   });
 
-  it("starts at index zero with a copied card order", () => {
-    const cardOrderIds = ["card-1", "card-2"];
-
-    startStudySession("deck-1", cardOrderIds);
-    cardOrderIds.pop();
+  it("starts at index zero with the configured card order", () => {
+    startSession("deck-1", ["card-1", "card-2"]);
 
     expect(store.getState().sessionsByDeckId["deck-1"]).toMatchObject({
       cardOrderIds: ["card-1", "card-2"],
@@ -53,9 +58,9 @@ describe("study store", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
 
-    startStudySession("deck-1", ["card-1", "card-2"]);
+    startSession("deck-1", ["card-1", "card-2"]);
     vi.setSystemTime(2000);
-    startStudySession("deck-2", ["card-3"]);
+    startSession("deck-2", ["card-3"]);
 
     expect(store.getState().sessionsByDeckId).toEqual({
       "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 0, lastStudiedAt: 1000 },
@@ -66,8 +71,8 @@ describe("study store", () => {
   it("updates only the requested session and its last studied time", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    startStudySession("deck-1", ["card-1", "card-2"]);
-    startStudySession("deck-2", ["card-3", "card-4"]);
+    startSession("deck-1", ["card-1", "card-2"]);
+    startSession("deck-2", ["card-3", "card-4"]);
 
     vi.setSystemTime(3000);
     setStudySessionIndex("deck-1", 1);
@@ -77,7 +82,7 @@ describe("study store", () => {
   });
 
   it("moves within a session and removes it when movement reaches an edge", () => {
-    startStudySession("deck-1", ["card-1", "card-2"]);
+    startSession("deck-1", ["card-1", "card-2"]);
 
     moveStudySession("deck-1", "next");
     expect(getStudySession("deck-1")?.currentIndex).toBe(1);
@@ -89,7 +94,7 @@ describe("study store", () => {
   it.each([-1, 2, 0.5])("does not persist an invalid session index: %s", (currentIndex) => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    startStudySession("deck-1", ["card-1", "card-2"]);
+    startSession("deck-1", ["card-1", "card-2"]);
 
     vi.setSystemTime(3000);
     setStudySessionIndex("deck-1", currentIndex);
@@ -100,7 +105,7 @@ describe("study store", () => {
   it("touches only an existing requested session", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    startStudySession("deck-1", ["card-1"]);
+    startSession("deck-1", ["card-1"]);
 
     vi.setSystemTime(4000);
     touchStudySession("deck-1");
@@ -111,8 +116,8 @@ describe("study store", () => {
   });
 
   it("removes only the requested session", () => {
-    startStudySession("deck-1", ["card-1"]);
-    startStudySession("deck-2", ["card-2"]);
+    startSession("deck-1", ["card-1"]);
+    startSession("deck-2", ["card-2"]);
 
     removeStudySession("deck-1");
 
@@ -123,7 +128,7 @@ describe("study store", () => {
 
   it("clears both memory and persisted storage", async () => {
     localStorage.clear();
-    startStudySession("deck-1", ["card-1"]);
+    startSession("deck-1", ["card-1"]);
 
     expect(getStudySession("deck-1")).toBeDefined();
     expect(localStorage.getItem(STUDY_STORAGE_KEY)).not.toBeNull();
@@ -146,7 +151,7 @@ describe("study store", () => {
   it("persists exactly the session map in a v3 envelope", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
-    startStudySession("deck-1", ["card-1"]);
+    startSession("deck-1", ["card-1"]);
 
     const persistedSession = localStorage.getItem(STUDY_STORAGE_KEY);
     expect(JSON.parse(persistedSession ?? "{}")).toEqual({

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -79,7 +79,7 @@ export const studySessionStore = createStore<StudySessionState>()(
 export const getStudySession = (deckId: DeckId): StudySession | undefined =>
   studySessionStore.getState().sessionsByDeckId[deckId];
 
-export const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
+const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
   studySessionStore.setState((state) => {
     state.sessionsByDeckId[deckId] = {
       deckId,

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -1,5 +1,10 @@
 import type { CardId } from "@/entities/card/@x/study-session";
 import type { DeckId } from "@/entities/deck/@x/study-session";
+import {
+  buildStudyCardOrder,
+  type CardProgressFields,
+  type StudyCardOrderOptions,
+} from "@/entities/study-progress/@x/study-session";
 
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -84,6 +89,15 @@ export const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void 
       lastStudiedAt: Date.now(),
     };
   });
+};
+
+// Session start owns the state mutation while study-progress owns how the card order is derived.
+export const startStudy = (
+  deckId: DeckId,
+  cards: CardProgressFields[],
+  studyPreferences: StudyCardOrderOptions
+): void => {
+  startStudySession(deckId, buildStudyCardOrder(cards, studyPreferences));
 };
 
 export const touchStudySession = (deckId: DeckId): void => {

--- a/src/features/study-session-start/index.ts
+++ b/src/features/study-session-start/index.ts
@@ -1,2 +1,1 @@
-export { startStudy } from "./model/startStudy";
 export { StudySessionStartView } from "./ui/StudySessionStartView";

--- a/src/features/study-session-start/model/startStudy.ts
+++ b/src/features/study-session-start/model/startStudy.ts
@@ -1,9 +1,0 @@
-import type { Card } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
-import type { Preferences } from "@/entities/preferences";
-import { startStudySession } from "@/entities/study-session";
-import { buildStudyCardOrder } from "@/entities/study-progress";
-
-export const startStudy = (deckId: DeckId, cards: Card[], studyPreferences: Preferences["study"]): void => {
-  startStudySession(deckId, buildStudyCardOrder(cards, studyPreferences));
-};

--- a/src/features/study/hooks/useStudy.spec.tsx
+++ b/src/features/study/hooks/useStudy.spec.tsx
@@ -1,6 +1,6 @@
 import type { Card } from "@/entities/card";
 import type { Preferences } from "@/entities/preferences";
-import { clearStudySessions, startStudySession } from "@/entities/study-session";
+import { clearStudySessions, startStudy } from "@/entities/study-session";
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,10 +64,7 @@ describe("useStudy", () => {
       showSwipeFeedback: true,
       cardSwipeRight: "GoToNextCardMastered",
     });
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startStudy(deckId, cards, { shuffled: false, maxNumberOfCardsToLearn: 0 });
   });
 
   afterEach(() => vi.useRealTimers());

--- a/src/features/study/hooks/useStudyActions.spec.tsx
+++ b/src/features/study/hooks/useStudyActions.spec.tsx
@@ -4,7 +4,7 @@ import {
   clearStudySessions,
   getStudySession,
   setStudySessionIndex,
-  startStudySession,
+  startStudy,
   touchStudySession,
 } from "@/entities/study-session";
 
@@ -43,6 +43,10 @@ const cards: Card[] = ["card-1", "card-2"].map((id) => ({
   lastSeenAt: 0,
 }));
 
+const startSession = (sessionCards: Card[] = cards): void => {
+  startStudy(deckId, sessionCards, { shuffled: false, maxNumberOfCardsToLearn: 0 });
+};
+
 describe("useStudyActions", () => {
   const saveProgress = vi.fn();
   const onSwipe = vi.fn();
@@ -68,10 +72,7 @@ describe("useStudyActions", () => {
     renderHook(() => useStudyActions(deckId, { cards, saveProgress, onSwipe, onCardChanged }));
 
   it("persists the current card before advancing the session", async () => {
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startSession();
     let finishWrite: () => void = () => undefined;
     saveProgress.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -101,10 +102,7 @@ describe("useStudyActions", () => {
   });
 
   it("keeps the visible session unchanged when persistence fails", async () => {
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startSession();
     saveProgress.mockRejectedValueOnce(new Error("write failed"));
     const { result } = renderActions();
 
@@ -116,10 +114,7 @@ describe("useStudyActions", () => {
   });
 
   it("blocks a second swipe while the first write is unresolved", async () => {
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startSession();
     let finishWrite: () => void = () => undefined;
     saveProgress.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -139,10 +134,7 @@ describe("useStudyActions", () => {
   });
 
   it("does not advance a session changed by the controller during the write", async () => {
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startSession();
     let finishWrite: () => void = () => undefined;
     saveProgress.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -163,10 +155,7 @@ describe("useStudyActions", () => {
   });
 
   it("advances after a timestamp-only session touch during the write", async () => {
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startSession();
     let finishWrite: () => void = () => undefined;
     saveProgress.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -188,10 +177,7 @@ describe("useStudyActions", () => {
   });
 
   it("handles DoNothing and GoBack without writing progress", async () => {
-    startStudySession(
-      deckId,
-      cards.map(({ id }) => id)
-    );
+    startSession();
     const { result } = renderActions();
 
     await actAsync(() => result.current.swipeDown());
@@ -204,7 +190,7 @@ describe("useStudyActions", () => {
   });
 
   it("removes the session after the final card is persisted", async () => {
-    startStudySession(deckId, ["card-1"]);
+    startSession(cards.slice(0, 1));
     const { result } = renderActions();
 
     await actAsync(() => result.current.swipeRight());

--- a/src/pages/deck-start/ui/DeckStartPage.spec.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.spec.tsx
@@ -24,6 +24,9 @@ vi.mock("@/entities/card", () => ({
 vi.mock("@/entities/deck", () => ({
   useDeck: () => mocks.deck ?? undefined,
 }));
+vi.mock("@/entities/study-session", () => ({
+  startStudy: () => mocks.start(),
+}));
 vi.mock("@/features/deck-filter", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/deck-filter")>();
   return {
@@ -39,13 +42,6 @@ vi.mock("@/features/deck-filter", async (importOriginal) => {
       setSelectedTags: vi.fn(),
       setTagAndFilter: vi.fn(),
     }),
-  };
-});
-vi.mock("@/features/study-session-start", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/features/study-session-start")>();
-  return {
-    ...actual,
-    startStudy: () => mocks.start(),
   };
 });
 vi.mock("@/entities/preferences", () => ({

--- a/src/pages/deck-start/ui/DeckStartPage.tsx
+++ b/src/pages/deck-start/ui/DeckStartPage.tsx
@@ -8,8 +8,9 @@ import { useKey } from "react-use";
 
 import { useCardsByDeckId } from "@/entities/card";
 import { usePreferences } from "@/entities/preferences";
+import { startStudy } from "@/entities/study-session";
 import { DeckFilterForm, useDeckFilterState, useFilteredStudyCards } from "@/features/deck-filter";
-import { startStudy, StudySessionStartView } from "@/features/study-session-start";
+import { StudySessionStartView } from "@/features/study-session-start";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 


### PR DESCRIPTION
## Related issue

None

## Summary

- Move `startStudy` from `features/study-session-start` to the `study-session` entity store.
- Keep card-order calculation in `study-progress` and expose only the required cross-entity contract through `@x/study-session`.
- Update `DeckStartPage` to call the entity API and relocate the existing behavior tests with the entity.

## Testing

- Not run locally: this environment cannot reach GitHub to create the required checkout/worktree, so `mise run check` could not be executed here.