### PR TITLE
[No issue] Clarify study session state names

### DIFF
--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -35,7 +35,7 @@ describe("resolveStudySession", () => {
 
   it("resolves the card at the persisted session position", () => {
     expect(resolveStudySession(session, cards)).toEqual({
-      status: "ready",
+      status: "studying",
       session,
       card: cards[1],
     });

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -41,13 +41,13 @@ describe("resolveStudySession", () => {
     });
   });
 
-  it("waits while cards for an active session are still loading", () => {
-    expect(resolveStudySession(session, [])).toEqual({ status: "loading" });
+  it("waits while cards for an active session are being prepared", () => {
+    expect(resolveStudySession(session, [])).toEqual({ status: "preparing" });
   });
 
-  it("reports unavailable when the session or its active card is missing", () => {
-    expect(resolveStudySession(undefined, cards)).toEqual({ status: "unavailable" });
-    expect(resolveStudySession(session, cards.slice(0, 1))).toEqual({ status: "unavailable" });
+  it("reports invalid when the session or its active card is missing", () => {
+    expect(resolveStudySession(undefined, cards)).toEqual({ status: "invalid" });
+    expect(resolveStudySession(session, cards.slice(0, 1))).toEqual({ status: "invalid" });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -15,13 +15,13 @@ export const resolveStudySession = <Card extends StudySessionCard>(
   session: StudySession | undefined,
   cards: readonly Card[]
 ): ResolvedStudySession<Card> => {
-  if (session == null) return { status: "unavailable" };
+  if (session == null) return { status: "invalid" };
 
   const cardId = getCurrentStudySessionCardId(session);
   const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
   if (card != null) return { status: "studying", session, card };
   // An empty collection can still be an in-flight read; a populated collection proves the persisted card is absent.
-  return { status: cardId != null && cards.length === 0 ? "loading" : "unavailable" };
+  return { status: cardId != null && cards.length === 0 ? "preparing" : "invalid" };
 };
 
 export const resolveStudySessionSwipeEffect = (swipeAction: SwipeAction): StudySessionSwipeEffect => {

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -1,15 +1,12 @@
 import type { SwipeAction } from "@/entities/preferences/@x/study-session";
 
-import type { StudySession } from "./types";
-
-export type StudySessionMovement = "previous" | "next";
-export type StudySessionSwipeEffect = "none" | "exit" | StudySessionMovement;
-
-type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
-
-export type ResolvedStudySession<Card extends StudySessionCard> =
-  | { status: "loading" | "unavailable" }
-  | { status: "ready"; session: StudySession; card: Card };
+import type {
+  ResolvedStudySession,
+  StudySession,
+  StudySessionCard,
+  StudySessionMovement,
+  StudySessionSwipeEffect,
+} from "./types";
 
 export const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
@@ -22,7 +19,7 @@ export const resolveStudySession = <Card extends StudySessionCard>(
 
   const cardId = getCurrentStudySessionCardId(session);
   const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  if (card != null) return { status: "ready", session, card };
+  if (card != null) return { status: "studying", session, card };
   // An empty collection can still be an in-flight read; a populated collection proves the persisted card is absent.
   return { status: cardId != null && cards.length === 0 ? "loading" : "unavailable" };
 };

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -5,8 +5,8 @@ import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
-import { calculateStudySessionIndex, type StudySessionMovement } from "./rules";
-import type { StudySession, StudySessions } from "./types";
+import { calculateStudySessionIndex } from "./rules";
+import type { StudySession, StudySessionMovement, StudySessions } from "./types";
 
 const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -35,5 +35,5 @@ export type StudySessionSwipeEffect = "none" | "exit" | StudySessionMovement;
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
 
 export type ResolvedStudySession<Card extends StudySessionCard> =
-  | { status: "loading" | "unavailable" }
+  | { status: "preparing" | "invalid" }
   | { status: "studying"; session: StudySession; card: Card };

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -28,3 +28,12 @@ export interface StudySession {
  * so one corrupt session does not discard valid progress for other decks.
  */
 export type StudySessions = Partial<Record<DeckId, StudySession>>;
+
+export type StudySessionMovement = "previous" | "next";
+export type StudySessionSwipeEffect = "none" | "exit" | StudySessionMovement;
+
+export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
+
+export type ResolvedStudySession<Card extends StudySessionCard> =
+  | { status: "loading" | "unavailable" }
+  | { status: "studying"; session: StudySession; card: Card };

--- a/src/features/study/hooks/useStudy.spec.tsx
+++ b/src/features/study/hooks/useStudy.spec.tsx
@@ -11,7 +11,7 @@ import { createPreferences } from "@/test/factories";
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
   editStudyProgress: vi.fn(),
-  onUnavailable: vi.fn(),
+  onInvalid: vi.fn(),
   touchStudySession: vi.fn(),
 }));
 
@@ -73,7 +73,7 @@ describe("useStudy", () => {
   afterEach(() => vi.useRealTimers());
 
   it("coordinates display state, persistence, and session progression", async () => {
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onUnavailable));
+    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
     expect(result.current).toMatchObject({
       status: "studying",
       session: { deckId, cardOrderIds: ["card-1", "card-2"], currentIndex: 0 },
@@ -93,27 +93,27 @@ describe("useStudy", () => {
     expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
   });
 
-  it("reports loading while the session card is not available", () => {
-    const { result } = renderHook(() => useStudy(deckId, [], mocks.onUnavailable));
-    expect(result.current.status).toBe("loading");
-    expect(mocks.onUnavailable).not.toHaveBeenCalled();
+  it("reports preparing while the session card is not available", () => {
+    const { result } = renderHook(() => useStudy(deckId, [], mocks.onInvalid));
+    expect(result.current.status).toBe("preparing");
+    expect(mocks.onInvalid).not.toHaveBeenCalled();
   });
 
   it("advances the session while autoplay is enabled", () => {
     vi.useFakeTimers();
     mocks.preferences = createPreferences({ cardInterval: 1, defaultAutoPlay: true });
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onUnavailable));
+    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
 
     act(() => vi.advanceTimersByTime(1000));
 
     expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } });
   });
 
-  it("reports and handles an unavailable session", async () => {
+  it("reports and handles an invalid session", async () => {
     await clearStudySessions();
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onUnavailable));
+    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
 
-    expect(result.current.status).toBe("unavailable");
-    await waitFor(() => expect(mocks.onUnavailable).toHaveBeenCalledOnce());
+    expect(result.current.status).toBe("invalid");
+    await waitFor(() => expect(mocks.onInvalid).toHaveBeenCalledOnce());
   });
 });

--- a/src/features/study/hooks/useStudy.spec.tsx
+++ b/src/features/study/hooks/useStudy.spec.tsx
@@ -75,7 +75,7 @@ describe("useStudy", () => {
   it("coordinates display state, persistence, and session progression", async () => {
     const { result } = renderHook(() => useStudy(deckId, cards, mocks.onUnavailable));
     expect(result.current).toMatchObject({
-      status: "ready",
+      status: "studying",
       session: { deckId, cardOrderIds: ["card-1", "card-2"], currentIndex: 0 },
       card: { id: "card-1" },
       showBackText: false,
@@ -85,10 +85,10 @@ describe("useStudy", () => {
     expect(mocks.touchStudySession).toHaveBeenCalledWith(deckId);
 
     act(() => result.current.toggleBackText());
-    expect(result.current).toMatchObject({ status: "ready", showBackText: true });
+    expect(result.current).toMatchObject({ status: "studying", showBackText: true });
     await actAsync(() => result.current.swipeRight());
 
-    await waitFor(() => expect(result.current).toMatchObject({ status: "ready", card: { id: "card-2" } }));
+    await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } }));
     expect(result.current).toMatchObject({ showBackText: false, swipeFeedback: "cardSwipeRight" });
     expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
   });
@@ -106,7 +106,7 @@ describe("useStudy", () => {
 
     act(() => vi.advanceTimersByTime(1000));
 
-    expect(result.current).toMatchObject({ status: "ready", card: { id: "card-2" } });
+    expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } });
   });
 
   it("reports and handles an unavailable session", async () => {

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -30,7 +30,7 @@ export type StudyState = StudyCommands &
   (
     | { status: "loading" | "unavailable" }
     | {
-        status: "ready";
+        status: "studying";
         session: StudySession;
         card: Card;
         showHeader: boolean;
@@ -64,12 +64,12 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
   const exitingDeck = React.useRef<DeckId>(undefined);
 
   React.useEffect(() => {
-    if (resolvedSession.status !== "ready") return;
+    if (resolvedSession.status !== "studying") return;
     touchStudySession(deckId);
   }, [deckId, resolvedSession.status]);
 
   React.useEffect(() => {
-    if (resolvedSession.status === "ready") {
+    if (resolvedSession.status === "studying") {
       exitingDeck.current = undefined;
       return;
     }
@@ -84,7 +84,7 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
   React.useEffect(() => {
     const nextIndex = session == null ? undefined : calculateStudySessionIndex(session, "next");
     if (
-      resolvedSession.status !== "ready" ||
+      resolvedSession.status !== "studying" ||
       !autoPlay ||
       preferences.study.cardInterval <= 0 ||
       nextIndex === undefined
@@ -103,10 +103,10 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
     toggleAutoPlay,
   };
 
-  if (resolvedSession.status !== "ready") return { status: resolvedSession.status, ...commands };
+  if (resolvedSession.status !== "studying") return { status: resolvedSession.status, ...commands };
 
   return {
-    status: "ready",
+    status: "studying",
     ...commands,
     session: resolvedSession.session,
     card: resolvedSession.card,

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -28,7 +28,7 @@ interface StudyCommands {
 
 export type StudyState = StudyCommands &
   (
-    | { status: "loading" | "unavailable" }
+    | { status: "preparing" | "invalid" }
     | {
         status: "studying";
         session: StudySession;
@@ -43,7 +43,7 @@ export type StudyState = StudyCommands &
       }
   );
 
-export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: () => void): StudyState => {
+export const useStudy = (deckId: DeckId, cards: readonly Card[], onInvalid: () => void): StudyState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
   const [showBackText, setShowBackText] = React.useState(false);
@@ -73,13 +73,13 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onUnavailable: 
       exitingDeck.current = undefined;
       return;
     }
-    if (resolvedSession.status === "loading" || exitingDeck.current === deckId) return;
+    if (resolvedSession.status === "preparing" || exitingDeck.current === deckId) return;
 
     // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
     exitingDeck.current = deckId;
     removeStudySession(deckId);
-    onUnavailable();
-  }, [deckId, onUnavailable, resolvedSession.status]);
+    onInvalid();
+  }, [deckId, onInvalid, resolvedSession.status]);
 
   React.useEffect(() => {
     const nextIndex = session == null ? undefined : calculateStudySessionIndex(session, "next");

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   cards: [] as Card[],
   navigate: vi.fn(),
   studyState: undefined as StudyState | undefined,
-  studyArgs: undefined as { cards: readonly Card[]; deckId: string; onUnavailable: () => void } | undefined,
+  studyArgs: undefined as { cards: readonly Card[]; deckId: string; onInvalid: () => void } | undefined,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -29,8 +29,8 @@ vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
   return {
     ...actual,
-    useStudy: (deckId: string, cards: readonly Card[], onUnavailable: () => void) => {
-      mocks.studyArgs = { deckId, cards, onUnavailable };
+    useStudy: (deckId: string, cards: readonly Card[], onInvalid: () => void) => {
+      mocks.studyArgs = { deckId, cards, onInvalid };
       if (mocks.studyState == null) throw new Error("Study state not initialized");
       return mocks.studyState;
     },
@@ -123,17 +123,17 @@ describe("DeckStudyPage", () => {
   });
 
   it.each([
-    ["loading", "Loading…"],
-    ["unavailable", "Study session unavailable."],
+    ["preparing", "Loading…"],
+    ["invalid", "Study session unavailable."],
   ] as const)("renders route feedback for %s workflow state", (status, title) => {
     mocks.studyState = { status, ...commands() };
     render(<DeckStudyPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
   });
 
-  it("converts unavailable intent into current route navigation", () => {
+  it("converts invalid session intent into current route navigation", () => {
     render(<DeckStudyPage />);
-    act(() => mocks.studyArgs?.onUnavailable());
+    act(() => mocks.studyArgs?.onInvalid());
     expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
   });
 

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -79,8 +79,8 @@ const commands = () => ({
   toggleBackText: vi.fn(),
   toggleAutoPlay: vi.fn(),
 });
-const readyState = (): StudyState => ({
-  status: "ready",
+const studyingState = (): StudyState => ({
+  status: "studying",
   ...commands(),
   session: {
     deckId: deck.id,
@@ -103,7 +103,7 @@ describe("DeckStudyPage", () => {
     mocks.params.id = deck.id;
     mocks.deck = deck;
     mocks.cards = [card];
-    mocks.studyState = readyState();
+    mocks.studyState = studyingState();
     mocks.studyArgs = undefined;
     window.history.replaceState(null, document.title, document.location.href);
   });
@@ -140,7 +140,7 @@ describe("DeckStudyPage", () => {
   it("delegates a representative Study shortcut to the workflow action", () => {
     render(<DeckStudyPage />);
     const state = mocks.studyState;
-    if (state?.status !== "ready") throw new Error("expected ready workflow state");
+    if (state?.status !== "studying") throw new Error("expected studying workflow state");
 
     fireEvent.keyDown(window, { key: "ArrowLeft" });
 

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -12,7 +12,7 @@ import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
 const renderStudyScreen = (deck: Deck, state: StudyState) => {
-  if (state.status !== "ready") {
+  if (state.status !== "studying") {
     return state.status === "loading" ? (
       <RouteFeedback title="Loading…" tone="loading" />
     ) : (

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -13,7 +13,7 @@ import { AppLayout } from "@/widgets/app-layout";
 
 const renderStudyScreen = (deck: Deck, state: StudyState) => {
   if (state.status !== "studying") {
-    return state.status === "loading" ? (
+    return state.status === "preparing" ? (
       <RouteFeedback title="Loading…" tone="loading" />
     ) : (
       <RouteFeedback title="Study session unavailable." tone="not-found" />
@@ -78,10 +78,10 @@ const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => 
 
 const DeckStudyContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const navigate = useNavigate();
-  const handleUnavailable = () => {
+  const handleInvalidSession = () => {
     void navigate("/", { replace: true });
   };
-  const study = useStudy(deck.id, cards, handleUnavailable);
+  const study = useStudy(deck.id, cards, handleInvalidSession);
 
   return <DeckStudyScreen deck={deck} state={study} />;
 };


### PR DESCRIPTION
## Related issue

None

## Summary

- Name the study workflow states `preparing`, `studying`, and `invalid` according to their lifecycle meaning.
- Move shared study-session types from `rules.ts` to `types.ts`.
- Update affected callbacks, consumers, and behavior tests.

## Testing

- `mise run check`