### PR TITLE
[No issue] Enable no-unnecessary-template-expression lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -145,7 +145,6 @@ export default [
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-misused-promises": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",
-      "@typescript-eslint/no-unnecessary-template-expression": "off",
       "@typescript-eslint/no-unnecessary-type-conversion": "off",
       "@typescript-eslint/prefer-reduce-type-parameter": "off",
       "@typescript-eslint/require-await": "off",


### PR DESCRIPTION
## Related issue

None

## Summary

- Enable `@typescript-eslint/no-unnecessary-template-expression` by removing its override.
- Keep unnecessary template expressions covered by the strict type-checked ESLint rules.

## Testing

- `mise run check`