### PR TITLE
[No issue] Enable noSkippedTests lint rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -125,6 +125,7 @@
         "noDeprecatedImports": "error",
         "noImportCycles": "error",
         "noLeakedRender": "error",
+        "noSkippedTests": "error",
         "noUnnecessaryConditions": "error"
       }
     }


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable Biome noSkippedTests as an error.
- Prevent disabled tests from being merged without an explicit suppression.

## Testing

- `mise run check`