### PR TITLE
[No issue] Enable await-thenable ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -138,7 +138,6 @@ export default [
       // Shorthand callbacks that intentionally return void are established project style, not ambiguous expressions.
       "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
       // Biome owns these checks, including promise handling and the Types domain rollout in #1013.
-      "@typescript-eslint/await-thenable": "off",
       "@typescript-eslint/no-base-to-string": "off",
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-misused-promises": "off",


### PR DESCRIPTION
## Related issue

None

## Summary

- Enable @typescript-eslint/await-thenable from the strict type-checked preset.
- Prevent awaiting non-Promise values without requiring source changes.

## Testing

- mise run check