### PR TITLE
[No issue] Enable no-base-to-string ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -138,7 +138,6 @@ export default [
       // Shorthand callbacks that intentionally return void are established project style, not ambiguous expressions.
       "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
       // Biome owns these checks, including promise handling and the Types domain rollout in #1013.
-      "@typescript-eslint/no-base-to-string": "off",
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-misused-promises": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",


### PR DESCRIPTION
## Related issue

None

## Summary

- Enable @typescript-eslint/no-base-to-string from the strict type-checked preset.
- Prevent default object stringification without requiring source changes.

## Testing

- mise run check