### PR TITLE
[No issue] Simplify deck list section building

### DIFF
--- a/src/features/deck-list/model/buildDeckListSections.ts
+++ b/src/features/deck-list/model/buildDeckListSections.ts
@@ -1,11 +1,6 @@
 import { countCardsByDeckId, type Card } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
-
-interface DeckListStudySession {
-  cardOrderIds: string[];
-  currentIndex: number;
-  lastStudiedAt: number;
-}
+import type { StudySession } from "@/entities/study-session";
 
 export interface DeckListStudyProgress {
   currentIndex: number;
@@ -26,40 +21,36 @@ export interface DeckListSections {
 
 const compareNames = (left: DeckListItem, right: DeckListItem) => left.deck.name.localeCompare(right.deck.name);
 
+const createDeckListStudyProgress = (session: StudySession): DeckListStudyProgress => ({
+  currentIndex: session.currentIndex,
+  cardCount: session.cardOrderIds.length,
+  lastStudiedAt: session.lastStudiedAt,
+});
+
 export const buildDeckListSections = (
   decks: Deck[],
   cards: Card[],
-  sessionsByDeckId: Partial<Record<DeckId, DeckListStudySession>>
+  sessionsByDeckId: Partial<Record<DeckId, StudySession>>
 ): DeckListSections => {
   const cardCounts = countCardsByDeckId(cards);
-
-  const studying: DeckListItem[] = [];
-  const other: DeckListItem[] = [];
-
-  for (const deck of decks) {
+  const items = decks.map((deck): DeckListItem => {
     const session = sessionsByDeckId[deck.id];
-    const item: DeckListItem = {
+
+    return {
       deck,
       cardCount: cardCounts.get(deck.id) ?? 0,
-      ...(session == null
-        ? {}
-        : {
-            studyProgress: {
-              currentIndex: session.currentIndex,
-              cardCount: session.cardOrderIds.length,
-              lastStudiedAt: session.lastStudiedAt,
-            },
-          }),
+      ...(session == null ? {} : { studyProgress: createDeckListStudyProgress(session) }),
     };
-    if (session == null) other.push(item);
-    else studying.push(item);
-  }
+  });
 
-  studying.sort(
-    (left, right) =>
-      (right.studyProgress?.lastStudiedAt ?? 0) - (left.studyProgress?.lastStudiedAt ?? 0) || compareNames(left, right)
-  );
-  other.sort(compareNames);
+  const studying = items
+    .filter((item) => item.studyProgress != null)
+    .sort(
+      (left, right) =>
+        (right.studyProgress?.lastStudiedAt ?? 0) - (left.studyProgress?.lastStudiedAt ?? 0) ||
+        compareNames(left, right)
+    );
+  const other = items.filter((item) => item.studyProgress == null).sort(compareNames);
 
   return { studying, other };
 };

--- a/src/features/deck-list/ui/DeckList.spec.tsx
+++ b/src/features/deck-list/ui/DeckList.spec.tsx
@@ -23,11 +23,13 @@ const cards = [
 ];
 const sessionsByDeckId: DeckListProps["sessionsByDeckId"] = {
   [oldDeck.id]: {
+    deckId: oldDeck.id,
     cardOrderIds: ["old-1", "old-2"],
     currentIndex: 0,
     lastStudiedAt: 1000,
   },
   [recentDeck.id]: {
+    deckId: recentDeck.id,
     cardOrderIds: ["recent-1", "recent-2", "recent-3"],
     currentIndex: 1,
     lastStudiedAt: 2000,


### PR DESCRIPTION
## Summary

- build all deck list items before classifying them into studying and other sections
- extract study-session-to-list-progress conversion and use the StudySession entity type
- keep classification and ordering explicit with map, filter, and sort

## Testing

- mise run check