### PR TITLE
No issue: Move deck recency ordering to study-session entity

### DIFF
--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,6 +1,7 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
 export {
   calculateStudySessionIndex,
+  compareStudySessionsByLastStudiedAt,
   getCurrentStudySessionCardId,
   isStudySessionPositionUnchanged,
   resolveStudySession,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   calculateStudySessionIndex,
+  compareStudySessionsByLastStudiedAt,
   isStudySessionPositionUnchanged,
   resolveStudySession,
   resolveStudySessionSwipeEffect,
@@ -24,6 +25,18 @@ describe("calculateStudySessionIndex", () => {
   it("returns no index when movement completes the session", () => {
     expect(calculateStudySessionIndex({ ...session, currentIndex: 0 }, "previous")).toBeUndefined();
     expect(calculateStudySessionIndex({ ...session, currentIndex: 2 }, "next")).toBeUndefined();
+  });
+});
+
+describe("compareStudySessionsByLastStudiedAt", () => {
+  it("orders more recently studied sessions first", () => {
+    const older = { ...session, deckId: "older", lastStudiedAt: 100 };
+    const newer = { ...session, deckId: "newer", lastStudiedAt: 200 };
+
+    expect([older, newer].sort(compareStudySessionsByLastStudiedAt).map(({ deckId }) => deckId)).toEqual([
+      "newer",
+      "older",
+    ]);
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -11,6 +11,11 @@ import type {
 export const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
+export const compareStudySessionsByLastStudiedAt = (
+  left: Pick<StudySession, "lastStudiedAt">,
+  right: Pick<StudySession, "lastStudiedAt">
+): number => right.lastStudiedAt - left.lastStudiedAt;
+
 export const resolveStudySession = <Card extends StudySessionCard>(
   session: StudySession | undefined,
   cards: readonly Card[]

--- a/src/features/deck-list/model/buildDeckListSections.ts
+++ b/src/features/deck-list/model/buildDeckListSections.ts
@@ -1,6 +1,6 @@
 import { countCardsByDeckId, type Card } from "@/entities/card";
 import type { Deck, DeckId } from "@/entities/deck";
-import type { StudySession } from "@/entities/study-session";
+import { compareStudySessionsByLastStudiedAt, type StudySession } from "@/entities/study-session";
 
 export interface DeckListStudyProgress {
   currentIndex: number;
@@ -19,7 +19,11 @@ export interface DeckListSections {
   other: DeckListItem[];
 }
 
+type StudyingDeckListItem = DeckListItem & { studyProgress: DeckListStudyProgress };
+
 const compareNames = (left: DeckListItem, right: DeckListItem) => left.deck.name.localeCompare(right.deck.name);
+
+const isStudyingDeckListItem = (item: DeckListItem): item is StudyingDeckListItem => item.studyProgress != null;
 
 const createDeckListStudyProgress = (session: StudySession): DeckListStudyProgress => ({
   currentIndex: session.currentIndex,
@@ -44,11 +48,10 @@ export const buildDeckListSections = (
   });
 
   const studying = items
-    .filter((item) => item.studyProgress != null)
+    .filter(isStudyingDeckListItem)
     .sort(
       (left, right) =>
-        (right.studyProgress?.lastStudiedAt ?? 0) - (left.studyProgress?.lastStudiedAt ?? 0) ||
-        compareNames(left, right)
+        compareStudySessionsByLastStudiedAt(left.studyProgress, right.studyProgress) || compareNames(left, right)
     );
   const other = items.filter((item) => item.studyProgress == null).sort(compareNames);
 


### PR DESCRIPTION
## Summary

- move the `lastStudiedAt` descending comparison into `study-session` domain rules
- make `deck-list` consume that rule instead of defining the product ordering itself
- keep the deck-name tie breaker in `deck-list` as presentation-specific ordering
- add a unit test for the study-session recency rule

## Why

Active decks are ordered by the most recent study time. That is a product/domain rule rather than a deck-list presentation concern. The Entities conventions place pure domain rules, calculations, selections, and transformations in `model/rules.ts`, so the ordering rule belongs with `study-session`.

## Validation

Local `mise run check` could not be executed because this environment cannot resolve `github.com` to clone the repository. The branch is based directly on the current `main`, and the GitHub diff is limited to the study-session rule/export/test and its deck-list consumer.