### PR TITLE
No issue: Rename deck start page for study flow

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -29,7 +29,7 @@ vi.mock("@/pages/card-view", () => ({ CardViewPage: () => null }));
 vi.mock("@/pages/deck-form", () => ({ DeckFormPage: () => null }));
 vi.mock("@/pages/deck-import", () => ({ DeckImportPage: () => null }));
 vi.mock("@/pages/deck-list", () => ({ DeckListPage: () => <div>Deck list</div> }));
-vi.mock("@/pages/deck-start", () => ({ DeckStartPage: () => null }));
+vi.mock("@/pages/deck-study-start", () => ({ DeckStudyStartPage: () => null }));
 vi.mock("@/pages/deck-study", () => ({ DeckStudyPage: () => null }));
 vi.mock("@/pages/settings", () => ({ SettingsPage: () => null }));
 

--- a/src/app/App.stories.tsx
+++ b/src/app/App.stories.tsx
@@ -48,7 +48,7 @@ export const DeckForm: Story = {
   parameters: { page: page(`/deck/${PAGE_STORY_DECK_ID}/edit`) },
 };
 
-export const DeckStart: Story = {
+export const DeckStudyStart: Story = {
   parameters: { page: page(`/deck/${PAGE_STORY_DECK_ID}/start`) },
 };
 

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -15,7 +15,7 @@ import { CardViewPage } from "@/pages/card-view";
 import { DeckFormPage } from "@/pages/deck-form";
 import { DeckImportPage } from "@/pages/deck-import";
 import { DeckListPage } from "@/pages/deck-list";
-import { DeckStartPage } from "@/pages/deck-start";
+import { DeckStudyStartPage } from "@/pages/deck-study-start";
 import { DeckStudyPage } from "@/pages/deck-study";
 import { SettingsPage } from "@/pages/settings";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
@@ -50,7 +50,7 @@ export const AppRoutes: React.FC = () => (
     <Route path="/" element={<DeckListPage />} />
     <Route path="/deck/:id" element={<CardListPage />} />
     <Route path="/deck/:id/edit" element={<DeckFormPage />} />
-    <Route path="/deck/:id/start" element={<DeckStartPage />} />
+    <Route path="/deck/:id/start" element={<DeckStudyStartPage />} />
     <Route path="/deck/:id/study" element={<DeckStudyPage />} />
     <Route path="/card/:id" element={<CardViewPage />} />
     <Route path="/card/:id/edit" element={<CardFormPage />} />

--- a/src/pages/deck-start/index.ts
+++ b/src/pages/deck-start/index.ts
@@ -1,1 +1,0 @@
-export { DeckStartPage } from "./ui/DeckStartPage";

--- a/src/pages/deck-study-start/index.ts
+++ b/src/pages/deck-study-start/index.ts
@@ -1,0 +1,1 @@
+export { DeckStudyStartPage } from "./ui/DeckStudyStartPage";

--- a/src/pages/deck-study-start/ui/DeckStudyStartPage.spec.tsx
+++ b/src/pages/deck-study-start/ui/DeckStudyStartPage.spec.tsx
@@ -54,9 +54,9 @@ vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
 }));
 
-import { DeckStartPage } from "./DeckStartPage";
+import { DeckStudyStartPage } from "./DeckStudyStartPage";
 
-describe("DeckStartPage", () => {
+describe("DeckStudyStartPage", () => {
   beforeEach(() => {
     mocks.params.id = "deck-id";
     mocks.preferences = createPreferences({ appearance: { darkMode: false }, study: { maxNumberOfCardsToLearn: 1 } });
@@ -66,7 +66,7 @@ describe("DeckStartPage", () => {
   });
 
   it("composes route data, the application shell, and the study view", () => {
-    render(<DeckStartPage />);
+    render(<DeckStudyStartPage />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Start 1 card" })).toBeVisible();
@@ -74,7 +74,7 @@ describe("DeckStartPage", () => {
   });
 
   it("starts from Enter only outside interactive controls", () => {
-    render(<DeckStartPage />);
+    render(<DeckStudyStartPage />);
 
     fireEvent.keyDown(document.body, { key: "Enter" });
     expect(mocks.start).toHaveBeenCalledOnce();
@@ -86,7 +86,7 @@ describe("DeckStartPage", () => {
 
   it("owns navigation after the study session starts", () => {
     mocks.start.mockImplementationOnce(() => expect(mocks.navigate).not.toHaveBeenCalled());
-    render(<DeckStartPage />);
+    render(<DeckStudyStartPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "Start 1 card" }));
 
@@ -96,7 +96,7 @@ describe("DeckStartPage", () => {
 
   it("does not start when no cards match", () => {
     mocks.cards = [];
-    render(<DeckStartPage />);
+    render(<DeckStudyStartPage />);
 
     fireEvent.keyDown(document.body, { key: "Enter" });
     expect(mocks.start).not.toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe("DeckStartPage", () => {
 
   it("renders missing-deck recovery outside the application shell", () => {
     mocks.deck = null;
-    render(<DeckStartPage />);
+    render(<DeckStudyStartPage />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Deck not found" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
@@ -113,6 +113,6 @@ describe("DeckStartPage", () => {
 
   it("rejects a route without a deck id", () => {
     mocks.params.id = undefined;
-    expect(() => render(<DeckStartPage />)).toThrowError("invalid deck id");
+    expect(() => render(<DeckStudyStartPage />)).toThrowError("invalid deck id");
   });
 });

--- a/src/pages/deck-study-start/ui/DeckStudyStartPage.tsx
+++ b/src/pages/deck-study-start/ui/DeckStudyStartPage.tsx
@@ -21,7 +21,7 @@ import { AppLayout } from "@/widgets/app-layout";
 const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
   target instanceof Element && target.closest("a[href], button, input, select, textarea") != null;
 
-const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
+const DeckStudyStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
   const { deck, cards, preferences, tags } = props;
   const navigate = useNavigate();
   const deckFilter = useDeckFilterState(deck);
@@ -48,7 +48,7 @@ const DeckStartContent = (props: { deck: Deck; cards: Card[]; preferences: Prefe
   );
 };
 
-export const DeckStartPage: React.FC = () => {
+export const DeckStudyStartPage: React.FC = () => {
   const params = useParams();
   const navigate = useNavigate();
   const deckId = params.id;
@@ -70,5 +70,5 @@ export const DeckStartPage: React.FC = () => {
     );
   }
 
-  return <DeckStartContent deck={deck} cards={cards} preferences={preferences} tags={tags} />;
+  return <DeckStudyStartContent deck={deck} cards={cards} preferences={preferences} tags={tags} />;
 };


### PR DESCRIPTION
## Summary

- rename deck-start to deck-study-start to clarify that the page starts a study session
- update the page component, tests, route imports, and Storybook story name
- keep the existing /deck/:id/start URL unchanged

## Testing

- mise run check