### PR TITLE
[No issue] Enable prefer-reduce-type-parameter ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -142,7 +142,6 @@ export default [
       "@typescript-eslint/no-misused-promises": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",
       "@typescript-eslint/no-unnecessary-type-conversion": "off",
-      "@typescript-eslint/prefer-reduce-type-parameter": "off",
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/restrict-plus-operands": "off",
       // Primitive template interpolation and polymorphic `this` are project policy, not correctness constraints.


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable the prefer-reduce-type-parameter ESLint rule.
- Confirm the project already complies without source changes.

## Testing

- mise run lint-fix
- mise run check