### PR TITLE
[No issue] Move study card ordering to study session entity

### DIFF
--- a/src/entities/study-progress/@x/study-session.ts
+++ b/src/entities/study-progress/@x/study-session.ts
@@ -1,2 +1,0 @@
-export { buildStudyCardOrder } from "../model/rules";
-export type { CardProgressFields, StudyCardOrderOptions } from "../model/types";

--- a/src/entities/study-progress/model/rules.spec.ts
+++ b/src/entities/study-progress/model/rules.spec.ts
@@ -1,13 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import type { SwipeAction } from "@/entities/preferences/@x/study-progress";
 
-const mocks = vi.hoisted(() => ({ shuffle: vi.fn((ids: string[]) => [...ids].reverse()) }));
-
-vi.mock("lodash", () => ({ shuffle: mocks.shuffle }));
-
 import {
-  buildStudyCardOrder,
   createStudyProgressFromCard,
   getNextStudyAvailabilityAt,
   isStudyProgressEligible,
@@ -108,35 +103,5 @@ describe("study progress selection", () => {
     ];
 
     expect(getNextStudyAvailabilityAt(progresses, 1000)).toBe(1500);
-  });
-});
-
-describe("buildStudyCardOrder", () => {
-  const cards = [cardProgress("a"), cardProgress("b"), cardProgress("c"), cardProgress("d")];
-
-  it("returns the progress-based card order when shuffle and maximum are disabled", () => {
-    expect(buildStudyCardOrder(cards, { shuffled: false, maxNumberOfCardsToLearn: 0 })).toEqual(["a", "b", "c", "d"]);
-  });
-
-  it("returns no card IDs for an empty selection", () => {
-    expect(buildStudyCardOrder([], { shuffled: false, maxNumberOfCardsToLearn: 0 })).toEqual([]);
-  });
-
-  it("limits the number of cards", () => {
-    expect(buildStudyCardOrder(cards, { shuffled: false, maxNumberOfCardsToLearn: 2 })).toEqual(["a", "b"]);
-  });
-
-  it("orders cards by study progress before applying the maximum", () => {
-    const unorderedCards = [cardProgress("seen", 5), cardProgress("new", 1), cardProgress("middle", 3)];
-
-    expect(buildStudyCardOrder(unorderedCards, { shuffled: false, maxNumberOfCardsToLearn: 2 })).toEqual([
-      "new",
-      "middle",
-    ]);
-  });
-
-  it("shuffles before applying the maximum", () => {
-    expect(buildStudyCardOrder(cards, { shuffled: true, maxNumberOfCardsToLearn: 2 })).toEqual(["d", "c"]);
-    expect(mocks.shuffle).toHaveBeenCalledWith(["a", "b", "c", "d"]);
   });
 });

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -1,16 +1,7 @@
-import * as lodash from "lodash";
-
 import type { SwipeAction } from "@/entities/preferences/@x/study-progress";
 
 import { createStudyProgress } from "./defaults";
-import type {
-  CardProgressFields,
-  StudyCardOrderOptions,
-  StudyProgress,
-  StudyProgressEdit,
-  StudyProgressFilter,
-  StudyRating,
-} from "./types";
+import type { CardProgressFields, StudyProgress, StudyProgressEdit, StudyProgressFilter, StudyRating } from "./types";
 
 const resolveStudyRating = (swipeAction: SwipeAction): StudyRating => {
   if (swipeAction === "GoToNextCardMastered") return "mastered";
@@ -58,23 +49,6 @@ export const isStudyProgressEligible = (progress: StudyProgress, filter: StudyPr
     return false;
   }
   return true;
-};
-
-const compareStudyProgress = (first: StudyProgress, second: StudyProgress): number =>
-  first.numberOfSeen - second.numberOfSeen;
-
-export const buildStudyCardOrder = (
-  cards: CardProgressFields[],
-  options: StudyCardOrderOptions
-): StudyProgress["cardId"][] => {
-  let cardOrderIds = cards
-    .map(createStudyProgressFromCard)
-    .sort(compareStudyProgress)
-    .map((progress) => progress.cardId);
-  // The maximum follows shuffling so a limited randomized session can draw from the complete card set.
-  if (options.shuffled) cardOrderIds = lodash.shuffle(cardOrderIds);
-  if (options.maxNumberOfCardsToLearn > 0) cardOrderIds = cardOrderIds.slice(0, options.maxNumberOfCardsToLearn);
-  return cardOrderIds;
 };
 
 export const getNextStudyAvailabilityAt = (

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -32,9 +32,4 @@ export interface CardProgressFields {
   interval?: number | undefined;
 }
 
-export interface StudyCardOrderOptions {
-  shuffled: boolean;
-  maxNumberOfCardsToLearn: number;
-}
-
 export type EditStudyProgressInput = z.infer<typeof editStudyProgressSchema>;

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ shuffle: vi.fn((ids: string[]) => [...ids].reverse()) }));
+
+vi.mock("lodash", () => ({ shuffle: mocks.shuffle }));
 
 import {
+  buildStudyCardOrder,
   calculateStudySessionIndex,
   isStudySessionPositionUnchanged,
   resolveStudySession,
@@ -8,12 +13,44 @@ import {
 } from "./rules";
 import type { StudySession } from "./types";
 
+const studyCard = (id: string, numberOfSeen = 0) => ({ id, numberOfSeen });
+
 const session: StudySession = {
   deckId: "deck-1",
   cardOrderIds: ["card-1", "card-2", "card-3"],
   currentIndex: 1,
   lastStudiedAt: 0,
 };
+
+describe("buildStudyCardOrder", () => {
+  const cards = [studyCard("a"), studyCard("b"), studyCard("c"), studyCard("d")];
+
+  it("returns the progress-based card order when shuffle and maximum are disabled", () => {
+    expect(buildStudyCardOrder(cards, { shuffled: false, maxNumberOfCardsToLearn: 0 })).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns no card IDs for an empty selection", () => {
+    expect(buildStudyCardOrder([], { shuffled: false, maxNumberOfCardsToLearn: 0 })).toEqual([]);
+  });
+
+  it("limits the number of cards", () => {
+    expect(buildStudyCardOrder(cards, { shuffled: false, maxNumberOfCardsToLearn: 2 })).toEqual(["a", "b"]);
+  });
+
+  it("orders cards by study progress before applying the maximum", () => {
+    const unorderedCards = [studyCard("seen", 5), studyCard("new", 1), studyCard("middle", 3)];
+
+    expect(buildStudyCardOrder(unorderedCards, { shuffled: false, maxNumberOfCardsToLearn: 2 })).toEqual([
+      "new",
+      "middle",
+    ]);
+  });
+
+  it("shuffles before applying the maximum", () => {
+    expect(buildStudyCardOrder(cards, { shuffled: true, maxNumberOfCardsToLearn: 2 })).toEqual(["d", "c"]);
+    expect(mocks.shuffle).toHaveBeenCalledWith(["a", "b", "c", "d"]);
+  });
+});
 
 describe("calculateStudySessionIndex", () => {
   it("moves within the session card order", () => {

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -1,3 +1,5 @@
+import * as lodash from "lodash";
+
 import type { SwipeAction } from "@/entities/preferences/@x/study-session";
 
 import type {
@@ -5,8 +7,24 @@ import type {
   StudySession,
   StudySessionCard,
   StudySessionMovement,
+  StudySessionStartCard,
+  StudySessionStartOptions,
   StudySessionSwipeEffect,
 } from "./types";
+
+const compareStudySessionStartCards = (first: StudySessionStartCard, second: StudySessionStartCard): number =>
+  first.numberOfSeen - second.numberOfSeen;
+
+export const buildStudyCardOrder = (
+  cards: StudySessionStartCard[],
+  options: StudySessionStartOptions
+): StudySession["cardOrderIds"] => {
+  let cardOrderIds = [...cards].sort(compareStudySessionStartCards).map((card) => card.id);
+  // The maximum follows shuffling so a limited randomized session can draw from the complete card set.
+  if (options.shuffled) cardOrderIds = lodash.shuffle(cardOrderIds);
+  if (options.maxNumberOfCardsToLearn > 0) cardOrderIds = cardOrderIds.slice(0, options.maxNumberOfCardsToLearn);
+  return cardOrderIds;
+};
 
 export const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -1,17 +1,18 @@
 import type { CardId } from "@/entities/card/@x/study-session";
 import type { DeckId } from "@/entities/deck/@x/study-session";
-import {
-  buildStudyCardOrder,
-  type CardProgressFields,
-  type StudyCardOrderOptions,
-} from "@/entities/study-progress/@x/study-session";
 
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
-import { calculateStudySessionIndex } from "./rules";
-import type { StudySession, StudySessionMovement, StudySessions } from "./types";
+import { buildStudyCardOrder, calculateStudySessionIndex } from "./rules";
+import type {
+  StudySession,
+  StudySessionMovement,
+  StudySessions,
+  StudySessionStartCard,
+  StudySessionStartOptions,
+} from "./types";
 
 const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
@@ -91,11 +92,10 @@ const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
   });
 };
 
-// Session start owns the state mutation while study-progress owns how the card order is derived.
 export const startStudy = (
   deckId: DeckId,
-  cards: CardProgressFields[],
-  studyPreferences: StudyCardOrderOptions
+  cards: StudySessionStartCard[],
+  studyPreferences: StudySessionStartOptions
 ): void => {
   startStudySession(deckId, buildStudyCardOrder(cards, studyPreferences));
 };

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -34,6 +34,15 @@ export type StudySessionSwipeEffect = "none" | "exit" | StudySessionMovement;
 
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
 
+export interface StudySessionStartCard extends StudySessionCard {
+  numberOfSeen: number;
+}
+
+export interface StudySessionStartOptions {
+  shuffled: boolean;
+  maxNumberOfCardsToLearn: number;
+}
+
 export type ResolvedStudySession<Card extends StudySessionCard> =
   | { status: "preparing" | "invalid" }
   | { status: "studying"; session: StudySession; card: Card };


### PR DESCRIPTION
## Related issue

None

## Summary

- move study card order derivation into the study-session entity that owns the session order snapshot
- keep sorting, optional shuffling, and card limits unchanged while removing the study-progress cross-slice contract
- colocate ordering tests with the study-session rules

## Testing

- mise run check