### PR TITLE
[No issue] Move study swipe domain logic into entities

### DIFF
--- a/src/entities/study-progress/@x/study-session.ts
+++ b/src/entities/study-progress/@x/study-session.ts
@@ -1,2 +1,2 @@
-export { buildStudyCardOrder } from "../model/rules";
-export type { CardProgressFields, StudyCardOrderOptions } from "../model/types";
+export { buildStudyCardOrder, recordCardStudyProgress } from "../model/rules";
+export type { CardProgressFields, StudyCardOrderOptions, StudyProgressEdit } from "../model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,3 +1,3 @@
 export { editStudyProgress } from "./api/firestore";
-export { getNextStudyAvailabilityAt, recordCardStudyProgress } from "./model/rules";
+export { getNextStudyAvailabilityAt } from "./model/rules";
 export type { StudyProgressEdit } from "./model/types";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,10 +1,9 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
 export {
   calculateStudySessionIndex,
-  getCurrentStudySessionCardId,
   isStudySessionPositionUnchanged,
+  planStudySessionSwipe,
   resolveStudySession,
-  resolveStudySessionSwipeEffect,
 } from "./model/rules";
 export type { StudySession } from "./model/types";
 export {

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   calculateStudySessionIndex,
   isStudySessionPositionUnchanged,
+  planStudySessionSwipe,
   resolveStudySession,
-  resolveStudySessionSwipeEffect,
 } from "./rules";
 import type { StudySession } from "./types";
 
@@ -51,17 +51,45 @@ describe("resolveStudySession", () => {
   });
 });
 
-describe("resolveStudySessionSwipeEffect", () => {
+describe("planStudySessionSwipe", () => {
+  const cards = [
+    { id: "card-1", score: 0, numberOfSeen: 0 },
+    { id: "card-2", score: 2, numberOfSeen: 3 },
+  ];
+
+  it("plans the progress edit and session movement for the active card", () => {
+    expect(planStudySessionSwipe(session, cards, "GoToNextCardMastered", 1_786_512_000_000)).toEqual({
+      effect: "next",
+      session,
+      progress: {
+        cardId: "card-2",
+        score: 3,
+        numberOfSeen: 4,
+        lastSeenAt: 1_786_512_000_000,
+      },
+    });
+  });
+
   it.each([
-    ["DoNothing", "none"],
-    ["GoBack", "exit"],
     ["GoToPrevCard", "previous"],
     ["GoToNextCard", "next"],
     ["GoToNextCardMastered", "next"],
     ["GoToNextCardNotMastered", "next"],
     ["GoToNextCardToggleMastered", "next"],
-  ] as const)("maps %s to the %s session effect", (swipeAction, effect) => {
-    expect(resolveStudySessionSwipeEffect(swipeAction)).toBe(effect);
+  ] as const)("plans %s to move %s after persistence", (swipeAction, effect) => {
+    expect(planStudySessionSwipe(session, cards, swipeAction, 0)).toMatchObject({ effect, session });
+  });
+
+  it.each([
+    ["DoNothing", "none"],
+    ["GoBack", "exit"],
+  ] as const)("plans %s as %s without a progress edit", (swipeAction, effect) => {
+    expect(planStudySessionSwipe(session, cards, swipeAction, 0)).toEqual({ effect });
+  });
+
+  it("ignores swipes without a resolvable active session", () => {
+    expect(planStudySessionSwipe(undefined, cards, "GoToNextCard", 0)).toEqual({ effect: "none" });
+    expect(planStudySessionSwipe(session, cards.slice(0, 1), "GoToNextCard", 0)).toEqual({ effect: "none" });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -1,14 +1,16 @@
 import type { SwipeAction } from "@/entities/preferences/@x/study-session";
+import { type CardProgressFields, recordCardStudyProgress } from "@/entities/study-progress/@x/study-session";
 
 import type {
   ResolvedStudySession,
   StudySession,
   StudySessionCard,
   StudySessionMovement,
+  StudySessionSwipePlan,
   StudySessionSwipeEffect,
 } from "./types";
 
-export const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
+const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
 export const resolveStudySession = <Card extends StudySessionCard>(
@@ -24,10 +26,31 @@ export const resolveStudySession = <Card extends StudySessionCard>(
   return { status: cardId != null && cards.length === 0 ? "preparing" : "invalid" };
 };
 
-export const resolveStudySessionSwipeEffect = (swipeAction: SwipeAction): StudySessionSwipeEffect => {
+const resolveStudySessionSwipeEffect = (swipeAction: SwipeAction): StudySessionSwipeEffect => {
   if (swipeAction === "DoNothing") return "none";
   if (swipeAction === "GoBack") return "exit";
   return swipeAction === "GoToPrevCard" ? "previous" : "next";
+};
+
+export const planStudySessionSwipe = (
+  session: StudySession | undefined,
+  cards: readonly CardProgressFields[],
+  swipeAction: SwipeAction,
+  studiedAt: number
+): StudySessionSwipePlan => {
+  if (session == null) return { effect: "none" };
+
+  const effect = resolveStudySessionSwipeEffect(swipeAction);
+  if (effect === "none" || effect === "exit") return { effect };
+
+  const resolvedSession = resolveStudySession(session, cards);
+  if (resolvedSession.status !== "studying") return { effect: "none" };
+
+  return {
+    effect,
+    session,
+    progress: recordCardStudyProgress(resolvedSession.card, swipeAction, studiedAt),
+  };
 };
 
 export const isStudySessionPositionUnchanged = (previous: StudySession, current: StudySession | undefined): boolean =>

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -1,5 +1,6 @@
 import type { CardId } from "@/entities/card/@x/study-session";
 import type { DeckId } from "@/entities/deck/@x/study-session";
+import type { StudyProgressEdit } from "@/entities/study-progress/@x/study-session";
 
 /**
  * Persisted progress for one deck's active study run.
@@ -31,6 +32,15 @@ export type StudySessions = Partial<Record<DeckId, StudySession>>;
 
 export type StudySessionMovement = "previous" | "next";
 export type StudySessionSwipeEffect = "none" | "exit" | StudySessionMovement;
+
+export type StudySessionSwipePlan =
+  | { effect: "none" }
+  | { effect: "exit" }
+  | {
+      effect: StudySessionMovement;
+      session: StudySession;
+      progress: StudyProgressEdit;
+    };
 
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
 

--- a/src/features/study/hooks/useStudyActions.ts
+++ b/src/features/study/hooks/useStudyActions.ts
@@ -1,15 +1,14 @@
-import { mustFindCardById, type Card } from "@/entities/card";
+import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import type { SwipeDirection } from "@/entities/preferences";
 import { usePreferences } from "@/entities/preferences";
-import { recordCardStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+import type { StudyProgressEdit } from "@/entities/study-progress";
 import {
-  getCurrentStudySessionCardId,
   getStudySession,
   isStudySessionPositionUnchanged,
   moveStudySession,
+  planStudySessionSwipe,
   removeStudySession,
-  resolveStudySessionSwipeEffect,
   setStudySessionIndex,
 } from "@/entities/study-session";
 
@@ -37,30 +36,22 @@ export const useStudyActions = (
   const preferences = usePreferences();
   const swipeState = React.useRef<{ inProgress: boolean }>({ inProgress: false });
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Keeping the persistence and transition order inline makes the swipe invariant auditable.
   const swipe = async (direction: SwipeDirection): Promise<void> => {
     // biome-ignore lint/suspicious/noUnnecessaryConditions: The awaited write lets another event enter this closure.
     if (swipeState.current.inProgress) return;
-    const session = getStudySession(deckId);
-    if (session == null) return;
 
     const swipeAction = preferences.controls[direction];
-    const sessionEffect = resolveStudySessionSwipeEffect(swipeAction);
-    if (sessionEffect === "none") return;
-    if (sessionEffect === "exit") {
+    const swipePlan = planStudySessionSwipe(getStudySession(deckId), cards, swipeAction, Date.now());
+    if (swipePlan.effect === "none") return;
+    if (swipePlan.effect === "exit") {
       onSwipe?.(direction);
       removeStudySession(deckId);
       return;
     }
 
-    const cardId = getCurrentStudySessionCardId(session);
-    if (cardId == null) return;
-    const card = mustFindCardById(cards, cardId);
-    const patch = recordCardStudyProgress(card, swipeAction, Date.now());
-
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saved = await saveProgress(patch).then(
+    const saved = await saveProgress(swipePlan.progress).then(
       () => true,
       () => false
     );
@@ -69,11 +60,11 @@ export const useStudyActions = (
 
     const currentSession = getStudySession(deckId);
     // Position changes during the write own the newer card, while timestamp-only touches still allow advancement.
-    if (!isStudySessionPositionUnchanged(session, currentSession)) return;
+    if (!isStudySessionPositionUnchanged(swipePlan.session, currentSession)) return;
 
     onSwipe?.(direction);
     if (preferences.appearance.hideBodyWhenCardChanged) onCardChanged?.();
-    moveStudySession(deckId, sessionEffect);
+    moveStudySession(deckId, swipePlan.effect);
   };
 
   return {


### PR DESCRIPTION
## Summary

- move swipe planning from `features/study/hooks/useStudyActions` into a pure `study-session` Entity rule
- derive the session effect and study-progress edit as one domain plan before coordinating persistence
- narrow the public Entity APIs and add behavior coverage for every swipe outcome and invalid session state

## Why

`useStudyActions` mixed domain decisions (action mapping, active-card resolution, and progress calculation) with React-side persistence sequencing. Keeping those decisions in Entities makes the feature hook responsible only for coordinating side effects.

## Impact

Study behavior is unchanged. Swipes still persist progress before moving the visible card, ignore concurrent or invalid transitions, and preserve the existing feedback and session-exit behavior.

## Validation

- `mise run check`
- 99 test files passed, 536 tests passed
- TypeScript, ESLint, Biome, FSD, knip, Markdown, Docker, and sample checks passed