### PR TITLE
[No issue] Enable no-unnecessary-type-conversion ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -141,7 +141,6 @@ export default [
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-misused-promises": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",
-      "@typescript-eslint/no-unnecessary-type-conversion": "off",
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/restrict-plus-operands": "off",
       // Primitive template interpolation and polymorphic `this` are project policy, not correctness constraints.


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable the no-unnecessary-type-conversion ESLint rule.
- Confirm the project already complies without source changes.

## Testing

- mise run lint-fix
- mise run check