### PR TITLE
refactor(#915): simplify deck import internals

### DIFF
--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -1,9 +1,3 @@
-/**
- * @file Verifies the "useDeckImport" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "previews a file without
- * writing until import is confirmed" and "keeps invalid files in preview without mutating state".
- */
-
 import type { Card, CardMutation } from "@/entities/card";
 import type { Deck, DeckCreateInput, DeckId, LocalDeckCreateInput } from "@/entities/deck";
 
@@ -93,7 +87,6 @@ describe("useDeckImport", () => {
     });
 
     expect(result.current.preview).toMatchObject({
-      fileName: "deck.csv",
       deckName: "deck.csv",
       analysis: { invalidCount: 0 },
       plan: { created: 1, updated: 0, unchanged: 0 },

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -7,11 +7,7 @@ import { fetchCards, mutateCards } from "@/entities/card";
 import { fetchDecks } from "@/entities/deck";
 import { useAuthUid } from "@/entities/auth";
 import { parseCsv } from "../lib/cardCsv";
-import type {
-  DeckImportAttempt,
-  DeckImportExecutionDependencies,
-  DeckImportRequest,
-} from "../model/deckImportExecution";
+import type { DeckImportAttempt, DeckImportExecutionDependencies } from "../model/deckImportExecution";
 import { executePreparedDeckImport, partialResultFrom, prepareDeckImport } from "../model/deckImportExecution";
 import type { DeckImportPreview, DeckImportResult, DeckImportStorageMode } from "../model/deckImportTypes";
 import { prepareSampleDeck } from "../model/sampleDeck";
@@ -96,7 +92,6 @@ export const useDeckImport = ({ cards, createDeck, decks, generateCardId }: Deck
     target.retryAttempt = attempt;
     publish(target, { pending: true, error: null });
     try {
-      if (!isCurrent(target)) throw new Error("Deck import user changed before the import could start");
       const result = await executePreparedDeckImport(attempt, executionDependencies);
       publish(target, { data: result });
       return result;
@@ -152,27 +147,16 @@ export const useDeckImport = ({ cards, createDeck, decks, generateCardId }: Deck
       const analysis = await parseCsv(await file.text());
       if (!isCurrent(target)) throw new Error("Deck import user changed before the preview could finish");
 
-      let activeDecks = decks;
-      let activeCards = cards;
-      if (target.storageMode === "remote") {
-        // Listener-backed stores can lag, so remote file imports are planned from authoritative server reads.
-        [activeDecks, activeCards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
-      }
+      // Listener-backed stores can lag, so remote file imports are planned from authoritative server reads.
+      const [activeDecks, activeCards]: [Deck[], Card[]] =
+        target.storageMode === "remote" ? await Promise.all([fetchDecks(uid), fetchCards(uid)]) : [decks, cards];
 
       if (!isCurrent(target)) throw new Error("Deck import user changed before the preview could finish");
-      const request = {
-        name: file.name,
-        rows: analysis.rows,
-        storageMode: target.storageMode,
-      } satisfies DeckImportRequest;
-      const attempt = prepareDeckImport(request, {
-        uid,
-        decks: activeDecks,
-        cards: activeCards,
-        generateCardId,
-      });
+      const attempt = prepareDeckImport(
+        { name: file.name, rows: analysis.rows, storageMode: target.storageMode },
+        { uid, decks: activeDecks, cards: activeCards, generateCardId }
+      );
       const preview = {
-        fileName: file.name,
         deckName: file.name,
         analysis,
         plan: attempt.plan,

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -1,10 +1,3 @@
-/**
- * @file Verifies the "sample Deck bootstrap" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "adds the sample once for a
- * server-confirmed empty user under StrictMode", "waits for the server before treating an empty cache
- * as an empty user", "does not add the sample when the user already has a Deck".
- */
-
 import type { Deck, DeckCreateInput, LocalDeckCreateInput } from "@/entities/deck";
 
 import { renderHook, waitFor } from "@testing-library/react";
@@ -35,10 +28,6 @@ const useTestSampleDeckBootstrap = () =>
     generateCardId: vi.fn(() => "card-id"),
   });
 
-/**
- * Provides the strict mode test helper used by this file.
- * Keeping this setup in one function lets each test focus on the behavior it is proving.
- */
 const strictMode = ({ children }: { children: ReactNode }) => <React.StrictMode>{children}</React.StrictMode>;
 
 describe("sample Deck bootstrap", () => {

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -52,6 +52,25 @@ describe("sample Deck bootstrap", () => {
     expect(mocks.addSample).not.toHaveBeenCalled();
   });
 
+  it("adds the sample again when Decks become empty after a completed bootstrap", async () => {
+    const { unmount } = renderHook(useTestSampleDeckBootstrap);
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    unmount();
+
+    mocks.remote.decks = [{ id: "sample" } as Deck];
+    const { unmount: unmountPopulated } = renderHook(useTestSampleDeckBootstrap);
+    expect(mocks.addSample).toHaveBeenCalledOnce();
+    unmountPopulated();
+
+    mocks.remote.decks = [];
+    renderHook(useTestSampleDeckBootstrap);
+
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledTimes(2));
+  });
+
   it("deduplicates concurrent starts for one user", async () => {
     let finish: () => void = () => undefined;
     mocks.addSample.mockImplementation(

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -6,18 +6,17 @@ import type { SampleDeckOptions } from "../model/sampleDeck";
 
 type AddSample = () => Promise<unknown>;
 
-const bootstrapsByUid = new Map<string, Promise<unknown>>();
+const pendingBootstrapsByUid = new Map<string, Promise<unknown>>();
 
 const startSampleDeckBootstrap = (uid: string, addSample: AddSample) => {
-  const existing = bootstrapsByUid.get(uid);
+  const existing = pendingBootstrapsByUid.get(uid);
   if (existing != null) return existing;
 
-  const operation = Promise.resolve().then(addSample);
-  bootstrapsByUid.set(uid, operation);
-  // Successful operations stay cached across StrictMode remounts; failures are removed so a later render can retry.
-  void operation.catch(() => {
-    bootstrapsByUid.delete(uid);
-  });
+  // Only overlapping effects share work; Deck state remains the source of truth for later bootstrap decisions.
+  const operation = Promise.resolve()
+    .then(addSample)
+    .finally(() => pendingBootstrapsByUid.delete(uid));
+  pendingBootstrapsByUid.set(uid, operation);
   return operation;
 };
 

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -1,9 +1,3 @@
-/**
- * @file Provides the import feature's Use Sample Deck Bootstrap React hook.
- * The hook combines state and operations behind one interface so components do not need to
- * coordinate services themselves.
- */
-
 import { useEffect } from "react";
 
 import { useAuthUid } from "@/entities/auth";
@@ -12,52 +6,29 @@ import type { SampleDeckOptions } from "../model/sampleDeck";
 
 type AddSample = () => Promise<unknown>;
 
-/**
- * Creates and configures a sample deck bootstrap controller.
- * Optional dependencies or settings let production code and tests reuse the same behavior in
- * different environments.
- */
-const createSampleDeckBootstrapController = () => {
-  const completedUids = new Set<string>();
-  const pendingByUid = new Map<string, Promise<unknown>>();
+const bootstrapsByUid = new Map<string, Promise<unknown>>();
 
-  return {
-    start: (uid: string, addSample: AddSample) => {
-      if (completedUids.has(uid)) return;
-      const pending = pendingByUid.get(uid);
-      if (pending != null) return pending;
+const startSampleDeckBootstrap = (uid: string, addSample: AddSample) => {
+  const existing = bootstrapsByUid.get(uid);
+  if (existing != null) return existing;
 
-      const operation = Promise.resolve().then(addSample);
-      pendingByUid.set(uid, operation);
-      void operation.then(
-        () => {
-          pendingByUid.delete(uid);
-          completedUids.add(uid);
-        },
-        () => pendingByUid.delete(uid)
-      );
-      return operation;
-    },
-  };
+  const operation = Promise.resolve().then(addSample);
+  bootstrapsByUid.set(uid, operation);
+  // Successful operations stay cached across StrictMode remounts; failures are removed so a later render can retry.
+  void operation.catch(() => {
+    bootstrapsByUid.delete(uid);
+  });
+  return operation;
 };
 
-const sampleDeckBootstrapController = createSampleDeckBootstrapController();
-
-/**
- * Provides the sample deck bootstrap values and operations needed by React components.
- * Callers receive one focused interface without coordinating the import feature's stores and
- * services themselves.
- */
 export const useSampleDeckBootstrap = (options: SampleDeckOptions) => {
   const uid = useAuthUid();
   const { cards, createDeck, decks, generateCardId } = options;
 
   useEffect(() => {
-    if (uid === "" || decks.length > 0) {
-      return;
-    }
-    void sampleDeckBootstrapController
-      .start(uid, () => addSampleDeck(uid, { cards, createDeck, decks, generateCardId }))
-      ?.catch(() => undefined);
+    if (uid === "" || decks.length > 0) return;
+    void startSampleDeckBootstrap(uid, () => addSampleDeck(uid, { cards, createDeck, decks, generateCardId })).catch(
+      () => undefined
+    );
   }, [cards, createDeck, decks, generateCardId, uid]);
 };

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -107,27 +107,15 @@ export const prepareDeckImport = (
   const localMode = request.storageMode === "local";
   if (!localMode && uid === "") throw new Error("A confirmed user is required for remote imports");
 
-  let deck: DeckImportCreateInput | undefined = decks.find((candidate) =>
-    matchesImportDestination(candidate, request, localMode)
-  );
-  const createDeckPending = deck == null;
-  if (deck == null) deck = createImportDeck(request, uid, localMode);
+  const existingDeck = decks.find((candidate) => matchesImportDestination(candidate, request, localMode));
+  const deck = existingDeck ?? createImportDeck(request, uid, localMode);
 
   const existing = cards.filter((card) => card.deckId === deck.id && isRemoteCard(card) !== localMode);
-  const preparedCards = prepareCardMutations({
-    rows: request.rows,
-    existing,
-    deckId: deck.id,
-    uid,
-    localMode,
-    generateCardId,
-  });
-
   return {
     uid,
     deck,
-    createDeckPending,
-    ...preparedCards,
+    createDeckPending: existingDeck == null,
+    ...prepareCardMutations({ rows: request.rows, existing, deckId: deck.id, uid, localMode, generateCardId }),
   };
 };
 

--- a/src/features/deck-import/model/deckImportTypes.ts
+++ b/src/features/deck-import/model/deckImportTypes.ts
@@ -1,9 +1,3 @@
-/**
- * @file Defines the data contracts shared by the deck-import screen, hook, and analysis logic.
- * Keeping preview, result, and row shapes here lets each layer exchange import data without
- * depending on another layer's implementation.
- */
-
 import type { CardRaw } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 
@@ -41,7 +35,6 @@ export interface DeckImportPlan {
 }
 
 export interface DeckImportPreview {
-  fileName: string;
   deckName: string;
   analysis: DeckImportAnalysis;
   plan: DeckImportPlan;

--- a/src/features/deck-import/model/sampleDeck.ts
+++ b/src/features/deck-import/model/sampleDeck.ts
@@ -1,17 +1,14 @@
-import type { Card, CardRaw } from "@/entities/card";
+import type { Card } from "@/entities/card";
 import type { Deck, DeckCreateInput, DeckId } from "@/entities/deck";
 
 import { mutateCards } from "@/entities/card";
 import sampleCards from "../../../../sample/build/output.json";
 import { executePreparedDeckImport, prepareDeckImport } from "./deckImportExecution";
-import type { DeckImportRow } from "./deckImportTypes";
 
 const SAMPLE_DECK_NAME = "Sample Deck";
 const SAMPLE_VERSION = 1;
 
 const sampleDeckId = (uid: string): DeckId => `sample-v${SAMPLE_VERSION}-${uid}`;
-const rowsFromCards = (cards: CardRaw[]): DeckImportRow[] =>
-  cards.map((card, index) => ({ rowNumber: index + 1, card }));
 
 export interface SampleDeckOptions {
   cards: Card[];
@@ -25,7 +22,7 @@ export const prepareSampleDeck = (uid: string, options: Omit<SampleDeckOptions, 
     {
       name: SAMPLE_DECK_NAME,
       preferredDeckId: sampleDeckId(uid),
-      rows: rowsFromCards(sampleCards),
+      rows: sampleCards.map((card, index) => ({ rowNumber: index + 1, card })),
     },
     { uid, ...options }
   );

--- a/src/features/deck-import/sampleCsv.ts
+++ b/src/features/deck-import/sampleCsv.ts
@@ -8,6 +8,4 @@ export const SAMPLE_CSV_TEXT = `\
 const SAMPLE_CSV_FILE_NAME = "sample.csv";
 const CSV_MIME_TYPE = "text/plain;charset=utf-8";
 
-export const downloadSampleCsv = (): void => {
-  downloadTextFile(SAMPLE_CSV_TEXT, SAMPLE_CSV_FILE_NAME, CSV_MIME_TYPE);
-};
+export const downloadSampleCsv = (): void => downloadTextFile(SAMPLE_CSV_TEXT, SAMPLE_CSV_FILE_NAME, CSV_MIME_TYPE);

--- a/src/features/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/features/deck-import/ui/DeckImportView.spec.tsx
@@ -1,10 +1,3 @@
-/**
- * @file Verifies the "DeckImportView" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "composes a bounded semantic
- * import route surface", "passes a real file to the upload callback and disables upload while
- * busy", "documents uniqueKey and exposes sample add, download, and code controls".
- */
-
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
@@ -15,7 +8,6 @@ import type { DeckImportPreview, DeckImportResult } from "../model/deckImportTyp
 import { DeckImportView } from "./DeckImportView";
 
 const preview = {
-  fileName: "deck.csv",
   deckName: "deck.csv",
   analysis: {
     rows: [

--- a/src/features/deck-import/ui/DeckImportView.stories.tsx
+++ b/src/features/deck-import/ui/DeckImportView.stories.tsx
@@ -1,9 +1,3 @@
-/**
- * @file Defines Storybook examples for the Deck Import Page view.
- * These isolated scenarios show developers how the component looks, which props it accepts, and
- * how it responds to interaction.
- */
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
@@ -13,7 +7,6 @@ import { SAMPLE_CSV_TEXT } from "../sampleCsv";
 import { DeckImportView as Template } from "./DeckImportView";
 
 const preview = {
-  fileName: "spanish-basics.csv",
   deckName: "spanish-basics.csv",
   analysis: {
     rows: [

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -1,8 +1,3 @@
-/**
- * @file Composes the Deck Import Page's presentation.
- * Data and callbacks arrive through props, which keeps this presentation usable in Storybook.
- */
-
 import type * as React from "react";
 import { AiOutlineCloudDownload } from "react-icons/ai";
 
@@ -31,10 +26,6 @@ interface DeckImportViewProps {
   storageMode?: DeckImportStorageMode;
 }
 
-/**
- * Renders the created, updated, skipped, and failed totals for an import result.
- * The same compact summary is used for successful and partially failed imports.
- */
 const resultCounts = (result: DeckImportResult) => (
   <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption">
     <li>{result.created} created</li>
@@ -52,11 +43,6 @@ interface ImportResultProps {
   onBack: (() => void) | undefined;
 }
 
-/**
- * Composes the complete Import Result screen from reusable UI components.
- * All data and callbacks arrive through props, allowing the same screen to run in tests and
- * Storybook.
- */
 const ImportResult = (props: ImportResultProps) => {
   if (props.partialResult != null) {
     return (
@@ -125,11 +111,6 @@ interface ImportPreviewProps {
   onImport: (() => void) | undefined;
 }
 
-/**
- * Composes the complete Import Preview screen from reusable UI components.
- * All data and callbacks arrive through props, allowing the same screen to run in tests and
- * Storybook.
- */
 const ImportPreview = (props: ImportPreviewProps) => {
   const { preview } = props;
   if (preview == null) return null;
@@ -235,11 +216,6 @@ const ImportPreview = (props: ImportPreviewProps) => {
   );
 };
 
-/**
- * Composes the Deck Import screen from reusable UI components.
- * All data and callbacks arrive through props, allowing the same screen to run in tests and
- * Storybook.
- */
 export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
   const busy = Boolean(props.pending || props.validating);
   const storageMode = props.storageMode ?? "remote";
@@ -298,7 +274,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
           </fieldset>
           <Upload
             disabled={busy}
-            {...(props.preview !== undefined ? { fileName: props.preview.fileName } : {})}
+            {...(props.preview !== undefined ? { fileName: props.preview.deckName } : {})}
             {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
           />
         </section>

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -74,7 +74,6 @@ vi.mock("@/entities/preferences", () => ({
 import { DeckImportPage } from "./DeckImportPage";
 
 const preview = {
-  fileName: "deck.csv",
   deckName: "deck.csv",
   analysis: {
     rows: [


### PR DESCRIPTION
## Related issue

Fixes #915

## Summary

- Reduce Sample Deck bootstrap bookkeeping to one per-user operation cache.
- Remove duplicate preview naming and inline straightforward import preparation.
- Remove redundant wrappers and comments while preserving UID, retry, and storage-mode safeguards.

## Testing

- mise run check (99 test files, 544 tests)