### PR TITLE
Clarify Entity-owned domain logic in Features

### DIFF
--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -1,0 +1,14 @@
+# Features Instructions
+
+- Treat `src/features` as the FSD Features layer and each `src/features/<feature>` directory as a Feature slice.
+- Feature code may coordinate user interactions, UI state, and feature-specific workflows across Entities.
+
+## `model/`
+
+- Do not implement or duplicate domain logic that should be owned by an Entity.
+- Entity-owned domain logic includes rules, calculations, relationships, selections, and transformations that describe Entity behavior independently of a particular Feature or UI.
+- If Feature code needs an Entity-owned domain decision, implement and expose that decision from the appropriate `entities` slice, then consume its result from the Feature.
+- Feature-specific workflow and orchestration may remain in `features` when it coordinates Entity operations rather than defining Entity behavior.
+- For list/view Features, define UI-facing interfaces and transform Entity data into those interfaces.
+- Keep list/view transformations limited to presentation concerns such as selecting already-derived values, combining, renaming, or restructuring data for the UI.
+- Do not reimplement Entity rules while building UI-facing models.

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -1,14 +1,8 @@
 # Features Instructions
 
-- Treat `src/features` as the FSD Features layer and each `src/features/<feature>` directory as a Feature slice.
-- Feature code may coordinate user interactions, UI state, and feature-specific workflows across Entities.
-
 ## `model/`
 
-- Do not implement or duplicate domain logic that should be owned by an Entity.
-- Entity-owned domain logic includes rules, calculations, relationships, selections, and transformations that describe Entity behavior independently of a particular Feature or UI.
-- If Feature code needs an Entity-owned domain decision, implement and expose that decision from the appropriate `entities` slice, then consume its result from the Feature.
-- Feature-specific workflow and orchestration may remain in `features` when it coordinates Entity operations rather than defining Entity behavior.
-- For list/view Features, define UI-facing interfaces and transform Entity data into those interfaces.
-- Keep list/view transformations limited to presentation concerns such as selecting already-derived values, combining, renaming, or restructuring data for the UI.
-- Do not reimplement Entity rules while building UI-facing models.
+- Do not implement or duplicate domain logic owned by an Entity. Entity-owned logic is logic that remains valid independently of a specific Feature or UI.
+- If needed, expose Entity-owned logic from `entities` and consume it here.
+- Feature-specific workflows may coordinate multiple Entities.
+- For list/view Features, define UI-facing interfaces and map Entity data to them without reimplementing Entity rules.


### PR DESCRIPTION
## Summary

- add `src/features/AGENTS.md`
- clarify that Features must not implement or duplicate domain logic owned by Entities
- define Entity-owned logic as rules, calculations, relationships, selections, and transformations independent of a specific Feature/UI
- allow Feature-specific workflow and orchestration that coordinates Entity operations
- clarify that list/view models should project Entity data into UI-facing interfaces without reimplementing Entity rules

## Why

A blanket ban on business logic in `features` is too broad and would incorrectly prohibit legitimate Feature-specific use cases such as import or authentication workflows. The boundary should instead prohibit logic that belongs to an Entity while allowing orchestration specific to the Feature.

## Validation

- documentation-only change
- confirmed the branch differs from `main` only by the new `src/features/AGENTS.md`