### PR TITLE
[No issue] Enable no-unnecessary-condition ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -140,7 +140,6 @@ export default [
       // Biome owns these checks, including promise handling and the Types domain rollout in #1013.
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-misused-promises": "off",
-      "@typescript-eslint/no-unnecessary-condition": "off",
       // Primitive template interpolation and polymorphic `this` are project policy, not correctness constraints.
       "@typescript-eslint/prefer-return-this-type": "off",
       "@typescript-eslint/restrict-template-expressions": "off",

--- a/src/features/card-edit/ui/CardForm.tsx
+++ b/src/features/card-edit/ui/CardForm.tsx
@@ -116,7 +116,7 @@ export const CardForm: React.FC<CardFormProps> = (props) => {
         <dl className="mt-4 grid gap-3 text-caption">
           <div className="min-w-0">
             <dt className="font-medium text-ink-muted">Unique key</dt>
-            <dd className="break-all text-ink">{props.card.uniqueKey ?? ""}</dd>
+            <dd className="break-all text-ink">{props.card.uniqueKey}</dd>
           </div>
           <div className="min-w-0">
             <dt className="font-medium text-ink-muted">ID</dt>

--- a/src/features/card-list/ui/Card.tsx
+++ b/src/features/card-list/ui/Card.tsx
@@ -106,7 +106,7 @@ export const Card: React.FC<{ className?: string; card: CardEntity } & CardActio
     onSwipedRight: withSwipeId(props.onSwipedRight),
     trackMouse: true,
   });
-  const seenCount = props.card.numberOfSeen ?? 0;
+  const seenCount = props.card.numberOfSeen;
 
   return (
     <article


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable the no-unnecessary-condition ESLint rule.
- Remove two nullish fallbacks that are unnecessary for required card fields.

## Testing

- mise run lint-fix
- mise run check