### PR TITLE
Clarify edit Feature model responsibility

### DIFF
--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -6,3 +6,4 @@
 - If needed, expose Entity-owned logic from `entities` and consume it here.
 - Feature-specific workflows may coordinate multiple Entities.
 - For list/view Features, define UI-facing interfaces and map Entity data to them without reimplementing Entity rules.
+- For edit Features, define UI-facing form interfaces and map Entity data and constraints to form state/input without reimplementing Entity rules.


### PR DESCRIPTION
## Summary

- clarify `edit` Feature model responsibility in `src/features/AGENTS.md`
- define edit models as mapping Entity data and constraints to UI-facing form interfaces/state/input
- keep Entity rules out of Feature form logic

## Validation

- documentation-only change
- diff is one added rule