### PR TITLE
#1102 Move study card filtering to deck filter feature

### DIFF
--- a/src/entities/card/@x/deck.ts
+++ b/src/entities/card/@x/deck.ts
@@ -1,2 +1,1 @@
 export { deleteLocalCardsByDeckId } from "../model/store";
-export type { Card } from "../model/types";

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -3,7 +3,6 @@ export { createDeck, deleteDeck, editDeck } from "./api/mutations";
 export { generateDeckId } from "./model/id";
 export {
   CATEGORY,
-  filterCardsForDeck,
   getCategory,
   isHighlightLanguage,
   mustFindDeckById,

--- a/src/entities/deck/model/rules.spec.ts
+++ b/src/entities/deck/model/rules.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
-import { createCard, createDeck } from "@/test/factories";
-import { CATEGORY, filterCardsForDeck, getCategory, isHighlightLanguage, mustFindDeckById } from "./rules";
+import { createDeck } from "@/test/factories";
+import { CATEGORY, getCategory, isHighlightLanguage, mustFindDeckById } from "./rules";
 
 describe("category", () => {
   it("defines supported categories including application categories and major languages", () => {
@@ -47,64 +47,5 @@ describe("mustFindDeckById", () => {
 
   it("throws when no deck matches the specified id", () => {
     expect(() => mustFindDeckById([], "missing")).toThrow("Deck not found: missing");
-  });
-});
-
-describe("filterCardsForDeck", () => {
-  const now = 1000;
-  const baseDeck = createDeck({ selectedTags: [], tagAndFilter: false, scoreMax: null, scoreMin: null });
-  const basePreferences = { useCardInterval: false };
-
-  it("returns all cards when no filters are active", () => {
-    const cards = [createCard({ id: "a" }), createCard({ id: "b" })];
-    expect(filterCardsForDeck(cards, baseDeck, basePreferences, now)).toHaveLength(2);
-  });
-
-  it("filters tags with OR semantics", () => {
-    const cards = [createCard({ id: "a", tags: ["x"] }), createCard({ id: "b", tags: ["y"] })];
-    const deck = { ...baseDeck, selectedTags: ["x"], tagAndFilter: false };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
-  });
-
-  it("filters tags with AND semantics", () => {
-    const cards = [createCard({ id: "a", tags: ["x", "y"] }), createCard({ id: "b", tags: ["x"] })];
-    const deck = { ...baseDeck, selectedTags: ["x", "y"], tagAndFilter: true };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
-  });
-
-  it("includes the configured score boundaries", () => {
-    const cards = [
-      createCard({ id: "low", score: 1 }),
-      createCard({ id: "middle", score: 2 }),
-      createCard({ id: "high", score: 3 }),
-    ];
-    const deck = { ...baseDeck, scoreMin: 1, scoreMax: 3 };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual([
-      "low",
-      "middle",
-      "high",
-    ]);
-  });
-
-  it("excludes scores outside the configured range", () => {
-    const cards = [
-      createCard({ id: "low", score: 1 }),
-      createCard({ id: "middle", score: 2 }),
-      createCard({ id: "high", score: 3 }),
-    ];
-    const deck = { ...baseDeck, scoreMin: 2, scoreMax: 2 };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["middle"]);
-  });
-
-  it("filters unavailable cards when intervals are enabled", () => {
-    const cards = [createCard({ id: "future", nextSeeingAt: new Date(now + 1) }), createCard({ id: "available" })];
-    expect(filterCardsForDeck(cards, baseDeck, { useCardInterval: true }, now).map((card) => card.id)).toEqual([
-      "available",
-    ]);
-  });
-
-  it("preserves input order while filtering", () => {
-    const cards = [createCard({ id: "seen", numberOfSeen: 5 }), createCard({ id: "new", numberOfSeen: 1 })];
-    expect(filterCardsForDeck(cards, baseDeck, basePreferences, now).map((card) => card.id)).toEqual(["seen", "new"]);
   });
 });

--- a/src/entities/deck/model/rules.ts
+++ b/src/entities/deck/model/rules.ts
@@ -1,6 +1,3 @@
-import type { Card } from "@/entities/card/@x/deck";
-import { createStudyProgressFromCard, isStudyProgressEligible } from "@/entities/study-progress/@x/deck";
-
 import type { Category, Deck, DeckId } from "./types";
 
 const APPLICATION_CATEGORIES: Category[] = ["raw", "math"];
@@ -51,32 +48,6 @@ export const getCategory = (category: Category, tags: string[]): Category => {
 
   return tagCategory ?? category;
 };
-
-const isCardMatchingTags = (card: Card, deck: Pick<Deck, "selectedTags" | "tagAndFilter">) => {
-  const tags = deck.selectedTags;
-  if (tags.length === 0) return true;
-  if (deck.tagAndFilter) return tags.every((tag) => card.tags.includes(tag));
-  return tags.some((tag) => card.tags.includes(tag));
-};
-
-export const filterCardsForDeck = <TCard extends Card>(
-  cards: TCard[],
-  deck: Pick<Deck, "selectedTags" | "tagAndFilter" | "scoreMax" | "scoreMin">,
-  study: { useCardInterval: boolean },
-  now: number
-): TCard[] =>
-  cards.filter((card) => {
-    if (!isCardMatchingTags(card, deck)) return false;
-    return isStudyProgressEligible(
-      createStudyProgressFromCard(card),
-      {
-        maximumScore: deck.scoreMax,
-        minimumScore: deck.scoreMin,
-        respectNextSeeingAt: study.useCardInterval,
-      },
-      now
-    );
-  });
 
 export const mustFindDeckById = (decks: readonly Deck[], id: DeckId): Deck => {
   const deck = decks.find((candidate) => candidate.id === id);

--- a/src/entities/study-progress/@x/deck.ts
+++ b/src/entities/study-progress/@x/deck.ts
@@ -1,1 +1,0 @@
-export { createStudyProgressFromCard, isStudyProgressEligible } from "../model/rules";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,3 +1,3 @@
 export { editStudyProgress } from "./api/firestore";
-export { getNextStudyAvailabilityAt } from "./model/rules";
+export { createStudyProgressFromCard, isStudyProgressEligible } from "./model/rules";
 export type { StudyProgressEdit } from "./model/types";

--- a/src/entities/study-progress/model/rules.spec.ts
+++ b/src/entities/study-progress/model/rules.spec.ts
@@ -9,7 +9,6 @@ vi.mock("lodash", () => ({ shuffle: mocks.shuffle }));
 import {
   buildStudyCardOrder,
   createStudyProgressFromCard,
-  getNextStudyAvailabilityAt,
   isStudyProgressEligible,
   recordCardStudyProgress,
 } from "./rules";
@@ -98,16 +97,6 @@ describe("study progress selection", () => {
     expect(
       isStudyProgressEligible({ ...initialStudyProgress("future"), nextSeeingAt: new Date(1001) }, filter, 1000)
     ).toBe(false);
-  });
-
-  it("finds the nearest future seeing time", () => {
-    const progresses = [
-      { ...initialStudyProgress("past"), nextSeeingAt: new Date(900) },
-      { ...initialStudyProgress("later"), nextSeeingAt: new Date(2000) },
-      { ...initialStudyProgress("next"), nextSeeingAt: new Date(1500) },
-    ];
-
-    expect(getNextStudyAvailabilityAt(progresses, 1000)).toBe(1500);
   });
 });
 

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -76,17 +76,3 @@ export const buildStudyCardOrder = (
   if (options.maxNumberOfCardsToLearn > 0) cardOrderIds = cardOrderIds.slice(0, options.maxNumberOfCardsToLearn);
   return cardOrderIds;
 };
-
-export const getNextStudyAvailabilityAt = (
-  scheduledItems: readonly { nextSeeingAt?: Date | undefined }[],
-  now: number
-): number | undefined => {
-  let next: number | undefined;
-  for (const item of scheduledItems) {
-    const candidate = item.nextSeeingAt?.getTime();
-    if (candidate !== undefined && candidate > now && (next === undefined || candidate < next)) {
-      next = candidate;
-    }
-  }
-  return next;
-};

--- a/src/features/deck-filter/model/filterStudyCards.spec.ts
+++ b/src/features/deck-filter/model/filterStudyCards.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+
+import { createCard, createDeck } from "@/test/factories";
+import { filterStudyCards } from "./filterStudyCards";
+
+describe("filterStudyCards", () => {
+  const now = 1000;
+  const baseDeck = createDeck({ selectedTags: [], tagAndFilter: false, scoreMax: null, scoreMin: null });
+  const basePreferences = { useCardInterval: false };
+
+  it("returns all cards when no filters are active", () => {
+    const cards = [createCard({ id: "a" }), createCard({ id: "b" })];
+    expect(filterStudyCards(cards, baseDeck, basePreferences, now)).toHaveLength(2);
+  });
+
+  it("filters tags with OR semantics", () => {
+    const cards = [createCard({ id: "a", tags: ["x"] }), createCard({ id: "b", tags: ["y"] })];
+    const deck = { ...baseDeck, selectedTags: ["x"], tagAndFilter: false };
+    expect(filterStudyCards(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
+  });
+
+  it("filters tags with AND semantics", () => {
+    const cards = [createCard({ id: "a", tags: ["x", "y"] }), createCard({ id: "b", tags: ["x"] })];
+    const deck = { ...baseDeck, selectedTags: ["x", "y"], tagAndFilter: true };
+    expect(filterStudyCards(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
+  });
+
+  it("includes the configured score boundaries", () => {
+    const cards = [
+      createCard({ id: "low", score: 1 }),
+      createCard({ id: "middle", score: 2 }),
+      createCard({ id: "high", score: 3 }),
+    ];
+    const deck = { ...baseDeck, scoreMin: 1, scoreMax: 3 };
+    expect(filterStudyCards(cards, deck, basePreferences, now).map((card) => card.id)).toEqual([
+      "low",
+      "middle",
+      "high",
+    ]);
+  });
+
+  it("excludes scores outside the configured range", () => {
+    const cards = [
+      createCard({ id: "low", score: 1 }),
+      createCard({ id: "middle", score: 2 }),
+      createCard({ id: "high", score: 3 }),
+    ];
+    const deck = { ...baseDeck, scoreMin: 2, scoreMax: 2 };
+    expect(filterStudyCards(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["middle"]);
+  });
+
+  it("filters unavailable cards when intervals are enabled", () => {
+    const cards = [createCard({ id: "future", nextSeeingAt: new Date(now + 1) }), createCard({ id: "available" })];
+    expect(filterStudyCards(cards, baseDeck, { useCardInterval: true }, now).map((card) => card.id)).toEqual([
+      "available",
+    ]);
+  });
+
+  it("preserves input order while filtering", () => {
+    const cards = [createCard({ id: "seen", numberOfSeen: 5 }), createCard({ id: "new", numberOfSeen: 1 })];
+    expect(filterStudyCards(cards, baseDeck, basePreferences, now).map((card) => card.id)).toEqual(["seen", "new"]);
+  });
+});

--- a/src/features/deck-filter/model/filterStudyCards.ts
+++ b/src/features/deck-filter/model/filterStudyCards.ts
@@ -1,0 +1,33 @@
+import type { Card } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import type { Preferences } from "@/entities/preferences";
+import { createStudyProgressFromCard, isStudyProgressEligible } from "@/entities/study-progress";
+
+type DeckFilter = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
+type StudyFilter = Pick<Preferences["study"], "useCardInterval">;
+
+const isCardMatchingTags = (card: Card, deck: Pick<DeckFilter, "selectedTags" | "tagAndFilter">) => {
+  const tags = deck.selectedTags;
+  if (tags.length === 0) return true;
+  if (deck.tagAndFilter) return tags.every((tag) => card.tags.includes(tag));
+  return tags.some((tag) => card.tags.includes(tag));
+};
+
+export const filterStudyCards = <TCard extends Card>(
+  cards: TCard[],
+  deck: DeckFilter,
+  study: StudyFilter,
+  now: number
+): TCard[] =>
+  cards.filter((card) => {
+    if (!isCardMatchingTags(card, deck)) return false;
+    return isStudyProgressEligible(
+      createStudyProgressFromCard(card),
+      {
+        maximumScore: deck.scoreMax,
+        minimumScore: deck.scoreMin,
+        respectNextSeeingAt: study.useCardInterval,
+      },
+      now
+    );
+  });

--- a/src/features/deck-filter/model/useFilteredStudyCards.spec.tsx
+++ b/src/features/deck-filter/model/useFilteredStudyCards.spec.tsx
@@ -35,18 +35,22 @@ describe("useFilteredStudyCards", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
     const deck = createDeck({ id: "scheduled" });
-    const card = createCard({ id: "scheduled-card", deckId: deck.id, nextSeeingAt: new Date(1500) });
+    const next = createCard({ id: "next", deckId: deck.id, nextSeeingAt: new Date(1500) });
+    const later = createCard({ id: "later", deckId: deck.id, nextSeeingAt: new Date(2000) });
+    const cards = [next, later];
     const { result } = renderHook(() => ({
-      enabled: useFilteredStudyCards(deck, [card], createPreferences({ useCardInterval: true })),
-      disabled: useFilteredStudyCards(deck, [card], createPreferences({ useCardInterval: false })),
+      enabled: useFilteredStudyCards(deck, cards, createPreferences({ useCardInterval: true })),
+      disabled: useFilteredStudyCards(deck, cards, createPreferences({ useCardInterval: false })),
     }));
 
     expect(result.current.enabled).toEqual([]);
-    expect(result.current.disabled).toEqual([card]);
+    expect(result.current.disabled).toEqual(cards);
     act(() => vi.advanceTimersByTime(499));
     expect(result.current.enabled).toEqual([]);
     act(() => vi.advanceTimersByTime(1));
-    expect(result.current.enabled).toEqual([card]);
+    expect(result.current.enabled).toEqual([next]);
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.enabled).toEqual(cards);
   });
 
   it("re-evaluates a changed card list against the current time", () => {

--- a/src/features/deck-filter/model/useFilteredStudyCards.ts
+++ b/src/features/deck-filter/model/useFilteredStudyCards.ts
@@ -1,12 +1,23 @@
 import { useEffect, useState } from "react";
 
 import type { Card } from "@/entities/card";
-import { type Deck, filterCardsForDeck } from "@/entities/deck";
+import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
-import { getNextStudyAvailabilityAt } from "@/entities/study-progress";
+import { filterStudyCards } from "./filterStudyCards";
 
 // Browsers clamp longer delays; capped timers reschedule until the actual availability time is reached.
 const MAX_TIMEOUT_MS = 2_147_483_647;
+
+const getNextStudyAvailabilityAt = (cards: Card[], now: number): number | undefined => {
+  let next: number | undefined;
+  for (const card of cards) {
+    const candidate = card.nextSeeingAt?.getTime();
+    if (candidate !== undefined && candidate > now && (next === undefined || candidate < next)) {
+      next = candidate;
+    }
+  }
+  return next;
+};
 
 export const useFilteredStudyCards = (deck: Deck | undefined, cards: Card[], preferences: Preferences): Card[] => {
   const [now, setNow] = useState(() => Date.now());
@@ -21,5 +32,5 @@ export const useFilteredStudyCards = (deck: Deck | undefined, cards: Card[], pre
     return () => window.clearTimeout(availability);
   }, [cards, now]);
 
-  return deck == null ? [] : filterCardsForDeck(cards, deck, preferences.study, now);
+  return deck == null ? [] : filterStudyCards(cards, deck, preferences.study, now);
 };


### PR DESCRIPTION
## Related issue

Closes #1102

## Summary

- Move Deck/Card/StudyProgress/preferences filtering orchestration from `entities/deck` into `features/deck-filter`.
- Keep StudyProgress-owned conversion and eligibility rules available through the StudyProgress public API.
- Keep next-availability timer scheduling private to `useFilteredStudyCards` and remove obsolete cross-slice exports.

## Why

The previous filter lived in the Deck entity even though it combined several domains and UI-specific scheduling needs. Keeping that orchestration in the deck-filter use case makes the Entity APIs focused while preserving the existing card selection behavior.

## Impact

Study card filtering and time-based refresh behavior remain unchanged for users. The ownership and public API boundaries are simpler for maintainers.

## Testing

- `mise run check`