### PR TITLE
[No issue] Enable no-misused-promises ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,8 +137,6 @@ export default [
       ...strictTypeCheckedRules,
       // Shorthand callbacks that intentionally return void are established project style, not ambiguous expressions.
       "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
-      // Biome owns these checks, including promise handling and the Types domain rollout in #1013.
-      "@typescript-eslint/no-misused-promises": "off",
       // Primitive template interpolation and polymorphic `this` are project policy, not correctness constraints.
       "@typescript-eslint/prefer-return-this-type": "off",
       "@typescript-eslint/restrict-template-expressions": "off",

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -31,8 +31,8 @@ const UnknownRoute = () => {
     <RouteFeedback
       title="Page not found"
       tone="not-found"
-      primaryAction={{ label: "Go home", onClick: () => navigate("/") }}
-      secondaryAction={{ label: "Go back", onClick: () => navigate(-1) }}
+      primaryAction={{ label: "Go home", onClick: () => void navigate("/") }}
+      secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
     />
   );
 };

--- a/src/features/card-edit/model/useCardFormState.ts
+++ b/src/features/card-edit/model/useCardFormState.ts
@@ -31,6 +31,10 @@ export const useCardFormState = ({
     },
     resolver: zodResolver(cardFormSchema),
   });
+  const submit = handleSubmit((values) => onSubmit({ id: card.id, ...values }));
+  const onFormSubmit = (event?: Parameters<typeof submit>[0]) => {
+    void submit(event);
+  };
 
   return {
     card,
@@ -49,6 +53,6 @@ export const useCardFormState = ({
     },
     isSubmitting: formState.isSubmitting,
     onCancel,
-    onSubmit: handleSubmit((values) => onSubmit({ id: card.id, ...values })),
+    onSubmit: onFormSubmit,
   };
 };

--- a/src/features/deck-edit/model/useDeckFormState.ts
+++ b/src/features/deck-edit/model/useDeckFormState.ts
@@ -25,6 +25,10 @@ export const useDeckFormState = ({ deck, onCancel, onSubmit }: UseDeckFormStateO
     },
     resolver: zodResolver(deckFormSchema),
   });
+  const submit = handleSubmit((values) => onSubmit({ id: deck.id, ...values, url: values.url ?? null }));
+  const onFormSubmit = (event?: Parameters<typeof submit>[0]) => {
+    void submit(event);
+  };
 
   return {
     deck,
@@ -44,6 +48,6 @@ export const useDeckFormState = ({ deck, onCancel, onSubmit }: UseDeckFormStateO
     },
     isSubmitting: formState.isSubmitting,
     onCancel,
-    onSubmit: handleSubmit((values) => onSubmit({ id: deck.id, ...values, url: values.url ?? null })),
+    onSubmit: onFormSubmit,
   };
 };

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -40,7 +40,7 @@ export const DeckImportPage: React.FC = () => {
             .catch(() => undefined);
         }}
         onRetry={deckImport.retry}
-        onBack={() => navigate(-1)}
+        onBack={() => void navigate(-1)}
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -23,10 +23,10 @@ const renderStudyScreen = (deck: Deck, state: StudyState) => {
   const category = getCategory(deck.category, state.card.tags);
   const swipeActions = {
     disabled: false,
-    onClickUp: state.swipeUp,
-    onClickDown: state.swipeDown,
-    onClickLeft: state.swipeLeft,
-    onClickRight: state.swipeRight,
+    onClickUp: () => void state.swipeUp(),
+    onClickDown: () => void state.swipeDown(),
+    onClickLeft: () => void state.swipeLeft(),
+    onClickRight: () => void state.swipeRight(),
   };
 
   return (
@@ -40,10 +40,10 @@ const renderStudyScreen = (deck: Deck, state: StudyState) => {
           <FrontText
             category={category}
             text={state.card.frontText}
-            onSwipeUp={state.swipeUp}
-            onSwipeDown={state.swipeDown}
-            onSwipeLeft={state.swipeLeft}
-            onSwipeRight={state.swipeRight}
+            onSwipeUp={swipeActions.onClickUp}
+            onSwipeDown={swipeActions.onClickDown}
+            onSwipeLeft={swipeActions.onClickLeft}
+            onSwipeRight={swipeActions.onClickRight}
             onClick={state.toggleBackText}
           />
         }
@@ -64,10 +64,10 @@ const renderStudyScreen = (deck: Deck, state: StudyState) => {
 };
 
 const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => {
-  useKey("ArrowUp", state.swipeUp);
-  useKey("ArrowDown", state.swipeDown);
-  useKey("ArrowLeft", state.swipeLeft);
-  useKey("ArrowRight", state.swipeRight);
+  useKey("ArrowUp", () => void state.swipeUp());
+  useKey("ArrowDown", () => void state.swipeDown());
+  useKey("ArrowLeft", () => void state.swipeLeft());
+  useKey("ArrowRight", () => void state.swipeRight());
   useKey("Enter", state.toggleBackText);
   useKey("h", toggleShowHeader);
   useKey("b", toggleShowSwipeButtonList);


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable the no-misused-promises ESLint rule and remove its stale opt-out comment.
- Wrap Promise-returning navigation, form submission, and study actions at void callback boundaries.
- Preserve submit events when adapting React Hook Form handlers.

## Testing

- mise run lint-fix
- mise run check