### PR TITLE
[No issue] Enable prefer-return-this-type ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,8 +137,7 @@ export default [
       ...strictTypeCheckedRules,
       // Shorthand callbacks that intentionally return void are established project style, not ambiguous expressions.
       "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
-      // Primitive template interpolation and polymorphic `this` are project policy, not correctness constraints.
-      "@typescript-eslint/prefer-return-this-type": "off",
+      // Primitive template interpolation is project policy, not a correctness constraint.
       "@typescript-eslint/restrict-template-expressions": "off",
       // Keep the unsafe-any boundary introduced by #533 explicit as the preset expands around it.
       "@typescript-eslint/no-unsafe-argument": "error",


### PR DESCRIPTION
## Related issue

None.

## Summary

- Enable the prefer-return-this-type ESLint rule.
- Update the adjacent comment so it only describes the remaining template-expression opt-out.
- Confirm the project already complies without source changes.

## Testing

- mise run lint-fix
- mise run check