### PR TITLE
[No issue] Encapsulate sample deck bootstrap dependencies

### DIFF
--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -1,4 +1,5 @@
-import type { Deck, DeckCreateInput, LocalDeckCreateInput } from "@/entities/deck";
+import type { Card } from "@/entities/card";
+import type { Deck, DeckCreateInput } from "@/entities/deck";
 
 import { renderHook, waitFor } from "@testing-library/react";
 import React, { type ReactNode } from "react";
@@ -7,26 +8,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   auth: { status: "authenticated", uid: "uid-a" } as { status: "authenticated"; uid: string } | { status: "loading" },
   remote: {
+    cards: [] as Card[],
     decks: [] as Deck[],
   },
+  createDeck: vi.fn<(_uid: string, _deck: DeckCreateInput) => Promise<unknown>>(),
+  generateCardId: vi.fn(() => "card-id"),
   addSample: vi.fn<() => Promise<unknown>>(),
 }));
 
 vi.mock("@/entities/auth", () => ({
   useAuthUid: () => (mocks.auth.status === "authenticated" ? mocks.auth.uid : ""),
 }));
+vi.mock("@/entities/card", () => ({
+  generateCardId: mocks.generateCardId,
+  useCards: () => mocks.remote.cards,
+}));
+vi.mock("@/entities/deck", () => ({
+  createDeck: mocks.createDeck,
+  useDecks: () => mocks.remote.decks,
+}));
 vi.mock("../model/sampleDeck", () => ({ addSampleDeck: mocks.addSample }));
 
 import { useSampleDeckBootstrap } from "./useSampleDeckBootstrap";
-
-const createDeck = vi.fn<(uid: string, deck: DeckCreateInput | LocalDeckCreateInput) => Promise<unknown>>();
-const useTestSampleDeckBootstrap = () =>
-  useSampleDeckBootstrap({
-    cards: [],
-    createDeck,
-    decks: mocks.remote.decks,
-    generateCardId: vi.fn(() => "card-id"),
-  });
 
 const strictMode = ({ children }: { children: ReactNode }) => <React.StrictMode>{children}</React.StrictMode>;
 
@@ -34,12 +37,12 @@ describe("sample Deck bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.auth = { status: "authenticated", uid: crypto.randomUUID() };
-    mocks.remote = { decks: [] };
+    mocks.remote = { cards: [], decks: [] };
     mocks.addSample.mockResolvedValue(undefined);
   });
 
   it("adds the sample once for an empty user under StrictMode", async () => {
-    renderHook(useTestSampleDeckBootstrap, { wrapper: strictMode });
+    renderHook(useSampleDeckBootstrap, { wrapper: strictMode });
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
   });
@@ -47,13 +50,13 @@ describe("sample Deck bootstrap", () => {
   it("does not add the sample when the user already has a Deck", () => {
     mocks.remote.decks = [{ id: "existing" } as Deck];
 
-    renderHook(useTestSampleDeckBootstrap);
+    renderHook(useSampleDeckBootstrap);
 
     expect(mocks.addSample).not.toHaveBeenCalled();
   });
 
   it("adds the sample again when Decks become empty after a completed bootstrap", async () => {
-    const { unmount } = renderHook(useTestSampleDeckBootstrap);
+    const { unmount } = renderHook(useSampleDeckBootstrap);
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
@@ -61,12 +64,12 @@ describe("sample Deck bootstrap", () => {
     unmount();
 
     mocks.remote.decks = [{ id: "sample" } as Deck];
-    const { unmount: unmountPopulated } = renderHook(useTestSampleDeckBootstrap);
+    const { unmount: unmountPopulated } = renderHook(useSampleDeckBootstrap);
     expect(mocks.addSample).toHaveBeenCalledOnce();
     unmountPopulated();
 
     mocks.remote.decks = [];
-    renderHook(useTestSampleDeckBootstrap);
+    renderHook(useSampleDeckBootstrap);
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledTimes(2));
   });
@@ -80,8 +83,8 @@ describe("sample Deck bootstrap", () => {
         })
     );
 
-    renderHook(useTestSampleDeckBootstrap);
-    renderHook(useTestSampleDeckBootstrap);
+    renderHook(useSampleDeckBootstrap);
+    renderHook(useSampleDeckBootstrap);
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
     finish();

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
 
 import { useAuthUid } from "@/entities/auth";
+import { generateCardId, useCards } from "@/entities/card";
+import { createDeck, useDecks } from "@/entities/deck";
 import { addSampleDeck } from "../model/sampleDeck";
-import type { SampleDeckOptions } from "../model/sampleDeck";
 
 type AddSample = () => Promise<unknown>;
 
@@ -20,14 +21,15 @@ const startSampleDeckBootstrap = (uid: string, addSample: AddSample) => {
   return operation;
 };
 
-export const useSampleDeckBootstrap = (options: SampleDeckOptions) => {
+export const useSampleDeckBootstrap = () => {
   const uid = useAuthUid();
-  const { cards, createDeck, decks, generateCardId } = options;
+  const cards = useCards();
+  const decks = useDecks();
 
   useEffect(() => {
     if (uid === "" || decks.length > 0) return;
     void startSampleDeckBootstrap(uid, () => addSampleDeck(uid, { cards, createDeck, decks, generateCardId })).catch(
       () => undefined
     );
-  }, [cards, createDeck, decks, generateCardId, uid]);
+  }, [cards, decks, uid]);
 };

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -114,7 +114,7 @@ describe("DeckListPage", () => {
 
     expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/settings");
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import");
-    expect(mocks.sampleBootstrap).toHaveBeenCalledWith(expect.objectContaining({ decks: [deck], cards: [card] }));
+    expect(mocks.sampleBootstrap).toHaveBeenCalledWith();
   });
 
   it("renders empty list when no decks exist", () => {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { useAuthUid } from "@/entities/auth";
-import { generateCardId, useCards } from "@/entities/card";
-import { createDeck, deleteDeck, useDecks } from "@/entities/deck";
+import { useCards } from "@/entities/card";
+import { deleteDeck, useDecks } from "@/entities/deck";
 import { removeStudySession, touchStudySession, useStudySessions } from "@/entities/study-session";
 import { useSampleDeckBootstrap } from "@/features/deck-import";
 import { DeckList } from "@/features/deck-list";
@@ -17,12 +17,7 @@ export const DeckListPage: React.FC = () => {
   const decks = useDecks();
   const sessionsByDeckId = useStudySessions();
 
-  useSampleDeckBootstrap({
-    cards,
-    createDeck,
-    decks,
-    generateCardId,
-  });
+  useSampleDeckBootstrap();
   useKey("s", () => void navigate("/settings"));
   useKey("i", () => void navigate("/import"));
 


### PR DESCRIPTION
## Related issue

None.

## Summary

- Make `useSampleDeckBootstrap` resolve its own card and Deck dependencies.
- Simplify `DeckListPage` to call the bootstrap hook without assembling options.
- Update hook and page tests for the encapsulated interface.

## Testing

- `mise run check`