### PR TITLE
refactor(#1105): remove sample bootstrap deduplication

### DIFF
--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -58,9 +58,6 @@ describe("sample Deck bootstrap", () => {
   it("adds the sample again when Decks become empty after a completed bootstrap", async () => {
     const { unmount } = renderHook(useSampleDeckBootstrap);
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
     unmount();
 
     mocks.remote.decks = [{ id: "sample" } as Deck];
@@ -69,6 +66,17 @@ describe("sample Deck bootstrap", () => {
     unmountPopulated();
 
     mocks.remote.decks = [];
+    renderHook(useSampleDeckBootstrap);
+
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledTimes(2));
+  });
+
+  it("adds the sample again after a failed bootstrap", async () => {
+    mocks.addSample.mockRejectedValueOnce(new Error("failed"));
+    const { unmount } = renderHook(useSampleDeckBootstrap);
+    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
+    unmount();
+
     renderHook(useSampleDeckBootstrap);
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledTimes(2));

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.spec.tsx
@@ -2,7 +2,6 @@ import type { Card } from "@/entities/card";
 import type { Deck, DeckCreateInput } from "@/entities/deck";
 
 import { renderHook, waitFor } from "@testing-library/react";
-import React, { type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -31,8 +30,6 @@ vi.mock("../model/sampleDeck", () => ({ addSampleDeck: mocks.addSample }));
 
 import { useSampleDeckBootstrap } from "./useSampleDeckBootstrap";
 
-const strictMode = ({ children }: { children: ReactNode }) => <React.StrictMode>{children}</React.StrictMode>;
-
 describe("sample Deck bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,8 +38,8 @@ describe("sample Deck bootstrap", () => {
     mocks.addSample.mockResolvedValue(undefined);
   });
 
-  it("adds the sample once for an empty user under StrictMode", async () => {
-    renderHook(useSampleDeckBootstrap, { wrapper: strictMode });
+  it("adds the sample for an empty user", async () => {
+    renderHook(useSampleDeckBootstrap);
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
   });
@@ -69,32 +66,5 @@ describe("sample Deck bootstrap", () => {
     renderHook(useSampleDeckBootstrap);
 
     await waitFor(() => expect(mocks.addSample).toHaveBeenCalledTimes(2));
-  });
-
-  it("adds the sample again after a failed bootstrap", async () => {
-    mocks.addSample.mockRejectedValueOnce(new Error("failed"));
-    const { unmount } = renderHook(useSampleDeckBootstrap);
-    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
-    unmount();
-
-    renderHook(useSampleDeckBootstrap);
-
-    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledTimes(2));
-  });
-
-  it("deduplicates concurrent starts for one user", async () => {
-    let finish: () => void = () => undefined;
-    mocks.addSample.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          finish = resolve;
-        })
-    );
-
-    renderHook(useSampleDeckBootstrap);
-    renderHook(useSampleDeckBootstrap);
-
-    await waitFor(() => expect(mocks.addSample).toHaveBeenCalledOnce());
-    finish();
   });
 });

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -5,20 +5,6 @@ import { generateCardId, useCards } from "@/entities/card";
 import { createDeck, useDecks } from "@/entities/deck";
 import { addSampleDeck } from "../model/sampleDeck";
 
-const bootstrappingUids = new Set<string>();
-
-const startSampleDeckBootstrap = async (uid: string, addSample: () => Promise<unknown>) => {
-  if (bootstrappingUids.has(uid)) return;
-
-  // Only overlapping effects share work; Deck state remains the source of truth for later bootstrap decisions.
-  bootstrappingUids.add(uid);
-  try {
-    await addSample();
-  } finally {
-    bootstrappingUids.delete(uid);
-  }
-};
-
 export const useSampleDeckBootstrap = () => {
   const uid = useAuthUid();
   const cards = useCards();
@@ -26,8 +12,6 @@ export const useSampleDeckBootstrap = () => {
 
   useEffect(() => {
     if (uid === "" || decks.length > 0) return;
-    void startSampleDeckBootstrap(uid, () => addSampleDeck(uid, { cards, createDeck, decks, generateCardId })).catch(
-      () => undefined
-    );
+    void addSampleDeck(uid, { cards, createDeck, decks, generateCardId }).catch(() => undefined);
   }, [cards, decks, uid]);
 };

--- a/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
+++ b/src/features/deck-import/hooks/useSampleDeckBootstrap.ts
@@ -5,20 +5,18 @@ import { generateCardId, useCards } from "@/entities/card";
 import { createDeck, useDecks } from "@/entities/deck";
 import { addSampleDeck } from "../model/sampleDeck";
 
-type AddSample = () => Promise<unknown>;
+const bootstrappingUids = new Set<string>();
 
-const pendingBootstrapsByUid = new Map<string, Promise<unknown>>();
-
-const startSampleDeckBootstrap = (uid: string, addSample: AddSample) => {
-  const existing = pendingBootstrapsByUid.get(uid);
-  if (existing != null) return existing;
+const startSampleDeckBootstrap = async (uid: string, addSample: () => Promise<unknown>) => {
+  if (bootstrappingUids.has(uid)) return;
 
   // Only overlapping effects share work; Deck state remains the source of truth for later bootstrap decisions.
-  const operation = Promise.resolve()
-    .then(addSample)
-    .finally(() => pendingBootstrapsByUid.delete(uid));
-  pendingBootstrapsByUid.set(uid, operation);
-  return operation;
+  bootstrappingUids.add(uid);
+  try {
+    await addSample();
+  } finally {
+    bootstrappingUids.delete(uid);
+  }
 };
 
 export const useSampleDeckBootstrap = () => {


### PR DESCRIPTION
## Related issue

Related to #1105

## Summary

- remove the module-level in-flight bootstrap tracker and helper
- call `addSampleDeck` directly when the observed Deck state is empty
- remove tests for StrictMode and concurrent-start deduplication
- remove timer-based synchronization from the remaining bootstrap regression test

## Testing

- `mise run check`