### PR TITLE
[No issue] Move study session cleanup into deck deletion

### DIFF
--- a/src/entities/deck/api/mutations.spec.ts
+++ b/src/entities/deck/api/mutations.spec.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   deleteRemoteDeck: vi.fn(),
   editRemoteDeck: vi.fn(),
   deleteLocalCardsByDeckId: vi.fn(),
+  removeStudySession: vi.fn(),
 }));
 
 vi.mock("./firestore", () => ({
@@ -20,6 +21,10 @@ vi.mock("./firestore", () => ({
 
 vi.mock("@/entities/card/@x/deck", () => ({
   deleteLocalCardsByDeckId: mocks.deleteLocalCardsByDeckId,
+}));
+
+vi.mock("@/entities/study-session/@x/deck", () => ({
+  removeStudySession: mocks.removeStudySession,
 }));
 
 describe("Deck mutations", () => {
@@ -42,6 +47,7 @@ describe("Deck mutations", () => {
 
     expect(findDeckById(deck.id)).toBeUndefined();
     expect(mocks.deleteLocalCardsByDeckId).toHaveBeenCalledExactlyOnceWith(deck.id);
+    expect(mocks.removeStudySession).toHaveBeenCalledExactlyOnceWith(deck.id);
     expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
   });
 
@@ -58,6 +64,7 @@ describe("Deck mutations", () => {
     expect(mocks.editRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", edit);
     expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", { id: deck.id, uid: deck.uid });
     expect(mocks.deleteLocalCardsByDeckId).not.toHaveBeenCalled();
+    expect(mocks.removeStudySession).toHaveBeenCalledExactlyOnceWith(deck.id);
   });
 
   it("rejects edit and delete when the Deck cannot be resolved", async () => {
@@ -68,5 +75,6 @@ describe("Deck mutations", () => {
 
     expect(mocks.editRemoteDeck).not.toHaveBeenCalled();
     expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
+    expect(mocks.removeStudySession).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/deck/api/mutations.ts
+++ b/src/entities/deck/api/mutations.ts
@@ -1,6 +1,7 @@
 import type { DeckCreateInput, DeckId, EditDeckInput, LocalDeckCreateInput } from "../model/types";
 
 import { deleteLocalCardsByDeckId } from "@/entities/card/@x/deck";
+import { removeStudySession } from "@/entities/study-session/@x/deck";
 import { createLocalDeck, deleteLocalDeck, editLocalDeck, findDeckById } from "../model/store";
 import {
   createDeck as createRemoteDeck,
@@ -35,7 +36,10 @@ export const deleteDeck = async (uid: string, deck: { id: DeckId }): Promise<voi
   if (currentDeck.localMode) {
     deleteLocalCardsByDeckId(deck.id);
     deleteLocalDeck(deck.id);
-    return;
+  } else {
+    await deleteRemoteDeck(uid, { id: deck.id, uid: currentDeck.uid });
   }
-  await deleteRemoteDeck(uid, { id: deck.id, uid: currentDeck.uid });
+
+  // A deleted Deck must not leave a resumable session behind in persisted client state.
+  removeStudySession(deck.id);
 };

--- a/src/entities/study-session/@x/deck.ts
+++ b/src/entities/study-session/@x/deck.ts
@@ -1,0 +1,1 @@
+export { removeStudySession } from "../model/store";

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Preferences } from "@/entities/preferences";
 import type { ComponentProps } from "react";
 import type { DeckList } from "@/features/deck-list";
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,7 +18,6 @@ const mocks = vi.hoisted(() => ({
   cards: [] as Card[],
   authUid: "user-1",
   deleteDeck: vi.fn(async (_uid: string, _deck: Deck) => undefined),
-  removeStudySession: vi.fn(),
   touchStudySession: vi.fn(),
   navigate: vi.fn(),
   sampleBootstrap: vi.fn(),
@@ -42,7 +41,6 @@ vi.mock("@/entities/deck", () => ({
 }));
 vi.mock("@/features/deck-import", () => ({ useSampleDeckBootstrap: mocks.sampleBootstrap }));
 vi.mock("@/entities/study-session", () => ({
-  removeStudySession: mocks.removeStudySession,
   touchStudySession: mocks.touchStudySession,
   useStudySessions: () => ({}),
 }));
@@ -88,7 +86,7 @@ describe("DeckListPage", () => {
     mocks.authUid = "user-1";
   });
 
-  it("composes route and reusable feature actions around the Deck List Feature", async () => {
+  it("composes route and reusable feature actions around the Deck List Feature", () => {
     render(<DeckListPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "View deck" }));
@@ -103,7 +101,6 @@ describe("DeckListPage", () => {
     expect(mocks.navigate).toHaveBeenNthCalledWith(3, `/deck/${deck.id}/start`);
     expect(mocks.navigate).toHaveBeenNthCalledWith(4, `/deck/${deck.id}/edit`);
     expect(mocks.deleteDeck).toHaveBeenCalledExactlyOnceWith(mocks.authUid, deck);
-    await waitFor(() => expect(mocks.removeStudySession).toHaveBeenCalledExactlyOnceWith(deck.id));
   });
 
   it("keeps route shortcuts and sample bootstrap wiring", () => {

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -5,7 +5,7 @@ import { useKey } from "react-use";
 import { useAuthUid } from "@/entities/auth";
 import { useCards } from "@/entities/card";
 import { deleteDeck, useDecks } from "@/entities/deck";
-import { removeStudySession, touchStudySession, useStudySessions } from "@/entities/study-session";
+import { touchStudySession, useStudySessions } from "@/entities/study-session";
 import { useSampleDeckBootstrap } from "@/features/deck-import";
 import { DeckList } from "@/features/deck-list";
 import { AppLayout } from "@/widgets/app-layout";
@@ -34,10 +34,7 @@ export const DeckListPage: React.FC = () => {
         }}
         onStartDeck={(id) => void navigate(`/deck/${id}/start`)}
         onEditDeck={(id) => void navigate(`/deck/${id}/edit`)}
-        onDeleteDeck={async (deck) => {
-          await deleteDeck(uid, deck);
-          removeStudySession(deck.id);
-        }}
+        onDeleteDeck={(deck) => deleteDeck(uid, deck)}
       />
     </AppLayout>
   );


### PR DESCRIPTION
## Related issue

None

## Summary

- Move study session cleanup into `deleteDeck` so every caller preserves the deletion invariant
- Expose the cleanup through the explicit study-session cross-slice contract
- Simplify `DeckListPage` and update responsibility-focused tests

## Testing

- `mise run check`