### PR TITLE
[No issue] Disallow numeric template interpolation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,7 +137,7 @@ export default [
       ...strictTypeCheckedRules,
       // Shorthand callbacks that intentionally return void are established project style, not ambiguous expressions.
       "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
-      // Numeric interpolation is intentional for labels and identifiers; other non-string types remain rejected.
+      // Require explicit conversion so interpolation cannot silently widen as value types evolve.
       "@typescript-eslint/restrict-template-expressions": [
         "error",
         {
@@ -145,7 +145,7 @@ export default [
           allowBoolean: false,
           allowNever: false,
           allowNullish: false,
-          allowNumber: true,
+          allowNumber: false,
           allowRegExp: false,
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,18 +137,6 @@ export default [
       ...strictTypeCheckedRules,
       // Shorthand callbacks that intentionally return void are established project style, not ambiguous expressions.
       "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
-      // Require explicit conversion so interpolation cannot silently widen as value types evolve.
-      "@typescript-eslint/restrict-template-expressions": [
-        "error",
-        {
-          allowAny: false,
-          allowBoolean: false,
-          allowNever: false,
-          allowNullish: false,
-          allowNumber: false,
-          allowRegExp: false,
-        },
-      ],
       // Keep the unsafe-any boundary introduced by #533 explicit as the preset expands around it.
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-assignment": "error",

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -19,7 +19,7 @@ export class CardBulkMutationError extends Error {
     total: number,
     options?: ErrorOptions
   ) {
-    super(`${failedIds.length} of ${total} Card writes failed`, options);
+    super(`${String(failedIds.length)} of ${String(total)} Card writes failed`, options);
   }
 }
 

--- a/src/features/card-list/ui/Card.tsx
+++ b/src/features/card-list/ui/Card.tsx
@@ -35,7 +35,7 @@ export type CardProps = CardActionsProps;
  */
 const studiedText = (count: number) => {
   if (count === 0) return "not studied yet";
-  return `studied ${count} ${count === 1 ? "time" : "times"}`;
+  return `studied ${String(count)} ${count === 1 ? "time" : "times"}`;
 };
 
 /**

--- a/src/features/card-list/ui/CardListView.tsx
+++ b/src/features/card-list/ui/CardListView.tsx
@@ -37,16 +37,18 @@ export interface CardListViewProps {
  * Formats the count label text shown to the user.
  * The helper keeps wording and singular or plural rules consistent across the screen.
  */
-const countLabel = (count: number) => `${count} ${count === 1 ? "card" : "cards"}`;
+const countLabel = (count: number) => `${String(count)} ${count === 1 ? "card" : "cards"}`;
 
 /**
  * Formats the score range label text shown to the user.
  * The helper keeps wording and singular or plural rules consistent across the screen.
  */
 const scoreRangeLabel = (filter: CardListFilterState) => {
-  if (filter.scoreMin != null && filter.scoreMax != null) return `score ${filter.scoreMin}–${filter.scoreMax}`;
-  if (filter.scoreMin != null) return `score ≥ ${filter.scoreMin}`;
-  if (filter.scoreMax != null) return `score ≤ ${filter.scoreMax}`;
+  if (filter.scoreMin != null && filter.scoreMax != null) {
+    return `score ${String(filter.scoreMin)}–${String(filter.scoreMax)}`;
+  }
+  if (filter.scoreMin != null) return `score ≥ ${String(filter.scoreMin)}`;
+  if (filter.scoreMax != null) return `score ≤ ${String(filter.scoreMax)}`;
   return null;
 };
 
@@ -59,7 +61,7 @@ const filterLabel = (filter: CardListFilterState) => {
   const score = scoreRangeLabel(filter);
   if (score != null) labels.push(score);
   if (filter.selectedTags.length > 0) {
-    labels.push(`${filter.selectedTags.length} ${filter.selectedTags.length === 1 ? "tag" : "tags"}`);
+    labels.push(`${String(filter.selectedTags.length)} ${filter.selectedTags.length === 1 ? "tag" : "tags"}`);
   }
   return labels.length > 0 ? labels.join(" · ") : "No filters";
 };

--- a/src/features/card-view/ui/CardOverlay.tsx
+++ b/src/features/card-view/ui/CardOverlay.tsx
@@ -22,7 +22,7 @@ export const CardOverlay: React.FC<{ card?: Card }> = (props) => {
       <div className="mx-auto flex max-w-reading flex-row items-center gap-2 bg-surface-elevated p-2 text-ink">
         <Score score={card?.score ?? 0} />
         <Description>
-          {card?.numberOfSeen != null && `${card.numberOfSeen} times`}
+          {card?.numberOfSeen != null && `${String(card.numberOfSeen)} times`}
           {card?.lastSeenAt != null && ` since ${new Date(card.lastSeenAt).toLocaleDateString()}`}
         </Description>
       </div>

--- a/src/features/deck-filter/ui/DeckFilterForm.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.tsx
@@ -18,7 +18,7 @@ interface ScoreLimitProps {
   onChange: (value: number | null) => void;
 }
 
-const displayScore = (value: number): string => `${value}`.replace("-", "−");
+const displayScore = (value: number): string => String(value).replace("-", "−");
 
 const scoreRangeLabel = (min: number | null, max: number | null): string => {
   if (min != null && max != null) return `${displayScore(min)} to ${displayScore(max)}`;
@@ -53,7 +53,7 @@ const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
         <Slider
           id={props.sliderId}
           name={props.sliderId}
-          value={`${props.value ?? 0}`}
+          value={String(props.value ?? 0)}
           step={1}
           max={10}
           min={-10}

--- a/src/features/deck-import/lib/cardCsv.ts
+++ b/src/features/deck-import/lib/cardCsv.ts
@@ -79,7 +79,7 @@ export const parseCsv = async (content: string): Promise<DeckImportAnalysis> => 
       invalidRows.add(rowNumber);
       issues.push({
         rowNumber,
-        message: `Expected 4 columns, found ${columns.length}.`,
+        message: `Expected 4 columns, found ${String(columns.length)}.`,
         context: rowContext(columns),
       });
       return;

--- a/src/features/deck-import/model/sampleDeck.ts
+++ b/src/features/deck-import/model/sampleDeck.ts
@@ -8,7 +8,7 @@ import { executePreparedDeckImport, prepareDeckImport } from "./deckImportExecut
 const SAMPLE_DECK_NAME = "Sample Deck";
 const SAMPLE_VERSION = 1;
 
-const sampleDeckId = (uid: string): DeckId => `sample-v${SAMPLE_VERSION}-${uid}`;
+const sampleDeckId = (uid: string): DeckId => `sample-v${String(SAMPLE_VERSION)}-${uid}`;
 
 export interface SampleDeckOptions {
   cards: Card[];

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -155,8 +155,10 @@ const ImportPreview = (props: ImportPreviewProps) => {
           <h3 className="font-semibold">Fix these CSV rows</h3>
           <ul className="mt-2 space-y-2">
             {preview.analysis.issues.map((issue) => (
-              <li key={`${issue.rowNumber ?? "file"}-${issue.message}-${issue.context ?? ""}`}>
-                <span className="font-semibold">{issue.rowNumber == null ? "File" : `Row ${issue.rowNumber}`}:</span>{" "}
+              <li key={`${String(issue.rowNumber ?? "file")}-${issue.message}-${issue.context ?? ""}`}>
+                <span className="font-semibold">
+                  {issue.rowNumber == null ? "File" : `Row ${String(issue.rowNumber)}`}:
+                </span>{" "}
                 {issue.message}
                 {issue.context == null ? null : (
                   <code className="mt-1 block overflow-x-auto whitespace-pre-wrap text-ink-muted">{issue.context}</code>

--- a/src/features/deck-list/ui/DeckListCard.tsx
+++ b/src/features/deck-list/ui/DeckListCard.tsx
@@ -41,14 +41,14 @@ const formatLastStudied = (timestamp: number): string => {
   const elapsedSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
   if (elapsedSeconds < 60) return "just now";
   const elapsedMinutes = Math.floor(elapsedSeconds / 60);
-  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+  if (elapsedMinutes < 60) return `${String(elapsedMinutes)}m ago`;
   const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+  if (elapsedHours < 24) return `${String(elapsedHours)}h ago`;
   const elapsedDays = Math.floor(elapsedHours / 24);
-  if (elapsedDays < 30) return `${elapsedDays}d ago`;
+  if (elapsedDays < 30) return `${String(elapsedDays)}d ago`;
   const elapsedMonths = Math.floor(elapsedDays / 30);
-  if (elapsedMonths < 12) return `${elapsedMonths}mo ago`;
-  return `${Math.floor(elapsedMonths / 12)}y ago`;
+  if (elapsedMonths < 12) return `${String(elapsedMonths)}mo ago`;
+  return `${String(Math.floor(elapsedMonths / 12))}y ago`;
 };
 
 const primaryActionClassName =
@@ -70,8 +70,8 @@ const DeckListCardStatus: React.FC<{
     )}
     <span className="truncate">
       {active && studyProgress
-        ? `${progressValue} / ${studyProgress.cardCount} · ${formatLastStudied(studyProgress.lastStudiedAt)}`
-        : `${cardCount} ${cardCount === 1 ? "card" : "cards"}`}
+        ? `${String(progressValue)} / ${String(studyProgress.cardCount)} · ${formatLastStudied(studyProgress.lastStudiedAt)}`
+        : `${String(cardCount)} ${cardCount === 1 ? "card" : "cards"}`}
     </span>
   </span>
 );
@@ -93,7 +93,7 @@ const DeckListCardProgressBar: React.FC<{
       aria-valuenow={progressValue}
       className="mt-2 block h-1 overflow-hidden rounded-pill bg-surface-muted"
     >
-      <span className="block h-full rounded-pill bg-accent-primary" style={{ width: `${progressPercent}%` }} />
+      <span className="block h-full rounded-pill bg-accent-primary" style={{ width: `${String(progressPercent)}%` }} />
     </span>
   );
 };

--- a/src/features/deck-list/ui/DeckListView.tsx
+++ b/src/features/deck-list/ui/DeckListView.tsx
@@ -17,7 +17,7 @@ export interface DeckListViewProps {
  * Formats the count label text shown to the user.
  * The helper keeps wording and singular or plural rules consistent across the screen.
  */
-const countLabel = (count: number) => `${count} ${count === 1 ? "deck" : "decks"}`;
+const countLabel = (count: number) => `${String(count)} ${count === 1 ? "deck" : "decks"}`;
 
 /**
  * Renders one labeled group of Deck List items.

--- a/src/features/preferences-edit/ui/components/SettingsForm.tsx
+++ b/src/features/preferences-edit/ui/components/SettingsForm.tsx
@@ -161,7 +161,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
                 {...props.fields.maxNumberOfCardsToLearn}
                 id={inputIds.maxNumberOfCardsToLearn}
                 aria-describedby={descriptionId(inputIds.maxNumberOfCardsToLearn)}
-                aria-valuetext={`${props.maxNumberOfCardsToLearn} cards`}
+                aria-valuetext={`${String(props.maxNumberOfCardsToLearn)} cards`}
               />
               <span className="min-w-10 rounded-control bg-surface-muted px-2 py-1 text-center text-caption font-bold text-accent-primary">
                 {props.maxNumberOfCardsToLearn}
@@ -196,7 +196,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
                 {...props.fields.cardInterval}
                 id={inputIds.cardInterval}
                 aria-describedby={descriptionId(inputIds.cardInterval)}
-                aria-valuetext={`${props.cardInterval} seconds`}
+                aria-valuetext={`${String(props.cardInterval)} seconds`}
               />
               <span className="min-w-10 rounded-control bg-surface-muted px-2 py-1 text-center text-caption font-bold text-accent-primary">
                 {props.cardInterval}s

--- a/src/features/study-session-start/ui/StudySessionStartView.tsx
+++ b/src/features/study-session-start/ui/StudySessionStartView.tsx
@@ -10,7 +10,7 @@ export interface StudySessionStartViewProps {
   onClickStart?: () => void;
 }
 
-const cardsLabel = (count: number) => `${count} ${count === 1 ? "card" : "cards"}`;
+const cardsLabel = (count: number) => `${String(count)} ${count === 1 ? "card" : "cards"}`;
 
 export const StudySessionStartView: React.FC<StudySessionStartViewProps> = (props) => {
   const sessionCardsLength =

--- a/src/features/study/ui/Controller.tsx
+++ b/src/features/study/ui/Controller.tsx
@@ -36,7 +36,7 @@ export const Controller: React.FC<ControllerProps> = (props) => {
             }}
           />
         </div>
-        {index < numberOfCards && <Title>{`${index + 1} / ${numberOfCards}`}</Title>}
+        {index < numberOfCards && <Title>{`${String(index + 1)} / ${String(numberOfCards)}`}</Title>}
       </div>
     </IconContext.Provider>
   );

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -39,7 +39,7 @@ const sizeClasses: Record<ButtonSize, string> = {
 const resolveVariant = (props: ButtonProps): ButtonVariant => props.variant ?? "secondary";
 const resolveSize = (props: ButtonProps): ButtonSize => props.size ?? "md";
 const getLoadingAnnouncement = (content: React.ReactNode) =>
-  typeof content === "string" || typeof content === "number" ? `Loading ${content}` : "Loading";
+  typeof content === "string" || typeof content === "number" ? `Loading ${String(content)}` : "Loading";
 
 /**
  * Renders the Button user interface.

--- a/src/shared/ui/content/Score.tsx
+++ b/src/shared/ui/content/Score.tsx
@@ -17,13 +17,17 @@ const scoreDisplayLimit = 99;
 export const Score: React.FC<{ score?: number; large?: boolean; className?: string }> = (props) => {
   const score = props.score ?? 0;
   const displayScore =
-    score > scoreDisplayLimit ? `>${scoreDisplayLimit}` : score < -scoreDisplayLimit ? `<-${scoreDisplayLimit}` : score;
+    score > scoreDisplayLimit
+      ? `>${String(scoreDisplayLimit)}`
+      : score < -scoreDisplayLimit
+        ? `<-${String(scoreDisplayLimit)}`
+        : score;
   const isDisplayBounded = Math.abs(score) > scoreDisplayLimit;
   const cue = score > 0 ? "positive" : score < 0 ? "negative" : "neutral";
   return (
     <div
       role="status"
-      aria-label={`Score ${score}, ${cue}`}
+      aria-label={`Score ${String(score)}, ${cue}`}
       className={cx(
         "inline-flex justify-center rounded-pill font-semibold text-ink-inverse",
         {


### PR DESCRIPTION
## Related issue

None.

## Summary

- Disallow implicit numeric interpolation in template literals.
- Convert numeric values explicitly at interpolation boundaries.
- Keep the remaining restrict-template-expressions checks strict.

## Testing

- mise run lint-fix
- mise run check