### PR TITLE
[No issue] Clarify Entity domain boundaries

### DIFF
--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -13,6 +13,7 @@
 - Define Entity domain types and boundary-specific types.
 - Keep types separate when domain, store, persistence, or public API meanings differ.
 - Derive types from Zod when Zod defines the validation boundary.
+- Do not export domain types from the Entity Public API.
 
 ## `model/dto.ts`
 
@@ -26,6 +27,7 @@
 ## `model/rules.ts`
 
 - Define pure domain rules, calculations, relationships, selections, and transformations.
+- Express rules using Entity domain types, not store, persistence, or public API types.
 - Do not access stores, React, browser APIs, or external systems.
 
 ## `model/store.ts`

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -28,6 +28,7 @@
 
 - Define pure domain rules, calculations, relationships, selections, and transformations.
 - Express rules using Entity domain types, not store, persistence, or public API types.
+- Let callers pass public Entity types directly when they satisfy the required domain shape; do not map to or construct domain types outside the Entity.
 - Do not access stores, React, browser APIs, or external systems.
 
 ## `model/store.ts`

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -10,8 +10,13 @@
 
 ## `model/types.ts`
 
-- Define shared Entity types and interfaces.
-- Prefer deriving types from Zod schemas.
+- Define Entity domain types and boundary-specific types.
+- Keep types separate when domain, store, persistence, or public API meanings differ.
+- Derive types from Zod when Zod defines the validation boundary.
+
+## `model/dto.ts`
+
+- Define pure mappings between Entity boundary types.
 
 ## `model/defaults.ts`
 


### PR DESCRIPTION
## Related issue

None

## Summary

- Clarify domain and boundary-specific type responsibilities in `src/entities/AGENTS.md`.
- Keep domain types internal to the Entity Public API.
- Require `model/rules.ts` to depend on Entity domain types rather than store, persistence, or public API types.
- Define `model/dto.ts` as the place for pure boundary mappings.

## Testing

- Documentation-only change; not run.