### PR TITLE
No issue: Simplify Deck import state management

### DIFF
--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -18,7 +18,6 @@ type DeckImportFailure = { stage: "preview"; error: unknown } | { stage: "import
 
 interface DeckImportState {
   uid: string;
-  generation: number;
   storageMode: DeckImportStorageMode;
   status: DeckImportStatus;
   preview: DeckImportPreview | undefined;
@@ -32,9 +31,8 @@ interface DeckImportExecutionState {
   retryAttempt: DeckImportAttempt | undefined;
 }
 
-const initialState = (uid: string, generation: number): DeckImportState => ({
+const initialState = (uid: string): DeckImportState => ({
   uid,
-  generation,
   storageMode: "remote",
   status: "idle",
   preview: undefined,
@@ -57,18 +55,13 @@ export const useDeckImport = () => {
   const generationRef = useRef(0);
   // Execution state must update synchronously so operations cannot overlap before React publishes status.
   const executionRef = useRef<DeckImportExecutionState>(createExecutionState());
-  const [state, setState] = useState<DeckImportState>(() => initialState(uid, generationRef.current));
-  const currentState =
-    state.uid === uid && state.generation === generationRef.current ? state : initialState(uid, generationRef.current);
+  const [state, setState] = useState<DeckImportState>(() => initialState(uid));
 
-  const updateState = (update: Partial<Omit<DeckImportState, "uid" | "generation">>) => {
-    setState((current) => {
-      const base =
-        current.uid === uid && current.generation === generationRef.current
-          ? current
-          : initialState(uid, generationRef.current);
-      return { ...base, ...update };
-    });
+  if (state.uid !== uid) setState(initialState(uid));
+  const currentState = state.uid === uid ? state : initialState(uid);
+
+  const updateState = (update: Partial<Omit<DeckImportState, "uid">>) => {
+    setState((current) => ({ ...(current.uid === uid ? current : initialState(uid)), ...update }));
   };
 
   useEffect(() => {

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -18,6 +18,22 @@ type DeckImportFailure =
   | { stage: "preview"; error: unknown }
   | { stage: "import"; error: unknown };
 
+interface DeckImportState {
+  storageMode: DeckImportStorageMode;
+  status: DeckImportStatus;
+  preview: DeckImportPreview | undefined;
+  failure: DeckImportFailure | undefined;
+  data: DeckImportResult | undefined;
+}
+
+const INITIAL_STATE: DeckImportState = {
+  storageMode: "remote",
+  status: "idle",
+  preview: undefined,
+  failure: undefined,
+  data: undefined,
+};
+
 export const useDeckImport = () => {
   const uid = useAuthUid();
   const cards = useCards();
@@ -29,23 +45,18 @@ export const useDeckImport = () => {
   const busyRef = useRef(false);
   const previewAttemptRef = useRef<DeckImportAttempt | undefined>(undefined);
   const retryAttemptRef = useRef<DeckImportAttempt | undefined>(undefined);
+  const [state, setState] = useState<DeckImportState>(INITIAL_STATE);
 
-  const [storageMode, setStorageModeState] = useState<DeckImportStorageMode>("remote");
-  const [status, setStatus] = useState<DeckImportStatus>("idle");
-  const [preview, setPreview] = useState<DeckImportPreview | undefined>(undefined);
-  const [failure, setFailure] = useState<DeckImportFailure | undefined>(undefined);
-  const [data, setData] = useState<DeckImportResult | undefined>(undefined);
+  const updateState = (update: Partial<DeckImportState>) => {
+    setState((current) => ({ ...current, ...update }));
+  };
 
   useEffect(() => {
     generationRef.current += 1;
     busyRef.current = false;
     previewAttemptRef.current = undefined;
     retryAttemptRef.current = undefined;
-    setStorageModeState("remote");
-    setStatus("idle");
-    setPreview(undefined);
-    setFailure(undefined);
-    setData(undefined);
+    setState(INITIAL_STATE);
   }, [uid]);
 
   const isCurrent = (generation: number) => generation === generationRef.current;
@@ -56,8 +67,7 @@ export const useDeckImport = () => {
     const generation = generationRef.current;
     busyRef.current = true;
     retryAttemptRef.current = attempt;
-    setStatus("importing");
-    setFailure(undefined);
+    updateState({ status: "importing", failure: undefined });
 
     try {
       const result = await executePreparedDeckImport(attempt, {
@@ -65,18 +75,15 @@ export const useDeckImport = () => {
         createDeck: (deck) => createDeck(uid, deck),
         mutateCards: (mutations) => mutateCards(uid, mutations),
       });
-      if (isCurrent(generation)) setData(result);
+      if (isCurrent(generation)) updateState({ data: result });
       return result;
     } catch (error) {
-      if (isCurrent(generation)) {
-        setData(undefined);
-        setFailure({ stage: "import", error });
-      }
+      if (isCurrent(generation)) updateState({ data: undefined, failure: { stage: "import", error } });
       throw error;
     } finally {
       if (isCurrent(generation)) {
         busyRef.current = false;
-        setStatus("idle");
+        updateState({ status: "idle" });
       }
     }
   };
@@ -86,28 +93,23 @@ export const useDeckImport = () => {
     if (attempt != null && !busyRef.current) void run(attempt).catch(() => undefined);
   };
 
-  const setStorageMode = (nextStorageMode: DeckImportStorageMode) => {
-    if (busyRef.current || storageMode === nextStorageMode) return;
+  const setStorageMode = (storageMode: DeckImportStorageMode) => {
+    if (busyRef.current || state.storageMode === storageMode) return;
 
     previewAttemptRef.current = undefined;
     retryAttemptRef.current = undefined;
-    setStorageModeState(nextStorageMode);
-    setPreview(undefined);
-    setFailure(undefined);
-    setData(undefined);
+    updateState({ storageMode, preview: undefined, failure: undefined, data: undefined });
   };
 
   const selectFile = async (file: File) => {
     if (busyRef.current) throw new Error("A Deck import is already running");
 
     const generation = generationRef.current;
+    const storageMode = state.storageMode;
     busyRef.current = true;
     previewAttemptRef.current = undefined;
     retryAttemptRef.current = undefined;
-    setStatus("validating");
-    setPreview(undefined);
-    setFailure(undefined);
-    setData(undefined);
+    updateState({ status: "validating", preview: undefined, failure: undefined, data: undefined });
 
     try {
       const analysis = await parseCsv(await file.text());
@@ -123,32 +125,32 @@ export const useDeckImport = () => {
         { name: file.name, rows: analysis.rows, storageMode },
         { uid, decks: activeDecks, cards: activeCards, generateCardId }
       );
-      const nextPreview = {
+      const preview = {
         deckName: file.name,
         analysis,
         plan: attempt.plan,
       };
       previewAttemptRef.current = attempt;
-      setPreview(nextPreview);
-      return nextPreview;
+      updateState({ preview });
+      return preview;
     } catch (error) {
-      if (isCurrent(generation)) setFailure({ stage: "preview", error });
+      if (isCurrent(generation)) updateState({ failure: { stage: "preview", error } });
       throw error;
     } finally {
       if (isCurrent(generation)) {
         busyRef.current = false;
-        setStatus("idle");
+        updateState({ status: "idle" });
       }
     }
   };
 
   const importPreview = () => {
     if (busyRef.current) return Promise.reject(new Error("A Deck import is already running"));
-    if (preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
-    if (preview.analysis.invalidCount > 0) {
+    if (state.preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
+    if (state.preview.analysis.invalidCount > 0) {
       return Promise.reject(new Error("Fix invalid CSV rows before importing"));
     }
-    if (preview.analysis.rows.length === 0) {
+    if (state.preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
 
@@ -157,20 +159,20 @@ export const useDeckImport = () => {
     return run(attempt);
   };
 
-  const error = failure?.stage === "import" ? failure.error : null;
+  const error = state.failure?.stage === "import" ? state.failure.error : null;
 
   return {
     selectFile,
     setStorageMode,
     importPreview,
     addSample: () => run(prepareSampleDeck(uid, { cards, decks, generateCardId })),
-    storageMode,
-    preview,
-    validating: status === "validating",
-    pending: status === "importing",
+    storageMode: state.storageMode,
+    preview: state.preview,
+    validating: state.status === "validating",
+    pending: state.status === "importing",
     error,
-    previewError: failure?.stage === "preview" ? failure.error : null,
-    data,
+    previewError: state.failure?.stage === "preview" ? state.failure.error : null,
+    data: state.data,
     partialResult: partialResultFrom(error),
     retry,
   };

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -7,171 +7,143 @@ import { useAuthUid } from "@/entities/auth";
 import { fetchCards, generateCardId, mutateCards, useCards } from "@/entities/card";
 import { createDeck, fetchDecks, useDecks } from "@/entities/deck";
 import { parseCsv } from "../lib/cardCsv";
-import type { DeckImportAttempt, DeckImportExecutionDependencies } from "../model/deckImportExecution";
+import type { DeckImportAttempt } from "../model/deckImportExecution";
 import { executePreparedDeckImport, partialResultFrom, prepareDeckImport } from "../model/deckImportExecution";
 import type { DeckImportPreview, DeckImportResult, DeckImportStorageMode } from "../model/deckImportTypes";
 import { prepareSampleDeck } from "../model/sampleDeck";
 
-interface DeckImportSession {
-  uid: string;
-  running: boolean;
-  storageMode: DeckImportStorageMode;
-  previewAttempt: DeckImportAttempt | undefined;
-  retryAttempt: DeckImportAttempt | undefined;
-}
+type DeckImportStatus = "idle" | "validating" | "importing";
 
-interface DeckImportState {
-  uid: string;
-  storageMode: DeckImportStorageMode;
-  pending: boolean;
-  validating: boolean;
-  preview: DeckImportPreview | undefined;
-  previewError: unknown;
-  error: unknown;
-  data: DeckImportResult | undefined;
-}
-
-const createSession = (uid: string): DeckImportSession => ({
-  uid,
-  running: false,
-  storageMode: "remote",
-  previewAttempt: undefined,
-  retryAttempt: undefined,
-});
-
-const initialState = (uid: string): DeckImportState => ({
-  uid,
-  storageMode: "remote",
-  pending: false,
-  validating: false,
-  preview: undefined,
-  previewError: null,
-  error: null,
-  data: undefined,
-});
+type DeckImportFailure =
+  | { stage: "preview"; error: unknown }
+  | { stage: "import"; error: unknown };
 
 export const useDeckImport = () => {
   const uid = useAuthUid();
   const cards = useCards();
   const decks = useDecks();
-  const sessionRef = useRef(createSession(uid));
-  const [state, setState] = useState(() => initialState(uid));
-  const currentState = state.uid === uid ? state : initialState(uid);
-  useEffect(() => {
-    if (sessionRef.current.uid === uid) return;
-    sessionRef.current = createSession(uid);
-    setState(initialState(uid));
-  }, [uid]);
-  // Object identity rejects stale work even across an A-to-B-to-A user transition where the UID matches again.
-  const isCurrent = (target: DeckImportSession) => sessionRef.current === target;
-  const publish = (target: DeckImportSession, update: Partial<Omit<DeckImportState, "uid">>) => {
-    if (!isCurrent(target)) return;
-    setState((current) => (current.uid === target.uid ? { ...current, ...update } : current));
-  };
-  const startSession = (target: DeckImportSession) => {
-    if (target.uid !== uid || !isCurrent(target)) {
-      throw new Error("Deck import user changed before the import could start");
-    }
-    if (target.running) throw new Error("A Deck import is already running");
-    target.running = true;
-  };
-  const executionDependencies: DeckImportExecutionDependencies = {
-    uid,
-    createDeck: (deck) => createDeck(uid, deck),
-    mutateCards: (mutations) => mutateCards(uid, mutations),
-  };
 
-  const run = async (attempt: DeckImportAttempt, target: DeckImportSession) => {
-    startSession(target);
-    // Retries reuse the prepared IDs and only retain mutations that still failed.
-    target.retryAttempt = attempt;
-    publish(target, { pending: true, error: null });
+  // The generation invalidates stale async work even when auth changes A-to-B-to-A.
+  const generationRef = useRef(0);
+  // Lock synchronously before React publishes status so operations cannot overlap in the same render.
+  const busyRef = useRef(false);
+  const previewAttemptRef = useRef<DeckImportAttempt | undefined>(undefined);
+  const retryAttemptRef = useRef<DeckImportAttempt | undefined>(undefined);
+
+  const [storageMode, setStorageModeState] = useState<DeckImportStorageMode>("remote");
+  const [status, setStatus] = useState<DeckImportStatus>("idle");
+  const [preview, setPreview] = useState<DeckImportPreview | undefined>(undefined);
+  const [failure, setFailure] = useState<DeckImportFailure | undefined>(undefined);
+  const [data, setData] = useState<DeckImportResult | undefined>(undefined);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    busyRef.current = false;
+    previewAttemptRef.current = undefined;
+    retryAttemptRef.current = undefined;
+    setStorageModeState("remote");
+    setStatus("idle");
+    setPreview(undefined);
+    setFailure(undefined);
+    setData(undefined);
+  }, [uid]);
+
+  const isCurrent = (generation: number) => generation === generationRef.current;
+
+  const run = async (attempt: DeckImportAttempt) => {
+    if (busyRef.current) throw new Error("A Deck import is already running");
+
+    const generation = generationRef.current;
+    busyRef.current = true;
+    retryAttemptRef.current = attempt;
+    setStatus("importing");
+    setFailure(undefined);
+
     try {
-      const result = await executePreparedDeckImport(attempt, executionDependencies);
-      publish(target, { data: result });
+      const result = await executePreparedDeckImport(attempt, {
+        uid,
+        createDeck: (deck) => createDeck(uid, deck),
+        mutateCards: (mutations) => mutateCards(uid, mutations),
+      });
+      if (isCurrent(generation)) setData(result);
       return result;
-    } catch (importError) {
-      publish(target, { data: undefined, error: importError });
-      throw importError;
+    } catch (error) {
+      if (isCurrent(generation)) {
+        setData(undefined);
+        setFailure({ stage: "import", error });
+      }
+      throw error;
     } finally {
-      if (isCurrent(target)) {
-        target.running = false;
-        publish(target, { pending: false });
+      if (isCurrent(generation)) {
+        busyRef.current = false;
+        setStatus("idle");
       }
     }
   };
 
   const retry = () => {
-    const target = sessionRef.current;
-    const attempt = target.retryAttempt;
-    if (attempt != null && !target.running) void run(attempt, target).catch(() => undefined);
+    const attempt = retryAttemptRef.current;
+    if (attempt != null && !busyRef.current) void run(attempt).catch(() => undefined);
   };
 
   const setStorageMode = (nextStorageMode: DeckImportStorageMode) => {
-    const target = sessionRef.current;
-    if (target.running || target.storageMode === nextStorageMode) return;
-    // A prepared plan is destination-specific and must never execute after the user changes that destination.
-    target.storageMode = nextStorageMode;
-    target.previewAttempt = undefined;
-    target.retryAttempt = undefined;
-    publish(target, {
-      storageMode: nextStorageMode,
-      preview: undefined,
-      previewError: null,
-      error: null,
-      data: undefined,
-    });
+    if (busyRef.current || storageMode === nextStorageMode) return;
+
+    previewAttemptRef.current = undefined;
+    retryAttemptRef.current = undefined;
+    setStorageModeState(nextStorageMode);
+    setPreview(undefined);
+    setFailure(undefined);
+    setData(undefined);
   };
 
   const selectFile = async (file: File) => {
-    const target = sessionRef.current;
-    if (target.uid !== uid || !isCurrent(target)) {
-      throw new Error("Deck import user changed before the preview could start");
-    }
-    if (target.running) throw new Error("A Deck import is already running");
-    target.previewAttempt = undefined;
-    target.retryAttempt = undefined;
-    publish(target, {
-      validating: true,
-      preview: undefined,
-      previewError: null,
-      error: null,
-      data: undefined,
-    });
+    if (busyRef.current) throw new Error("A Deck import is already running");
+
+    const generation = generationRef.current;
+    busyRef.current = true;
+    previewAttemptRef.current = undefined;
+    retryAttemptRef.current = undefined;
+    setStatus("validating");
+    setPreview(undefined);
+    setFailure(undefined);
+    setData(undefined);
+
     try {
       const analysis = await parseCsv(await file.text());
-      if (!isCurrent(target)) throw new Error("Deck import user changed before the preview could finish");
+      if (!isCurrent(generation)) throw new Error("Deck import user changed before the preview could finish");
 
       // Listener-backed stores can lag, so remote file imports are planned from authoritative server reads.
       const [activeDecks, activeCards]: [Deck[], Card[]] =
-        target.storageMode === "remote" ? await Promise.all([fetchDecks(uid), fetchCards(uid)]) : [decks, cards];
+        storageMode === "remote" ? await Promise.all([fetchDecks(uid), fetchCards(uid)]) : [decks, cards];
 
-      if (!isCurrent(target)) throw new Error("Deck import user changed before the preview could finish");
+      if (!isCurrent(generation)) throw new Error("Deck import user changed before the preview could finish");
+
       const attempt = prepareDeckImport(
-        { name: file.name, rows: analysis.rows, storageMode: target.storageMode },
+        { name: file.name, rows: analysis.rows, storageMode },
         { uid, decks: activeDecks, cards: activeCards, generateCardId }
       );
-      const preview = {
+      const nextPreview = {
         deckName: file.name,
         analysis,
         plan: attempt.plan,
       };
-      target.previewAttempt = attempt;
-      publish(target, { preview });
-      return preview;
-    } catch (caughtPreviewError) {
-      publish(target, { previewError: caughtPreviewError });
-      throw caughtPreviewError;
+      previewAttemptRef.current = attempt;
+      setPreview(nextPreview);
+      return nextPreview;
+    } catch (error) {
+      if (isCurrent(generation)) setFailure({ stage: "preview", error });
+      throw error;
     } finally {
-      publish(target, { validating: false });
+      if (isCurrent(generation)) {
+        busyRef.current = false;
+        setStatus("idle");
+      }
     }
   };
 
-  const { storageMode, preview, previewError, validating, pending, error, data } = currentState;
-
   const importPreview = () => {
-    const target = sessionRef.current;
-    if (target.running) return Promise.reject(new Error("A Deck import is already running"));
+    if (busyRef.current) return Promise.reject(new Error("A Deck import is already running"));
     if (preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
     if (preview.analysis.invalidCount > 0) {
       return Promise.reject(new Error("Fix invalid CSV rows before importing"));
@@ -179,21 +151,25 @@ export const useDeckImport = () => {
     if (preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
-    if (target.previewAttempt == null) return Promise.reject(new Error("The prepared Deck import is not available"));
-    return run(target.previewAttempt, target);
+
+    const attempt = previewAttemptRef.current;
+    if (attempt == null) return Promise.reject(new Error("The prepared Deck import is not available"));
+    return run(attempt);
   };
+
+  const error = failure?.stage === "import" ? failure.error : null;
 
   return {
     selectFile,
     setStorageMode,
     importPreview,
-    addSample: () => run(prepareSampleDeck(uid, { cards, decks, generateCardId }), sessionRef.current),
+    addSample: () => run(prepareSampleDeck(uid, { cards, decks, generateCardId })),
     storageMode,
     preview,
-    validating,
-    pending,
+    validating: status === "validating",
+    pending: status === "importing",
     error,
-    previewError,
+    previewError: failure?.stage === "preview" ? failure.error : null,
     data,
     partialResult: partialResultFrom(error),
     retry,

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -58,10 +58,7 @@ export const useDeckImport = () => {
   // Execution state must update synchronously so operations cannot overlap before React publishes status.
   const executionRef = useRef<DeckImportExecutionState>(createExecutionState());
   const [state, setState] = useState<DeckImportState>(() => initialState(uid, generationRef.current));
-  const currentState =
-    state.uid === uid && state.generation === generationRef.current
-      ? state
-      : initialState(uid, generationRef.current);
+  const currentState = state.uid === uid && state.generation === generationRef.current ? state : initialState(uid, generationRef.current);
 
   const updateState = (update: Partial<Omit<DeckImportState, "uid" | "generation">>) => {
     setState((current) => {

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -17,6 +17,8 @@ type DeckImportStatus = "idle" | "validating" | "importing";
 type DeckImportFailure = { stage: "preview"; error: unknown } | { stage: "import"; error: unknown };
 
 interface DeckImportState {
+  uid: string;
+  generation: number;
   storageMode: DeckImportStorageMode;
   status: DeckImportStatus;
   preview: DeckImportPreview | undefined;
@@ -30,13 +32,15 @@ interface DeckImportExecutionState {
   retryAttempt: DeckImportAttempt | undefined;
 }
 
-const INITIAL_STATE: DeckImportState = {
+const initialState = (uid: string, generation: number): DeckImportState => ({
+  uid,
+  generation,
   storageMode: "remote",
   status: "idle",
   preview: undefined,
   failure: undefined,
   result: undefined,
-};
+});
 
 const createExecutionState = (): DeckImportExecutionState => ({
   running: false,
@@ -53,16 +57,25 @@ export const useDeckImport = () => {
   const generationRef = useRef(0);
   // Execution state must update synchronously so operations cannot overlap before React publishes status.
   const executionRef = useRef<DeckImportExecutionState>(createExecutionState());
-  const [state, setState] = useState<DeckImportState>(INITIAL_STATE);
+  const [state, setState] = useState<DeckImportState>(() => initialState(uid, generationRef.current));
+  const currentState =
+    state.uid === uid && state.generation === generationRef.current
+      ? state
+      : initialState(uid, generationRef.current);
 
-  const updateState = (update: Partial<DeckImportState>) => {
-    setState((current) => ({ ...current, ...update }));
+  const updateState = (update: Partial<Omit<DeckImportState, "uid" | "generation">>) => {
+    setState((current) => {
+      const base =
+        current.uid === uid && current.generation === generationRef.current
+          ? current
+          : initialState(uid, generationRef.current);
+      return { ...base, ...update };
+    });
   };
 
   useEffect(() => {
     generationRef.current += 1;
     executionRef.current = createExecutionState();
-    setState(INITIAL_STATE);
   }, [uid]);
 
   const isCurrent = (generation: number) => generation === generationRef.current;
@@ -107,7 +120,7 @@ export const useDeckImport = () => {
 
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
     const execution = executionRef.current;
-    if (execution.running || state.storageMode === storageMode) return;
+    if (execution.running || currentState.storageMode === storageMode) return;
 
     execution.previewAttempt = undefined;
     execution.retryAttempt = undefined;
@@ -119,7 +132,7 @@ export const useDeckImport = () => {
     if (execution.running) throw new Error("A Deck import is already running");
 
     const generation = generationRef.current;
-    const { storageMode } = state;
+    const { storageMode } = currentState;
     execution.running = true;
     execution.previewAttempt = undefined;
     execution.retryAttempt = undefined;
@@ -161,11 +174,11 @@ export const useDeckImport = () => {
   const importPreview = () => {
     const execution = executionRef.current;
     if (execution.running) return Promise.reject(new Error("A Deck import is already running"));
-    if (state.preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
-    if (state.preview.analysis.invalidCount > 0) {
+    if (currentState.preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
+    if (currentState.preview.analysis.invalidCount > 0) {
       return Promise.reject(new Error("Fix invalid CSV rows before importing"));
     }
-    if (state.preview.analysis.rows.length === 0) {
+    if (currentState.preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
     if (execution.previewAttempt == null) {
@@ -174,20 +187,20 @@ export const useDeckImport = () => {
     return run(execution.previewAttempt);
   };
 
-  const importError = state.failure?.stage === "import" ? state.failure.error : null;
+  const importError = currentState.failure?.stage === "import" ? currentState.failure.error : null;
 
   return {
     selectFile,
     setStorageMode,
     importPreview,
     addSample: () => run(prepareSampleDeck(uid, { cards, decks, generateCardId })),
-    storageMode: state.storageMode,
-    preview: state.preview,
-    validating: state.status === "validating",
-    pending: state.status === "importing",
+    storageMode: currentState.storageMode,
+    preview: currentState.preview,
+    validating: currentState.status === "validating",
+    pending: currentState.status === "importing",
     error: importError,
-    previewError: state.failure?.stage === "preview" ? state.failure.error : null,
-    result: state.result,
+    previewError: currentState.failure?.stage === "preview" ? currentState.failure.error : null,
+    result: currentState.result,
     partialResult: partialResultFrom(importError),
     retry,
   };

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -24,6 +24,12 @@ interface DeckImportState {
   result: DeckImportResult | undefined;
 }
 
+interface DeckImportExecutionState {
+  running: boolean;
+  previewAttempt: DeckImportAttempt | undefined;
+  retryAttempt: DeckImportAttempt | undefined;
+}
+
 const INITIAL_STATE: DeckImportState = {
   storageMode: "remote",
   status: "idle",
@@ -32,6 +38,12 @@ const INITIAL_STATE: DeckImportState = {
   result: undefined,
 };
 
+const createExecutionState = (): DeckImportExecutionState => ({
+  running: false,
+  previewAttempt: undefined,
+  retryAttempt: undefined,
+});
+
 export const useDeckImport = () => {
   const uid = useAuthUid();
   const cards = useCards();
@@ -39,10 +51,8 @@ export const useDeckImport = () => {
 
   // The generation invalidates stale async work even when auth changes A-to-B-to-A.
   const generationRef = useRef(0);
-  // Lock synchronously before React publishes status so operations cannot overlap in the same render.
-  const busyRef = useRef(false);
-  const previewAttemptRef = useRef<DeckImportAttempt | undefined>(undefined);
-  const retryAttemptRef = useRef<DeckImportAttempt | undefined>(undefined);
+  // Execution state must update synchronously so operations cannot overlap before React publishes status.
+  const executionRef = useRef<DeckImportExecutionState>(createExecutionState());
   const [state, setState] = useState<DeckImportState>(INITIAL_STATE);
 
   const updateState = (update: Partial<DeckImportState>) => {
@@ -51,20 +61,22 @@ export const useDeckImport = () => {
 
   useEffect(() => {
     generationRef.current += 1;
-    busyRef.current = false;
-    previewAttemptRef.current = undefined;
-    retryAttemptRef.current = undefined;
+    executionRef.current = createExecutionState();
     setState(INITIAL_STATE);
   }, [uid]);
 
   const isCurrent = (generation: number) => generation === generationRef.current;
+  const assertCurrent = (generation: number) => {
+    if (!isCurrent(generation)) throw new Error("Deck import user changed before the preview could finish");
+  };
 
   const run = async (attempt: DeckImportAttempt) => {
-    if (busyRef.current) throw new Error("A Deck import is already running");
+    const execution = executionRef.current;
+    if (execution.running) throw new Error("A Deck import is already running");
 
     const generation = generationRef.current;
-    busyRef.current = true;
-    retryAttemptRef.current = attempt;
+    execution.running = true;
+    execution.retryAttempt = attempt;
     updateState({ status: "importing", failure: undefined });
 
     try {
@@ -75,49 +87,53 @@ export const useDeckImport = () => {
       });
       if (isCurrent(generation)) updateState({ result });
       return result;
-    } catch (error) {
-      if (isCurrent(generation)) updateState({ result: undefined, failure: { stage: "import", error } });
-      throw error;
+    } catch (caughtError) {
+      if (isCurrent(generation)) {
+        updateState({ result: undefined, failure: { stage: "import", error: caughtError } });
+      }
+      throw caughtError;
     } finally {
       if (isCurrent(generation)) {
-        busyRef.current = false;
+        execution.running = false;
         updateState({ status: "idle" });
       }
     }
   };
 
   const retry = () => {
-    const attempt = retryAttemptRef.current;
-    if (attempt != null && !busyRef.current) void run(attempt).catch(() => undefined);
+    const { retryAttempt, running } = executionRef.current;
+    if (retryAttempt != null && !running) void run(retryAttempt).catch(() => undefined);
   };
 
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
-    if (busyRef.current || state.storageMode === storageMode) return;
+    const execution = executionRef.current;
+    if (execution.running || state.storageMode === storageMode) return;
 
-    previewAttemptRef.current = undefined;
-    retryAttemptRef.current = undefined;
+    execution.previewAttempt = undefined;
+    execution.retryAttempt = undefined;
     updateState({ storageMode, preview: undefined, failure: undefined, result: undefined });
   };
 
   const selectFile = async (file: File) => {
-    if (busyRef.current) throw new Error("A Deck import is already running");
+    const execution = executionRef.current;
+    if (execution.running) throw new Error("A Deck import is already running");
 
     const generation = generationRef.current;
-    const storageMode = state.storageMode;
-    busyRef.current = true;
-    previewAttemptRef.current = undefined;
-    retryAttemptRef.current = undefined;
+    const { storageMode } = state;
+    execution.running = true;
+    execution.previewAttempt = undefined;
+    execution.retryAttempt = undefined;
     updateState({ status: "validating", preview: undefined, failure: undefined, result: undefined });
 
     try {
       const analysis = await parseCsv(await file.text());
-      if (!isCurrent(generation)) throw new Error("Deck import user changed before the preview could finish");
+      assertCurrent(generation);
 
       // Listener-backed stores can lag, so remote file imports are planned from authoritative server reads.
       const [activeDecks, activeCards]: [Deck[], Card[]] =
         storageMode === "remote" ? await Promise.all([fetchDecks(uid), fetchCards(uid)]) : [decks, cards];
 
-      if (!isCurrent(generation)) throw new Error("Deck import user changed before the preview could finish");
+      assertCurrent(generation);
 
       const attempt = prepareDeckImport(
         { name: file.name, rows: analysis.rows, storageMode },
@@ -128,22 +144,23 @@ export const useDeckImport = () => {
         analysis,
         plan: attempt.plan,
       };
-      previewAttemptRef.current = attempt;
+      execution.previewAttempt = attempt;
       updateState({ preview });
       return preview;
-    } catch (error) {
-      if (isCurrent(generation)) updateState({ failure: { stage: "preview", error } });
-      throw error;
+    } catch (caughtError) {
+      if (isCurrent(generation)) updateState({ failure: { stage: "preview", error: caughtError } });
+      throw caughtError;
     } finally {
       if (isCurrent(generation)) {
-        busyRef.current = false;
+        execution.running = false;
         updateState({ status: "idle" });
       }
     }
   };
 
   const importPreview = () => {
-    if (busyRef.current) return Promise.reject(new Error("A Deck import is already running"));
+    const execution = executionRef.current;
+    if (execution.running) return Promise.reject(new Error("A Deck import is already running"));
     if (state.preview == null) return Promise.reject(new Error("Select a CSV file before importing"));
     if (state.preview.analysis.invalidCount > 0) {
       return Promise.reject(new Error("Fix invalid CSV rows before importing"));
@@ -151,13 +168,13 @@ export const useDeckImport = () => {
     if (state.preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
-
-    const attempt = previewAttemptRef.current;
-    if (attempt == null) return Promise.reject(new Error("The prepared Deck import is not available"));
-    return run(attempt);
+    if (execution.previewAttempt == null) {
+      return Promise.reject(new Error("The prepared Deck import is not available"));
+    }
+    return run(execution.previewAttempt);
   };
 
-  const error = state.failure?.stage === "import" ? state.failure.error : null;
+  const importError = state.failure?.stage === "import" ? state.failure.error : null;
 
   return {
     selectFile,
@@ -168,10 +185,10 @@ export const useDeckImport = () => {
     preview: state.preview,
     validating: state.status === "validating",
     pending: state.status === "importing",
-    error,
+    error: importError,
     previewError: state.failure?.stage === "preview" ? state.failure.error : null,
     result: state.result,
-    partialResult: partialResultFrom(error),
+    partialResult: partialResultFrom(importError),
     retry,
   };
 };

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -58,7 +58,8 @@ export const useDeckImport = () => {
   // Execution state must update synchronously so operations cannot overlap before React publishes status.
   const executionRef = useRef<DeckImportExecutionState>(createExecutionState());
   const [state, setState] = useState<DeckImportState>(() => initialState(uid, generationRef.current));
-  const currentState = state.uid === uid && state.generation === generationRef.current ? state : initialState(uid, generationRef.current);
+  const currentState =
+    state.uid === uid && state.generation === generationRef.current ? state : initialState(uid, generationRef.current);
 
   const updateState = (update: Partial<Omit<DeckImportState, "uid" | "generation">>) => {
     setState((current) => {

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -14,9 +14,7 @@ import { prepareSampleDeck } from "../model/sampleDeck";
 
 type DeckImportStatus = "idle" | "validating" | "importing";
 
-type DeckImportFailure =
-  | { stage: "preview"; error: unknown }
-  | { stage: "import"; error: unknown };
+type DeckImportFailure = { stage: "preview"; error: unknown } | { stage: "import"; error: unknown };
 
 interface DeckImportState {
   storageMode: DeckImportStorageMode;


### PR DESCRIPTION
## What changed

- Removed the duplicated `DeckImportSession` state machine from `useDeckImport`.
- Replaced session object identity checks with a single operation generation used only to invalidate stale async work across auth changes.
- Consolidated UI state into one `DeckImportState` with an explicit `idle` / `validating` / `importing` status.
- Kept prepared preview and retry attempts as refs because they are execution state rather than render state.
- Added a synchronous busy guard so preview/import operations cannot overlap before React publishes the next status.

## Why

`useDeckImport` was maintaining the same concerns in both React state and a mutable session object (`uid`, storage mode, running state, prepared attempts). That made the hook behave like a custom state machine and required helper layers such as `isCurrent`, `publish`, and `startSession`.

The new structure keeps render state in React and keeps only the minimal non-render execution state in refs. The auth generation preserves the existing A-to-B-to-A stale-work protection without retaining a parallel session object.

## Impact

The public `useDeckImport` interface and existing behavior are unchanged. Existing tests for previewing, remote/local planning, retries, partial failures, duplicate import prevention, and auth transitions are intended to remain valid without test changes.

## Validation

Local `mise run check` could not be executed in the current environment because the sandbox has no `gh` binary and cannot resolve `github.com` to clone the repository. The pull request CI is used as the available validation path.