### PR TITLE
[No issue] Simplify Deck import hook result props

### DIFF
--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -437,7 +437,7 @@ describe("useDeckImport", () => {
 
     act(() => result.current.retry());
     await waitFor(() =>
-      expect(result.current.data).toEqual({
+      expect(result.current.result).toEqual({
         created: 2,
         updated: 0,
         skipped: 0,
@@ -460,7 +460,7 @@ describe("useDeckImport", () => {
     const { result } = renderHook(useDeckImport);
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
     await actAsync(async () => result.current.addSample());
-    expect(result.current.data).toBeDefined();
+    expect(result.current.result).toBeDefined();
 
     mocks.bulkUpsert.mockRejectedValueOnce(new Error("failed"));
     await actAsync(async () => {
@@ -469,7 +469,7 @@ describe("useDeckImport", () => {
     expect(result.current.error).toBeDefined();
 
     await actAsync(async () => result.current.selectFile(file));
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
     expect(result.current.error).toBeNull();
   });
 
@@ -493,7 +493,7 @@ describe("useDeckImport", () => {
 
     finishOld();
     await oldOperation;
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
     expect(result.current.error).toBeNull();
     expect(result.current.pending).toBe(false);
   });
@@ -520,7 +520,7 @@ describe("useDeckImport", () => {
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
     expect(result.current.pending).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
   });
 
   it("does not publish or import a file preview after an A-to-B-to-A UID transition", async () => {
@@ -568,14 +568,14 @@ describe("useDeckImport", () => {
   it("does not resurrect import data after an A-to-B-to-A UID transition", async () => {
     const { result, rerender } = renderHook(useDeckImport);
     await actAsync(async () => result.current.addSample());
-    expect(result.current.data).toBeDefined();
+    expect(result.current.result).toBeDefined();
 
     mocks.uid = "uid-b";
     rerender();
     mocks.uid = "uid-a";
     rerender();
 
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
     expect(result.current.error).toBeNull();
   });
 

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -28,7 +28,7 @@ interface DeckImportState {
   preview: DeckImportPreview | undefined;
   previewError: unknown;
   error: unknown;
-  data: DeckImportResult | undefined;
+  result: DeckImportResult | undefined;
 }
 
 const createSession = (uid: string): DeckImportSession => ({
@@ -47,7 +47,7 @@ const initialState = (uid: string): DeckImportState => ({
   preview: undefined,
   previewError: null,
   error: null,
-  data: undefined,
+  result: undefined,
 });
 
 export const useDeckImport = () => {
@@ -88,10 +88,10 @@ export const useDeckImport = () => {
     publish(target, { pending: true, error: null });
     try {
       const result = await executePreparedDeckImport(attempt, executionDependencies);
-      publish(target, { data: result });
+      publish(target, { result });
       return result;
     } catch (importError) {
-      publish(target, { data: undefined, error: importError });
+      publish(target, { result: undefined, error: importError });
       throw importError;
     } finally {
       if (isCurrent(target)) {
@@ -119,7 +119,7 @@ export const useDeckImport = () => {
       preview: undefined,
       previewError: null,
       error: null,
-      data: undefined,
+      result: undefined,
     });
   };
 
@@ -136,7 +136,7 @@ export const useDeckImport = () => {
       preview: undefined,
       previewError: null,
       error: null,
-      data: undefined,
+      result: undefined,
     });
     try {
       const analysis = await parseCsv(await file.text());
@@ -167,7 +167,7 @@ export const useDeckImport = () => {
     }
   };
 
-  const { storageMode, preview, previewError, validating, pending, error, data } = currentState;
+  const { storageMode, preview, previewError, validating, pending, error, result } = currentState;
 
   const importPreview = () => {
     const target = sessionRef.current;
@@ -194,7 +194,7 @@ export const useDeckImport = () => {
     pending,
     error,
     previewError,
-    data,
+    result,
     partialResult: partialResultFrom(error),
     retry,
   };

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -18,9 +18,9 @@ interface DeckImportViewProps {
   dark?: boolean;
   validating?: boolean;
   pending?: boolean;
-  preview?: DeckImportPreview;
-  result?: DeckImportResult;
-  partialResult?: DeckImportResult;
+  preview?: DeckImportPreview | undefined;
+  result?: DeckImportResult | undefined;
+  partialResult?: DeckImportResult | undefined;
   error?: unknown;
   previewError?: unknown;
   storageMode?: DeckImportStorageMode;

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   downloadSampleCsv: vi.fn(),
   setDarkMode: vi.fn(),
   preview: undefined as DeckImportPreview | undefined,
-  data: undefined as DeckImportResult | undefined,
+  result: undefined as DeckImportResult | undefined,
   partialResult: undefined as DeckImportResult | undefined,
   pending: false,
   validating: false,
@@ -54,7 +54,7 @@ vi.mock("@/features/deck-import", async (importOriginal) => ({
     addSample: mocks.addSample,
     retry: mocks.retry,
     preview: mocks.preview,
-    data: mocks.data,
+    result: mocks.result,
     partialResult: mocks.partialResult,
     pending: mocks.pending,
     validating: mocks.validating,
@@ -107,7 +107,7 @@ describe("DeckImportPage", () => {
     mocks.importPreview.mockResolvedValue({});
     mocks.addSample.mockResolvedValue({});
     mocks.preview = undefined;
-    mocks.data = undefined;
+    mocks.result = undefined;
     mocks.partialResult = undefined;
     mocks.pending = false;
     mocks.validating = false;

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -35,9 +35,9 @@ export const DeckImportPage: React.FC = () => {
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}
-        {...(deckImport.preview !== undefined ? { preview: deckImport.preview } : {})}
-        {...(deckImport.data !== undefined ? { result: deckImport.data } : {})}
-        {...(deckImport.partialResult !== undefined ? { partialResult: deckImport.partialResult } : {})}
+        preview={deckImport.preview}
+        result={deckImport.result}
+        partialResult={deckImport.partialResult}
         error={deckImport.error}
         previewError={deckImport.previewError}
         dark={preferences.appearance.darkMode}


### PR DESCRIPTION
## Related issue

None

## Summary

- Rename the Deck import hook completion value from `data` to `result` to match the view contract.
- Allow optional view result props to receive explicit `undefined` values under `exactOptionalPropertyTypes`.
- Pass preview and result state directly from the page without conditional object spreads.

## Testing

- `mise run check`