### PR TITLE
[No issue] Simplify Deck import internals

### DIFF
--- a/src/features/deck-import/lib/cardCsv.ts
+++ b/src/features/deck-import/lib/cardCsv.ts
@@ -5,20 +5,17 @@ import * as Papa from "papaparse";
 import type { DeckImportAnalysis, DeckImportIssue, DeckImportRow } from "../model/deckImportTypes";
 
 const fromRow = (row: string[]): CardRaw => ({
-  frontText: row[0] || "",
-  backText: row[1] || "",
-  tags:
-    typeof row[2] === "string"
-      ? [
-          ...new Set(
-            row[2]
-              .split(",")
-              .map((tag) => tag.trim())
-              .filter(Boolean)
-          ),
-        ]
-      : [],
-  uniqueKey: (row[3] || "").trim(),
+  frontText: row[0] ?? "",
+  backText: row[1] ?? "",
+  tags: [
+    ...new Set(
+      (row[2] ?? "")
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+    ),
+  ],
+  uniqueKey: (row[3] ?? "").trim(),
 });
 
 const rowContext = (columns: string[]) => JSON.stringify(columns);
@@ -52,25 +49,21 @@ export const parseCsv = async (content: string): Promise<DeckImportAnalysis> => 
   const skippedRows: number[] = [];
   const issues: DeckImportIssue[] = [];
   const invalidRows = new Set<number>();
-  const parseErrorRows = new Set<number>();
   const uniqueKeys = new Set<string>();
-  let fileIssueCount = 0;
 
   parsed.errors.forEach((error) => {
     if (error.row == null) {
-      fileIssueCount += 1;
       issues.push({ message: error.message });
       return;
     }
     const rowNumber = error.row + 1;
     invalidRows.add(rowNumber);
-    parseErrorRows.add(error.row);
     issues.push({ rowNumber, message: error.message, context: rowContext(parsed.data[error.row] ?? []) });
   });
 
   parsed.data.forEach((columns, index) => {
     const rowNumber = index + 1;
-    if (parseErrorRows.has(index)) return;
+    if (invalidRows.has(rowNumber)) return;
     if (columns.every((column) => column.trim() === "")) {
       skippedRows.push(rowNumber);
       return;
@@ -96,9 +89,9 @@ export const parseCsv = async (content: string): Promise<DeckImportAnalysis> => 
   });
 
   if (rows.length === 0 && issues.length === 0) {
-    fileIssueCount += 1;
     issues.push({ message: "The CSV file is empty." });
   }
 
+  const fileIssueCount = issues.filter((issue) => issue.rowNumber === undefined).length;
   return { rows, skippedRows, issues, invalidCount: invalidRows.size + fileIssueCount };
 };

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -5,7 +5,6 @@ import { CardBulkMutationError, hasSameEditableCardContent, indexCardsByUniqueKe
 import { generateDeckId } from "@/entities/deck";
 
 import type {
-  DeckImportAction,
   DeckImportPlan,
   DeckImportPlanRow,
   DeckImportResult,
@@ -23,21 +22,21 @@ export interface DeckImportAttempt {
   plan: DeckImportPlan;
 }
 
-export interface DeckImportRequest {
+interface DeckImportRequest {
   name: string;
   preferredDeckId?: DeckId;
   rows: DeckImportRow[];
   storageMode?: DeckImportStorageMode;
 }
 
-export interface DeckImportPreparationDependencies {
+interface DeckImportPreparationDependencies {
   uid: string;
   decks: Deck[];
   cards: Card[];
   generateCardId: () => string;
 }
 
-export interface DeckImportExecutionDependencies {
+interface DeckImportExecutionDependencies {
   uid: string;
   createDeck: (deck: DeckImportCreateInput) => Promise<unknown>;
   mutateCards: (mutations: CardMutation[]) => Promise<unknown>;
@@ -75,7 +74,7 @@ const prepareCardMutations = ({
   const byUniqueKey = indexCardsByUniqueKey(existing);
   const planRows: DeckImportPlanRow[] = [];
   const remainingMutations: CardMutation[] = [];
-  const counts: Record<DeckImportAction, number> = { create: 0, update: 0, unchanged: 0 };
+  const counts: Record<DeckImportPlanRow["action"], number> = { create: 0, update: 0, unchanged: 0 };
   for (const row of rows) {
     const current = byUniqueKey.get(row.card.uniqueKey);
     const action = current == null ? "create" : hasSameEditableCardContent(current, row.card) ? "unchanged" : "update";

--- a/src/features/deck-import/model/deckImportTypes.ts
+++ b/src/features/deck-import/model/deckImportTypes.ts
@@ -21,10 +21,8 @@ export interface DeckImportAnalysis {
   invalidCount: number;
 }
 
-export type DeckImportAction = "create" | "update" | "unchanged";
-
 export interface DeckImportPlanRow extends DeckImportRow {
-  action: DeckImportAction;
+  action: "create" | "update" | "unchanged";
 }
 
 export interface DeckImportPlan {

--- a/src/features/deck-import/model/sampleDeck.ts
+++ b/src/features/deck-import/model/sampleDeck.ts
@@ -14,7 +14,7 @@ const SAMPLE_VERSION = 1;
 
 const sampleDeckId = (uid: string): DeckId => `sample-v${String(SAMPLE_VERSION)}-${uid}`;
 
-export interface SampleDeckPreparationOptions {
+interface SampleDeckPreparationOptions {
   cards: Card[];
   decks: Deck[];
   generateCardId: () => string;


### PR DESCRIPTION
## Related issue

None.

## Summary

- Simplify CSV row normalization and error bookkeeping.
- Keep Deck import implementation types private and derive action counts from the plan row type.

## Testing

- mise run check