### PR TITLE
No issue: Remove Deck import partial retries

### DIFF
--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -94,21 +94,31 @@ describe("Card mutations", () => {
     expect(mocks.editRemoteCard).toHaveBeenCalledWith("uid-a", edited);
   });
 
-  it("rejects when a Card mutation fails", async () => {
+  it("waits for every Card mutation before rejecting with the first failure", async () => {
     const deck = createDeckFixture({ id: "remote-deck", localMode: false });
     const first = createCardFixture({ id: "first", deckId: deck.id });
     const second = createCardFixture({ id: "second", deckId: deck.id });
+    let finishEdit!: () => void;
     mocks.findDeckById.mockReturnValue(deck);
     cardStore.setState({ remoteCards: [second], localCards: [] });
     mocks.createRemoteCard.mockRejectedValueOnce(new Error("create failed"));
-    mocks.editRemoteCard.mockRejectedValueOnce(new Error("edit failed"));
+    mocks.editRemoteCard.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishEdit = resolve;
+      })
+    );
 
-    await expect(
-      mutateCards("uid-a", [
-        { kind: "create", card: first },
-        { kind: "edit", card: second },
-      ])
-    ).rejects.toThrow("create failed");
+    const mutation = mutateCards("uid-a", [
+      { kind: "create", card: first },
+      { kind: "edit", card: second },
+    ]);
+    const settled = vi.fn();
+    void mutation.then(settled, settled);
+    await Promise.resolve();
+
+    expect(settled).not.toHaveBeenCalled();
+    finishEdit();
+    await expect(mutation).rejects.toThrow("create failed");
   });
 
   it("rejects edit and delete when the Card cannot be resolved", async () => {

--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -7,7 +7,7 @@ import {
   createLocalDeck,
 } from "@/test/factories";
 
-import { type CardBulkMutationError, type CardMutation, deleteCard, editCard, mutateCards } from "./mutations";
+import { type CardMutation, deleteCard, editCard, mutateCards } from "./mutations";
 import { cardStore, findCardById } from "../model/store";
 
 const mocks = vi.hoisted(() => ({
@@ -72,9 +72,7 @@ describe("Card mutations", () => {
     const card = createLocalCard({ id: "ownerless-card", deckId: deck.id });
     mocks.findDeckById.mockReturnValue(deck);
 
-    await expect(mutateCards("uid", [{ kind: "create", card }])).rejects.toMatchObject({
-      failedIds: [card.id],
-    });
+    await expect(mutateCards("uid", [{ kind: "create", card }])).rejects.toThrow();
 
     expect(mocks.createRemoteCard).not.toHaveBeenCalled();
   });
@@ -96,7 +94,7 @@ describe("Card mutations", () => {
     expect(mocks.editRemoteCard).toHaveBeenCalledWith("uid-a", edited);
   });
 
-  it("reports every failed Card while allowing other writes to finish", async () => {
+  it("rejects when a Card mutation fails", async () => {
     const deck = createDeckFixture({ id: "remote-deck", localMode: false });
     const first = createCardFixture({ id: "first", deckId: deck.id });
     const second = createCardFixture({ id: "second", deckId: deck.id });
@@ -110,10 +108,7 @@ describe("Card mutations", () => {
         { kind: "create", card: first },
         { kind: "edit", card: second },
       ])
-    ).rejects.toMatchObject({
-      failedIds: [first.id, second.id],
-      message: "2 of 2 Card writes failed",
-    } satisfies Partial<CardBulkMutationError>);
+    ).rejects.toThrow("create failed");
   });
 
   it("rejects edit and delete when the Card cannot be resolved", async () => {

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -53,11 +53,13 @@ export const editCard = async (uid: string, card: CardEditInput): Promise<void> 
 };
 
 export const mutateCards = async (uid: string, mutations: CardMutation[]): Promise<void> => {
-  await Promise.all(
+  const results = await Promise.allSettled(
     mutations.map((mutation) =>
       mutation.kind === "create" ? createCard(uid, mutation.card) : editCard(uid, mutation.card)
     )
   );
+  const failure = results.find((result) => result.status === "rejected");
+  if (failure?.status === "rejected") throw failure.reason;
 };
 
 export const deleteCard = async (uid: string, card: { id: CardId }): Promise<void> => {

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -13,16 +13,6 @@ type CardMutationCreateInput = CardCreateInput | LocalCardCreateInput;
 
 export type CardMutation = { kind: "create"; card: CardMutationCreateInput } | { kind: "edit"; card: CardEditInput };
 
-export class CardBulkMutationError extends Error {
-  constructor(
-    readonly failedIds: CardId[],
-    total: number,
-    options?: ErrorOptions
-  ) {
-    super(`${String(failedIds.length)} of ${String(total)} Card writes failed`, options);
-  }
-}
-
 const isLocalDeck = (deckId: string): boolean => findDeckById(deckId)?.localMode ?? false;
 
 const requireCard = (id: CardId) => {
@@ -63,17 +53,11 @@ export const editCard = async (uid: string, card: CardEditInput): Promise<void> 
 };
 
 export const mutateCards = async (uid: string, mutations: CardMutation[]): Promise<void> => {
-  // Let every independent write settle so callers can retry only failures without replaying successful writes.
-  const results = await Promise.allSettled(
+  await Promise.all(
     mutations.map((mutation) =>
       mutation.kind === "create" ? createCard(uid, mutation.card) : editCard(uid, mutation.card)
     )
   );
-  const failedIds = results.flatMap((result, index) => {
-    const mutation = mutations[index];
-    return result.status === "rejected" && mutation != null ? [mutation.card.id] : [];
-  });
-  if (failedIds.length > 0) throw new CardBulkMutationError(failedIds, mutations.length);
 };
 
 export const deleteCard = async (uid: string, card: { id: CardId }): Promise<void> => {

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,6 +1,6 @@
 export { fetchCards, subscribeCards } from "./api/firestore";
 export { generateCardId } from "./api/id";
-export { CardBulkMutationError, deleteCard, editCard, mutateCards } from "./api/mutations";
+export { deleteCard, editCard, mutateCards } from "./api/mutations";
 export type { CardMutation } from "./api/mutations";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
 export { cardContentSchema } from "./model/schema";

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -5,11 +5,8 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCard, createDeck, createLocalCard, createLocalDeck } from "@/test/factories";
-import { CardBulkMutationError } from "@/entities/card";
 import type { DeckImportResult } from "../model/deckImportTypes";
 import { actAsync } from "@/test/act";
-
-type CardCreateInput = Extract<CardMutation, { kind: "create" }>["card"];
 
 const mocks = vi.hoisted(() => ({
   uid: "uid-a",
@@ -112,7 +109,7 @@ describe("useDeckImport", () => {
         },
       },
     ]);
-    expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, failed: 0, deckId: "deck" });
+    expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, deckId: "deck" });
     expect(mocks.fetchDecks).toHaveBeenCalledOnce();
     expect(mocks.fetchCards).toHaveBeenCalledOnce();
   });
@@ -274,7 +271,7 @@ describe("useDeckImport", () => {
     expect(result.current.preview?.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
     expect(mocks.createDeck).not.toHaveBeenCalled();
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
-    expect(imported).toEqual({ created: 0, updated: 0, skipped: 1, failed: 0, deckId: "deck" });
+    expect(imported).toEqual({ created: 0, updated: 0, skipped: 1, deckId: "deck" });
   });
 
   it("adds the bundled sample with a stable per-user Deck id", async () => {
@@ -339,121 +336,6 @@ describe("useDeckImport", () => {
       await first;
     });
     expect(result.current.pending).toBe(false);
-  });
-
-  it("retains successful and failed counts after a partial Card write failure", async () => {
-    mocks.bulkUpsert.mockRejectedValueOnce(new CardBulkMutationError(["card"], 1));
-    const { result } = renderHook(useDeckImport);
-    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
-
-    await actAsync(async () => {
-      await result.current.selectFile(file);
-    });
-    await actAsync(async () => {
-      await expect(result.current.importPreview()).rejects.toThrow("did not complete");
-    });
-
-    expect(result.current.partialResult).toEqual({
-      created: 0,
-      updated: 0,
-      skipped: 0,
-      failed: 1,
-      deckId: "deck",
-    });
-  });
-
-  it("reports successful creates separately from failed updates", async () => {
-    const deck = createDeck({ id: "deck", name: "deck.csv", uid: "uid-a" });
-    const existing = createCard({
-      id: "existing",
-      deckId: deck.id,
-      uid: deck.uid,
-      frontText: "old front",
-      backText: "back",
-      uniqueKey: "existing",
-    });
-    mocks.fetchDecks.mockResolvedValueOnce([deck]);
-    mocks.fetchCards.mockResolvedValueOnce([existing]);
-    mocks.generateCardId.mockReturnValueOnce("created");
-    mocks.bulkUpsert.mockRejectedValueOnce(new CardBulkMutationError([existing.id], 2));
-    const { result } = renderHook(useDeckImport);
-    const file = new File(['"new front","back","","existing"\n"front","back","","created"'], "deck.csv", {
-      type: "text/csv",
-    });
-
-    await actAsync(async () => result.current.selectFile(file));
-    await actAsync(async () => {
-      await expect(result.current.importPreview()).rejects.toThrow("did not complete");
-    });
-
-    expect(result.current.partialResult).toEqual({
-      created: 1,
-      updated: 0,
-      skipped: 0,
-      failed: 1,
-      deckId: deck.id,
-    });
-  });
-
-  it("retries only failed prepared Cards with stable IDs before listener publication", async () => {
-    const deck = createDeck({ id: "destination", uid: "uid-a" });
-    const first = {
-      id: "prepared-first",
-      deckId: deck.id,
-      uid: deck.uid,
-      frontText: "front-1",
-      backText: "back-1",
-      tags: [],
-      uniqueKey: "first",
-    } satisfies CardCreateInput;
-    const second = {
-      id: "prepared-second",
-      deckId: deck.id,
-      uid: deck.uid,
-      frontText: "front-2",
-      backText: "back-2",
-      tags: [],
-      uniqueKey: "second",
-    } satisfies CardCreateInput;
-    mocks.generateDeckId.mockReturnValueOnce(deck.id);
-    mocks.generateCardId.mockReturnValueOnce(first.id).mockReturnValueOnce(second.id);
-    mocks.bulkUpsert.mockRejectedValueOnce(new CardBulkMutationError([second.id], 2)).mockResolvedValueOnce(undefined);
-    const { result } = renderHook(useDeckImport);
-    const file = new File(['"front-1","back-1","","first"\n"front-2","back-2","","second"'], "deck.csv", {
-      type: "text/csv",
-    });
-
-    await actAsync(async () => result.current.selectFile(file));
-    await actAsync(async () => {
-      await expect(result.current.importPreview()).rejects.toThrow("did not complete");
-    });
-    expect(result.current.partialResult).toEqual({
-      created: 1,
-      updated: 0,
-      skipped: 0,
-      failed: 1,
-      deckId: deck.id,
-    });
-
-    act(() => result.current.retry());
-    await waitFor(() =>
-      expect(result.current.result).toEqual({
-        created: 2,
-        updated: 0,
-        skipped: 0,
-        failed: 0,
-        deckId: deck.id,
-      })
-    );
-
-    expect(mocks.decks).toEqual([]);
-    expect(mocks.cards).toEqual([]);
-    expect(mocks.createDeck).toHaveBeenCalledOnce();
-    expect(mocks.bulkUpsert).toHaveBeenNthCalledWith(1, [
-      { kind: "create", card: first },
-      { kind: "create", card: second },
-    ]);
-    expect(mocks.bulkUpsert).toHaveBeenNthCalledWith(2, [{ kind: "create", card: second }]);
   });
 
   it("clears operation data and error when a new file is selected", async () => {
@@ -602,30 +484,6 @@ describe("useDeckImport", () => {
     await actAsync(async () => {
       finish();
       await operation;
-    });
-  });
-
-  it("keeps successful import rows successful when authoritative recovery fails", async () => {
-    mocks.generateCardId.mockReturnValueOnce("first").mockReturnValueOnce("second");
-    mocks.bulkUpsert.mockRejectedValueOnce(
-      new CardBulkMutationError(["second"], 2, { cause: new Error("authoritative read failed") })
-    );
-    const { result } = renderHook(useDeckImport);
-    const file = new File(['"front-1","back-1","","first"\n"front-2","back-2","","second"'], "deck.csv", {
-      type: "text/csv",
-    });
-
-    await actAsync(async () => result.current.selectFile(file));
-    await actAsync(async () => {
-      await expect(result.current.importPreview()).rejects.toThrow("did not complete");
-    });
-
-    expect(result.current.partialResult).toEqual({
-      created: 1,
-      updated: 0,
-      skipped: 0,
-      failed: 1,
-      deckId: "deck",
     });
   });
 });

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -8,7 +8,7 @@ import { fetchCards, generateCardId, mutateCards, useCards } from "@/entities/ca
 import { createDeck, fetchDecks, useDecks } from "@/entities/deck";
 import { parseCsv } from "../lib/cardCsv";
 import type { DeckImportAttempt } from "../model/deckImportExecution";
-import { executePreparedDeckImport, partialResultFrom, prepareDeckImport } from "../model/deckImportExecution";
+import { executePreparedDeckImport, prepareDeckImport } from "../model/deckImportExecution";
 import type { DeckImportPreview, DeckImportResult, DeckImportStorageMode } from "../model/deckImportTypes";
 import { prepareSampleDeck } from "../model/sampleDeck";
 
@@ -28,7 +28,6 @@ interface DeckImportState {
 interface DeckImportExecutionState {
   running: boolean;
   previewAttempt: DeckImportAttempt | undefined;
-  retryAttempt: DeckImportAttempt | undefined;
 }
 
 const initialState = (uid: string): DeckImportState => ({
@@ -43,7 +42,6 @@ const initialState = (uid: string): DeckImportState => ({
 const createExecutionState = (): DeckImportExecutionState => ({
   running: false,
   previewAttempt: undefined,
-  retryAttempt: undefined,
 });
 
 export const useDeckImport = () => {
@@ -80,7 +78,6 @@ export const useDeckImport = () => {
 
     const generation = generationRef.current;
     execution.running = true;
-    execution.retryAttempt = attempt;
     updateState({ status: "importing", failure: undefined });
 
     try {
@@ -104,17 +101,11 @@ export const useDeckImport = () => {
     }
   };
 
-  const retry = () => {
-    const { retryAttempt, running } = executionRef.current;
-    if (retryAttempt != null && !running) void run(retryAttempt).catch(() => undefined);
-  };
-
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
     const execution = executionRef.current;
     if (execution.running || currentState.storageMode === storageMode) return;
 
     execution.previewAttempt = undefined;
-    execution.retryAttempt = undefined;
     updateState({ storageMode, preview: undefined, failure: undefined, result: undefined });
   };
 
@@ -126,7 +117,6 @@ export const useDeckImport = () => {
     const { storageMode } = currentState;
     execution.running = true;
     execution.previewAttempt = undefined;
-    execution.retryAttempt = undefined;
     updateState({ status: "validating", preview: undefined, failure: undefined, result: undefined });
 
     try {
@@ -178,8 +168,6 @@ export const useDeckImport = () => {
     return run(execution.previewAttempt);
   };
 
-  const importError = currentState.failure?.stage === "import" ? currentState.failure.error : null;
-
   return {
     selectFile,
     setStorageMode,
@@ -189,10 +177,8 @@ export const useDeckImport = () => {
     preview: currentState.preview,
     validating: currentState.status === "validating",
     pending: currentState.status === "importing",
-    error: importError,
+    error: currentState.failure?.stage === "import" ? currentState.failure.error : null,
     previewError: currentState.failure?.stage === "preview" ? currentState.failure.error : null,
     result: currentState.result,
-    partialResult: partialResultFrom(importError),
-    retry,
   };
 };

--- a/src/features/deck-import/model/deckImportExecution.spec.ts
+++ b/src/features/deck-import/model/deckImportExecution.spec.ts
@@ -19,7 +19,7 @@ describe("prepareDeckImport", () => {
     );
 
     expect(attempt.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
-    expect(attempt.remainingMutations).toEqual([
+    expect(attempt.mutations).toEqual([
       { kind: "create", card: expect.objectContaining({ id: "card", uniqueKey: "key-1" }) },
     ]);
   });
@@ -39,7 +39,7 @@ describe("prepareDeckImport", () => {
     );
 
     expect(attempt.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(attempt.remainingMutations).toEqual([
+    expect(attempt.mutations).toEqual([
       { kind: "edit", card: expect.objectContaining({ id: existing.id, frontText: "front" }) },
     ]);
   });
@@ -53,7 +53,7 @@ describe("prepareDeckImport", () => {
     );
 
     expect(attempt.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
-    expect(attempt.remainingMutations).toEqual([]);
+    expect(attempt.mutations).toEqual([]);
   });
 
   it("prepares local Deck and Card creation without an account owner", () => {
@@ -63,7 +63,7 @@ describe("prepareDeckImport", () => {
     );
 
     expect(attempt.deck).toEqual({ id: expect.any(String), name: "local.csv", localMode: true });
-    expect(attempt.remainingMutations).toEqual([
+    expect(attempt.mutations).toEqual([
       {
         kind: "create",
         card: {
@@ -97,7 +97,7 @@ describe("prepareDeckImport", () => {
 
     expect(attempt.deck.id).toBe(localDeck.id);
     expect(attempt.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(attempt.remainingMutations).toEqual([
+    expect(attempt.mutations).toEqual([
       { kind: "edit", card: expect.objectContaining({ id: localCard.id, frontText: "front" }) },
     ]);
   });

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -1,7 +1,7 @@
 import type { Card, CardMutation, RemoteCard } from "@/entities/card";
 import type { Deck, DeckCreateInput, DeckId, LocalDeckCreateInput } from "@/entities/deck";
 
-import { CardBulkMutationError, hasSameEditableCardContent, indexCardsByUniqueKey } from "@/entities/card";
+import { hasSameEditableCardContent, indexCardsByUniqueKey } from "@/entities/card";
 import { generateDeckId } from "@/entities/deck";
 
 import type {
@@ -17,8 +17,8 @@ type DeckImportCreateInput = DeckCreateInput | LocalDeckCreateInput;
 export interface DeckImportAttempt {
   uid: string;
   deck: DeckImportCreateInput;
-  createDeckPending: boolean;
-  remainingMutations: CardMutation[];
+  createDeck: boolean;
+  mutations: CardMutation[];
   plan: DeckImportPlan;
 }
 
@@ -70,10 +70,10 @@ const prepareCardMutations = ({
   uid: string;
   localMode: boolean;
   generateCardId: () => string;
-}): Pick<DeckImportAttempt, "plan" | "remainingMutations"> => {
+}): Pick<DeckImportAttempt, "plan" | "mutations"> => {
   const byUniqueKey = indexCardsByUniqueKey(existing);
   const planRows: DeckImportPlanRow[] = [];
-  const remainingMutations: CardMutation[] = [];
+  const mutations: CardMutation[] = [];
   const counts: Record<DeckImportPlanRow["action"], number> = { create: 0, update: 0, unchanged: 0 };
   for (const row of rows) {
     const current = byUniqueKey.get(row.card.uniqueKey);
@@ -84,14 +84,14 @@ const prepareCardMutations = ({
       const cardFields = { ...row.card, id: generateCardId(), deckId };
       // Local persistence stays account-agnostic; Card mutation routing follows the parent Deck's localMode.
       const card = localMode ? cardFields : { ...cardFields, uid };
-      remainingMutations.push({ kind: "create", card });
+      mutations.push({ kind: "create", card });
     } else if (action === "update" && current != null) {
-      remainingMutations.push({ kind: "edit", card: { ...current, ...row.card } });
+      mutations.push({ kind: "edit", card: { ...current, ...row.card } });
     }
   }
 
   return {
-    remainingMutations,
+    mutations,
     plan: {
       rows: planRows,
       created: counts.create,
@@ -116,33 +116,8 @@ export const prepareDeckImport = (
   return {
     uid,
     deck,
-    createDeckPending: existingDeck == null,
+    createDeck: existingDeck == null,
     ...prepareCardMutations({ rows: request.rows, existing, deckId: deck.id, uid, localMode, generateCardId }),
-  };
-};
-
-class DeckImportExecutionError extends Error {
-  readonly result: DeckImportResult;
-
-  constructor(message: string, options: ErrorOptions & { result: DeckImportResult }) {
-    super(message, options);
-    this.result = options.result;
-  }
-}
-
-export const partialResultFrom = (error: unknown): DeckImportResult | undefined =>
-  error instanceof DeckImportExecutionError ? error.result : undefined;
-
-const resultFrom = (attempt: DeckImportAttempt, failedMutations: CardMutation[]): DeckImportResult => {
-  const failedCreates = failedMutations.filter((mutation) => mutation.kind === "create").length;
-  const failedUpdates = failedMutations.length - failedCreates;
-  // The plan remains the total source of truth while retries retain only mutations that still failed.
-  return {
-    created: attempt.plan.created - failedCreates,
-    updated: attempt.plan.updated - failedUpdates,
-    skipped: attempt.plan.unchanged,
-    failed: failedMutations.length,
-    deckId: attempt.deck.id,
   };
 };
 
@@ -151,26 +126,13 @@ export const executePreparedDeckImport = async (
   { uid, createDeck, mutateCards }: DeckImportExecutionDependencies
 ): Promise<DeckImportResult> => {
   if (attempt.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
-  if (attempt.createDeckPending) {
-    await createDeck(attempt.deck);
-    attempt.createDeckPending = false;
-  }
+  if (attempt.createDeck) await createDeck(attempt.deck);
+  if (attempt.mutations.length > 0) await mutateCards(attempt.mutations);
 
-  const mutations = attempt.remainingMutations;
-  try {
-    if (mutations.length > 0) await mutateCards(mutations);
-  } catch (error) {
-    const failedIds =
-      error instanceof CardBulkMutationError ? error.failedIds : mutations.map((mutation) => mutation.card.id);
-    const failed = new Set(failedIds);
-    // Preserve only failed writes so a retry keeps stable IDs without replaying writes that already succeeded.
-    attempt.remainingMutations = mutations.filter((mutation) => failed.has(mutation.card.id));
-    throw new DeckImportExecutionError(`Deck import did not complete: ${String(error)}`, {
-      cause: error,
-      result: resultFrom(attempt, attempt.remainingMutations),
-    });
-  }
-
-  attempt.remainingMutations = [];
-  return resultFrom(attempt, []);
+  return {
+    created: attempt.plan.created,
+    updated: attempt.plan.updated,
+    skipped: attempt.plan.unchanged,
+    deckId: attempt.deck.id,
+  };
 };

--- a/src/features/deck-import/model/deckImportTypes.ts
+++ b/src/features/deck-import/model/deckImportTypes.ts
@@ -42,6 +42,5 @@ export interface DeckImportResult {
   created: number;
   updated: number;
   skipped: number;
-  failed: number;
   deckId: DeckId;
 }

--- a/src/features/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/features/deck-import/ui/DeckImportView.spec.tsx
@@ -173,19 +173,15 @@ describe("DeckImportView", () => {
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
   });
 
-  it("keeps success and partial failure results visible with recovery actions", async () => {
+  it("shows success and failure results without a retry action", async () => {
     const onBack = vi.fn();
-    const onRetry = vi.fn();
     const success = {
       created: 2,
       updated: 1,
       skipped: 3,
-      failed: 0,
       deckId: "deck",
     } satisfies DeckImportResult;
-    const view = render(
-      <DeckImportView sampleText="front,back,,key" result={success} onBack={onBack} onRetry={onRetry} />
-    );
+    const view = render(<DeckImportView sampleText="front,back,,key" result={success} onBack={onBack} />);
 
     expect(screen.getByRole("status")).toHaveTextContent("Import complete");
     expect(screen.getByRole("status")).toHaveTextContent("2 created");
@@ -195,19 +191,11 @@ describe("DeckImportView", () => {
     expect(onBack).toHaveBeenCalledOnce();
 
     view.rerender(
-      <DeckImportView
-        sampleText="front,back,,key"
-        error={new Error("Card writes failed")}
-        partialResult={{ ...success, created: 1, failed: 1 }}
-        onBack={onBack}
-        onRetry={onRetry}
-      />
+      <DeckImportView sampleText="front,back,,key" error={new Error("Card writes failed")} onBack={onBack} />
     );
     const alert = screen.getByRole("alert");
-    expect(alert).toHaveTextContent("Import partially completed");
-    expect(alert).toHaveTextContent("1 created");
-    expect(alert).toHaveTextContent("1 failed");
-    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-    expect(onRetry).toHaveBeenCalledOnce();
+    expect(alert).toHaveTextContent("Import failed");
+    expect(alert).toHaveTextContent("Card writes failed");
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
   });
 });

--- a/src/features/deck-import/ui/DeckImportView.stories.tsx
+++ b/src/features/deck-import/ui/DeckImportView.stories.tsx
@@ -98,15 +98,14 @@ export const Pending: Story = {
 export const Success: Story = {
   args: {
     preview,
-    result: { created: 1, updated: 1, skipped: 0, failed: 0, deckId: "spanish-basics" },
+    result: { created: 1, updated: 1, skipped: 0, deckId: "spanish-basics" },
   },
 };
 
-export const PartialFailure: Story = {
+export const Failure: Story = {
   args: {
     preview,
-    error: new Error("1 Card write failed"),
-    partialResult: { created: 1, updated: 0, skipped: 0, failed: 1, deckId: "spanish-basics" },
+    error: new Error("Card writes failed"),
   },
 };
 

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -12,7 +12,6 @@ interface DeckImportViewProps {
   onAddSample?: () => void;
   onDownloadSample?: () => void;
   onImport?: () => void;
-  onRetry?: () => void;
   onBack?: () => void;
   sampleText: string;
   dark?: boolean;
@@ -20,7 +19,6 @@ interface DeckImportViewProps {
   pending?: boolean;
   preview?: DeckImportPreview | undefined;
   result?: DeckImportResult | undefined;
-  partialResult?: DeckImportResult | undefined;
   error?: unknown;
   previewError?: unknown;
   storageMode?: DeckImportStorageMode;
@@ -31,47 +29,22 @@ const resultCounts = (result: DeckImportResult) => (
     <li>{result.created} created</li>
     <li>{result.updated} updated</li>
     <li>{result.skipped} skipped</li>
-    {result.failed > 0 ? <li>{result.failed} failed</li> : null}
   </ul>
 );
 
 interface ImportResultProps {
   result: DeckImportResult | undefined;
-  partialResult: DeckImportResult | undefined;
   error: unknown;
-  onRetry: (() => void) | undefined;
   onBack: (() => void) | undefined;
 }
 
 const ImportResult = (props: ImportResultProps) => {
-  if (props.partialResult != null) {
-    return (
-      <section role="alert" className="rounded-surface border border-warning bg-surface-muted p-4 text-ink">
-        <h2 className="font-bold">Import partially completed</h2>
-        <p className="mt-1 text-caption text-ink-muted">
-          Successful rows are kept. Retry safely rechecks each uniqueKey before writing.
-        </p>
-        {resultCounts(props.partialResult)}
-        <div className="mt-3 flex flex-wrap gap-2">
-          <Button size="sm" {...(props.onRetry !== undefined ? { onClick: props.onRetry } : {})}>
-            Retry
-          </Button>
-          <Button variant="quiet" size="sm" {...(props.onBack !== undefined ? { onClick: props.onBack } : {})}>
-            Back to decks
-          </Button>
-        </div>
-      </section>
-    );
-  }
   if (props.error != null) {
     const message = props.error instanceof Error ? props.error.message : "The import could not be completed.";
     return (
       <section role="alert" className="rounded-surface border border-danger bg-surface-muted p-4 text-ink">
         <h2 className="font-bold">Import failed</h2>
         <p className="mt-1 break-words text-caption text-ink-muted">{message}</p>
-        <Button className="mt-3" size="sm" {...(props.onRetry !== undefined ? { onClick: props.onRetry } : {})}>
-          Retry
-        </Button>
       </section>
     );
   }
@@ -235,13 +208,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
             Importing…
           </p>
         ) : null}
-        <ImportResult
-          result={props.result}
-          partialResult={props.partialResult}
-          error={props.error}
-          onRetry={props.onRetry}
-          onBack={props.onBack}
-        />
+        <ImportResult result={props.result} error={props.error} onBack={props.onBack} />
         <PreviewError error={props.previewError} />
         <section className="space-y-4">
           <h2 className="mb-3 break-words text-title font-bold text-ink">Choose a CSV file</h2>

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -23,13 +23,11 @@ const mocks = vi.hoisted(() => ({
   selectFile: vi.fn(),
   importPreview: vi.fn(),
   addSample: vi.fn(),
-  retry: vi.fn(),
   navigate: vi.fn(),
   downloadSampleCsv: vi.fn(),
   setDarkMode: vi.fn(),
   preview: undefined as DeckImportPreview | undefined,
   result: undefined as DeckImportResult | undefined,
-  partialResult: undefined as DeckImportResult | undefined,
   pending: false,
   validating: false,
   error: null as unknown,
@@ -52,10 +50,8 @@ vi.mock("@/features/deck-import", async (importOriginal) => ({
     selectFile: mocks.selectFile,
     importPreview: mocks.importPreview,
     addSample: mocks.addSample,
-    retry: mocks.retry,
     preview: mocks.preview,
     result: mocks.result,
-    partialResult: mocks.partialResult,
     pending: mocks.pending,
     validating: mocks.validating,
     error: mocks.error,
@@ -108,7 +104,6 @@ describe("DeckImportPage", () => {
     mocks.addSample.mockResolvedValue({});
     mocks.preview = undefined;
     mocks.result = undefined;
-    mocks.partialResult = undefined;
     mocks.pending = false;
     mocks.validating = false;
     mocks.error = null;

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -30,14 +30,12 @@ export const DeckImportPage: React.FC = () => {
             .then(() => navigate("/"))
             .catch(() => undefined);
         }}
-        onRetry={deckImport.retry}
         onBack={() => void navigate(-1)}
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}
         preview={deckImport.preview}
         result={deckImport.result}
-        partialResult={deckImport.partialResult}
         error={deckImport.error}
         previewError={deckImport.previewError}
         dark={preferences.appearance.darkMode}

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -124,10 +124,7 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
         { kind: "create", card: valid },
         { kind: "create", card: invalid },
       ])
-    ).rejects.toMatchObject({
-      failedIds: [invalid.id],
-      message: "1 of 2 Card writes failed",
-    });
+    ).rejects.toThrow();
 
     expect((await getDoc(doc(db, "card", valid.id))).data()).toEqual(valid);
   });
@@ -140,7 +137,7 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
     replaceRemoteCards([card]);
     await deleteDoc(doc(db, "card", card.id));
 
-    await expect(mutateCards("uid", [{ kind: "edit", card }])).rejects.toMatchObject({ failedIds: [card.id] });
+    await expect(mutateCards("uid", [{ kind: "edit", card }])).rejects.toThrow();
     const ownedCards = await getDocs(query(collection(db, "card"), where("uid", "==", "uid")));
     expect(ownedCards.docs.some((snapshot) => snapshot.id === card.id)).toBe(false);
   });


### PR DESCRIPTION
## Summary

- remove partial import results and failed-mutation retry state
- simplify Deck import execution to a single success or failure outcome
- remove failed Card ID aggregation and the import Retry UI

## Testing

- `mise run check`