### PR TITLE
[No issue] Prevent retrying failed prepared Deck imports

### DIFF
--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -338,6 +338,31 @@ describe("useDeckImport", () => {
     expect(result.current.pending).toBe(false);
   });
 
+  it("requires a new preview before retrying a failed import", async () => {
+    const createdDeck = createDeck({ id: "deck", name: "deck.csv", uid: "uid-a" });
+    mocks.fetchDecks.mockResolvedValueOnce([]).mockResolvedValueOnce([createdDeck]);
+    mocks.bulkUpsert.mockRejectedValueOnce(new Error("card mutation failed")).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(useDeckImport);
+    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
+
+    await actAsync(async () => result.current.selectFile(file));
+    await actAsync(async () => {
+      await expect(result.current.importPreview()).rejects.toThrow("card mutation failed");
+    });
+
+    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
+    await expect(result.current.importPreview()).rejects.toThrow("prepared Deck import is not available");
+    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
+
+    await actAsync(async () => result.current.selectFile(file));
+    await actAsync(async () => result.current.importPreview());
+
+    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).toHaveBeenCalledTimes(2);
+  });
+
   it("clears operation data and error when a new file is selected", async () => {
     const { result } = renderHook(useDeckImport);
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -165,7 +165,9 @@ export const useDeckImport = () => {
     if (execution.previewAttempt == null) {
       return Promise.reject(new Error("The prepared Deck import is not available"));
     }
-    return run(execution.previewAttempt);
+    const attempt = execution.previewAttempt;
+    execution.previewAttempt = undefined;
+    return run(attempt);
   };
 
   return {


### PR DESCRIPTION
## Related issue

None. Follow-up to #1126.

## Summary

- consume a prepared Deck import attempt when execution starts
- reject repeated Import actions after a failed execution
- allow retry only after selecting the CSV again and preparing a new attempt

## Testing

- `mise run test-unit -- ./src/features/deck-import/hooks/useDeckImport.spec.tsx`
- `mise run check`