### PR TITLE
[No issue] Move study session transitions to entity

### DIFF
--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -10,7 +10,7 @@ export type { StudySession } from "./model/types";
 export {
   clearStudySessions,
   getStudySession,
-  moveStudySessionIfPositionUnchanged,
+  moveStudySession,
   removeStudySession,
   setStudySessionIndex,
   startStudy,

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -3,7 +3,6 @@ export {
   calculateStudySessionIndex,
   compareActiveDecks,
   groupDecksByStudyStatus,
-  isStudySessionPositionUnchanged,
   planStudySessionSwipe,
   resolveStudySession,
 } from "./model/rules";
@@ -11,7 +10,7 @@ export type { StudySession } from "./model/types";
 export {
   clearStudySessions,
   getStudySession,
-  moveStudySession,
+  moveStudySessionIfPositionUnchanged,
   removeStudySession,
   setStudySessionIndex,
   startStudy,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -11,6 +11,7 @@ import {
 import type { StudySession } from "./types";
 
 const session: StudySession = {
+  sessionId: "session-1",
   deckId: "deck-1",
   cardOrderIds: ["card-1", "card-2", "card-3"],
   currentIndex: 1,
@@ -132,7 +133,8 @@ describe("isStudySessionPositionUnchanged", () => {
     expect(isStudySessionPositionUnchanged(session, { ...session, lastStudiedAt: 1 })).toBe(true);
   });
 
-  it("detects a changed index, active card, or removed session", () => {
+  it("detects a replaced session, changed index, active card, or removed session", () => {
+    expect(isStudySessionPositionUnchanged(session, { ...session, sessionId: "session-2" })).toBe(false);
     expect(isStudySessionPositionUnchanged(session, { ...session, currentIndex: 2 })).toBe(false);
     expect(
       isStudySessionPositionUnchanged(session, {

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -97,8 +97,9 @@ export const planStudySessionSwipe = (
 };
 
 export const isStudySessionPositionUnchanged = (previous: StudySession, current: StudySession | undefined): boolean =>
-  // Persistence timestamps may change during a write, but a position change means another interaction owns the card.
-  current?.currentIndex === previous.currentIndex &&
+  // Timestamps may change during a write, but replacements and position changes belong to a newer interaction.
+  current?.sessionId === previous.sessionId &&
+  current.currentIndex === previous.currentIndex &&
   getCurrentStudySessionCardId(current) === getCurrentStudySessionCardId(previous);
 
 export const calculateStudySessionIndex = (

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearStudySessions,
   getStudySession,
-  moveStudySession,
+  moveStudySessionIfPositionUnchanged,
   removeStudySession,
   setStudySessionIndex,
   startStudy,
@@ -83,12 +83,29 @@ describe("study store", () => {
 
   it("moves within a session and removes it when movement reaches an edge", () => {
     startSession("deck-1", ["card-1", "card-2"]);
+    const firstCard = getStudySession("deck-1");
+    if (firstCard == null) throw new Error("Expected an active study session");
 
-    moveStudySession("deck-1", "next");
+    expect(moveStudySessionIfPositionUnchanged("deck-1", firstCard, "next")).toBe(true);
     expect(getStudySession("deck-1")?.currentIndex).toBe(1);
 
-    moveStudySession("deck-1", "next");
+    const finalCard = getStudySession("deck-1");
+    if (finalCard == null) throw new Error("Expected an active study session");
+    expect(moveStudySessionIfPositionUnchanged("deck-1", finalCard, "next")).toBe(true);
     expect(getStudySession("deck-1")).toBeUndefined();
+  });
+
+  it("moves only when the persisted swipe still owns the active card", () => {
+    startSession("deck-1", ["card-1", "card-2"]);
+    const previous = getStudySession("deck-1");
+    if (previous == null) throw new Error("Expected an active study session");
+
+    touchStudySession("deck-1");
+    expect(moveStudySessionIfPositionUnchanged("deck-1", previous, "next")).toBe(true);
+    expect(getStudySession("deck-1")?.currentIndex).toBe(1);
+
+    expect(moveStudySessionIfPositionUnchanged("deck-1", previous, "next")).toBe(false);
+    expect(getStudySession("deck-1")?.currentIndex).toBe(1);
   });
 
   it.each([-1, 2, 0.5])("does not persist an invalid session index: %s", (currentIndex) => {

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearStudySessions,
   getStudySession,
-  moveStudySessionIfPositionUnchanged,
+  moveStudySession,
   removeStudySession,
   setStudySessionIndex,
   startStudy,
@@ -63,8 +63,20 @@ describe("study store", () => {
     startSession("deck-2", ["card-3"]);
 
     expect(store.getState().sessionsByDeckId).toEqual({
-      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 0, lastStudiedAt: 1000 },
-      "deck-2": { deckId: "deck-2", cardOrderIds: ["card-3"], currentIndex: 0, lastStudiedAt: 2000 },
+      "deck-1": {
+        sessionId: expect.any(String),
+        deckId: "deck-1",
+        cardOrderIds: ["card-1", "card-2"],
+        currentIndex: 0,
+        lastStudiedAt: 1000,
+      },
+      "deck-2": {
+        sessionId: expect.any(String),
+        deckId: "deck-2",
+        cardOrderIds: ["card-3"],
+        currentIndex: 0,
+        lastStudiedAt: 2000,
+      },
     });
   });
 
@@ -86,12 +98,12 @@ describe("study store", () => {
     const firstCard = getStudySession("deck-1");
     if (firstCard == null) throw new Error("Expected an active study session");
 
-    expect(moveStudySessionIfPositionUnchanged("deck-1", firstCard, "next")).toBe(true);
+    expect(moveStudySession(firstCard, "next")).toBe(true);
     expect(getStudySession("deck-1")?.currentIndex).toBe(1);
 
     const finalCard = getStudySession("deck-1");
     if (finalCard == null) throw new Error("Expected an active study session");
-    expect(moveStudySessionIfPositionUnchanged("deck-1", finalCard, "next")).toBe(true);
+    expect(moveStudySession(finalCard, "next")).toBe(true);
     expect(getStudySession("deck-1")).toBeUndefined();
   });
 
@@ -101,11 +113,24 @@ describe("study store", () => {
     if (previous == null) throw new Error("Expected an active study session");
 
     touchStudySession("deck-1");
-    expect(moveStudySessionIfPositionUnchanged("deck-1", previous, "next")).toBe(true);
+    expect(moveStudySession(previous, "next")).toBe(true);
     expect(getStudySession("deck-1")?.currentIndex).toBe(1);
 
-    expect(moveStudySessionIfPositionUnchanged("deck-1", previous, "next")).toBe(false);
+    expect(moveStudySession(previous, "next")).toBe(false);
     expect(getStudySession("deck-1")?.currentIndex).toBe(1);
+  });
+
+  it("does not move a replacement session that starts on the same card", () => {
+    startSession("deck-1", ["card-1", "card-2"]);
+    const previous = getStudySession("deck-1");
+    if (previous == null) throw new Error("Expected an active study session");
+
+    startSession("deck-1", ["card-1", "card-2"]);
+    const replacement = getStudySession("deck-1");
+
+    expect(replacement?.sessionId).not.toBe(previous.sessionId);
+    expect(moveStudySession(previous, "next")).toBe(false);
+    expect(getStudySession("deck-1")?.currentIndex).toBe(0);
   });
 
   it.each([-1, 2, 0.5])("does not persist an invalid session index: %s", (currentIndex) => {
@@ -165,19 +190,20 @@ describe("study store", () => {
     expect(() => clearStudySessions()).toThrow(failure);
   });
 
-  it("persists exactly the session map in a v3 envelope", async () => {
+  it("persists exactly the session map in a v4 envelope", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);
     startSession("deck-1", ["card-1"]);
+    const sessionId = getStudySession("deck-1")?.sessionId;
 
     const persistedSession = localStorage.getItem(STUDY_STORAGE_KEY);
     expect(JSON.parse(persistedSession ?? "{}")).toEqual({
       state: {
         sessionsByDeckId: {
-          "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
+          "deck-1": { sessionId, deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
         },
       },
-      version: 3,
+      version: 4,
     });
 
     store.setState({ sessionsByDeckId: {} });
@@ -185,33 +211,46 @@ describe("study store", () => {
     await store.persist.rehydrate();
     expect(store.getState()).toMatchObject({
       sessionsByDeckId: {
-        "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
+        "deck-1": { sessionId, deckId: "deck-1", cardOrderIds: ["card-1"], currentIndex: 0, lastStudiedAt: 1000 },
       },
     });
     expect(store.getState()).not.toHaveProperty("session");
   });
 
-  it("hydrates valid v3 sessions independently and drops unknown metadata", async () => {
+  it("hydrates valid v4 sessions independently and drops unknown metadata", async () => {
     setVersionedStorage(
       {
         sessionsByDeckId: {
           "deck-1": {
+            sessionId: "session-1",
             deckId: "deck-1",
             cardOrderIds: ["card-1", "card-2"],
             currentIndex: 1,
             lastStudiedAt: 1000,
             unknownSessionMetadata: "drop",
           },
-          broken: { deckId: "broken", cardOrderIds: [], currentIndex: 0, lastStudiedAt: 2000 },
+          broken: {
+            sessionId: "session-broken",
+            deckId: "broken",
+            cardOrderIds: [],
+            currentIndex: 0,
+            lastStudiedAt: 2000,
+          },
         },
         unknownRootMetadata: "drop",
       },
-      3
+      4
     );
     await store.persist.rehydrate();
 
     expect(store.getState().sessionsByDeckId).toEqual({
-      "deck-1": { deckId: "deck-1", cardOrderIds: ["card-1", "card-2"], currentIndex: 1, lastStudiedAt: 1000 },
+      "deck-1": {
+        sessionId: "session-1",
+        deckId: "deck-1",
+        cardOrderIds: ["card-1", "card-2"],
+        currentIndex: 1,
+        lastStudiedAt: 1000,
+      },
     });
     expect(store.getState()).not.toHaveProperty("unknownRootMetadata");
   });

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -10,7 +10,7 @@ import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
-import { calculateStudySessionIndex } from "./rules";
+import { calculateStudySessionIndex, isStudySessionPositionUnchanged } from "./rules";
 import type { StudySession, StudySessionMovement, StudySessions } from "./types";
 
 const STUDY_STORAGE_KEY = "tango-study";
@@ -107,7 +107,8 @@ export const touchStudySession = (deckId: DeckId): void => {
   });
 };
 
-export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): void => {
+export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): boolean => {
+  let updated = false;
   studySessionStore.setState((state) => {
     const session = state.sessionsByDeckId[deckId];
     // Never persist a resume point that cannot identify an active card.
@@ -121,22 +122,31 @@ export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): void
     }
     session.currentIndex = currentIndex;
     session.lastStudiedAt = Date.now();
+    updated = true;
   });
+  return updated;
 };
 
-export const moveStudySession = (deckId: DeckId, movement: StudySessionMovement): void => {
+export const moveStudySessionIfPositionUnchanged = (
+  deckId: DeckId,
+  previous: StudySession,
+  movement: StudySessionMovement
+): boolean => {
+  let moved = false;
   studySessionStore.setState((state) => {
-    const session = state.sessionsByDeckId[deckId];
-    if (session == null) return;
+    const current = state.sessionsByDeckId[deckId];
+    // A persisted swipe may commit after another interaction; only the interaction still owning the card may advance it.
+    if (current == null || !isStudySessionPositionUnchanged(previous, current)) return;
 
-    const nextIndex = calculateStudySessionIndex(session, movement);
-    if (nextIndex === undefined) {
-      delete state.sessionsByDeckId[deckId];
-      return;
+    const nextIndex = calculateStudySessionIndex(current, movement);
+    if (nextIndex === undefined) delete state.sessionsByDeckId[deckId];
+    else {
+      current.currentIndex = nextIndex;
+      current.lastStudiedAt = Date.now();
     }
-    session.currentIndex = nextIndex;
-    session.lastStudiedAt = Date.now();
+    moved = true;
   });
+  return moved;
 };
 
 export const removeStudySession = (deckId: DeckId): void => {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -15,7 +15,7 @@ import type { StudySession, StudySessionMovement, StudySessions } from "./types"
 
 const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
-const STUDY_STORAGE_VERSION = 3;
+const STUDY_STORAGE_VERSION = 4;
 
 interface StudySessionState {
   sessionsByDeckId: StudySessions;
@@ -27,8 +27,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 // Rebuild canonical sessions from untrusted browser storage so malformed fields cannot break resume logic.
 const sanitizeStudySession = (value: unknown): StudySession | undefined => {
   if (!isRecord(value)) return;
-  const { deckId, cardOrderIds, currentIndex, lastStudiedAt } = value;
+  const { sessionId, deckId, cardOrderIds, currentIndex, lastStudiedAt } = value;
   if (
+    typeof sessionId !== "string" ||
+    sessionId.length === 0 ||
     typeof deckId !== "string" ||
     !Array.isArray(cardOrderIds) ||
     cardOrderIds.length === 0 ||
@@ -44,7 +46,7 @@ const sanitizeStudySession = (value: unknown): StudySession | undefined => {
     return;
   }
 
-  return { deckId, cardOrderIds: [...cardOrderIds], currentIndex, lastStudiedAt };
+  return { sessionId, deckId, cardOrderIds: [...cardOrderIds], currentIndex, lastStudiedAt };
 };
 
 const sanitizePersistedState = (persistedState: unknown): StudySessionState => {
@@ -82,6 +84,8 @@ export const getStudySession = (deckId: DeckId): StudySession | undefined =>
 const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
   studySessionStore.setState((state) => {
     state.sessionsByDeckId[deckId] = {
+      // A fresh identity distinguishes a restarted deck even when it begins on the same card and index.
+      sessionId: crypto.randomUUID(),
       deckId,
       // The store owns this ordering snapshot even if the caller later reuses its array.
       cardOrderIds: [...cardOrderIds],
@@ -127,19 +131,15 @@ export const setStudySessionIndex = (deckId: DeckId, currentIndex: number): bool
   return updated;
 };
 
-export const moveStudySessionIfPositionUnchanged = (
-  deckId: DeckId,
-  previous: StudySession,
-  movement: StudySessionMovement
-): boolean => {
+export const moveStudySession = (previous: StudySession, movement: StudySessionMovement): boolean => {
   let moved = false;
   studySessionStore.setState((state) => {
-    const current = state.sessionsByDeckId[deckId];
+    const current = state.sessionsByDeckId[previous.deckId];
     // A persisted swipe may commit after another interaction; only the interaction still owning the card may advance it.
     if (current == null || !isStudySessionPositionUnchanged(previous, current)) return;
 
     const nextIndex = calculateStudySessionIndex(current, movement);
-    if (nextIndex === undefined) delete state.sessionsByDeckId[deckId];
+    if (nextIndex === undefined) delete state.sessionsByDeckId[previous.deckId];
     else {
       current.currentIndex = nextIndex;
       current.lastStudiedAt = Date.now();

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -11,6 +11,8 @@ import type { StudyProgressEdit } from "@/entities/study-progress/@x/study-sessi
  * sessions that preserve the invariants documented below.
  */
 export interface StudySession {
+  /** Immutable identity for rejecting commits from a study run that has already been replaced. */
+  readonly sessionId: string;
   /** Must match its key in {@link StudySessions}; hydration drops mismatches. */
   deckId: DeckId;
   /** Snapshot fixed at start so later caller mutations cannot reorder the run. */

--- a/src/features/deck-list/model/buildDeckListSections.spec.ts
+++ b/src/features/deck-list/model/buildDeckListSections.spec.ts
@@ -21,18 +21,21 @@ describe("buildDeckListSections", () => {
     ];
     const sessionsByDeckId = {
       "active-old": {
+        sessionId: "session-active-old",
         deckId: "active-old",
         cardOrderIds: ["old-1", "old-2"],
         currentIndex: 0,
         lastStudiedAt: 100,
       },
       "active-new": {
+        sessionId: "session-active-new",
         deckId: "active-new",
         cardOrderIds: ["new-1", "new-2", "new-3"],
         currentIndex: 1,
         lastStudiedAt: 200,
       },
       missing: {
+        sessionId: "session-missing",
         deckId: "missing",
         cardOrderIds: ["missing-card"],
         currentIndex: 0,

--- a/src/features/deck-list/ui/DeckList.spec.tsx
+++ b/src/features/deck-list/ui/DeckList.spec.tsx
@@ -23,12 +23,14 @@ const cards = [
 ];
 const sessionsByDeckId: DeckListProps["sessionsByDeckId"] = {
   [oldDeck.id]: {
+    sessionId: "session-old",
     deckId: oldDeck.id,
     cardOrderIds: ["old-1", "old-2"],
     currentIndex: 0,
     lastStudiedAt: 1000,
   },
   [recentDeck.id]: {
+    sessionId: "session-recent",
     deckId: recentDeck.id,
     cardOrderIds: ["recent-1", "recent-2", "recent-3"],
     currentIndex: 1,

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -6,7 +6,7 @@ import { editStudyProgress } from "@/entities/study-progress";
 import {
   calculateStudySessionIndex,
   getStudySession,
-  moveStudySessionIfPositionUnchanged,
+  moveStudySession,
   planStudySessionSwipe,
   removeStudySession,
   resolveStudySession,
@@ -79,7 +79,7 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onInvalid: () =
     swipeState.current.inProgress = false;
     if (!saved) return;
 
-    if (!moveStudySessionIfPositionUnchanged(deckId, swipePlan.session, swipePlan.effect)) return;
+    if (!moveStudySession(swipePlan.session, swipePlan.effect)) return;
 
     feedback.showSwipe(direction);
     if (preferences.appearance.hideBodyWhenCardChanged) hideBackText();

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -6,8 +6,7 @@ import { editStudyProgress } from "@/entities/study-progress";
 import {
   calculateStudySessionIndex,
   getStudySession,
-  isStudySessionPositionUnchanged,
-  moveStudySession,
+  moveStudySessionIfPositionUnchanged,
   planStudySessionSwipe,
   removeStudySession,
   resolveStudySession,
@@ -80,18 +79,14 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onInvalid: () =
     swipeState.current.inProgress = false;
     if (!saved) return;
 
-    const currentSession = getStudySession(deckId);
-    // Position changes during the write own the newer card, while timestamp-only touches still allow advancement.
-    if (!isStudySessionPositionUnchanged(swipePlan.session, currentSession)) return;
+    if (!moveStudySessionIfPositionUnchanged(deckId, swipePlan.session, swipePlan.effect)) return;
 
     feedback.showSwipe(direction);
     if (preferences.appearance.hideBodyWhenCardChanged) hideBackText();
-    moveStudySession(deckId, swipePlan.effect);
   };
   const updateIndex = (currentIndex: number): void => {
-    if (getStudySession(deckId) == null) return;
+    if (!setStudySessionIndex(deckId, currentIndex)) return;
     hideBackText();
-    setStudySessionIndex(deckId, currentIndex);
   };
   const session = useStudySession(deckId);
   const resolvedSession = resolveStudySession(session, cards);
@@ -126,9 +121,7 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onInvalid: () =
       return;
     }
     const timeout = window.setTimeout(() => {
-      if (getStudySession(deckId) == null) return;
-      setShowBackText(false);
-      setStudySessionIndex(deckId, nextIndex);
+      if (setStudySessionIndex(deckId, nextIndex)) setShowBackText(false);
     }, preferences.study.cardInterval * 1000);
     return () => window.clearTimeout(timeout);
   }, [autoPlay, deckId, preferences.study.cardInterval, resolvedSession.status, session]);

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -81,6 +81,7 @@ const studyingState = (): StudyState => ({
   status: "studying",
   ...commands(),
   session: {
+    sessionId: "session-id",
     deckId: deck.id,
     cardOrderIds: [card.id],
     currentIndex: 0,


### PR DESCRIPTION
## Summary

- move guarded study-session advancement into the study-session entity store
- let entity mutations report whether index updates were applied
- remove superseded study-session public APIs from the feature workflow

## Testing

- `mise run check`