### PR TITLE
Constrain feature UI to presentational components

### DIFF
--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -7,3 +7,11 @@
 - Feature-specific workflows may coordinate multiple Entities.
 - For list/view Features, define UI-facing interfaces and map Entity data to them without reimplementing Entity rules.
 - For edit Features, define UI-facing form interfaces and map Entity data and constraints to form state/input without reimplementing Entity rules.
+
+## `ui/`
+
+- Keep Feature UI presentational: accept prepared data and state through props, and report user intent through callbacks.
+- Do not read Entity or Feature stores, invoke Entity or Feature state/workflow hooks, call mutations or APIs, or own routing/navigation directly from `ui/`.
+- Keep reusable Feature state, workflows, and orchestration in `model/`. Route-level Pages may connect lower-layer state/actions to Feature UI.
+- UI-only local state is allowed when it represents transient presentation behavior such as open/closed, focus, selection display, or animation state and does not encode domain or workflow state.
+- React and library hooks that only support presentation behavior are allowed.

--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,7 +1,8 @@
 # Pages Instructions
 
 - Keep URL routes and Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
-- Keep Pages UI-only. Import containers or components from lower layers and compose them into the Page layout.
-- Keep Page components concise. Limit them to simple UI composition, and move complex business logic, state coordination, data fetching, and workflows to the appropriate lower layers.
+- Treat Pages as route-level containers and wiring boundaries. Pages may read route params, navigation, Entity state, and Feature model/hooks needed to prepare props and callbacks for lower-layer UI.
+- Keep Page components concise and orchestration-only. Compose lower-layer UI and connect it to lower-layer state/actions; do not implement reusable domain rules or complex Feature workflows in Pages.
+- Move reusable business logic and Feature-specific workflows to the appropriate `entities` or `features/model` layer, then invoke them from the Page.
 - Do not define custom hooks in `src/pages`. Use framework or library hooks such as `useParams`, `useNavigate`, and `useKey`, or existing hooks exposed by lower layers.
 - Own screen-level keyboard shortcut mappings and registration in `src/pages`. Use `useKey` directly and delegate shortcut actions to lower layers.


### PR DESCRIPTION
## Summary

- define `features/**/ui` as presentational: prepared props in, user-intent callbacks out
- prohibit direct Entity/Feature store access, workflow hooks, mutations/APIs, and routing/navigation from Feature UI
- explicitly allow transient UI-only local state and presentation-only React/library hooks
- define Pages as route-level containers/wiring boundaries that connect lower-layer state/actions to Feature UI
- keep reusable domain logic and Feature workflows in `entities` or `features/model`

## Why

The current rules describe Pages as UI-only while some Feature UI components also own hooks and orchestration, leaving the container/presentation boundary ambiguous. This change makes ownership explicit without banning local UI state.

## Impact

Documentation/architecture-rule change only. Existing code is not migrated in this PR; follow-up refactors can move connected Feature UI toward the documented boundary incrementally.

## Validation

- compared `main...agent/constrain-feature-ui-presentational`
- only `src/features/AGENTS.md` and `src/pages/AGENTS.md` are changed
