### PR TITLE
[No issue] Explain entity invariants with intent comments

### DIFF
--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -5,12 +5,8 @@
 
 ## Comments
 
-- Add intent comments for Entity invariants, ownership boundaries, and ordering requirements that names and types cannot express.
-- Document why persisted-data recovery, compatibility handling, soft deletion, local/remote routing, and cross-slice cleanup must work a particular way.
-- Explain partial-failure behavior for multi-step or concurrent mutations so callers know what can already have changed when an error is reported.
-- Use JSDoc on exported domain types when consumers must preserve invariants beyond the type shape.
-- Keep straightforward schemas, accessors, selectors, and re-exports comment-free when the code already expresses the complete intent.
-- Update or remove nearby comments whenever the documented behavior changes.
+- Comment non-obvious Entity intent and invariants, especially ownership, persistence, compatibility, ordering, and partial failures.
+- Do not restate clear code; update or remove comments when behavior changes.
 
 ## `model/schema.ts`
 

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -3,6 +3,15 @@
 - Treat `src/entities` as the FSD Entities layer and each `src/entities/<entity>` directory as an Entity slice.
 - Keep Entity domain code in `model/` and expose the slice through `index.ts`.
 
+## Comments
+
+- Add intent comments for Entity invariants, ownership boundaries, and ordering requirements that names and types cannot express.
+- Document why persisted-data recovery, compatibility handling, soft deletion, local/remote routing, and cross-slice cleanup must work a particular way.
+- Explain partial-failure behavior for multi-step or concurrent mutations so callers know what can already have changed when an error is reported.
+- Use JSDoc on exported domain types when consumers must preserve invariants beyond the type shape.
+- Keep straightforward schemas, accessors, selectors, and re-exports comment-free when the code already expresses the complete intent.
+- Update or remove nearby comments whenever the documented behavior changes.
+
 ## `model/schema.ts`
 
 - Define Zod schemas, validation, refinements, and schema-level defaults.

--- a/src/entities/AGENTS.md
+++ b/src/entities/AGENTS.md
@@ -5,8 +5,8 @@
 
 ## Comments
 
-- Comment non-obvious Entity intent and invariants, especially ownership, persistence, compatibility, ordering, and partial failures.
-- Do not restate clear code; update or remove comments when behavior changes.
+- Add a brief leading comment to every function, including small helpers, that states what it does.
+- Include non-obvious intent and invariants when relevant, and update comments when behavior changes.
 
 ## `model/schema.ts`
 

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -5,6 +5,7 @@ import type { AuthAccount, AuthSessionState } from "./types";
 
 export const useAuthSession = (): AuthSessionState => useStore(authSessionStore);
 
+// Pre-authentication renders use a stable sentinel that remote command schemas reject as an unauthenticated uid.
 export const useAuthUid = (): string =>
   useStore(authSessionStore, (auth) => (auth.status === "authenticated" ? auth.uid : ""));
 

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -8,5 +8,6 @@ export const authSessionStore = createStore<AuthSessionState>()(() => initialAut
 export const getAuthSession = (): AuthSessionState => authSessionStore.getState();
 
 export const replaceAuthSession = (session: AuthSessionState): void => {
+  // Replace the union variant wholesale so fields from an earlier authenticated session cannot survive a transition.
   authSessionStore.setState(session, true);
 };

--- a/src/entities/card/api/document.ts
+++ b/src/entities/card/api/document.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 import { firestoreTimestampDateSchema, parseFirestoreDocument } from "@/shared/api";
 
+// Reads accept compatible legacy values; command schemas enforce the stricter invariants required for new writes.
 const cardDocumentSchema = z.object({
+  // Older documents may duplicate the Firestore document id in their stored fields.
   id: z.string().optional(),
   frontText: z.string(),
   backText: z.string(),

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -35,6 +35,7 @@ const convertCardDocumentToCard = (id: CardId, value: unknown): RemoteCard => {
     score: document.score,
     numberOfSeen: document.numberOfSeen,
   };
+  // Preserve exact optional-property semantics instead of exposing parsed fields whose value is explicitly undefined.
   if (document.lastSeenAt !== undefined) card.lastSeenAt = document.lastSeenAt;
   if (document.nextSeeingAt !== undefined) card.nextSeeingAt = document.nextSeeingAt;
   if (document.interval !== undefined) card.interval = document.interval;
@@ -99,6 +100,7 @@ export const editCard = async (uid: string, card: EditCardInput["card"]): Promis
 
 const removeCardDocument = async (id: string): Promise<void> => {
   const updatedAt = getCurrentTimeMillis();
+  // Individual Card deletion is tombstoned so synchronized readers can converge before both read paths hide it.
   await updateDoc(doc(db, CARD_COLLECTION, id), { updatedAt, deletedAt: updatedAt });
 };
 

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -13,6 +13,7 @@ type CardMutationCreateInput = CardCreateInput | LocalCardCreateInput;
 
 export type CardMutation = { kind: "create"; card: CardMutationCreateInput } | { kind: "edit"; card: CardEditInput };
 
+// The owning Deck is the source of truth for persistence mode; callers cannot route individual Cards independently.
 const isLocalDeck = (deckId: string): boolean => findDeckById(deckId)?.localMode ?? false;
 
 const requireCard = (id: CardId) => {
@@ -49,10 +50,12 @@ export const editCard = async (uid: string, card: CardEditInput): Promise<void> 
     editLocalCard(card);
     return;
   }
+  // Preserve the stored owner so an edit payload cannot move a remote Card between accounts.
   await editRemoteCard(uid, { ...card, uid: requireRemoteCard(currentCard).uid });
 };
 
 export const mutateCards = async (uid: string, mutations: CardMutation[]): Promise<void> => {
+  // Bulk imports are non-transactional: let every independent write settle before surfacing the first failure.
   const results = await Promise.allSettled(
     mutations.map((mutation) =>
       mutation.kind === "create" ? createCard(uid, mutation.card) : editCard(uid, mutation.card)

--- a/src/entities/card/model/rules.ts
+++ b/src/entities/card/model/rules.ts
@@ -30,6 +30,7 @@ export const filterCardsByDeckId = (cards: Card[], deckId: string): Card[] =>
 export const indexCardsByUniqueKey = <T extends Card>(cards: readonly T[]): Map<string, T> =>
   new Map(cards.map((card) => [card.uniqueKey, card]));
 
+// uniqueKey identifies the import target, so only fields controlled by imported content determine whether it changed.
 export const hasSameEditableCardContent = (left: CardRaw, right: CardRaw): boolean =>
   left.frontText === right.frontText &&
   left.backText === right.backText &&

--- a/src/entities/card/model/schema.ts
+++ b/src/entities/card/model/schema.ts
@@ -47,6 +47,7 @@ export const localCardSchema = localCardCreateSchema.extend({
   updatedAt: z.number(),
 });
 
+// Zustand JSON storage serializes Dates as strings; hydration accepts only strings that restore to valid Dates.
 const persistedDateSchema = z.preprocess(
   (value) => (typeof value === "string" ? new Date(value) : value),
   z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date")
@@ -58,6 +59,7 @@ export const localCardEditSchema = editableCardFieldsSchema.partial().extend({ i
 export const cardEditSchema = localCardEditSchema.extend({ uid: cardUidSchema });
 const cardIdentitySchema = z.object({ id: cardIdSchema, uid: cardUidSchema });
 
+// Ownership is established by the authenticated session and must never be selectable by a remote mutation payload.
 const validateCardOwner = (input: { uid: string; card: { uid: string } }, context: z.RefinementCtx): void => {
   if (input.card.uid !== input.uid) {
     context.addIssue({

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -27,6 +27,7 @@ interface CreateCardStoreOptions {
 
 const persistedCardStateSchema = z.object({ localCards: z.array(persistedCardSchema) });
 
+// Reject the stored collection as a unit so live state never mixes validated Cards with an incompatible payload.
 const parsePersistedCardState = (value: unknown): PersistedCardState => {
   const result = persistedCardStateSchema.safeParse(value);
   return result.success ? result.data : { localCards: [] };
@@ -44,6 +45,7 @@ const createCardStore = ({ storage, skipHydration }: CreateCardStoreOptions = {}
         ...currentState,
         ...parsePersistedCardState(persistedState),
       }),
+      // Remote Cards belong to the active subscription and must not survive authentication changes in browser storage.
       partialize: ({ localCards }) => ({ localCards }),
     })
   );
@@ -69,6 +71,7 @@ export const createLocalCard = (input: LocalCardCreateInput): LocalCard => {
   const card = localCardCreateSchema.parse(input);
   const timestamp = Date.now();
   const createdCard = localCardSchema.parse({ ...card, createdAt: timestamp, updatedAt: timestamp });
+  // Treat a retried create as an upsert by id so persisted local data cannot accumulate duplicate Cards.
   const localCards = cardStore.getState().localCards.filter(({ id }) => id !== createdCard.id);
   cardStore.setState({ localCards: [...localCards, createdCard] });
   return createdCard;

--- a/src/entities/card/model/types.ts
+++ b/src/entities/card/model/types.ts
@@ -12,8 +12,11 @@ import type {
   localCardSchema,
 } from "./schema";
 
+/** Firestore-backed Card data whose ownership and deletion metadata must remain at the Entity boundary. */
 export type RemoteCard = z.infer<typeof cardSchema>;
+/** Browser-persisted Card data owned by a local-mode Deck and therefore intentionally lacking a uid. */
 export type LocalCard = z.infer<typeof localCardSchema>;
+/** Entity read model spanning both persistence modes; mutations route through the owning Deck. */
 export type Card = RemoteCard | LocalCard;
 export type CardCreate = z.infer<typeof cardCreateSchema>;
 export type CardCreateInput = z.input<typeof cardCreateSchema>;

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -96,6 +96,7 @@ export const editDeck = async (uid: string, deck: EditDeckInput["deck"]): Promis
 };
 
 const deleteDeckDocuments = async (uid: string, deckId: string): Promise<void> => {
+  // Remove child Cards first so a partial failure leaves a recoverable Deck instead of orphaned Card documents.
   const snapshot = await getDocs(
     query(collection(db, CARD_COLLECTION), where("uid", "==", uid), where("deckId", "==", deckId))
   );

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -23,6 +23,7 @@ interface CreateDeckStoreOptions {
 
 const persistedDeckStateSchema = z.object({ localDecks: z.array(localDeckSchema) });
 
+// Reject the stored collection as a unit so live state never mixes validated Decks with an incompatible payload.
 const parsePersistedDeckState = (value: unknown): PersistedDeckState => {
   const result = persistedDeckStateSchema.safeParse(value);
   return result.success ? { localDecks: result.data.localDecks.map(toLocalDeckStore) } : { localDecks: [] };
@@ -40,6 +41,7 @@ const createDeckStore = ({ storage, skipHydration }: CreateDeckStoreOptions = {}
         ...currentState,
         ...parsePersistedDeckState(persistedState),
       }),
+      // Remote Decks belong to the active subscription and must not survive authentication changes in browser storage.
       partialize: ({ localDecks }) => ({ localDecks }),
     })
   );
@@ -65,6 +67,7 @@ export const createLocalDeck = (input: LocalDeckCreateInput): LocalDeck => {
   const deck = localDeckCreateSchema.parse(input);
   const timestamp = Date.now();
   const createdDeck = toLocalDeckStore(localDeckSchema.parse({ ...deck, createdAt: timestamp, updatedAt: timestamp }));
+  // Treat a retried create as an upsert by id so persisted local data cannot accumulate duplicate Decks.
   const localDecks = deckStore.getState().localDecks.filter(({ id }) => id !== createdDeck.id);
   deckStore.setState({ localDecks: [...localDecks, createdDeck] });
   return createdDeck;

--- a/src/entities/preferences/model/defaults.ts
+++ b/src/entities/preferences/model/defaults.ts
@@ -2,6 +2,7 @@ import { preferencesSchema } from "./schema";
 import type { Preferences } from "./types";
 
 const preferences = preferencesSchema.parse({});
+// Store creation and recovery share these defaults, so freeze every mutable branch to prevent cross-reset mutation.
 Object.freeze(preferences.study.selectedTags);
 Object.freeze(preferences.appearance);
 Object.freeze(preferences.study);

--- a/src/entities/preferences/model/schema.ts
+++ b/src/entities/preferences/model/schema.ts
@@ -2,6 +2,7 @@ import * as z from "zod";
 
 import { studyPreferencesLimits } from "./rules";
 
+// Preferences outlive releases in localStorage; field-level fallbacks preserve valid settings around obsolete values.
 const DEFAULT_APPEARANCE = {
   darkMode: false,
   showHeader: true,

--- a/src/entities/preferences/model/store.ts
+++ b/src/entities/preferences/model/store.ts
@@ -31,6 +31,7 @@ const createPreferencesStore = () =>
             Object.assign(state.preferences.study, study);
             Object.assign(state.preferences.controls, preferencesInput.controls);
             if (selectedTags != null) {
+              // Do not retain a caller-owned mutable array inside persisted state.
               state.preferences.study.selectedTags = [...selectedTags];
             }
             state.preferences = preferencesSchema.parse(state.preferences);
@@ -39,6 +40,7 @@ const createPreferencesStore = () =>
       {
         name: "tango-config",
         merge: (persistedState, currentState) => {
+          // Revalidate untrusted storage; the schema recovers fields independently and current defaults remain the fallback.
           const result = preferencesSchema.safeParse(
             (persistedState as Partial<PersistedPreferencesState> | undefined)?.preferences
           );

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -10,6 +10,7 @@ import { editStudyProgressSchema } from "../model/schema";
 export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });
   const { cardId, ...fields } = input.progress;
+  // StudyProgress is embedded in its Card document; patch only progress fields so Card content remains untouched.
   const document = omitUndefined({ ...fields, updatedAt: getCurrentTimeMillis() });
   await updateDoc(doc(db, "card", cardId), document);
 };

--- a/src/entities/study-progress/model/rules.ts
+++ b/src/entities/study-progress/model/rules.ts
@@ -32,6 +32,7 @@ export const createStudyProgressFromCard = (card: CardProgressFields): StudyProg
 };
 
 const calculateScore = (score: number, rating: StudyRating): number => {
+  // Score records rating direction as a streak; reversing direction must pass through neutral zero.
   if (rating === "mastered") return score >= 0 ? score + 1 : 0;
   if (rating === "not-mastered") return score <= 0 ? score - 1 : 0;
   return score;
@@ -67,6 +68,7 @@ export const buildStudyCardOrder = (
   cards: CardProgressFields[],
   options: StudyCardOrderOptions
 ): StudyProgress["cardId"][] => {
+  // Least-seen Cards lead; stable sorting preserves caller order for ties until optional shuffling.
   let cardOrderIds = cards
     .map(createStudyProgressFromCard)
     .sort(compareStudyProgress)

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -3,15 +3,20 @@ import type { z } from "zod";
 import type { CardId } from "@/entities/card/@x/study-progress";
 import type { editStudyProgressSchema } from "./schema";
 
+/** Card-scoped learning history shared by Deck filtering, session ordering, and persistence. */
 export interface StudyProgress {
   cardId: CardId;
+  /** Signed rating streak; switching between mastered and not-mastered passes through zero. */
   score: number;
+  /** Number of recorded study interactions, including interactions that do not change the score. */
   numberOfSeen: number;
   lastSeenAt?: number;
+  /** Earliest time the Card is eligible when interval filtering is enabled. */
   nextSeeingAt?: Date;
   interval?: number;
 }
 
+/** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
 export type StudyRating = "mastered" | "not-mastered" | "unrated";

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -131,6 +131,7 @@ export const moveStudySession = (deckId: DeckId, movement: StudySessionMovement)
 
     const nextIndex = calculateStudySessionIndex(session, movement);
     if (nextIndex === undefined) {
+      // Crossing either boundary removes the session; persisted state never represents a terminal sentinel index.
       delete state.sessionsByDeckId[deckId];
       return;
     }


### PR DESCRIPTION
## Related issue

None

## Summary

- Add comment expectations specific to Entity invariants, ownership, persistence, compatibility, and partial failure.
- Explain existing non-obvious contracts across Auth, Card, Deck, Preferences, StudyProgress, and StudySession.
- Preserve runtime behavior while making maintenance constraints explicit.

## Testing

- mise run check