### PR TITLE
No issue: Remove same-name deck import updates

### DIFF
--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -8,7 +8,7 @@ import type {
   RemoteCard,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import { collection, doc, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
 
 import { db } from "@/shared/firebase";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
@@ -59,13 +59,6 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
     },
     onError
   );
-
-export const fetchCards = async (uid: string): Promise<RemoteCard[]> => {
-  const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
-  return snapshot.docs
-    .map((document) => convertCardDocumentToCard(document.id, document.data()))
-    .filter((card) => card.deletedAt === null);
-};
 
 const createCardDocument = async (card: CardCreate): Promise<void> => {
   const createdAt = getCurrentTimeMillis();

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,4 @@
-export { fetchCards, subscribeCards } from "./api/firestore";
+export { subscribeCards } from "./api/firestore";
 export { generateCardId } from "./api/id";
 export { deleteCard, editCard, mutateCards } from "./api/mutations";
 export type { CardMutation } from "./api/mutations";

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -1,12 +1,4 @@
-import type {
-  DeckCreate,
-  DeckCreateInput,
-  DeckEdit,
-  DeckId,
-  DeleteDeckInput,
-  EditDeckInput,
-  Deck,
-} from "../model/types";
+import type { DeckCreate, DeckCreateInput, DeckEdit, DeckId, DeleteDeckInput, EditDeckInput } from "../model/types";
 
 import {
   collection,
@@ -14,7 +6,6 @@ import {
   deleteField,
   doc,
   getDocs,
-  getDocsFromServer,
   onSnapshot,
   query,
   setDoc,
@@ -25,7 +16,7 @@ import {
 import { db } from "@/shared/firebase";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
-import { toDeckDocument, toDeckView, toRemoteDeckStore } from "../model/dto";
+import { toDeckDocument, toRemoteDeckStore } from "../model/dto";
 import { createDeckSchema, deleteDeckSchema, editDeckSchema } from "../model/schema";
 import { replaceRemoteDecks } from "../model/store";
 import { parseDeckDocument } from "./document";
@@ -54,14 +45,6 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
     },
     onError
   );
-
-export const fetchDecks = async (uid: string): Promise<Deck[]> => {
-  const snapshot = await getDocsFromServer(query(collection(db, DECK_COLLECTION), where("uid", "==", uid)));
-  return snapshot.docs.flatMap((document) => {
-    const deck = readActiveRemoteDeck(document.id, document.data());
-    return deck === undefined ? [] : [toDeckView(deck)];
-  });
-};
 
 const createDeckDocument = async (deck: DeckCreate): Promise<void> => {
   const createdAt = getCurrentTimeMillis();

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,4 +1,4 @@
-export { fetchDecks, subscribeDecks } from "./api/firestore";
+export { subscribeDecks } from "./api/firestore";
 export { generateDeckId } from "./api/id";
 export { createDeck, deleteDeck, editDeck } from "./api/mutations";
 export {

--- a/src/features/deck-import/hooks/useDeckImport.spec.tsx
+++ b/src/features/deck-import/hooks/useDeckImport.spec.tsx
@@ -17,8 +17,6 @@ const mocks = vi.hoisted(() => ({
   generateCardId: vi.fn(() => "card"),
   createDeck: vi.fn(),
   bulkUpsert: vi.fn(),
-  fetchDecks: vi.fn(),
-  fetchCards: vi.fn(),
 }));
 
 vi.mock("@/entities/auth", () => ({
@@ -30,7 +28,6 @@ vi.mock("@/entities/card", async (importOriginal) => {
   return {
     ...actual,
     filterCardsByDeckId: (cards: Card[], id: DeckId) => cards.filter((card) => card.deckId === id),
-    fetchCards: mocks.fetchCards,
     generateCardId: mocks.generateCardId,
     mutateCards: (_uid: string, mutations: CardMutation[]) => mocks.bulkUpsert(mutations),
     useCards: () => mocks.cards,
@@ -42,7 +39,6 @@ vi.mock("@/entities/deck", async (importOriginal) => {
     ...actual,
     createDeck: (_uid: string, deck: Parameters<typeof actual.createDeck>[1]) => mocks.createDeck(deck),
     generateDeckId: mocks.generateDeckId,
-    fetchDecks: mocks.fetchDecks,
     useDecks: () => mocks.decks,
   };
 });
@@ -66,8 +62,6 @@ describe("useDeckImport", () => {
     mocks.generateCardId.mockReturnValue("card");
     mocks.createDeck.mockResolvedValue(undefined);
     mocks.bulkUpsert.mockResolvedValue(undefined);
-    mocks.fetchDecks.mockResolvedValue([]);
-    mocks.fetchCards.mockResolvedValue([]);
   });
 
   it("previews a file without writing until import is confirmed", async () => {
@@ -110,8 +104,6 @@ describe("useDeckImport", () => {
       },
     ]);
     expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, deckId: "deck" });
-    expect(mocks.fetchDecks).toHaveBeenCalledOnce();
-    expect(mocks.fetchCards).toHaveBeenCalledOnce();
   });
 
   it("imports a local Deck and Cards without Firestore reads or owner fields", async () => {
@@ -129,8 +121,6 @@ describe("useDeckImport", () => {
 
     await actAsync(async () => result.current.importPreview());
 
-    expect(mocks.fetchDecks).not.toHaveBeenCalled();
-    expect(mocks.fetchCards).not.toHaveBeenCalled();
     expect(mocks.createDeck).toHaveBeenCalledExactlyOnceWith({
       id: "deck",
       name: "local.csv",
@@ -151,7 +141,7 @@ describe("useDeckImport", () => {
     ]);
   });
 
-  it("plans a local re-import from local state", async () => {
+  it("creates a new local Deck instead of updating a same-name Deck", async () => {
     const deck = createLocalDeck({ id: "local-deck", name: "local.csv" });
     const card = createLocalCard({
       id: "local-card",
@@ -170,57 +160,10 @@ describe("useDeckImport", () => {
     );
     await actAsync(async () => result.current.importPreview());
 
-    expect(mocks.createDeck).not.toHaveBeenCalled();
-    expect(mocks.fetchDecks).not.toHaveBeenCalled();
-    expect(mocks.fetchCards).not.toHaveBeenCalled();
+    expect(mocks.createDeck).toHaveBeenCalledExactlyOnceWith({ id: "deck", name: "local.csv", localMode: true });
     expect(mocks.bulkUpsert).toHaveBeenCalledExactlyOnceWith([
-      { kind: "edit", card: expect.objectContaining({ id: card.id, backText: "new back" }) },
+      { kind: "create", card: expect.objectContaining({ id: "card", backText: "new back" }) },
     ]);
-  });
-
-  it("does not mutate when server-backed preview reads fail", async () => {
-    mocks.fetchDecks.mockRejectedValueOnce(new Error("server read failed"));
-    const { result } = renderHook(useDeckImport);
-    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
-
-    await actAsync(async () => {
-      await expect(result.current.selectFile(file)).rejects.toThrow("server read failed");
-    });
-
-    expect(result.current.preview).toBeUndefined();
-    expect(result.current.previewError).toEqual(new Error("server read failed"));
-    expect(result.current.error).toBeNull();
-    expect(mocks.createDeck).not.toHaveBeenCalled();
-    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
-  });
-
-  it("previews and executes the same server-backed plan when local state is stale", async () => {
-    const serverDeck = createDeck({ id: "server-deck", name: "deck.csv", uid: "uid-a" });
-    const serverCard = createCard({
-      id: "server-card",
-      deckId: serverDeck.id,
-      uid: "uid-a",
-      frontText: "front",
-      backText: "old back",
-      tags: [],
-      uniqueKey: "key",
-    });
-    mocks.fetchDecks.mockResolvedValueOnce([serverDeck]);
-    mocks.fetchCards.mockResolvedValueOnce([serverCard]);
-    const { result } = renderHook(useDeckImport);
-    const file = new File(['"front","new back","","key"'], "deck.csv", { type: "text/csv" });
-
-    await actAsync(async () => result.current.selectFile(file));
-    expect(result.current.preview?.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-
-    await actAsync(async () => result.current.importPreview());
-
-    expect(mocks.createDeck).not.toHaveBeenCalled();
-    expect(mocks.bulkUpsert).toHaveBeenCalledWith([
-      { kind: "edit", card: expect.objectContaining({ id: "server-card", backText: "new back" }) },
-    ]);
-    expect(mocks.fetchDecks).toHaveBeenCalledOnce();
-    expect(mocks.fetchCards).toHaveBeenCalledOnce();
   });
 
   it("keeps invalid files in preview without mutating state", async () => {
@@ -243,7 +186,7 @@ describe("useDeckImport", () => {
     expect(mocks.bulkUpsert).not.toHaveBeenCalled();
   });
 
-  it("skips an identical CSV re-import by uniqueKey", async () => {
+  it("creates a new Deck for an identical same-name CSV import", async () => {
     mocks.decks = [createDeck({ id: "deck", name: "deck.csv", uid: "uid-a" })];
     mocks.cards = [
       createCard({
@@ -255,8 +198,6 @@ describe("useDeckImport", () => {
         uniqueKey: "key",
       }),
     ];
-    mocks.fetchDecks.mockResolvedValueOnce(mocks.decks);
-    mocks.fetchCards.mockResolvedValueOnce(mocks.cards);
     const { result } = renderHook(useDeckImport);
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
     let imported: DeckImportResult | undefined;
@@ -268,10 +209,10 @@ describe("useDeckImport", () => {
       imported = await result.current.importPreview();
     });
 
-    expect(result.current.preview?.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
-    expect(mocks.createDeck).not.toHaveBeenCalled();
-    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
-    expect(imported).toEqual({ created: 0, updated: 0, skipped: 1, deckId: "deck" });
+    expect(result.current.preview?.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
+    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.bulkUpsert).toHaveBeenCalledOnce();
+    expect(imported).toEqual({ created: 1, updated: 0, skipped: 0, deckId: "deck" });
   });
 
   it("adds the bundled sample with a stable per-user Deck id", async () => {
@@ -339,8 +280,6 @@ describe("useDeckImport", () => {
   });
 
   it("requires a new preview before retrying a failed import", async () => {
-    const createdDeck = createDeck({ id: "deck", name: "deck.csv", uid: "uid-a" });
-    mocks.fetchDecks.mockResolvedValueOnce([]).mockResolvedValueOnce([createdDeck]);
     mocks.bulkUpsert.mockRejectedValueOnce(new Error("card mutation failed")).mockResolvedValueOnce(undefined);
     const { result } = renderHook(useDeckImport);
     const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
@@ -359,7 +298,7 @@ describe("useDeckImport", () => {
     await actAsync(async () => result.current.selectFile(file));
     await actAsync(async () => result.current.importPreview());
 
-    expect(mocks.createDeck).toHaveBeenCalledOnce();
+    expect(mocks.createDeck).toHaveBeenCalledTimes(2);
     expect(mocks.bulkUpsert).toHaveBeenCalledTimes(2);
   });
 
@@ -403,31 +342,6 @@ describe("useDeckImport", () => {
     expect(result.current.result).toBeUndefined();
     expect(result.current.error).toBeNull();
     expect(result.current.pending).toBe(false);
-  });
-
-  it("does not write when the UID changes during server-backed preparation", async () => {
-    let finishServerRead!: (decks: Deck[]) => void;
-    mocks.fetchDecks.mockReturnValueOnce(
-      new Promise<Deck[]>((resolve) => {
-        finishServerRead = resolve;
-      })
-    );
-    const { result, rerender } = renderHook(useDeckImport);
-    const file = new File(['"front","back","","key"'], "deck.csv", { type: "text/csv" });
-
-    const operation = result.current.selectFile(file);
-    await waitFor(() => expect(mocks.fetchDecks).toHaveBeenCalledWith("uid-a"));
-
-    mocks.uid = "uid-b";
-    rerender();
-    finishServerRead([]);
-
-    await expect(operation).rejects.toThrow("user changed");
-    expect(mocks.createDeck).not.toHaveBeenCalled();
-    expect(mocks.bulkUpsert).not.toHaveBeenCalled();
-    expect(result.current.pending).toBe(false);
-    expect(result.current.error).toBeNull();
-    expect(result.current.result).toBeUndefined();
   });
 
   it("does not publish or import a file preview after an A-to-B-to-A UID transition", async () => {

--- a/src/features/deck-import/hooks/useDeckImport.ts
+++ b/src/features/deck-import/hooks/useDeckImport.ts
@@ -1,11 +1,8 @@
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
-
 import { useEffect, useRef, useState } from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { fetchCards, generateCardId, mutateCards, useCards } from "@/entities/card";
-import { createDeck, fetchDecks, useDecks } from "@/entities/deck";
+import { generateCardId, mutateCards, useCards } from "@/entities/card";
+import { createDeck, useDecks } from "@/entities/deck";
 import { type DeckImportAnalysis, parseCsv } from "../lib/cardCsv";
 import type { DeckImportResult, DeckImportStorageMode } from "../model/deckImportExecution";
 import { executePreparedDeckImport, prepareDeckImport } from "../model/deckImportExecution";
@@ -130,15 +127,9 @@ export const useDeckImport = () => {
       const analysis = await parseCsv(await file.text());
       assertCurrent(generation);
 
-      // Listener-backed stores can lag, so remote file imports are planned from authoritative server reads.
-      const [activeDecks, activeCards]: [Deck[], Card[]] =
-        storageMode === "remote" ? await Promise.all([fetchDecks(uid), fetchCards(uid)]) : [decks, cards];
-
-      assertCurrent(generation);
-
       const attempt = prepareDeckImport(
         { name: file.name, rows: analysis.rows, storageMode },
-        { uid, decks: activeDecks, cards: activeCards, generateCardId }
+        { uid, decks: [], cards: [], generateCardId }
       );
       const preview = {
         deckName: file.name,

--- a/src/features/deck-import/model/deckImportExecution.spec.ts
+++ b/src/features/deck-import/model/deckImportExecution.spec.ts
@@ -24,7 +24,7 @@ describe("prepareDeckImport", () => {
     ]);
   });
 
-  it("prepares an update from the Card with the same unique key", () => {
+  it("creates a new Deck when an existing Deck has the same name", () => {
     const deck = createDeck({ id: "deck", name: "deck.csv", uid: "uid" });
     const existing = createCard({
       id: "existing",
@@ -35,25 +35,29 @@ describe("prepareDeckImport", () => {
     });
     const attempt = prepareDeckImport(
       { name: deck.name, rows },
-      { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn() }
+      { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn(() => "new-card") }
     );
 
-    expect(attempt.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
+    expect(attempt.deck.id).not.toBe(deck.id);
+    expect(attempt.createDeck).toBe(true);
+    expect(attempt.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
     expect(attempt.mutations).toEqual([
-      { kind: "edit", card: expect.objectContaining({ id: existing.id, frontText: "front" }) },
+      { kind: "create", card: expect.objectContaining({ id: "new-card", frontText: "front" }) },
     ]);
   });
 
-  it("skips a Card with identical editable content", () => {
+  it("does not inspect Cards from a same-name Deck", () => {
     const deck = createDeck({ id: "deck", name: "deck.csv", uid: "uid" });
     const existing = createCard({ ...row.card, deckId: deck.id, uid: deck.uid });
     const attempt = prepareDeckImport(
       { name: deck.name, rows },
-      { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn() }
+      { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn(() => "new-card") }
     );
 
-    expect(attempt.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
-    expect(attempt.mutations).toEqual([]);
+    expect(attempt.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
+    expect(attempt.mutations).toEqual([
+      { kind: "create", card: expect.objectContaining({ id: "new-card", uniqueKey: "key-1" }) },
+    ]);
   });
 
   it("prepares local Deck and Card creation without an account owner", () => {
@@ -75,7 +79,7 @@ describe("prepareDeckImport", () => {
     ]);
   });
 
-  it("plans a local re-import from only the matching local Deck", () => {
+  it("creates a new local Deck when local and remote Decks have the same name", () => {
     const remoteDeck = createDeck({ id: "remote", name: "shared.csv", uid: "uid" });
     const localDeck = createLocalDeck({ id: "local", name: "shared.csv" });
     const remoteCard = createCard({ ...row.card, id: "remote-card", deckId: remoteDeck.id, uid: remoteDeck.uid });
@@ -91,14 +95,15 @@ describe("prepareDeckImport", () => {
         uid: "uid",
         decks: [remoteDeck, localDeck],
         cards: [remoteCard, localCard],
-        generateCardId: vi.fn(),
+        generateCardId: vi.fn(() => "new-card"),
       }
     );
 
-    expect(attempt.deck.id).toBe(localDeck.id);
-    expect(attempt.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
+    expect(attempt.deck.id).not.toBe(localDeck.id);
+    expect(attempt.createDeck).toBe(true);
+    expect(attempt.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
     expect(attempt.mutations).toEqual([
-      { kind: "edit", card: expect.objectContaining({ id: localCard.id, frontText: "front" }) },
+      { kind: "create", card: expect.objectContaining({ id: "new-card", frontText: "front" }) },
     ]);
   });
 });

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -48,7 +48,8 @@ const isRemoteCard = (card: Card): card is RemoteCard => "uid" in card;
 
 const matchesImportDestination = (candidate: Deck, request: DeckImportRequest, localMode: boolean): boolean =>
   candidate.localMode === localMode &&
-  (request.preferredDeckId === undefined ? candidate.name === request.name : candidate.id === request.preferredDeckId);
+  request.preferredDeckId !== undefined &&
+  candidate.id === request.preferredDeckId;
 
 const createImportDeck = (request: DeckImportRequest, uid: string, localMode: boolean): DeckImportCreateInput => {
   const id = request.preferredDeckId ?? generateDeckId();


### PR DESCRIPTION
## Summary

- create a new deck for every CSV import, even when a deck has the same name
- remove server reads used only to find same-name import destinations
- preserve fixed-ID reuse for the bundled sample deck

## Testing

- `mise run check`