### PR TITLE
[No issue] Fix study sessions on non-secure origins

### DIFF
--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -43,6 +43,7 @@ describe("study store", () => {
   afterEach(() => {
     vi.useRealTimers();
     clearStudySessions();
+    vi.unstubAllGlobals();
   });
 
   it("starts at index zero with the configured card order", () => {
@@ -52,6 +53,16 @@ describe("study store", () => {
       cardOrderIds: ["card-1", "card-2"],
       currentIndex: 0,
     });
+  });
+
+  it("starts a session when randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: () => new Uint32Array([1, 2, 3, 4]),
+    });
+
+    startSession("deck-1", ["card-1"]);
+
+    expect(getStudySession("deck-1")?.sessionId).toBe("1-2-3-4");
   });
 
   it("keeps independent study sessions for multiple decks", () => {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -17,6 +17,10 @@ const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
 const STUDY_STORAGE_VERSION = 4;
 
+// Keep session replacement detection available on non-secure origins where randomUUID is not exposed.
+const createStudySessionId = (): string =>
+  typeof crypto.randomUUID === "function" ? crypto.randomUUID() : crypto.getRandomValues(new Uint32Array(4)).join("-");
+
 interface StudySessionState {
   sessionsByDeckId: StudySessions;
 }
@@ -85,7 +89,7 @@ const startStudySession = (deckId: DeckId, cardOrderIds: CardId[]): void => {
   studySessionStore.setState((state) => {
     state.sessionsByDeckId[deckId] = {
       // A fresh identity distinguishes a restarted deck even when it begins on the same card and index.
-      sessionId: crypto.randomUUID(),
+      sessionId: createStudySessionId(),
       deckId,
       // The store owns this ordering snapshot even if the caller later reuses its array.
       cardOrderIds: [...cardOrderIds],

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -56,6 +56,7 @@ const persistedStudy = {
   state: {
     sessionsByDeckId: {
       [e2eDeck.id]: {
+        sessionId: "swipe-e2e-session",
         deckId: e2eDeck.id,
         cardOrderIds: e2eCards.map((card) => card.id),
         currentIndex: 0,
@@ -63,7 +64,7 @@ const persistedStudy = {
       },
     },
   },
-  version: 3,
+  version: 4,
 };
 
 const seedSwipeSession = async (page: Page) => {
@@ -148,7 +149,7 @@ test("updates study progress with a mastered deck swipe", async ({ page }) => {
           },
         },
       },
-      version: 3,
+      version: 4,
     });
   await expect
     .poll(async () => persistedStateBoundaries(page))


### PR DESCRIPTION
## Summary

- update the persisted study-session E2E fixture to storage version 4
- add the required immutable session identity
- assert the current persisted version after a swipe
- generate a Web Crypto fallback session identity when `randomUUID` is unavailable
- cover session startup on non-secure origins with a unit test

## Root cause

The study-session store moved to version 4 and now rejects sessions without a `sessionId`. The swipe E2E fixture still used version 3 without that field, so hydration discarded the session and redirected the study page back to the deck list.

After correcting the fixture, Actions traces showed that new sessions still failed to start because `crypto.randomUUID()` is unavailable on the E2E app's non-secure `http://app.test` origin. The store now falls back to 128 bits generated by `crypto.getRandomValues()` while retaining `randomUUID()` where supported.

## Impact

The E2E fixture now matches the production persistence schema, and study sessions can start on supported non-secure development and test origins without weakening replacement detection.

## Validation

- targeted `test/e2e/swipe.spec.ts`: 2 passed
- previously failing `deck-import-local.spec.ts` flow: passed
- previously failing `deck-list.spec.ts` study flow: passed
- `mise run check`: passed (101 files, 542 tests)
