### PR TITLE
[No issue] Remove useStudy invalid callback

### DIFF
--- a/src/features/study/hooks/useStudy.spec.tsx
+++ b/src/features/study/hooks/useStudy.spec.tsx
@@ -17,7 +17,6 @@ import { createPreferences } from "@/test/factories";
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
   editStudyProgress: vi.fn(),
-  onInvalid: vi.fn(),
   touchStudySession: vi.fn(),
 }));
 
@@ -85,7 +84,7 @@ describe("useStudy", () => {
   });
 
   it("coordinates display state, persistence, and session progression", async () => {
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
     expect(result.current).toMatchObject({
       status: "studying",
       session: { deckId, cardOrderIds: ["card-1", "card-2"], currentIndex: 0 },
@@ -106,32 +105,31 @@ describe("useStudy", () => {
   });
 
   it("reports preparing while the session card is not available", () => {
-    const { result } = renderHook(() => useStudy(deckId, [], mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, []));
     expect(result.current.status).toBe("preparing");
-    expect(mocks.onInvalid).not.toHaveBeenCalled();
   });
 
   it("advances the session while autoplay is enabled", () => {
     vi.useFakeTimers();
     mocks.preferences = createPreferences({ cardInterval: 1, defaultAutoPlay: true });
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     act(() => vi.advanceTimersByTime(1000));
 
     expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } });
   });
 
-  it("reports and handles an invalid session", async () => {
+  it("reports an invalid session and removes it", async () => {
     clearStudySessions();
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     expect(result.current.status).toBe("invalid");
-    await waitFor(() => expect(mocks.onInvalid).toHaveBeenCalledOnce());
+    await waitFor(() => expect(getStudySession(deckId)).toBeUndefined());
   });
 
   it("keeps the visible session unchanged when persistence fails", async () => {
     mocks.editStudyProgress.mockRejectedValueOnce(new Error("write failed"));
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     await actAsync(() => result.current.swipeRight());
 
@@ -146,7 +144,7 @@ describe("useStudy", () => {
         finishWrite = resolve;
       })
     );
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     const firstSwipe = result.current.swipeRight();
     await actAsync(() => result.current.swipeRight());
@@ -165,7 +163,7 @@ describe("useStudy", () => {
         finishWrite = resolve;
       })
     );
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     const swipe = result.current.swipeRight();
     setStudySessionIndex(deckId, 1);
@@ -186,7 +184,7 @@ describe("useStudy", () => {
         finishWrite = resolve;
       })
     );
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     const swipe = result.current.swipeRight();
     vi.mocked(Date.now).mockReturnValue(946_684_800_100);
@@ -202,7 +200,7 @@ describe("useStudy", () => {
 
   it("handles DoNothing and GoBack without writing progress", async () => {
     mocks.preferences = createPreferences({ cardSwipeDown: "DoNothing", cardSwipeLeft: "GoBack" });
-    const { result } = renderHook(() => useStudy(deckId, cards, mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards));
 
     await actAsync(() => result.current.swipeDown());
     expect(getStudySession(deckId)).toBeDefined();
@@ -215,7 +213,7 @@ describe("useStudy", () => {
   it("removes the session after the final card is persisted", async () => {
     clearStudySessions();
     startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 });
-    const { result } = renderHook(() => useStudy(deckId, cards.slice(0, 1), mocks.onInvalid));
+    const { result } = renderHook(() => useStudy(deckId, cards.slice(0, 1)));
 
     await actAsync(() => result.current.swipeRight());
 

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -41,7 +41,7 @@ export type StudyState = StudyCommands &
       }
   );
 
-export const useStudy = (deckId: DeckId, cards: readonly Card[], onInvalid: () => void): StudyState => {
+export const useStudy = (deckId: DeckId, cards: readonly Card[]): StudyState => {
   const preferences = usePreferences();
   const [showBackText, setShowBackText] = React.useState(false);
   const [autoPlay, setAutoPlay] = React.useState(preferences.study.defaultAutoPlay);
@@ -72,8 +72,7 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[], onInvalid: () =
     // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
     exitingDeck.current = deckId;
     removeStudySession(deckId);
-    onInvalid();
-  }, [deckId, onInvalid, resolvedSession.status]);
+  }, [deckId, resolvedSession.status]);
 
   React.useEffect(() => {
     const nextIndex = session == null ? undefined : calculateStudySessionIndex(session, "next");

--- a/src/features/study/hooks/useStudy.ts
+++ b/src/features/study/hooks/useStudy.ts
@@ -55,7 +55,6 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[]): StudyState => 
   };
   const session = useStudySession(deckId);
   const resolvedSession = resolveStudySession(session, cards);
-  const exitingDeck = React.useRef<DeckId>(undefined);
 
   React.useEffect(() => {
     if (resolvedSession.status !== "studying") return;
@@ -63,14 +62,9 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[]): StudyState => 
   }, [deckId, resolvedSession.status]);
 
   React.useEffect(() => {
-    if (resolvedSession.status === "studying") {
-      exitingDeck.current = undefined;
-      return;
-    }
-    if (resolvedSession.status === "preparing" || exitingDeck.current === deckId) return;
+    if (resolvedSession.status !== "invalid") return;
 
     // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
-    exitingDeck.current = deckId;
     removeStudySession(deckId);
   }, [deckId, resolvedSession.status]);
 

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { StudyState } from "@/features/study";
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,9 +10,8 @@ const mocks = vi.hoisted(() => ({
   params: { id: "deck-id" as string | undefined },
   deck: undefined as Deck | undefined,
   cards: [] as Card[],
-  navigate: vi.fn(),
   studyState: undefined as StudyState | undefined,
-  studyArgs: undefined as { cards: readonly Card[]; deckId: string; onInvalid: () => void } | undefined,
+  studyArgs: undefined as { cards: readonly Card[]; deckId: string } | undefined,
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -22,15 +21,15 @@ vi.mock("@/entities/deck", async (importOriginal) => {
 });
 vi.mock("@/entities/card", () => ({ useCards: () => mocks.cards }));
 vi.mock("react-router-dom", () => ({
-  useNavigate: () => mocks.navigate,
+  useNavigate: () => vi.fn(),
   useParams: () => mocks.params,
 }));
 vi.mock("@/features/study", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/study")>();
   return {
     ...actual,
-    useStudy: (deckId: string, cards: readonly Card[], onInvalid: () => void) => {
-      mocks.studyArgs = { deckId, cards, onInvalid };
+    useStudy: (deckId: string, cards: readonly Card[]) => {
+      mocks.studyArgs = { deckId, cards };
       if (mocks.studyState == null) throw new Error("Study state not initialized");
       return mocks.studyState;
     },
@@ -128,12 +127,6 @@ describe("DeckStudyPage", () => {
     mocks.studyState = { status, ...commands() };
     render(<DeckStudyPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
-  });
-
-  it("converts invalid session intent into current route navigation", () => {
-    render(<DeckStudyPage />);
-    act(() => mocks.studyArgs?.onInvalid());
-    expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
   });
 
   it("delegates a representative Study shortcut to the workflow action", () => {

--- a/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { StudyState } from "@/features/study";
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   params: { id: "deck-id" as string | undefined },
   deck: undefined as Deck | undefined,
   cards: [] as Card[],
+  navigate: vi.fn(),
   studyState: undefined as StudyState | undefined,
   studyArgs: undefined as { cards: readonly Card[]; deckId: string } | undefined,
 }));
@@ -21,7 +22,7 @@ vi.mock("@/entities/deck", async (importOriginal) => {
 });
 vi.mock("@/entities/card", () => ({ useCards: () => mocks.cards }));
 vi.mock("react-router-dom", () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mocks.navigate,
   useParams: () => mocks.params,
 }));
 vi.mock("@/features/study", async (importOriginal) => {
@@ -127,6 +128,13 @@ describe("DeckStudyPage", () => {
     mocks.studyState = { status, ...commands() };
     render(<DeckStudyPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
+  });
+
+  it("returns to the deck list when the study session is invalid", async () => {
+    mocks.studyState = { status: "invalid", ...commands() };
+    render(<DeckStudyPage />);
+
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true }));
   });
 
   it("delegates a representative Study shortcut to the workflow action", () => {

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -8,7 +8,6 @@ import { useKey } from "react-use";
 import { type Card, useCards } from "@/entities/card";
 import { CardOverlay, CardView, FrontText } from "@/features/card-view";
 import { DeckSwiperView, type StudyState, useStudy } from "@/features/study";
-import { routes, useNavigation } from "@/shared/routes";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -78,11 +77,7 @@ const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => 
 };
 
 const DeckStudyContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
-  const navigation = useNavigation();
-  const handleInvalidSession = () => {
-    void navigation.to(routes.deckList.to(), { replace: true });
-  };
-  const study = useStudy(deck.id, cards, handleInvalidSession);
+  const study = useStudy(deck.id, cards);
 
   return <DeckStudyScreen deck={deck} state={study} />;
 };

--- a/src/pages/deck-study/ui/DeckStudyPage.tsx
+++ b/src/pages/deck-study/ui/DeckStudyPage.tsx
@@ -1,13 +1,14 @@
 import { getCategory, type Deck, useDeck } from "@/entities/deck";
 import { toggleShowHeader, toggleShowSwipeButtonList } from "@/entities/preferences";
 
-import type * as React from "react";
+import * as React from "react";
 import { useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
 import { type Card, useCards } from "@/entities/card";
 import { CardOverlay, CardView, FrontText } from "@/features/card-view";
 import { DeckSwiperView, type StudyState, useStudy } from "@/features/study";
+import { routes, useNavigation } from "@/shared/routes";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
@@ -77,7 +78,13 @@ const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => 
 };
 
 const DeckStudyContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
+  const navigation = useNavigation();
   const study = useStudy(deck.id, cards);
+
+  React.useEffect(() => {
+    if (study.status !== "invalid") return;
+    void navigation.to(routes.deckList.to(), { replace: true });
+  }, [navigation, study.status]);
 
   return <DeckStudyScreen deck={deck} state={study} />;
 };


### PR DESCRIPTION
## Related issue

None.

## Summary

- remove the `onInvalid` callback parameter from `useStudy`
- keep invalid session cleanup inside the study hook
- remove the page-level redirect and update behavior-focused tests

## Testing

- `mise run check`