### PR TITLE
[No issue] Rename study session start page

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -29,9 +29,9 @@ vi.mock("@/pages/card-view", () => ({ CardViewPage: () => null }));
 vi.mock("@/pages/deck-form", () => ({ DeckFormPage: () => null }));
 vi.mock("@/pages/deck-import", () => ({ DeckImportPage: () => null }));
 vi.mock("@/pages/deck-list", () => ({ DeckListPage: () => <div>Deck list</div> }));
-vi.mock("@/pages/deck-study-start", () => ({ DeckStudyStartPage: () => null }));
 vi.mock("@/pages/deck-study", () => ({ DeckStudyPage: () => null }));
 vi.mock("@/pages/settings", () => ({ SettingsPage: () => null }));
+vi.mock("@/pages/study-session-start", () => ({ StudySessionStartPage: () => null }));
 
 import App from "./App";
 

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -15,9 +15,9 @@ import { CardViewPage } from "@/pages/card-view";
 import { DeckFormPage } from "@/pages/deck-form";
 import { DeckImportPage } from "@/pages/deck-import";
 import { DeckListPage } from "@/pages/deck-list";
-import { DeckStudyStartPage } from "@/pages/deck-study-start";
 import { DeckStudyPage } from "@/pages/deck-study";
 import { SettingsPage } from "@/pages/settings";
+import { StudySessionStartPage } from "@/pages/study-session-start";
 import { routes, useNavigation } from "@/shared/routes";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 
@@ -51,7 +51,7 @@ export const AppRoutes: React.FC = () => (
     <Route path={routes.deckList.path} element={<DeckListPage />} />
     <Route path={routes.cardList.path} element={<CardListPage />} />
     <Route path={routes.deckForm.path} element={<DeckFormPage />} />
-    <Route path={routes.deckStudyStart.path} element={<DeckStudyStartPage />} />
+    <Route path={routes.deckStudyStart.path} element={<StudySessionStartPage />} />
     <Route path={routes.deckStudy.path} element={<DeckStudyPage />} />
     <Route path={routes.cardView.path} element={<CardViewPage />} />
     <Route path={routes.cardForm.path} element={<CardFormPage />} />

--- a/src/pages/deck-study-start/index.ts
+++ b/src/pages/deck-study-start/index.ts
@@ -1,1 +1,0 @@
-export { DeckStudyStartPage } from "./ui/DeckStudyStartPage";

--- a/src/pages/study-session-start/index.ts
+++ b/src/pages/study-session-start/index.ts
@@ -1,0 +1,1 @@
+export { StudySessionStartPage } from "./ui/StudySessionStartPage";

--- a/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
@@ -54,9 +54,9 @@ vi.mock("react-router-dom", () => ({
   useParams: () => mocks.params,
 }));
 
-import { DeckStudyStartPage } from "./DeckStudyStartPage";
+import { StudySessionStartPage } from "./StudySessionStartPage";
 
-describe("DeckStudyStartPage", () => {
+describe("StudySessionStartPage", () => {
   beforeEach(() => {
     mocks.params.id = "deck-id";
     mocks.preferences = createPreferences({ appearance: { darkMode: false }, study: { maxNumberOfCardsToLearn: 1 } });
@@ -66,7 +66,7 @@ describe("DeckStudyStartPage", () => {
   });
 
   it("composes route data, the application shell, and the study view", () => {
-    render(<DeckStudyStartPage />);
+    render(<StudySessionStartPage />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Start 1 card" })).toBeVisible();
@@ -74,7 +74,7 @@ describe("DeckStudyStartPage", () => {
   });
 
   it("starts from Enter only outside interactive controls", () => {
-    render(<DeckStudyStartPage />);
+    render(<StudySessionStartPage />);
 
     fireEvent.keyDown(document.body, { key: "Enter" });
     expect(mocks.start).toHaveBeenCalledOnce();
@@ -86,7 +86,7 @@ describe("DeckStudyStartPage", () => {
 
   it("owns navigation after the study session starts", () => {
     mocks.start.mockImplementationOnce(() => expect(mocks.navigate).not.toHaveBeenCalled());
-    render(<DeckStudyStartPage />);
+    render(<StudySessionStartPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "Start 1 card" }));
 
@@ -96,7 +96,7 @@ describe("DeckStudyStartPage", () => {
 
   it("does not start when no cards match", () => {
     mocks.cards = [];
-    render(<DeckStudyStartPage />);
+    render(<StudySessionStartPage />);
 
     fireEvent.keyDown(document.body, { key: "Enter" });
     expect(mocks.start).not.toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe("DeckStudyStartPage", () => {
 
   it("renders missing-deck recovery outside the application shell", () => {
     mocks.deck = null;
-    render(<DeckStudyStartPage />);
+    render(<StudySessionStartPage />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Deck not found" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
@@ -113,6 +113,6 @@ describe("DeckStudyStartPage", () => {
 
   it("rejects a route without a deck id", () => {
     mocks.params.id = undefined;
-    expect(() => render(<DeckStudyStartPage />)).toThrowError("invalid deck id");
+    expect(() => render(<StudySessionStartPage />)).toThrowError("invalid deck id");
   });
 });

--- a/src/pages/study-session-start/ui/StudySessionStartPage.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.tsx
@@ -22,7 +22,7 @@ import { AppLayout } from "@/widgets/app-layout";
 const hasInteractiveShortcutTarget = (target: EventTarget | null): boolean =>
   target instanceof Element && target.closest("a[href], button, input, select, textarea") != null;
 
-const DeckStudyStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
+const StudySessionStartContent = (props: { deck: Deck; cards: Card[]; preferences: Preferences; tags: string[] }) => {
   const { deck, cards, preferences, tags } = props;
   const navigation = useNavigation();
   const deckFilter = useDeckFilterState(deck);
@@ -49,7 +49,7 @@ const DeckStudyStartContent = (props: { deck: Deck; cards: Card[]; preferences: 
   );
 };
 
-export const DeckStudyStartPage: React.FC = () => {
+export const StudySessionStartPage: React.FC = () => {
   const params = useParams();
   const navigation = useNavigation();
   const deckId = params.id;
@@ -71,5 +71,5 @@ export const DeckStudyStartPage: React.FC = () => {
     );
   }
 
-  return <DeckStudyStartContent deck={deck} cards={cards} preferences={preferences} tags={tags} />;
+  return <StudySessionStartContent deck={deck} cards={cards} preferences={preferences} tags={tags} />;
 };


### PR DESCRIPTION
## Related issue

None.

## Summary

- Rename the `pages/deck-study-start` slice to `pages/study-session-start`.
- Rename the page component and update route and test imports.

## Testing

- `mise run check`