### PR TITLE
[No issue] Rename study session page

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -29,8 +29,8 @@ vi.mock("@/pages/card-view", () => ({ CardViewPage: () => null }));
 vi.mock("@/pages/deck-form", () => ({ DeckFormPage: () => null }));
 vi.mock("@/pages/deck-import", () => ({ DeckImportPage: () => null }));
 vi.mock("@/pages/deck-list", () => ({ DeckListPage: () => <div>Deck list</div> }));
-vi.mock("@/pages/deck-study", () => ({ DeckStudyPage: () => null }));
 vi.mock("@/pages/settings", () => ({ SettingsPage: () => null }));
+vi.mock("@/pages/study-session", () => ({ StudySessionPage: () => null }));
 vi.mock("@/pages/study-session-start", () => ({ StudySessionStartPage: () => null }));
 
 import App from "./App";

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -15,8 +15,8 @@ import { CardViewPage } from "@/pages/card-view";
 import { DeckFormPage } from "@/pages/deck-form";
 import { DeckImportPage } from "@/pages/deck-import";
 import { DeckListPage } from "@/pages/deck-list";
-import { DeckStudyPage } from "@/pages/deck-study";
 import { SettingsPage } from "@/pages/settings";
+import { StudySessionPage } from "@/pages/study-session";
 import { StudySessionStartPage } from "@/pages/study-session-start";
 import { routes, useNavigation } from "@/shared/routes";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
@@ -52,7 +52,7 @@ export const AppRoutes: React.FC = () => (
     <Route path={routes.cardList.path} element={<CardListPage />} />
     <Route path={routes.deckForm.path} element={<DeckFormPage />} />
     <Route path={routes.deckStudyStart.path} element={<StudySessionStartPage />} />
-    <Route path={routes.deckStudy.path} element={<DeckStudyPage />} />
+    <Route path={routes.deckStudy.path} element={<StudySessionPage />} />
     <Route path={routes.cardView.path} element={<CardViewPage />} />
     <Route path={routes.cardForm.path} element={<CardFormPage />} />
     <Route path={routes.settings.path} element={<SettingsPage login={login} logout={signOutCurrentUser} />} />

--- a/src/pages/deck-study/index.ts
+++ b/src/pages/deck-study/index.ts
@@ -1,1 +1,0 @@
-export { DeckStudyPage } from "./ui/DeckStudyPage";

--- a/src/pages/study-session/index.ts
+++ b/src/pages/study-session/index.ts
@@ -1,0 +1,1 @@
+export { StudySessionPage } from "./ui/StudySessionPage";

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -37,7 +37,7 @@ vi.mock("@/features/study", async (importOriginal) => {
   };
 });
 
-import { DeckStudyPage } from "./DeckStudyPage";
+import { StudySessionPage } from "./StudySessionPage";
 
 const deck: Deck = {
   id: "deck-id",
@@ -96,7 +96,7 @@ const studyingState = (): StudyState => ({
   updateIndex: noop,
 });
 
-describe("DeckStudyPage", () => {
+describe("StudySessionPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.params.id = deck.id;
@@ -109,11 +109,11 @@ describe("DeckStudyPage", () => {
 
   it("validates the route parameter", () => {
     mocks.params.id = undefined;
-    expect(() => render(<DeckStudyPage />)).toThrow("invalid deck id");
+    expect(() => render(<StudySessionPage />)).toThrow("invalid deck id");
   });
 
   it("passes Entity reads to useStudy and composes the application shell", () => {
-    render(<DeckStudyPage />);
+    render(<StudySessionPage />);
 
     expect(mocks.studyArgs).toMatchObject({ deckId: deck.id, cards: [card] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
@@ -126,18 +126,18 @@ describe("DeckStudyPage", () => {
     ["invalid", "Study session unavailable."],
   ] as const)("renders route feedback for %s workflow state", (status, title) => {
     mocks.studyState = { status, ...commands() };
-    render(<DeckStudyPage />);
+    render(<StudySessionPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
   });
 
   it("converts invalid session intent into current route navigation", () => {
-    render(<DeckStudyPage />);
+    render(<StudySessionPage />);
     act(() => mocks.studyArgs?.onInvalid());
     expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true });
   });
 
   it("delegates a representative Study shortcut to the workflow action", () => {
-    render(<DeckStudyPage />);
+    render(<StudySessionPage />);
     const state = mocks.studyState;
     if (state?.status !== "studying") throw new Error("expected studying workflow state");
 
@@ -148,7 +148,7 @@ describe("DeckStudyPage", () => {
 
   it("shows route feedback when the Deck Entity is unavailable", () => {
     mocks.deck = undefined;
-    render(<DeckStudyPage />);
+    render(<StudySessionPage />);
     expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
   });
 });

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -64,7 +64,7 @@ const renderStudyScreen = (deck: Deck, state: StudyState) => {
   );
 };
 
-const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => {
+const StudySessionScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => {
   useKey("ArrowUp", () => void state.swipeUp());
   useKey("ArrowDown", () => void state.swipeDown());
   useKey("ArrowLeft", () => void state.swipeLeft());
@@ -77,17 +77,17 @@ const DeckStudyScreen = ({ deck, state }: { deck: Deck; state: StudyState }) => 
   return renderStudyScreen(deck, state);
 };
 
-const DeckStudyContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
+const StudySessionContent = ({ cards, deck }: { cards: Card[]; deck: Deck }) => {
   const navigation = useNavigation();
   const handleInvalidSession = () => {
     void navigation.to(routes.deckList.to(), { replace: true });
   };
   const study = useStudy(deck.id, cards, handleInvalidSession);
 
-  return <DeckStudyScreen deck={deck} state={study} />;
+  return <StudySessionScreen deck={deck} state={study} />;
 };
 
-export const DeckStudyPage: React.FC = () => {
+export const StudySessionPage: React.FC = () => {
   const params = useParams();
   const deckId = params.id;
   if (deckId == null) throw new Error("invalid deck id");
@@ -99,5 +99,5 @@ export const DeckStudyPage: React.FC = () => {
     return <RouteFeedback title="Study session unavailable." tone="not-found" />;
   }
 
-  return <DeckStudyContent key={deck.id} cards={cards} deck={deck} />;
+  return <StudySessionContent key={deck.id} cards={cards} deck={deck} />;
 };


### PR DESCRIPTION
## Related issue

None.

## Summary

- Rename the `pages/deck-study` slice to `pages/study-session`.
- Rename the page components and update route and test imports.
- Keep the existing study URL and route key unchanged.

## Testing

- `mise run check`