### PR TITLE
[No issue] Remove CardListComposition

### DIFF
--- a/src/features/card-list/model/useCardListState.ts
+++ b/src/features/card-list/model/useCardListState.ts
@@ -22,7 +22,7 @@ interface CardListAnswer {
 
 interface UseCardListStateOptions {
   cards: Card[];
-  deck: Deck;
+  deck: Deck | undefined;
   dark: boolean;
 }
 
@@ -84,7 +84,7 @@ export const useCardListState = ({ cards, deck, dark }: UseCardListStateOptions)
     }
   };
 
-  const category = shownCard == null ? undefined : getCategory(deck.category, shownCard.tags);
+  const category = shownCard == null || deck == null ? undefined : getCategory(deck.category, shownCard.tags);
   const answer: CardListAnswer | undefined =
     shownCard == null || category == null
       ? undefined

--- a/src/features/deck-filter/model/useDeckFilterState.ts
+++ b/src/features/deck-filter/model/useDeckFilterState.ts
@@ -16,22 +16,25 @@ export interface DeckFilterState {
 
 type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
 
-export const useDeckFilterState = (deck: Deck): DeckFilterState => {
+export const useDeckFilterState = (deck: Deck | undefined): DeckFilterState => {
   const uid = useAuthUid();
-  const [filter, setFilter] = useState<DeckFilterValues>(() => ({
-    scoreMax: deck.scoreMax,
-    scoreMin: deck.scoreMin,
-    selectedTags: deck.selectedTags,
-    tagAndFilter: deck.tagAndFilter,
-  }));
+  const [filter, setFilter] = useState<DeckFilterValues>();
+  const currentFilter = filter ?? {
+    scoreMax: deck?.scoreMax ?? null,
+    scoreMin: deck?.scoreMin ?? null,
+    selectedTags: deck?.selectedTags ?? [],
+    tagAndFilter: deck?.tagAndFilter ?? false,
+  };
 
   const updateFilter = <Key extends keyof DeckFilterValues>(key: Key, value: DeckFilterValues[Key]) => {
-    setFilter((current) => ({ ...current, [key]: value }));
+    setFilter((current) => ({ ...(current ?? currentFilter), [key]: value }));
+    // Route pages call this hook before their not-found return to preserve stable hook ordering.
+    if (deck == null) return;
     void editDeck(uid, { id: deck.id, [key]: value }).catch(() => undefined);
   };
 
   return {
-    ...filter,
+    ...currentFilter,
     setScoreMax: (value) => updateFilter("scoreMax", value),
     setScoreMin: (value) => updateFilter("scoreMin", value),
     setSelectedTags: (value) => updateFilter("selectedTags", value),

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -12,7 +12,7 @@ import { routes, useNavigation } from "@/shared/routes";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
-const CardListComposition = (props: {
+const CardListPageContent = (props: {
   deck: Deck;
   cards: Card[];
   tags: string[];
@@ -69,7 +69,7 @@ export const CardListPage: React.FC = () => {
 
   return (
     <AppLayout showHeader>
-      <CardListComposition
+      <CardListPageContent
         deck={deck}
         cards={cards}
         tags={tags}

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -2,45 +2,15 @@ import type * as React from "react";
 import { useParams } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { type Card, type CardId, useCardsByDeckId } from "@/entities/card";
-import { type Deck, filterCardsForDeck, useDeck } from "@/entities/deck";
-import { type Preferences, usePreferences } from "@/entities/preferences";
+import { useCardsByDeckId } from "@/entities/card";
+import { filterCardsForDeck, useDeck } from "@/entities/deck";
+import { usePreferences } from "@/entities/preferences";
 import { CardList, useCardListState } from "@/features/card-list";
 import { BackText } from "@/features/card-view";
 import { DeckFilterForm, useDeckFilterState } from "@/features/deck-filter";
 import { routes, useNavigation } from "@/shared/routes";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 import { AppLayout } from "@/widgets/app-layout";
-
-const CardListPageContent = (props: {
-  deck: Deck;
-  cards: Card[];
-  tags: string[];
-  preferences: Preferences;
-  onEditCard: (id: CardId) => void;
-}) => {
-  const deckFilter = useDeckFilterState(props.deck);
-  const cardList = useCardListState({
-    cards: props.cards,
-    deck: props.deck,
-    dark: props.preferences.appearance.darkMode,
-  });
-
-  return (
-    <CardList
-      state={cardList}
-      filter={{
-        scoreMax: deckFilter.scoreMax,
-        scoreMin: deckFilter.scoreMin,
-        selectedTags: deckFilter.selectedTags,
-        controls: <DeckFilterForm {...deckFilter} tags={props.tags} />,
-        onRemoveTag: (tag) => deckFilter.setSelectedTags(deckFilter.selectedTags.filter((value) => value !== tag)),
-      }}
-      {...(cardList.answer !== undefined ? { answerSlot: <BackText {...cardList.answer} /> } : {})}
-      onEditCard={props.onEditCard}
-    />
-  );
-};
 
 export const CardListPage: React.FC = () => {
   const params = useParams();
@@ -51,6 +21,12 @@ export const CardListPage: React.FC = () => {
   const deck = useDeck(deckId);
   const { cards: deckCards, tags } = useCardsByDeckId(deckId);
   const cards = deck == null ? [] : filterCardsForDeck(deckCards, deck, preferences.study);
+  const deckFilter = useDeckFilterState(deck);
+  const cardList = useCardListState({
+    cards,
+    deck,
+    dark: preferences.appearance.darkMode,
+  });
 
   useKey("t", () => void navigation.to(routes.deckList.to()));
   useKey("s", () => void navigation.to(routes.settings.to()));
@@ -69,11 +45,16 @@ export const CardListPage: React.FC = () => {
 
   return (
     <AppLayout showHeader>
-      <CardListPageContent
-        deck={deck}
-        cards={cards}
-        tags={tags}
-        preferences={preferences}
+      <CardList
+        state={cardList}
+        filter={{
+          scoreMax: deckFilter.scoreMax,
+          scoreMin: deckFilter.scoreMin,
+          selectedTags: deckFilter.selectedTags,
+          controls: <DeckFilterForm {...deckFilter} tags={tags} />,
+          onRemoveTag: (tag) => deckFilter.setSelectedTags(deckFilter.selectedTags.filter((value) => value !== tag)),
+        }}
+        {...(cardList.answer !== undefined ? { answerSlot: <BackText {...cardList.answer} /> } : {})}
         onEditCard={(id) => void navigation.to(routes.cardForm.to(id))}
       />
     </AppLayout>


### PR DESCRIPTION
## What changed

- Removed the `CardListComposition`/content wrapper and rendered `CardList` directly in `CardListPage`.
- Allowed the card-list and deck-filter state hooks to receive an unavailable deck so they can run before the page's not-found return with stable hook ordering.

## Impact

No user-facing behavior changes. Card-list composition now lives directly in the page.

## Validation

- `mise run check`