### PR TITLE
[No issue] Simplify useStudy hook composition

### DIFF
--- a/src/features/study/model/useStudy.ts
+++ b/src/features/study/model/useStudy.ts
@@ -1,19 +1,10 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preferences";
-import {
-  moveStudySession,
-  planStudySessionAutoPlay,
-  removeStudySession,
-  resolveStudySession,
-  setStudySessionIndex,
-  type StudySession,
-  touchStudySession,
-  useStudySession,
-} from "@/entities/study-session";
+import type { StudySession } from "@/entities/study-session";
 
-import * as React from "react";
-
+import { useStudyControls } from "./useStudyControls";
+import { useStudySessionState } from "./useStudySessionState";
 import { useSwipe } from "./useSwipe";
 
 interface StudyCommands {
@@ -44,66 +35,34 @@ export type StudyState = StudyCommands &
 
 export const useStudy = (deckId: DeckId, cards: readonly Card[]): StudyState => {
   const preferences = usePreferences();
-  const [showBackText, setShowBackText] = React.useState(false);
-  const [autoPlay, setAutoPlay] = React.useState(preferences.study.defaultAutoPlay);
-  const hideBackText = () => setShowBackText(false);
-  const toggleBackText = () => setShowBackText((visible) => !visible);
-  const toggleAutoPlay = () => setAutoPlay((playing) => !playing);
-  const swipe = useSwipe(deckId, cards, hideBackText);
-  const updateIndex = (currentIndex: number): void => {
-    if (!setStudySessionIndex(deckId, currentIndex)) return;
-    hideBackText();
-  };
-  const session = useStudySession(deckId);
-  const resolvedSession = resolveStudySession(session, cards);
-  const autoPlayPlan = planStudySessionAutoPlay(resolvedSession, {
-    enabled: autoPlay,
-    intervalSeconds: preferences.study.cardInterval,
+  const sessionState = useStudySessionState(deckId, cards);
+  const controls = useStudyControls(deckId, sessionState, {
+    defaultAutoPlay: preferences.study.defaultAutoPlay,
+    cardInterval: preferences.study.cardInterval,
   });
-  const autoPlaySession = autoPlayPlan?.session;
-  const autoPlayIntervalSeconds = autoPlayPlan?.intervalSeconds;
-
-  React.useEffect(() => {
-    if (resolvedSession.status !== "studying") return;
-    touchStudySession(deckId);
-  }, [deckId, resolvedSession.status]);
-
-  React.useEffect(() => {
-    if (resolvedSession.status !== "invalid") return;
-
-    // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
-    removeStudySession(deckId);
-  }, [deckId, resolvedSession.status]);
-
-  React.useEffect(() => {
-    if (autoPlaySession === undefined || autoPlayIntervalSeconds === undefined) return;
-    const timeout = window.setTimeout(() => {
-      if (moveStudySession(autoPlaySession, "next")) setShowBackText(false);
-    }, autoPlayIntervalSeconds * 1000);
-    return () => window.clearTimeout(timeout);
-  }, [autoPlayIntervalSeconds, autoPlaySession]);
+  const swipe = useSwipe(deckId, cards, controls.hideBackText);
   const commands: StudyCommands = {
     swipeUp: swipe.swipeUp,
     swipeDown: swipe.swipeDown,
     swipeLeft: swipe.swipeLeft,
     swipeRight: swipe.swipeRight,
-    toggleBackText,
-    toggleAutoPlay,
+    toggleBackText: controls.toggleBackText,
+    toggleAutoPlay: controls.toggleAutoPlay,
   };
 
-  if (resolvedSession.status !== "studying") return { status: resolvedSession.status, ...commands };
+  if (sessionState.status !== "studying") return { status: sessionState.status, ...commands };
 
   return {
     status: "studying",
     ...commands,
-    session: resolvedSession.session,
-    card: resolvedSession.card,
-    showHeader: preferences.appearance.showHeader && !showBackText,
-    showBackText,
+    session: sessionState.session,
+    card: sessionState.card,
+    showHeader: preferences.appearance.showHeader && !controls.showBackText,
+    showBackText: controls.showBackText,
     showController: preferences.study.cardInterval > 0,
     showSwipeButtonList: preferences.controls.showSwipeButtonList,
-    autoPlay,
-    updateIndex,
+    autoPlay: controls.autoPlay,
+    updateIndex: controls.updateIndex,
     ...(swipe.swipeFeedback !== undefined ? { swipeFeedback: swipe.swipeFeedback } : {}),
   };
 };

--- a/src/features/study/model/useStudyControls.ts
+++ b/src/features/study/model/useStudyControls.ts
@@ -1,0 +1,49 @@
+import type { DeckId } from "@/entities/deck";
+import { moveStudySession, planStudySessionAutoPlay, setStudySessionIndex } from "@/entities/study-session";
+
+import * as React from "react";
+
+import type { StudySessionState } from "./useStudySessionState";
+
+interface StudyControlOptions {
+  defaultAutoPlay: boolean;
+  cardInterval: number;
+}
+
+export const useStudyControls = (
+  deckId: DeckId,
+  sessionState: StudySessionState,
+  { defaultAutoPlay, cardInterval }: StudyControlOptions
+) => {
+  const [showBackText, setShowBackText] = React.useState(false);
+  const [autoPlay, setAutoPlay] = React.useState(defaultAutoPlay);
+  const hideBackText = () => setShowBackText(false);
+  const autoPlayPlan = planStudySessionAutoPlay(sessionState, {
+    enabled: autoPlay,
+    intervalSeconds: cardInterval,
+  });
+  const autoPlaySession = autoPlayPlan?.session;
+  const autoPlayIntervalSeconds = autoPlayPlan?.intervalSeconds;
+
+  React.useEffect(() => {
+    if (autoPlaySession === undefined || autoPlayIntervalSeconds === undefined) return;
+    const timeout = window.setTimeout(() => {
+      if (moveStudySession(autoPlaySession, "next")) setShowBackText(false);
+    }, autoPlayIntervalSeconds * 1000);
+    return () => window.clearTimeout(timeout);
+  }, [autoPlayIntervalSeconds, autoPlaySession]);
+
+  const updateIndex = (currentIndex: number): void => {
+    if (!setStudySessionIndex(deckId, currentIndex)) return;
+    hideBackText();
+  };
+
+  return {
+    showBackText,
+    autoPlay,
+    hideBackText,
+    toggleBackText: () => setShowBackText((visible) => !visible),
+    toggleAutoPlay: () => setAutoPlay((playing) => !playing),
+    updateIndex,
+  };
+};

--- a/src/features/study/model/useStudySessionState.ts
+++ b/src/features/study/model/useStudySessionState.ts
@@ -1,0 +1,26 @@
+import type { Card } from "@/entities/card";
+import type { DeckId } from "@/entities/deck";
+import { removeStudySession, resolveStudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+
+import * as React from "react";
+
+export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]) => {
+  const session = useStudySession(deckId);
+  const resolvedSession = resolveStudySession(session, cards);
+
+  React.useEffect(() => {
+    if (resolvedSession.status !== "studying") return;
+    touchStudySession(deckId);
+  }, [deckId, resolvedSession.status]);
+
+  React.useEffect(() => {
+    if (resolvedSession.status !== "invalid") return;
+
+    // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
+    removeStudySession(deckId);
+  }, [deckId, resolvedSession.status]);
+
+  return resolvedSession;
+};
+
+export type StudySessionState = ReturnType<typeof useStudySessionState>;


### PR DESCRIPTION
## Related issue

None

## Summary

- Keep useStudy as the public hook while reducing it to hook composition and state mapping.
- Extract study controls, autoplay, and session lifecycle behavior into focused internal hooks.
- Preserve the existing StudyState API and observable behavior.

## Testing

- mise run check