### PR TITLE
[No issue] Clarify Deck import model

### DIFF
--- a/src/features/deck-import/model/deckImportExecution.spec.ts
+++ b/src/features/deck-import/model/deckImportExecution.spec.ts
@@ -13,13 +13,13 @@ describe("prepareDeckImport", () => {
   const rows = [row];
 
   it("prepares a Card creation and its preview action together", () => {
-    const attempt = prepareDeckImport(
+    const preparedImport = prepareDeckImport(
       { name: "deck.csv", rows },
       { uid: "uid", decks: [], cards: [], generateCardId: vi.fn(() => "card") }
     );
 
-    expect(attempt.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
-    expect(attempt.mutations).toEqual([
+    expect(preparedImport.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
+    expect(preparedImport.mutations).toEqual([
       { kind: "create", card: expect.objectContaining({ id: "card", uniqueKey: "key-1" }) },
     ]);
   });
@@ -33,13 +33,13 @@ describe("prepareDeckImport", () => {
       frontText: "before",
       uniqueKey: "key-1",
     });
-    const attempt = prepareDeckImport(
+    const preparedImport = prepareDeckImport(
       { name: deck.name, rows },
       { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn() }
     );
 
-    expect(attempt.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(attempt.mutations).toEqual([
+    expect(preparedImport.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
+    expect(preparedImport.mutations).toEqual([
       { kind: "edit", card: expect.objectContaining({ id: existing.id, frontText: "front" }) },
     ]);
   });
@@ -47,29 +47,29 @@ describe("prepareDeckImport", () => {
   it("skips a Card with identical editable content", () => {
     const deck = createDeck({ id: "deck", name: "deck.csv", uid: "uid" });
     const existing = createCard({ ...row.card, deckId: deck.id, uid: deck.uid });
-    const attempt = prepareDeckImport(
+    const preparedImport = prepareDeckImport(
       { name: deck.name, rows },
       { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn() }
     );
 
-    expect(attempt.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
-    expect(attempt.mutations).toEqual([]);
+    expect(preparedImport.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
+    expect(preparedImport.mutations).toEqual([]);
   });
 
   it("prepares local Deck and Card creation without an account owner", () => {
-    const attempt = prepareDeckImport(
+    const preparedImport = prepareDeckImport(
       { name: "local.csv", rows, storageMode: "local" },
       { uid: "", decks: [], cards: [], generateCardId: vi.fn(() => "local-card") }
     );
 
-    expect(attempt.deck).toEqual({ id: expect.any(String), name: "local.csv", localMode: true });
-    expect(attempt.mutations).toEqual([
+    expect(preparedImport.destination).toEqual({ id: expect.any(String), name: "local.csv", localMode: true });
+    expect(preparedImport.mutations).toEqual([
       {
         kind: "create",
         card: {
           ...row.card,
           id: "local-card",
-          deckId: attempt.deck.id,
+          deckId: preparedImport.destination.id,
         },
       },
     ]);
@@ -85,7 +85,7 @@ describe("prepareDeckImport", () => {
       deckId: localDeck.id,
       frontText: "before",
     });
-    const attempt = prepareDeckImport(
+    const preparedImport = prepareDeckImport(
       { name: localDeck.name, rows, storageMode: "local" },
       {
         uid: "uid",
@@ -95,9 +95,9 @@ describe("prepareDeckImport", () => {
       }
     );
 
-    expect(attempt.deck.id).toBe(localDeck.id);
-    expect(attempt.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(attempt.mutations).toEqual([
+    expect(preparedImport.destination.id).toBe(localDeck.id);
+    expect(preparedImport.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
+    expect(preparedImport.mutations).toEqual([
       { kind: "edit", card: expect.objectContaining({ id: localCard.id, frontText: "front" }) },
     ]);
   });

--- a/src/features/deck-import/model/deckImportExecution.ts
+++ b/src/features/deck-import/model/deckImportExecution.ts
@@ -11,10 +11,10 @@ export type DeckImportStorageMode = "local" | "remote";
 
 type DeckImportAction = "create" | "update" | "unchanged";
 
-interface DeckImportAttempt {
+export interface PreparedDeckImport {
   uid: string;
-  deck: DeckImportCreateInput;
-  createDeck: boolean;
+  destination: DeckImportCreateInput;
+  needsDeckCreation: boolean;
   mutations: CardMutation[];
   plan: {
     rows: (DeckImportRow & { action: DeckImportAction })[];
@@ -24,7 +24,7 @@ interface DeckImportAttempt {
   };
 }
 
-interface DeckImportRequest {
+interface DeckImportSource {
   name: string;
   preferredDeckId?: DeckId;
   rows: DeckImportRow[];
@@ -46,46 +46,63 @@ interface DeckImportExecutionDependencies {
 
 const isRemoteCard = (card: Card): card is RemoteCard => "uid" in card;
 
-const matchesImportDestination = (candidate: Deck, request: DeckImportRequest, localMode: boolean): boolean =>
-  candidate.localMode === localMode &&
-  (request.preferredDeckId === undefined ? candidate.name === request.name : candidate.id === request.preferredDeckId);
+const usesStorageMode = (card: Card, storageMode: DeckImportStorageMode): boolean =>
+  storageMode === "remote" ? isRemoteCard(card) : !isRemoteCard(card);
 
-const createImportDeck = (request: DeckImportRequest, uid: string, localMode: boolean): DeckImportCreateInput => {
-  const id = request.preferredDeckId ?? generateDeckId();
-  return localMode ? { id, name: request.name, localMode: true } : { id, uid, name: request.name };
+const matchesDestination = (candidate: Deck, source: DeckImportSource, storageMode: DeckImportStorageMode): boolean => {
+  if (candidate.localMode !== (storageMode === "local")) return false;
+  return source.preferredDeckId === undefined
+    ? candidate.name === source.name
+    : candidate.id === source.preferredDeckId;
 };
 
-const reuseImportDeck = (deck: Deck, uid: string): DeckImportCreateInput =>
+const createDestination = (
+  source: DeckImportSource,
+  uid: string,
+  storageMode: DeckImportStorageMode
+): DeckImportCreateInput => {
+  const id = source.preferredDeckId ?? generateDeckId();
+  return storageMode === "local" ? { id, name: source.name, localMode: true } : { id, uid, name: source.name };
+};
+
+const reuseDestination = (deck: Deck, uid: string): DeckImportCreateInput =>
   deck.localMode ? { id: deck.id, name: deck.name, localMode: true } : { id: deck.id, uid, name: deck.name };
+
+const actionFor = (existing: Card | undefined, row: DeckImportRow): DeckImportAction => {
+  if (existing == null) return "create";
+  return hasSameEditableCardContent(existing, row.card) ? "unchanged" : "update";
+};
 
 const prepareCardMutations = ({
   rows,
   existing,
-  deckId,
+  destinationId,
   uid,
-  localMode,
+  storageMode,
   generateCardId,
 }: {
   rows: DeckImportRow[];
   existing: Card[];
-  deckId: DeckId;
+  destinationId: DeckId;
   uid: string;
-  localMode: boolean;
+  storageMode: DeckImportStorageMode;
   generateCardId: () => string;
-}): Pick<DeckImportAttempt, "plan" | "mutations"> => {
+}): Pick<PreparedDeckImport, "plan" | "mutations"> => {
   const byUniqueKey = indexCardsByUniqueKey(existing);
-  const planRows: DeckImportAttempt["plan"]["rows"] = [];
+  const planRows: PreparedDeckImport["plan"]["rows"] = [];
   const mutations: CardMutation[] = [];
   const counts: Record<DeckImportAction, number> = { create: 0, update: 0, unchanged: 0 };
+
   for (const row of rows) {
     const current = byUniqueKey.get(row.card.uniqueKey);
-    const action = current == null ? "create" : hasSameEditableCardContent(current, row.card) ? "unchanged" : "update";
+    const action = actionFor(current, row);
     counts[action] += 1;
     planRows.push({ ...row, action });
+
     if (action === "create") {
-      const cardFields = { ...row.card, id: generateCardId(), deckId };
+      const cardFields = { ...row.card, id: generateCardId(), deckId: destinationId };
       // Local persistence stays account-agnostic; Card mutation routing follows the parent Deck's localMode.
-      const card = localMode ? cardFields : { ...cardFields, uid };
+      const card = storageMode === "local" ? cardFields : { ...cardFields, uid };
       mutations.push({ kind: "create", card });
     } else if (action === "update" && current != null) {
       mutations.push({ kind: "edit", card: { ...current, ...row.card } });
@@ -104,38 +121,46 @@ const prepareCardMutations = ({
 };
 
 export const prepareDeckImport = (
-  request: DeckImportRequest,
+  source: DeckImportSource,
   { uid, decks, cards, generateCardId }: DeckImportPreparationDependencies
-): DeckImportAttempt => {
-  const localMode = request.storageMode === "local";
-  if (!localMode && uid === "") throw new Error("A confirmed user is required for remote imports");
+): PreparedDeckImport => {
+  const storageMode = source.storageMode ?? "remote";
+  if (storageMode === "remote" && uid === "") throw new Error("A confirmed user is required for remote imports");
 
-  const existingDeck = decks.find((candidate) => matchesImportDestination(candidate, request, localMode));
+  const existingDeck = decks.find((candidate) => matchesDestination(candidate, source, storageMode));
   // View models intentionally omit ownership metadata, so remote commands recover it from the active session.
-  const deck = existingDeck == null ? createImportDeck(request, uid, localMode) : reuseImportDeck(existingDeck, uid);
+  const destination =
+    existingDeck == null ? createDestination(source, uid, storageMode) : reuseDestination(existingDeck, uid);
 
-  const existing = cards.filter((card) => card.deckId === deck.id && isRemoteCard(card) !== localMode);
+  const existing = cards.filter((card) => card.deckId === destination.id && usesStorageMode(card, storageMode));
   return {
     uid,
-    deck,
-    createDeck: existingDeck == null,
-    ...prepareCardMutations({ rows: request.rows, existing, deckId: deck.id, uid, localMode, generateCardId }),
+    destination,
+    needsDeckCreation: existingDeck == null,
+    ...prepareCardMutations({
+      rows: source.rows,
+      existing,
+      destinationId: destination.id,
+      uid,
+      storageMode,
+      generateCardId,
+    }),
   };
 };
 
 export const executePreparedDeckImport = async (
-  attempt: DeckImportAttempt,
+  preparedImport: PreparedDeckImport,
   { uid, createDeck, mutateCards }: DeckImportExecutionDependencies
 ) => {
-  if (attempt.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
-  if (attempt.createDeck) await createDeck(attempt.deck);
-  if (attempt.mutations.length > 0) await mutateCards(attempt.mutations);
+  if (preparedImport.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
+  if (preparedImport.needsDeckCreation) await createDeck(preparedImport.destination);
+  if (preparedImport.mutations.length > 0) await mutateCards(preparedImport.mutations);
 
   return {
-    created: attempt.plan.created,
-    updated: attempt.plan.updated,
-    skipped: attempt.plan.unchanged,
-    deckId: attempt.deck.id,
+    created: preparedImport.plan.created,
+    updated: preparedImport.plan.updated,
+    skipped: preparedImport.plan.unchanged,
+    deckId: preparedImport.destination.id,
   };
 };
 

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -7,34 +7,31 @@ import { useAuthUid } from "@/entities/auth";
 import { fetchCards, generateCardId, mutateCards, useCards } from "@/entities/card";
 import { createDeck, fetchDecks, useDecks } from "@/entities/deck";
 import { type DeckImportAnalysis, parseCsv } from "../lib/cardCsv";
-import type { DeckImportResult, DeckImportStorageMode } from "./deckImportExecution";
+import type { DeckImportResult, DeckImportStorageMode, PreparedDeckImport } from "./deckImportExecution";
 import { executePreparedDeckImport, prepareDeckImport } from "./deckImportExecution";
 import { prepareSampleDeck } from "./sampleDeck";
-
-type DeckImportAttempt = ReturnType<typeof prepareDeckImport>;
 
 export interface DeckImportPreview {
   deckName: string;
   analysis: DeckImportAnalysis;
-  plan: DeckImportAttempt["plan"];
+  plan: PreparedDeckImport["plan"];
 }
 
 type DeckImportStatus = "idle" | "validating" | "importing";
-
-type DeckImportFailure = { stage: "preview"; error: unknown } | { stage: "import"; error: unknown };
 
 interface DeckImportState {
   uid: string;
   storageMode: DeckImportStorageMode;
   status: DeckImportStatus;
   preview: DeckImportPreview | undefined;
-  failure: DeckImportFailure | undefined;
+  previewError: unknown;
+  error: unknown;
   result: DeckImportResult | undefined;
 }
 
 interface DeckImportExecutionState {
   running: boolean;
-  previewAttempt: DeckImportAttempt | undefined;
+  preparedImport: PreparedDeckImport | undefined;
 }
 
 const initialState = (uid: string): DeckImportState => ({
@@ -42,14 +39,27 @@ const initialState = (uid: string): DeckImportState => ({
   storageMode: "remote",
   status: "idle",
   preview: undefined,
-  failure: undefined,
+  previewError: null,
+  error: null,
   result: undefined,
 });
 
 const createExecutionState = (): DeckImportExecutionState => ({
   running: false,
-  previewAttempt: undefined,
+  preparedImport: undefined,
 });
+
+const loadDestinationData = async (
+  storageMode: DeckImportStorageMode,
+  uid: string,
+  localData: { decks: Deck[]; cards: Card[] }
+): Promise<{ decks: Deck[]; cards: Card[] }> => {
+  if (storageMode === "local") return localData;
+
+  // Listener-backed stores may lag, so remote plans must use authoritative server reads.
+  const [decks, cards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
+  return { decks, cards };
+};
 
 export const useDeckImport = () => {
   const uid = useAuthUid();
@@ -79,16 +89,16 @@ export const useDeckImport = () => {
     if (!isCurrent(generation)) throw new Error("Deck import user changed before the preview could finish");
   };
 
-  const run = async (attempt: DeckImportAttempt) => {
+  const run = async (preparedImport: PreparedDeckImport) => {
     const execution = executionRef.current;
     if (execution.running) throw new Error("A Deck import is already running");
 
     const generation = generationRef.current;
     execution.running = true;
-    updateState({ status: "importing", failure: undefined });
+    updateState({ status: "importing", previewError: null, error: null });
 
     try {
-      const result = await executePreparedDeckImport(attempt, {
+      const result = await executePreparedDeckImport(preparedImport, {
         uid,
         createDeck: (deck) => createDeck(uid, deck),
         mutateCards: (mutations) => mutateCards(uid, mutations),
@@ -96,9 +106,7 @@ export const useDeckImport = () => {
       if (isCurrent(generation)) updateState({ result });
       return result;
     } catch (caughtError) {
-      if (isCurrent(generation)) {
-        updateState({ result: undefined, failure: { stage: "import", error: caughtError } });
-      }
+      if (isCurrent(generation)) updateState({ result: undefined, error: caughtError });
       throw caughtError;
     } finally {
       if (isCurrent(generation)) {
@@ -112,8 +120,8 @@ export const useDeckImport = () => {
     const execution = executionRef.current;
     if (execution.running || currentState.storageMode === storageMode) return;
 
-    execution.previewAttempt = undefined;
-    updateState({ storageMode, preview: undefined, failure: undefined, result: undefined });
+    execution.preparedImport = undefined;
+    updateState({ storageMode, preview: undefined, previewError: null, error: null, result: undefined });
   };
 
   const selectFile = async (file: File) => {
@@ -123,33 +131,37 @@ export const useDeckImport = () => {
     const generation = generationRef.current;
     const { storageMode } = currentState;
     execution.running = true;
-    execution.previewAttempt = undefined;
-    updateState({ status: "validating", preview: undefined, failure: undefined, result: undefined });
+    execution.preparedImport = undefined;
+    updateState({
+      status: "validating",
+      preview: undefined,
+      previewError: null,
+      error: null,
+      result: undefined,
+    });
 
     try {
       const analysis = await parseCsv(await file.text());
       assertCurrent(generation);
 
-      // Listener-backed stores can lag, so remote file imports are planned from authoritative server reads.
-      const [activeDecks, activeCards]: [Deck[], Card[]] =
-        storageMode === "remote" ? await Promise.all([fetchDecks(uid), fetchCards(uid)]) : [decks, cards];
+      const destinationData = await loadDestinationData(storageMode, uid, { decks, cards });
 
       assertCurrent(generation);
 
-      const attempt = prepareDeckImport(
+      const preparedImport = prepareDeckImport(
         { name: file.name, rows: analysis.rows, storageMode },
-        { uid, decks: activeDecks, cards: activeCards, generateCardId }
+        { uid, ...destinationData, generateCardId }
       );
       const preview = {
         deckName: file.name,
         analysis,
-        plan: attempt.plan,
+        plan: preparedImport.plan,
       };
-      execution.previewAttempt = attempt;
+      execution.preparedImport = preparedImport;
       updateState({ preview });
       return preview;
     } catch (caughtError) {
-      if (isCurrent(generation)) updateState({ failure: { stage: "preview", error: caughtError } });
+      if (isCurrent(generation)) updateState({ previewError: caughtError });
       throw caughtError;
     } finally {
       if (isCurrent(generation)) {
@@ -169,12 +181,12 @@ export const useDeckImport = () => {
     if (currentState.preview.analysis.rows.length === 0) {
       return Promise.reject(new Error("The CSV file has no valid rows"));
     }
-    if (execution.previewAttempt == null) {
+    if (execution.preparedImport == null) {
       return Promise.reject(new Error("The prepared Deck import is not available"));
     }
-    const attempt = execution.previewAttempt;
-    execution.previewAttempt = undefined;
-    return run(attempt);
+    const { preparedImport } = execution;
+    execution.preparedImport = undefined;
+    return run(preparedImport);
   };
 
   return {
@@ -186,8 +198,8 @@ export const useDeckImport = () => {
     preview: currentState.preview,
     validating: currentState.status === "validating",
     pending: currentState.status === "importing",
-    error: currentState.failure?.stage === "import" ? currentState.failure.error : null,
-    previewError: currentState.failure?.stage === "preview" ? currentState.failure.error : null,
+    error: currentState.error,
+    previewError: currentState.previewError,
     result: currentState.result,
   };
 };


### PR DESCRIPTION
## Related issue

None

## Summary

- Rename Deck import preparation concepts around sources, destinations, and prepared imports.
- Make storage-mode filtering and hook error state explicit.
- Preserve existing import behavior while aligning tests with the clearer terminology.

## Testing

- mise run check