### PR TITLE
[No issue] Simplify study state composition

### DIFF
--- a/src/features/study/model/useStudy.ts
+++ b/src/features/study/model/useStudy.ts
@@ -1,39 +1,12 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
-import { type SwipeDirection, usePreferences } from "@/entities/preferences";
-import type { StudySession } from "@/entities/study-session";
+import { usePreferences } from "@/entities/preferences";
 
 import { useStudyControls } from "./useStudyControls";
 import { useStudySessionState } from "./useStudySessionState";
 import { useSwipe } from "./useSwipe";
 
-interface StudyCommands {
-  swipeUp: () => Promise<void>;
-  swipeDown: () => Promise<void>;
-  swipeLeft: () => Promise<void>;
-  swipeRight: () => Promise<void>;
-  toggleBackText: () => void;
-  toggleAutoPlay: () => void;
-}
-
-export type StudyState = StudyCommands &
-  (
-    | { status: "preparing" | "invalid" }
-    | {
-        status: "studying";
-        session: StudySession;
-        card: Card;
-        showHeader: boolean;
-        showBackText: boolean;
-        showController: boolean;
-        showSwipeButtonList: boolean;
-        swipeFeedback?: SwipeDirection;
-        autoPlay: boolean;
-        updateIndex: (index: number) => void;
-      }
-  );
-
-export const useStudy = (deckId: DeckId, cards: readonly Card[]): StudyState => {
+export const useStudy = (deckId: DeckId, cards: readonly Card[]) => {
   const preferences = usePreferences();
   const sessionState = useStudySessionState(deckId, cards);
   const controls = useStudyControls(deckId, sessionState, {
@@ -41,28 +14,19 @@ export const useStudy = (deckId: DeckId, cards: readonly Card[]): StudyState => 
     cardInterval: preferences.study.cardInterval,
   });
   const swipe = useSwipe(deckId, cards, controls.hideBackText);
-  const commands: StudyCommands = {
-    swipeUp: swipe.swipeUp,
-    swipeDown: swipe.swipeDown,
-    swipeLeft: swipe.swipeLeft,
-    swipeRight: swipe.swipeRight,
-    toggleBackText: controls.toggleBackText,
-    toggleAutoPlay: controls.toggleAutoPlay,
-  };
-
-  if (sessionState.status !== "studying") return { status: sessionState.status, ...commands };
 
   return {
-    status: "studying",
-    ...commands,
-    session: sessionState.session,
-    card: sessionState.card,
+    ...sessionState,
+    ...swipe,
+    toggleBackText: controls.toggleBackText,
+    toggleAutoPlay: controls.toggleAutoPlay,
     showHeader: preferences.appearance.showHeader && !controls.showBackText,
     showBackText: controls.showBackText,
     showController: preferences.study.cardInterval > 0,
     showSwipeButtonList: preferences.controls.showSwipeButtonList,
     autoPlay: controls.autoPlay,
     updateIndex: controls.updateIndex,
-    ...(swipe.swipeFeedback !== undefined ? { swipeFeedback: swipe.swipeFeedback } : {}),
   };
 };
+
+export type StudyState = ReturnType<typeof useStudy>;

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -77,9 +77,18 @@ const commands = () => ({
   toggleBackText: vi.fn(),
   toggleAutoPlay: vi.fn(),
 });
+const commonState = () => ({
+  ...commands(),
+  showHeader: true,
+  showBackText: false,
+  showController: true,
+  showSwipeButtonList: true,
+  autoPlay: false,
+  updateIndex: noop,
+});
 const studyingState = (): StudyState => ({
   status: "studying",
-  ...commands(),
+  ...commonState(),
   session: {
     sessionId: "session-id",
     deckId: deck.id,
@@ -88,12 +97,6 @@ const studyingState = (): StudyState => ({
     lastStudiedAt: 0,
   },
   card,
-  showHeader: true,
-  showBackText: false,
-  showController: true,
-  showSwipeButtonList: true,
-  autoPlay: false,
-  updateIndex: noop,
 });
 
 describe("StudySessionPage", () => {
@@ -125,13 +128,13 @@ describe("StudySessionPage", () => {
     ["preparing", "Loading…"],
     ["invalid", "Study session unavailable."],
   ] as const)("renders route feedback for %s workflow state", (status, title) => {
-    mocks.studyState = { status, ...commands() };
+    mocks.studyState = { status, ...commonState() };
     render(<StudySessionPage />);
     expect(screen.getByRole("heading", { name: title })).toBeVisible();
   });
 
   it("returns to the deck list when the study session is invalid", async () => {
-    mocks.studyState = { status: "invalid", ...commands() };
+    mocks.studyState = { status: "invalid", ...commonState() };
     render(<StudySessionPage />);
 
     await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true }));


### PR DESCRIPTION
## Related issue

None.

## Summary

- infer `StudyState` from `useStudy`
- compose session, controls, swipe, and preference values without status branching
- update page test fixtures for the inferred common state

## Testing

- `mise run check`