### PR TITLE
[No issue] Preserve Page lifecycle boundaries

### DIFF
--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,8 +1,5 @@
 # Pages Instructions
 
-- Keep URL routes and exported Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
-- Treat Pages as route-level containers and wiring boundaries. Pages may read route params, navigation, Entity state, and Feature model/hooks needed to prepare props and callbacks for lower-layer UI.
-- Keep Page components concise and orchestration-only. Compose lower-layer UI and connect it to lower-layer state/actions; do not implement reusable domain rules or complex Feature workflows in Pages.
-- Move reusable business logic and Feature-specific workflows to the appropriate `entities` or `features/model` layer, then invoke them from the Page.
-- Do not define custom hooks in `src/pages`. Use framework or library hooks such as `useParams`, `useNavigate`, and `useKey`, or existing hooks exposed by lower layers.
-- Own screen-level keyboard shortcut mappings and registration in `src/pages`. Use `useKey` directly and delegate shortcut actions to lower layers.
+- Keep URL routes and exported Page components one-to-one.
+- Treat Pages as route-level containers focused on orchestration.
+- Keep reusable business logic and Feature workflows in lower layers.

--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,5 +1,8 @@
 # Pages Instructions
 
-- Keep URL routes and exported Page components one-to-one.
-- Treat Pages as route-level containers focused on orchestration.
-- Keep reusable business logic and Feature workflows in lower layers.
+- Keep URL routes and exported Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
+- Treat Pages as route-level containers and wiring boundaries. Pages may read route params, navigation, Entity state, and Feature model/hooks needed to prepare props and callbacks for lower-layer UI.
+- Keep Page components concise and orchestration-only. Compose lower-layer UI and connect it to lower-layer state/actions; do not implement reusable domain rules or complex Feature workflows in Pages.
+- Move reusable business logic and Feature-specific workflows to the appropriate `entities` or `features/model` layer, then invoke them from the Page.
+- Do not define custom hooks in `src/pages`. Use framework or library hooks such as `useParams`, `useNavigate`, and `useKey`, or existing hooks exposed by lower layers.
+- Own screen-level keyboard shortcut mappings and registration in `src/pages`. Use `useKey` directly and delegate shortcut actions to lower layers.

--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,6 +1,6 @@
 # Pages Instructions
 
-- Keep URL routes and Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
+- Keep URL routes and exported Page components one-to-one: each route renders one dedicated Page, and each Page serves one route.
 - Treat Pages as route-level containers and wiring boundaries. Pages may read route params, navigation, Entity state, and Feature model/hooks needed to prepare props and callbacks for lower-layer UI.
 - Keep Page components concise and orchestration-only. Compose lower-layer UI and connect it to lower-layer state/actions; do not implement reusable domain rules or complex Feature workflows in Pages.
 - Move reusable business logic and Feature-specific workflows to the appropriate `entities` or `features/model` layer, then invoke them from the Page.

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -39,5 +39,6 @@ export const CardFormPage: React.FC = () => {
     );
   }
 
-  return <CardFormContent card={card} />;
+  // Form state belongs to one route entity and must start fresh when navigation replaces the card.
+  return <CardFormContent key={card.id} card={card} />;
 };

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -2,6 +2,7 @@ import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
+import * as React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
@@ -51,10 +52,15 @@ vi.mock("@/features/card-list", () => ({
     filter: { selectedTags: string[]; onRemoveTag: (tag: string) => void };
     onEditCard: (id: string) => void;
   }) => {
+    const [shownDeckId, setShownDeckId] = React.useState<string>();
     mocks.cardListProps = props as unknown as Record<string, unknown>;
     return (
       <div>
         <span>Card list feature</span>
+        <span>{shownDeckId == null ? "No card shown" : `Card shown for ${shownDeckId}`}</span>
+        <button type="button" onClick={() => setShownDeckId(props.state.cards[0]?.deckId)}>
+          Show card
+        </button>
         <button type="button" onClick={() => props.onEditCard(props.state.cards[0]?.id ?? "missing")}>
           Edit card
         </button>
@@ -120,6 +126,23 @@ describe("CardListPage", () => {
     fireEvent.keyDown(window, { key: "s" });
     expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/", undefined);
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/settings", undefined);
+  });
+
+  it("resets deck-local feature state when the route deck changes", async () => {
+    const user = userEvent.setup();
+    const nextDeck = createDeck({ id: "next-deck" });
+    const nextCard = createCard({ id: "next-card", deckId: nextDeck.id });
+    const { rerender } = render(<CardListPage />);
+
+    await user.click(screen.getByRole("button", { name: "Show card" }));
+    expect(screen.getByText(`Card shown for ${deck.id}`)).toBeInTheDocument();
+
+    mocks.params.id = nextDeck.id;
+    mocks.deck = nextDeck;
+    mocks.cards = [nextCard];
+    rerender(<CardListPage />);
+
+    expect(screen.getByText("No card shown")).toBeInTheDocument();
   });
 
   it("renders not-found feedback with route navigation", async () => {

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -69,7 +69,9 @@ export const CardListPage: React.FC = () => {
 
   return (
     <AppLayout showHeader>
+      {/* Filters, dialogs, and the shown card belong to one deck and must not survive a route change. */}
       <CardListComposition
+        key={deck.id}
         deck={deck}
         cards={cards}
         tags={tags}

--- a/src/pages/deck-form/ui/DeckFormPage.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.tsx
@@ -27,7 +27,8 @@ export const DeckFormPage: React.FC = () => {
   if (deckId == null) throw new Error("invalid deck id");
   const deck = useDeck(deckId);
 
-  if (deck != null) return <DeckFormContent deck={deck} />;
+  // Form state belongs to one route entity and must start fresh when navigation replaces the deck.
+  if (deck != null) return <DeckFormContent key={deck.id} deck={deck} />;
 
   return (
     <RouteFeedback

--- a/src/pages/study-session-start/ui/StudySessionStartPage.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.tsx
@@ -71,5 +71,6 @@ export const StudySessionStartPage: React.FC = () => {
     );
   }
 
-  return <StudySessionStartContent deck={deck} cards={cards} preferences={preferences} tags={tags} />;
+  // Deck filters are session setup state and must not carry into a different route deck.
+  return <StudySessionStartContent key={deck.id} deck={deck} cards={cards} preferences={preferences} tags={tags} />;
 };

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -110,5 +110,6 @@ export const StudySessionPage: React.FC = () => {
     return <RouteFeedback title="Study session unavailable." tone="not-found" />;
   }
 
+  // Study state belongs to one deck, so route changes use a fresh session lifecycle.
   return <StudySessionContent key={deck.id} cards={cards} deck={deck} />;
 };


### PR DESCRIPTION
## Related issue

None

## Summary

- clarify that each route has one exported Page while allowing private lifecycle components
- key route-entity content boundaries so form, filter, and card-list state resets when navigation changes the entity
- keep Feature APIs strict instead of widening them for unresolved route entities
- cover CardList route changes so deck-local state cannot leak between decks

## Testing

- mise run check