### PR TITLE
[No issue] Extract study autoplay hook

### DIFF
--- a/src/features/study/model/useAutoPlay.ts
+++ b/src/features/study/model/useAutoPlay.ts
@@ -1,0 +1,38 @@
+import { moveStudySession, planStudySessionAutoPlay } from "@/entities/study-session";
+
+import * as React from "react";
+
+import type { StudySessionState } from "./useStudySessionState";
+
+interface AutoPlayOptions {
+  defaultAutoPlay: boolean;
+  cardInterval: number;
+  onAdvance: () => void;
+}
+
+export const useAutoPlay = (
+  sessionState: StudySessionState,
+  { defaultAutoPlay, cardInterval, onAdvance }: AutoPlayOptions
+) => {
+  const [autoPlay, setAutoPlay] = React.useState(defaultAutoPlay);
+  const onAdvanceEvent = React.useEffectEvent(onAdvance);
+  const autoPlayPlan = planStudySessionAutoPlay(sessionState, {
+    enabled: autoPlay,
+    intervalSeconds: cardInterval,
+  });
+  const autoPlaySession = autoPlayPlan?.session;
+  const autoPlayIntervalSeconds = autoPlayPlan?.intervalSeconds;
+
+  React.useEffect(() => {
+    if (autoPlaySession === undefined || autoPlayIntervalSeconds === undefined) return;
+    const timeout = window.setTimeout(() => {
+      if (moveStudySession(autoPlaySession, "next")) onAdvanceEvent();
+    }, autoPlayIntervalSeconds * 1000);
+    return () => window.clearTimeout(timeout);
+  }, [autoPlayIntervalSeconds, autoPlaySession]);
+
+  return {
+    autoPlay,
+    toggleAutoPlay: () => setAutoPlay((playing) => !playing),
+  };
+};

--- a/src/features/study/model/useStudy.spec.tsx
+++ b/src/features/study/model/useStudy.spec.tsx
@@ -113,10 +113,11 @@ describe("useStudy", () => {
     vi.useFakeTimers();
     mocks.preferences = createPreferences({ cardInterval: 1, defaultAutoPlay: true });
     const { result } = renderHook(() => useStudy(deckId, cards));
+    act(() => result.current.toggleBackText());
 
     act(() => vi.advanceTimersByTime(1000));
 
-    expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" } });
+    expect(result.current).toMatchObject({ status: "studying", card: { id: "card-2" }, showBackText: false });
   });
 
   it("does not advance a restarted session with an old autoplay timer", () => {

--- a/src/features/study/model/useStudyControls.ts
+++ b/src/features/study/model/useStudyControls.ts
@@ -1,8 +1,9 @@
 import type { DeckId } from "@/entities/deck";
-import { moveStudySession, planStudySessionAutoPlay, setStudySessionIndex } from "@/entities/study-session";
+import { setStudySessionIndex } from "@/entities/study-session";
 
 import * as React from "react";
 
+import { useAutoPlay } from "./useAutoPlay";
 import type { StudySessionState } from "./useStudySessionState";
 
 interface StudyControlOptions {
@@ -16,22 +17,12 @@ export const useStudyControls = (
   { defaultAutoPlay, cardInterval }: StudyControlOptions
 ) => {
   const [showBackText, setShowBackText] = React.useState(false);
-  const [autoPlay, setAutoPlay] = React.useState(defaultAutoPlay);
   const hideBackText = () => setShowBackText(false);
-  const autoPlayPlan = planStudySessionAutoPlay(sessionState, {
-    enabled: autoPlay,
-    intervalSeconds: cardInterval,
+  const { autoPlay, toggleAutoPlay } = useAutoPlay(sessionState, {
+    defaultAutoPlay,
+    cardInterval,
+    onAdvance: hideBackText,
   });
-  const autoPlaySession = autoPlayPlan?.session;
-  const autoPlayIntervalSeconds = autoPlayPlan?.intervalSeconds;
-
-  React.useEffect(() => {
-    if (autoPlaySession === undefined || autoPlayIntervalSeconds === undefined) return;
-    const timeout = window.setTimeout(() => {
-      if (moveStudySession(autoPlaySession, "next")) setShowBackText(false);
-    }, autoPlayIntervalSeconds * 1000);
-    return () => window.clearTimeout(timeout);
-  }, [autoPlayIntervalSeconds, autoPlaySession]);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;
@@ -43,7 +34,7 @@ export const useStudyControls = (
     autoPlay,
     hideBackText,
     toggleBackText: () => setShowBackText((visible) => !visible),
-    toggleAutoPlay: () => setAutoPlay((playing) => !playing),
+    toggleAutoPlay,
     updateIndex,
   };
 };


### PR DESCRIPTION
## Related issue

None.

## Summary

- Extract autoplay state and timer behavior into `useAutoPlay`.
- Keep `useStudyControls` focused on display and index controls.
- Verify autoplay still hides the card back after advancing.

## Testing

- `mise run check`