### PR TITLE
refactor: simplify study-session entity responsibilities

### DIFF
--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,11 +1,5 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
-export {
-  canMoveStudySession,
-  compareActiveDecks,
-  findCurrentStudySessionCard,
-  groupDecksByStudyStatus,
-  planStudySessionSwipe,
-} from "./model/rules";
+export { canMoveStudySession, compareActiveDecks, groupDecksByStudyStatus, planStudySessionSwipe } from "./model/rules";
 export type { StudySession } from "./model/types";
 export {
   clearStudySessions,

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,10 +1,10 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
 export {
+  canMoveStudySession,
   compareActiveDecks,
+  findCurrentStudySessionCard,
   groupDecksByStudyStatus,
-  planStudySessionAutoPlay,
   planStudySessionSwipe,
-  resolveStudySession,
 } from "./model/rules";
 export type { StudySession } from "./model/types";
 export {

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   calculateStudySessionIndex,
+  canMoveStudySession,
   compareActiveDecks,
+  findCurrentStudySessionCard,
   groupDecksByStudyStatus,
   isStudySessionPositionUnchanged,
-  planStudySessionAutoPlay,
   planStudySessionSwipe,
-  resolveStudySession,
 } from "./rules";
 import type { StudySession } from "./types";
 
@@ -63,58 +63,29 @@ describe("calculateStudySessionIndex", () => {
   });
 });
 
-describe("planStudySessionAutoPlay", () => {
-  const resolvedSession = {
-    status: "studying" as const,
-    session,
-    card: { id: "card-2" },
-  };
-
-  it("plans the active session and interval when autoplay can continue", () => {
-    expect(planStudySessionAutoPlay(resolvedSession, { enabled: true, intervalSeconds: 1 })).toEqual({
-      session,
-      intervalSeconds: 1,
-    });
-  });
-
-  it("returns no plan when autoplay is disabled, has no interval, or reaches the final card", () => {
-    expect(planStudySessionAutoPlay(resolvedSession, { enabled: false, intervalSeconds: 1 })).toBeUndefined();
-    expect(planStudySessionAutoPlay(resolvedSession, { enabled: true, intervalSeconds: 0 })).toBeUndefined();
-    expect(
-      planStudySessionAutoPlay(
-        { ...resolvedSession, session: { ...session, currentIndex: 2 }, card: { id: "card-3" } },
-        { enabled: true, intervalSeconds: 1 }
-      )
-    ).toBeUndefined();
-  });
-
-  it("returns no plan without an active study session", () => {
-    expect(planStudySessionAutoPlay({ status: "preparing" }, { enabled: true, intervalSeconds: 1 })).toBeUndefined();
-    expect(planStudySessionAutoPlay({ status: "invalid" }, { enabled: true, intervalSeconds: 1 })).toBeUndefined();
+describe("canMoveStudySession", () => {
+  it("reports whether movement stays inside the Card order", () => {
+    expect(canMoveStudySession(session, "previous")).toBe(true);
+    expect(canMoveStudySession(session, "next")).toBe(true);
+    expect(canMoveStudySession({ ...session, currentIndex: 0 }, "previous")).toBe(false);
+    expect(canMoveStudySession({ ...session, currentIndex: 2 }, "next")).toBe(false);
   });
 });
 
-describe("resolveStudySession", () => {
+describe("findCurrentStudySessionCard", () => {
   const cards = [
     { id: "card-1", label: "one" },
     { id: "card-2", label: "two" },
   ];
 
-  it("resolves the card at the persisted session position", () => {
-    expect(resolveStudySession(session, cards)).toEqual({
-      status: "studying",
-      session,
-      card: cards[1],
-    });
+  it("returns the Card at the persisted session position", () => {
+    expect(findCurrentStudySessionCard(session, cards)).toEqual(cards[1]);
   });
 
-  it("waits while cards for an active session are being prepared", () => {
-    expect(resolveStudySession(session, [])).toEqual({ status: "preparing" });
-  });
-
-  it("reports invalid when the session or its active card is missing", () => {
-    expect(resolveStudySession(undefined, cards)).toEqual({ status: "invalid" });
-    expect(resolveStudySession(session, cards.slice(0, 1))).toEqual({ status: "invalid" });
+  it("returns no Card when the session or active Card is unavailable", () => {
+    expect(findCurrentStudySessionCard(undefined, cards)).toBeUndefined();
+    expect(findCurrentStudySessionCard(session, [])).toBeUndefined();
+    expect(findCurrentStudySessionCard(session, cards.slice(0, 1))).toBeUndefined();
   });
 });
 

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -4,7 +4,6 @@ import {
   calculateStudySessionIndex,
   canMoveStudySession,
   compareActiveDecks,
-  findCurrentStudySessionCard,
   groupDecksByStudyStatus,
   isStudySessionPositionUnchanged,
   planStudySessionSwipe,
@@ -72,23 +71,6 @@ describe("canMoveStudySession", () => {
   });
 });
 
-describe("findCurrentStudySessionCard", () => {
-  const cards = [
-    { id: "card-1", label: "one" },
-    { id: "card-2", label: "two" },
-  ];
-
-  it("returns the Card at the persisted session position", () => {
-    expect(findCurrentStudySessionCard(session, cards)).toEqual(cards[1]);
-  });
-
-  it("returns no Card when the session or active Card is unavailable", () => {
-    expect(findCurrentStudySessionCard(undefined, cards)).toBeUndefined();
-    expect(findCurrentStudySessionCard(session, [])).toBeUndefined();
-    expect(findCurrentStudySessionCard(session, cards.slice(0, 1))).toBeUndefined();
-  });
-});
-
 describe("planStudySessionSwipe", () => {
   const cards = [
     { id: "card-1", score: 0, numberOfSeen: 0 },
@@ -128,6 +110,7 @@ describe("planStudySessionSwipe", () => {
   it("ignores swipes without a resolvable active session", () => {
     expect(planStudySessionSwipe(undefined, cards, "GoToNextCard", 0)).toEqual({ effect: "none" });
     expect(planStudySessionSwipe(session, cards.slice(0, 1), "GoToNextCard", 0)).toEqual({ effect: "none" });
+    expect(planStudySessionSwipe({ ...session, currentIndex: 3 }, cards, "GoToNextCard", 0)).toEqual({ effect: "none" });
   });
 });
 

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -110,7 +110,9 @@ describe("planStudySessionSwipe", () => {
   it("ignores swipes without a resolvable active session", () => {
     expect(planStudySessionSwipe(undefined, cards, "GoToNextCard", 0)).toEqual({ effect: "none" });
     expect(planStudySessionSwipe(session, cards.slice(0, 1), "GoToNextCard", 0)).toEqual({ effect: "none" });
-    expect(planStudySessionSwipe({ ...session, currentIndex: 3 }, cards, "GoToNextCard", 0)).toEqual({ effect: "none" });
+    expect(planStudySessionSwipe({ ...session, currentIndex: 3 }, cards, "GoToNextCard", 0)).toEqual({
+      effect: "none",
+    });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -2,7 +2,6 @@ import type { SwipeAction } from "@/entities/preferences/@x/study-session";
 import { type CardProgressFields, recordCardStudyProgress } from "@/entities/study-progress/@x/study-session";
 
 import type {
-  ResolvedStudySession,
   StudySession,
   StudySessionCard,
   StudySessionMovement,
@@ -31,18 +30,6 @@ interface ActiveDeck<TDeck> {
 interface DecksByStudyStatus<TDeck> {
   active: ActiveDeck<TDeck>[];
   inactive: TDeck[];
-}
-
-/** Preferences that control automatic study-session advancement. */
-interface StudySessionAutoPlayOptions {
-  enabled: boolean;
-  intervalSeconds: number;
-}
-
-/** Current session and delay required to schedule automatic advancement. */
-interface StudySessionAutoPlayPlan {
-  session: StudySession;
-  intervalSeconds: number;
 }
 
 // Compares Deck names with locale-aware ascending order for deterministic presentation ties.
@@ -75,18 +62,14 @@ export const groupDecksByStudyStatus = <TDeck extends StudySessionDeck>(
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
-// Resolves a session against loaded Cards, distinguishing an in-flight empty read from a proven missing Card.
-export const resolveStudySession = <Card extends StudySessionCard>(
+// Finds the loaded Card at the active session position without inferring application loading state.
+export const findCurrentStudySessionCard = <Card extends StudySessionCard>(
   session: StudySession | undefined,
   cards: readonly Card[]
-): ResolvedStudySession<Card> => {
-  if (session == null) return { status: "invalid" };
-
+): Card | undefined => {
+  if (session == null) return;
   const cardId = getCurrentStudySessionCardId(session);
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-  if (card != null) return { status: "studying", session, card };
-  // An empty collection can still be an in-flight read; a populated collection proves the persisted card is absent.
-  return { status: cardId != null && cards.length === 0 ? "preparing" : "invalid" };
+  return cardId == null ? undefined : cards.find(({ id }) => id === cardId);
 };
 
 // Collapses control actions into the movement, exit, or no-op effects understood by a study session.
@@ -108,13 +91,13 @@ export const planStudySessionSwipe = (
   const effect = resolveStudySessionSwipeEffect(swipeAction);
   if (effect === "none" || effect === "exit") return { effect };
 
-  const resolvedSession = resolveStudySession(session, cards);
-  if (resolvedSession.status !== "studying") return { effect: "none" };
+  const card = findCurrentStudySessionCard(session, cards);
+  if (card == null) return { effect: "none" };
 
   return {
     effect,
     session,
-    progress: recordCardStudyProgress(resolvedSession.card, swipeAction, studiedAt),
+    progress: recordCardStudyProgress(card, swipeAction, studiedAt),
   };
 };
 
@@ -133,12 +116,6 @@ export const calculateStudySessionIndex = (
   return nextIndex >= 0 && nextIndex < session.cardOrderIds.length ? nextIndex : undefined;
 };
 
-// Builds a timer plan only while the resolved session can advance automatically.
-export const planStudySessionAutoPlay = (
-  resolvedSession: ResolvedStudySession<StudySessionCard>,
-  { enabled, intervalSeconds }: StudySessionAutoPlayOptions
-): StudySessionAutoPlayPlan | undefined => {
-  if (resolvedSession.status !== "studying" || !enabled || intervalSeconds <= 0) return;
-  const nextIndex = calculateStudySessionIndex(resolvedSession.session, "next");
-  return nextIndex === undefined ? undefined : { session: resolvedSession.session, intervalSeconds };
-};
+// Reports whether the session can move without crossing either end of its Card order.
+export const canMoveStudySession = (session: StudySession, movement: StudySessionMovement): boolean =>
+  calculateStudySessionIndex(session, movement) !== undefined;

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -62,12 +62,11 @@ export const groupDecksByStudyStatus = <TDeck extends StudySessionDeck>(
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
-// Finds the loaded Card at the active session position without inferring application loading state.
-export const findCurrentStudySessionCard = <Card extends StudySessionCard>(
-  session: StudySession | undefined,
+// Finds the loaded Card at the active session position for swipe planning.
+const findCurrentStudySessionCard = <Card extends StudySessionCard>(
+  session: StudySession,
   cards: readonly Card[]
 ): Card | undefined => {
-  if (session == null) return;
   const cardId = getCurrentStudySessionCardId(session);
   return cardId == null ? undefined : cards.find(({ id }) => id === cardId);
 };

--- a/src/entities/study-session/model/schema.ts
+++ b/src/entities/study-session/model/schema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+import type { StudySession } from "./types";
+
+export const studySessionSchema: z.ZodType<StudySession> = z
+  .object({
+    sessionId: z.string().min(1),
+    deckId: z.string().min(1),
+    cardOrderIds: z.array(z.string().min(1)).min(1),
+    currentIndex: z.number().int().nonnegative(),
+    lastStudiedAt: z.number().finite().nonnegative(),
+  })
+  .refine((session) => session.currentIndex < session.cardOrderIds.length, {
+    message: "Study session index must point to an active card",
+    path: ["currentIndex"],
+  });
+
+export const persistedStudySessionStateSchema = z.object({
+  sessionsByDeckId: z.record(z.string(), z.unknown()),
+});

--- a/src/entities/study-session/model/schema.ts
+++ b/src/entities/study-session/model/schema.ts
@@ -8,7 +8,7 @@ export const studySessionSchema: z.ZodType<StudySession> = z
     deckId: z.string().min(1),
     cardOrderIds: z.array(z.string().min(1)).min(1),
     currentIndex: z.number().int().nonnegative(),
-    lastStudiedAt: z.number().finite().nonnegative(),
+    lastStudiedAt: z.number().nonnegative(),
   })
   .refine((session) => session.currentIndex < session.cardOrderIds.length, {
     message: "Study session index must point to an active card",

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -11,6 +11,7 @@ import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
 
 import { calculateStudySessionIndex, isStudySessionPositionUnchanged } from "./rules";
+import { persistedStudySessionStateSchema, studySessionSchema } from "./schema";
 import type { StudySession, StudySessionMovement, StudySessions } from "./types";
 
 const STUDY_STORAGE_KEY = "tango-study";
@@ -26,46 +27,17 @@ interface StudySessionState {
   sessionsByDeckId: StudySessions;
 }
 
-// Narrows unknown persisted data to a non-array object record.
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value != null && !Array.isArray(value);
-
-// Rebuild canonical sessions from untrusted browser storage so malformed fields cannot break resume logic.
-const sanitizeStudySession = (value: unknown): StudySession | undefined => {
-  if (!isRecord(value)) return;
-  const { sessionId, deckId, cardOrderIds, currentIndex, lastStudiedAt } = value;
-  if (
-    typeof sessionId !== "string" ||
-    sessionId.length === 0 ||
-    typeof deckId !== "string" ||
-    !Array.isArray(cardOrderIds) ||
-    cardOrderIds.length === 0 ||
-    !cardOrderIds.every((cardId) => typeof cardId === "string") ||
-    typeof currentIndex !== "number" ||
-    !Number.isInteger(currentIndex) ||
-    currentIndex < 0 ||
-    currentIndex >= cardOrderIds.length ||
-    typeof lastStudiedAt !== "number" ||
-    !Number.isFinite(lastStudiedAt) ||
-    lastStudiedAt < 0
-  ) {
-    return;
-  }
-
-  return { sessionId, deckId, cardOrderIds: [...cardOrderIds], currentIndex, lastStudiedAt };
-};
-
 // Restores only independently valid sessions whose Deck key matches their payload.
 const sanitizePersistedState = (persistedState: unknown): StudySessionState => {
-  if (!(isRecord(persistedState) && isRecord(persistedState.sessionsByDeckId))) {
-    return { sessionsByDeckId: {} };
-  }
+  const parsedState = persistedStudySessionStateSchema.safeParse(persistedState);
+  if (!parsedState.success) return { sessionsByDeckId: {} };
 
   const sessionsByDeckId: StudySessions = {};
-  // Validate entries independently and reject key/value mismatches so one bad payload cannot affect other decks.
-  for (const [deckId, value] of Object.entries(persistedState.sessionsByDeckId)) {
-    const session = sanitizeStudySession(value);
-    if (session?.deckId === deckId) sessionsByDeckId[deckId] = session;
+  for (const [deckId, value] of Object.entries(parsedState.data.sessionsByDeckId)) {
+    const parsedSession = studySessionSchema.safeParse(value);
+    if (parsedSession.success && parsedSession.data.deckId === deckId) {
+      sessionsByDeckId[deckId] = parsedSession.data;
+    }
   }
   return { sessionsByDeckId };
 };

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -49,8 +49,3 @@ export type StudySessionSwipePlan =
 
 /** Minimal Card identity needed to resolve a study session position. */
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
-
-/** Resolution state for a session and its currently selected Card. */
-export type ResolvedStudySession<Card extends StudySessionCard> =
-  | { status: "preparing" | "invalid" }
-  | { status: "studying"; session: StudySession; card: Card };

--- a/src/features/study/model/useAutoPlay.ts
+++ b/src/features/study/model/useAutoPlay.ts
@@ -1,4 +1,4 @@
-import { moveStudySession, planStudySessionAutoPlay } from "@/entities/study-session";
+import { canMoveStudySession, moveStudySession } from "@/entities/study-session";
 
 import * as React from "react";
 
@@ -16,20 +16,21 @@ export const useAutoPlay = (
 ) => {
   const [autoPlay, setAutoPlay] = React.useState(defaultAutoPlay);
   const onAdvanceEvent = React.useEffectEvent(onAdvance);
-  const autoPlayPlan = planStudySessionAutoPlay(sessionState, {
-    enabled: autoPlay,
-    intervalSeconds: cardInterval,
-  });
-  const autoPlaySession = autoPlayPlan?.session;
-  const autoPlayIntervalSeconds = autoPlayPlan?.intervalSeconds;
+  const autoPlaySession =
+    sessionState.status === "studying" &&
+    autoPlay &&
+    cardInterval > 0 &&
+    canMoveStudySession(sessionState.session, "next")
+      ? sessionState.session
+      : undefined;
 
   React.useEffect(() => {
-    if (autoPlaySession === undefined || autoPlayIntervalSeconds === undefined) return;
+    if (autoPlaySession === undefined) return;
     const timeout = window.setTimeout(() => {
       if (moveStudySession(autoPlaySession, "next")) onAdvanceEvent();
-    }, autoPlayIntervalSeconds * 1000);
+    }, cardInterval * 1000);
     return () => window.clearTimeout(timeout);
-  }, [autoPlayIntervalSeconds, autoPlaySession]);
+  }, [autoPlaySession, cardInterval]);
 
   return {
     autoPlay,

--- a/src/features/study/model/useStudy.spec.tsx
+++ b/src/features/study/model/useStudy.spec.tsx
@@ -109,6 +109,16 @@ describe("useStudy", () => {
     expect(result.current.status).toBe("preparing");
   });
 
+  it("reports invalid when the session has no current card", async () => {
+    clearStudySessions();
+    startStudy(deckId, [], { shuffled: false, maxNumberOfCardsToLearn: 0 });
+
+    const { result } = renderHook(() => useStudy(deckId, []));
+
+    expect(result.current.status).toBe("invalid");
+    await waitFor(() => expect(getStudySession(deckId)).toBeUndefined());
+  });
+
   it("advances the session while autoplay is enabled", () => {
     vi.useFakeTimers();
     mocks.preferences = createPreferences({ cardInterval: 1, defaultAutoPlay: true });

--- a/src/features/study/model/useStudySessionState.ts
+++ b/src/features/study/model/useStudySessionState.ts
@@ -17,14 +17,11 @@ export type StudySessionState =
 export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
   const session = useStudySession(deckId);
   const card = findCurrentStudySessionCard(session, cards);
-  const sessionState: StudySessionState =
-    session == null
-      ? { status: "invalid" }
-      : card != null
-        ? { status: "studying", session, card }
-        : cards.length === 0
-          ? { status: "preparing" }
-          : { status: "invalid" };
+
+  let sessionState: StudySessionState;
+  if (session == null) sessionState = { status: "invalid" };
+  else if (card != null) sessionState = { status: "studying", session, card };
+  else sessionState = { status: cards.length === 0 ? "preparing" : "invalid" };
 
   React.useEffect(() => {
     if (sessionState.status !== "studying") return;

--- a/src/features/study/model/useStudySessionState.ts
+++ b/src/features/study/model/useStudySessionState.ts
@@ -1,26 +1,42 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
-import { removeStudySession, resolveStudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+import {
+  findCurrentStudySessionCard,
+  removeStudySession,
+  type StudySession,
+  touchStudySession,
+  useStudySession,
+} from "@/entities/study-session";
 
 import * as React from "react";
 
-export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]) => {
+export type StudySessionState =
+  | { status: "preparing" | "invalid" }
+  | { status: "studying"; session: StudySession; card: Card };
+
+export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
   const session = useStudySession(deckId);
-  const resolvedSession = resolveStudySession(session, cards);
+  const card = findCurrentStudySessionCard(session, cards);
+  const sessionState: StudySessionState =
+    session == null
+      ? { status: "invalid" }
+      : card != null
+        ? { status: "studying", session, card }
+        : cards.length === 0
+          ? { status: "preparing" }
+          : { status: "invalid" };
 
   React.useEffect(() => {
-    if (resolvedSession.status !== "studying") return;
+    if (sessionState.status !== "studying") return;
     touchStudySession(deckId);
-  }, [deckId, resolvedSession.status]);
+  }, [deckId, sessionState.status]);
 
   React.useEffect(() => {
-    if (resolvedSession.status !== "invalid") return;
+    if (sessionState.status !== "invalid") return;
 
     // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
     removeStudySession(deckId);
-  }, [deckId, resolvedSession.status]);
+  }, [deckId, sessionState.status]);
 
-  return resolvedSession;
+  return sessionState;
 };
-
-export type StudySessionState = ReturnType<typeof useStudySessionState>;

--- a/src/features/study/model/useStudySessionState.ts
+++ b/src/features/study/model/useStudySessionState.ts
@@ -1,12 +1,6 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
-import {
-  findCurrentStudySessionCard,
-  removeStudySession,
-  type StudySession,
-  touchStudySession,
-  useStudySession,
-} from "@/entities/study-session";
+import { removeStudySession, type StudySession, touchStudySession, useStudySession } from "@/entities/study-session";
 
 import * as React from "react";
 
@@ -16,10 +10,11 @@ export type StudySessionState =
 
 export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
   const session = useStudySession(deckId);
-  const card = findCurrentStudySessionCard(session, cards);
+  const cardId = session?.cardOrderIds[session.currentIndex];
+  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
 
   let sessionState: StudySessionState;
-  if (session == null) sessionState = { status: "invalid" };
+  if (session == null || cardId == null) sessionState = { status: "invalid" };
   else if (card != null) sessionState = { status: "studying", session, card };
   else sessionState = { status: cards.length === 0 ? "preparing" : "invalid" };
 


### PR DESCRIPTION
## Summary

- move `preparing` / `invalid` loading-state interpretation out of the StudySession Entity and keep it in the study feature
- replace `planStudySessionAutoPlay` and its intermediate plan/options types with the direct `canMoveStudySession` domain rule
- replace manual persisted-session shape checks with Zod schemas while preserving independent session recovery and key/payload validation
- keep existing study, swipe, autoplay, and persistence behavior

## Why

`study-session` was owning application loading-state inference and an autoplay-specific plan object in addition to its domain/session rules. This made the Entity API larger than necessary and coupled it to feature-level control flow.

The refactor leaves the Entity responsible for session identity, current-card lookup, movement, swipe planning, and persisted-session invariants. The feature decides whether a missing loaded Card means `preparing` or `invalid`.

## Impact

The Entity diff is smaller overall and exposes more direct primitives. No persisted storage version or user-visible behavior is intentionally changed.

## Validation

- updated `study-session/model/rules.spec.ts` for the new direct rules
- existing `useStudy.spec.tsx` continues to cover preparing state and autoplay behavior
- existing `store.spec.ts` continues to cover v4 hydration, malformed session removal, and unknown metadata stripping
- local commands were not run because this environment has no repository checkout / GitHub CLI; the changes were published through the GitHub connector
