### PR TITLE
[No issue] Refactor deck list state types

### DIFF
--- a/src/features/deck-list/model/useDeckListState.ts
+++ b/src/features/deck-list/model/useDeckListState.ts
@@ -12,74 +12,40 @@ interface UseDeckListStateOptions {
   sessionsByDeckId: Partial<Record<DeckId, StudySession>>;
 }
 
-interface DeletionTarget {
-  deck: Deck;
-  cardCount: number;
-}
-
-export interface DeckListStudyProgress {
-  currentIndex: number;
-  cardCount: number;
-  lastStudiedAt: number;
-}
-
-export type DeckListDeck = Pick<Deck, "id" | "name" | "category" | "isPublic">;
-
-export interface DeckListItem {
-  deck: DeckListDeck;
-  cardCount: number;
-  studyProgress?: DeckListStudyProgress;
-}
-
-export interface DeckListSections {
-  studying: DeckListItem[];
-  other: DeckListItem[];
-}
-
-export interface DeckListState {
-  sections: DeckListSections;
-  deletionTarget: { deckName: string; cardCount: number; hasError: boolean } | undefined;
-  successMessage: string | undefined;
-  onDownload: (id: DeckId) => void;
-  onRequestDeletion: (id: DeckId) => void;
-  onCancelDeletion: () => void;
-  onConfirmDeletion: () => Promise<void>;
-}
-
 const compareDeckNames = (left: Deck, right: Deck): number => left.name.localeCompare(right.name);
-
-const createDeckListStudyProgress = (session: StudySession): DeckListStudyProgress => ({
-  currentIndex: session.currentIndex,
-  cardCount: session.cardOrderIds.length,
-  lastStudiedAt: session.lastStudiedAt,
-});
 
 const buildDeckListSections = (
   decks: Deck[],
   cards: Card[],
   sessionsByDeckId: Partial<Record<DeckId, StudySession>>
-): DeckListSections => {
+) => {
   const cardCounts = countCardsByDeckId(cards);
-  const createItem = (deck: Deck): DeckListItem => ({
+  const createItem = (deck: Pick<Deck, "id" | "name" | "category" | "isPublic">, session?: StudySession) => ({
     deck,
     cardCount: cardCounts.get(deck.id) ?? 0,
+    ...(session == null
+      ? {}
+      : {
+          studyProgress: {
+            currentIndex: session.currentIndex,
+            cardCount: session.cardOrderIds.length,
+            lastStudiedAt: session.lastStudiedAt,
+          },
+        }),
   });
   const { active: studyingDecks, inactive: otherDecks } = groupDecksByStudyStatus(decks, sessionsByDeckId);
   studyingDecks.sort(compareActiveDecks);
   otherDecks.sort(compareDeckNames);
 
   return {
-    studying: studyingDecks.map(({ deck, session }) => ({
-      ...createItem(deck),
-      studyProgress: createDeckListStudyProgress(session),
-    })),
-    other: otherDecks.map(createItem),
+    studying: studyingDecks.map(({ deck, session }) => createItem(deck, session)),
+    other: otherDecks.map((deck) => createItem(deck)),
   };
 };
 
-export const useDeckListState = ({ decks, cards, sessionsByDeckId }: UseDeckListStateOptions): DeckListState => {
+export const useDeckListState = ({ decks, cards, sessionsByDeckId }: UseDeckListStateOptions) => {
   const uid = useAuthUid();
-  const [deletionTarget, setDeletionTarget] = React.useState<DeletionTarget>();
+  const [deletionTarget, setDeletionTarget] = React.useState<{ deck: Deck; cardCount: number }>();
   const [deletionErrorDeckId, setDeletionErrorDeckId] = React.useState<DeckId>();
   const [successMessage, setSuccessMessage] = React.useState<string>();
 
@@ -127,3 +93,5 @@ export const useDeckListState = ({ decks, cards, sessionsByDeckId }: UseDeckList
     onConfirmDeletion: confirmDeletion,
   };
 };
+
+export type DeckListState = ReturnType<typeof useDeckListState>;

--- a/src/features/deck-list/ui/DeckListCard.tsx
+++ b/src/features/deck-list/ui/DeckListCard.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { AiFillCaretRight, AiOutlineCloud } from "react-icons/ai";
 
 import type { DeckId } from "@/entities/deck";
-import type { DeckListDeck, DeckListStudyProgress } from "../model/useDeckListState";
+import type { DeckListState } from "../model/useDeckListState";
 
 import { DeckActionsMenu } from "./DeckActionsMenu";
 
@@ -27,11 +27,7 @@ export interface DeckListCardActions {
   onCloseMenu?: () => void;
 }
 
-export interface DeckListCardProps extends DeckListCardActions {
-  deck: DeckListDeck;
-  cardCount: number;
-  studyProgress?: DeckListStudyProgress;
-}
+export type DeckListCardProps = DeckListCardActions & DeckListState["sections"]["other"][number];
 
 /**
  * Formats a deck's last-study time for display in the deck list.
@@ -55,9 +51,9 @@ const primaryActionClassName =
   "inline-flex min-h-touch shrink-0 items-center justify-center gap-1 rounded-control px-3 text-caption font-semibold transition-colors duration-fast ease-calm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
 const DeckListCardStatus: React.FC<{
-  deck: DeckListDeck;
+  deck: DeckListCardProps["deck"];
   active: boolean;
-  studyProgress: DeckListStudyProgress | undefined;
+  studyProgress: DeckListCardProps["studyProgress"];
   progressValue: number;
   cardCount: number;
   statusId: string;

--- a/src/features/deck-list/ui/DeckListView.spec.tsx
+++ b/src/features/deck-list/ui/DeckListView.spec.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { DeckId } from "@/entities/deck";
-import type { DeckListSections } from "../model/useDeckListState";
+import type { DeckListState } from "../model/useDeckListState";
 
 import * as React from "react";
 import { fireEvent, render, within, screen } from "@testing-library/react";
@@ -19,7 +19,7 @@ import { DeckListView } from "./DeckListView";
 const activeDeck = createDeck({ id: "active", name: "Active deck", category: "math" });
 const otherDeck = createDeck({ id: "other", name: "Other deck", category: "history" });
 
-const sections: DeckListSections = {
+const sections = {
   studying: [
     {
       deck: activeDeck,
@@ -28,7 +28,7 @@ const sections: DeckListSections = {
     },
   ],
   other: [{ deck: otherDeck, cardCount: 7 }],
-};
+} satisfies DeckListState["sections"];
 
 /**
  * Renders the test-only Controlled Deck List component with controlled state or providers.

--- a/src/features/deck-list/ui/DeckListView.stories.tsx
+++ b/src/features/deck-list/ui/DeckListView.stories.tsx
@@ -6,7 +6,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import type { DeckListDeck, DeckListItem, DeckListSections } from "../model/useDeckListState";
+import type { Deck } from "@/entities/deck";
+import type { DeckListState } from "../model/useDeckListState";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
@@ -17,14 +18,13 @@ import { DeckListView as Template } from "./DeckListView";
  * The helper keeps sample setup separate from the component configuration readers are meant to
  * inspect.
  */
-const otherItems = (decks: DeckListDeck[]): DeckListItem[] =>
-  decks.map((deck, index) => ({ deck, cardCount: 12 + index * 4 }));
+const otherItems = (decks: Deck[]) => decks.map((deck, index) => ({ deck, cardCount: 12 + index * 4 }));
 /**
  * Prepares studying items data for the Storybook examples in this file.
  * The helper keeps sample setup separate from the component configuration readers are meant to
  * inspect.
  */
-const studyingItems = (decks: DeckListDeck[]): DeckListItem[] =>
+const studyingItems = (decks: Deck[]) =>
   decks.map((deck, index) => ({
     deck,
     cardCount: 30 + index,
@@ -35,14 +35,14 @@ const studyingItems = (decks: DeckListDeck[]): DeckListItem[] =>
     },
   }));
 
-const mixed: DeckListSections = {
+const mixed = {
   studying: studyingItems(fixture.decks.default.slice(0, 3)),
   other: otherItems(fixture.decks.default.slice(3)),
-};
-const longSections: DeckListSections = {
+} satisfies DeckListState["sections"];
+const longSections = {
   studying: studyingItems(fixture.decks.long.slice(0, 4)),
   other: otherItems(fixture.decks.long.slice(4)),
-};
+} satisfies DeckListState["sections"];
 
 const meta = {
   title: "Features/DeckList/DeckListView",

--- a/src/features/deck-list/ui/DeckListView.tsx
+++ b/src/features/deck-list/ui/DeckListView.tsx
@@ -4,12 +4,12 @@
 
 import * as React from "react";
 
-import type { DeckListItem, DeckListSections } from "../model/useDeckListState";
+import type { DeckListState } from "../model/useDeckListState";
 
 import { DeckListCard, type DeckListCardActions } from "./DeckListCard";
 
 export interface DeckListViewProps {
-  sections: DeckListSections;
+  sections: DeckListState["sections"];
   deckCard?: DeckListCardActions;
 }
 
@@ -25,7 +25,7 @@ const countLabel = (count: number) => `${String(count)} ${count === 1 ? "deck" :
 const DeckListSection: React.FC<{
   title: string;
   note: string;
-  items: DeckListItem[];
+  items: DeckListState["sections"]["other"];
   actions: DeckListCardActions | undefined;
 }> = ({ title, note, items, actions }) => {
   const headingId = React.useId();


### PR DESCRIPTION
## Related issue

None

## Summary

- Infer the deck list state contract from useDeckListState instead of maintaining duplicate exported types.
- Derive view, card, test, and story types from the state contract while keeping the UI-facing deck fields narrow.
- Build list items through one inferred mapper for active and inactive decks.

## Testing

- mise run check