### PR TITLE
[No issue] Test Deck URL persistence behavior

### DIFF
--- a/src/entities/deck/api/firestore.spec.ts
+++ b/src/entities/deck/api/firestore.spec.ts
@@ -1,41 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createDeck as createDeckFixture } from "@/test/factories";
 
-const mocks = vi.hoisted(() => ({
-  deleteField: vi.fn(() => ({ type: "delete-field" })),
-  doc: vi.fn((...parts: unknown[]) => parts),
-  setDoc: vi.fn(),
-  updateDoc: vi.fn(),
-}));
-
-vi.mock("firebase/firestore", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("firebase/firestore")>();
-  return {
-    ...actual,
-    deleteField: mocks.deleteField,
-    doc: mocks.doc,
-    setDoc: mocks.setDoc,
-    updateDoc: mocks.updateDoc,
-  };
-});
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 
 import { createDeck, deleteDeck, editDeck } from "./firestore";
 
 describe("Deck Firestore persistence", () => {
   const deck = createDeckFixture({ id: "deck", uid: "uid-a" });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("does not persist localMode in a remote Deck document", async () => {
-    await createDeck("uid-a", deck);
-
-    expect(mocks.setDoc).toHaveBeenCalledWith([{}, "deck", "deck"], expect.not.objectContaining({ localMode: false }));
-    expect(mocks.setDoc.mock.calls[0]?.[1]).not.toHaveProperty("localMode");
-  });
 
   it("rejects create requests without a confirmed matching owner", async () => {
     await expect(createDeck("", deck)).rejects.toThrow("confirmed user");
@@ -44,18 +16,6 @@ describe("Deck Firestore persistence", () => {
 
   it("rejects edit requests without a confirmed user", async () => {
     await expect(editDeck("", { id: deck.id })).rejects.toThrow("confirmed user");
-  });
-
-  it("deletes a cleared URL while omitting an unchanged URL", async () => {
-    await editDeck("uid-a", { id: deck.id });
-    expect(mocks.updateDoc.mock.calls[0]?.[1]).not.toHaveProperty("url");
-
-    await editDeck("uid-a", { id: deck.id, url: null });
-    expect(mocks.deleteField).toHaveBeenCalledOnce();
-    expect(mocks.updateDoc).toHaveBeenLastCalledWith(
-      [{}, "deck", "deck"],
-      expect.objectContaining({ url: mocks.deleteField.mock.results[0]?.value })
-    );
   });
 
   it("rejects delete requests without a confirmed matching owner", async () => {

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -73,6 +73,17 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     expect(data).not.toHaveProperty("cardOrderIds");
   });
 
+  it("preserves an omitted URL and removes a cleared URL", async () => {
+    const deck = { ...newDeck, id: uuid(), url: "https://example.com/deck" };
+    await createDeck("uid", deck);
+
+    await editDeck("uid", { id: deck.id, name: "updated" });
+    expect((await getDoc(doc(db, "deck", deck.id))).data()).toMatchObject({ url: deck.url });
+
+    await editDeck("uid", { id: deck.id, url: null });
+    expect((await getDoc(doc(db, "deck", deck.id))).data()).not.toHaveProperty("url");
+  });
+
   it("should delete a deck and its Cards", async () => {
     const d = { ...newDeck, id: uuid() };
     const cards = [


### PR DESCRIPTION
## Related issue

None

## Summary

- Remove unit tests coupled to Firestore SDK call details.
- Keep the existing emulator coverage for omitted persistence metadata.
- Verify that omitted Deck URLs remain stored while cleared URLs are removed.

## Testing

- mise run check
- mise run test-integration