### PR TITLE
[No issue] Replace mutation mocks with behavior tests

### DIFF
--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -1,125 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  createCard as createCardFixture,
-  createDeck as createDeckFixture,
-  createLocalCard,
-  createLocalDeck,
-} from "@/test/factories";
+import { createCard as createCardFixture } from "@/test/factories";
 
-import type { CardMutation } from "../model/types";
-import { cardStore, findCardById } from "../model/store";
-import { deleteCard, editCard, mutateCards } from "./mutations";
+vi.mock("@/shared/firebase", () => ({ db: {} }));
 
-const mocks = vi.hoisted(() => ({
-  createRemoteCard: vi.fn(),
-  deleteRemoteCard: vi.fn(),
-  editRemoteCard: vi.fn(),
-  findDeckById: vi.fn(),
-}));
-
-vi.mock("./firestore", () => ({
-  createCard: mocks.createRemoteCard,
-  deleteCard: mocks.deleteRemoteCard,
-  editCard: mocks.editRemoteCard,
-}));
-
-vi.mock("@/entities/deck/@x/card", () => ({
-  findDeckById: mocks.findDeckById,
-}));
+import { cardStore } from "../model/store";
+import { deleteCard, editCard } from "./mutations";
 
 describe("Card mutations", () => {
   beforeEach(() => {
     cardStore.setState({ remoteCards: [], localCards: [] });
-    vi.resetAllMocks();
-  });
-
-  it("routes Card create, edit, and delete by its local parent Deck", async () => {
-    const deck = createLocalDeck({ id: "local-deck" });
-    const card = createLocalCard({ id: "local-card", deckId: deck.id });
-    mocks.findDeckById.mockReturnValue(deck);
-
-    await mutateCards("", [{ kind: "create", card }]);
-    await editCard("", { id: card.id, frontText: "Updated" });
-
-    expect(findCardById(card.id)).toMatchObject({ id: card.id, frontText: "Updated" });
-    expect(mocks.createRemoteCard).not.toHaveBeenCalled();
-    expect(mocks.editRemoteCard).not.toHaveBeenCalled();
-
-    await deleteCard("", card);
-
-    expect(findCardById(card.id)).toBeUndefined();
-    expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
-  });
-
-  it("preserves remote Card mutation behavior", async () => {
-    const deck = createDeckFixture({ id: "remote-deck", localMode: false });
-    const card = createCardFixture({ id: "remote-card", deckId: deck.id });
-    const edit = { id: card.id, frontText: "Updated" };
-    mocks.findDeckById.mockReturnValue(deck);
-    cardStore.setState({ remoteCards: [card] });
-
-    await mutateCards("uid", [{ kind: "create", card }]);
-    await editCard("uid", edit);
-    await deleteCard("uid", card);
-
-    expect(mocks.createRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", card);
-    expect(mocks.editRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", { ...edit, uid: card.uid });
-    expect(mocks.deleteRemoteCard).toHaveBeenCalledExactlyOnceWith("uid", { id: card.id, uid: card.uid });
-  });
-
-  it("rejects a remote Card create without an owner UID", async () => {
-    const deck = createDeckFixture({ id: "remote-deck", localMode: false });
-    const card = createLocalCard({ id: "ownerless-card", deckId: deck.id });
-    mocks.findDeckById.mockReturnValue(deck);
-
-    await expect(mutateCards("uid", [{ kind: "create", card }])).rejects.toThrow();
-
-    expect(mocks.createRemoteCard).not.toHaveBeenCalled();
-  });
-
-  it("executes each explicit Card mutation through the existing routing", async () => {
-    const deck = createDeckFixture({ id: "remote-deck", localMode: false });
-    const created = createCardFixture({ id: "created", deckId: deck.id });
-    const edited = createCardFixture({ id: "edited", deckId: deck.id });
-    const mutations = [
-      { kind: "create", card: created },
-      { kind: "edit", card: edited },
-    ] satisfies CardMutation[];
-    mocks.findDeckById.mockReturnValue(deck);
-    cardStore.setState({ remoteCards: [edited], localCards: [] });
-
-    await mutateCards("uid-a", mutations);
-
-    expect(mocks.createRemoteCard).toHaveBeenCalledWith("uid-a", created);
-    expect(mocks.editRemoteCard).toHaveBeenCalledWith("uid-a", edited);
-  });
-
-  it("waits for every Card mutation before rejecting with the first failure", async () => {
-    const deck = createDeckFixture({ id: "remote-deck", localMode: false });
-    const first = createCardFixture({ id: "first", deckId: deck.id });
-    const second = createCardFixture({ id: "second", deckId: deck.id });
-    let finishEdit!: () => void;
-    mocks.findDeckById.mockReturnValue(deck);
-    cardStore.setState({ remoteCards: [second], localCards: [] });
-    mocks.createRemoteCard.mockRejectedValueOnce(new Error("create failed"));
-    mocks.editRemoteCard.mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        finishEdit = resolve;
-      })
-    );
-
-    const mutation = mutateCards("uid-a", [
-      { kind: "create", card: first },
-      { kind: "edit", card: second },
-    ]);
-    const settled = vi.fn();
-    void mutation.then(settled, settled);
-    await Promise.resolve();
-
-    expect(settled).not.toHaveBeenCalled();
-    finishEdit();
-    await expect(mutation).rejects.toThrow("create failed");
+    localStorage.clear();
   });
 
   it("rejects edit and delete when the Card cannot be resolved", async () => {
@@ -129,9 +20,6 @@ describe("Card mutations", () => {
       'Card "missing" was not found'
     );
     await expect(deleteCard("uid", card)).rejects.toThrow('Card "missing" was not found');
-
-    expect(mocks.editRemoteCard).not.toHaveBeenCalled();
-    expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
   });
 
   it("rejects edit and delete when the Card parent Deck cannot be resolved", async () => {
@@ -142,8 +30,5 @@ describe("Card mutations", () => {
       'Deck "missing-deck" was not found'
     );
     await expect(deleteCard("uid", card)).rejects.toThrow('Deck "missing-deck" was not found');
-
-    expect(mocks.editRemoteCard).not.toHaveBeenCalled();
-    expect(mocks.deleteRemoteCard).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/deck/api/mutations.spec.ts
+++ b/src/entities/deck/api/mutations.spec.ts
@@ -1,70 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createDeck as createDeckFixture, createLocalDeck } from "@/test/factories";
+import { createDeck as createDeckFixture } from "@/test/factories";
 
-import { createDeck, deleteDeck, editDeck } from "./mutations";
-import { deckStore, findDeckById } from "../model/store";
+vi.mock("@/shared/firebase", () => ({ db: {} }));
 
-const mocks = vi.hoisted(() => ({
-  createRemoteDeck: vi.fn(),
-  deleteRemoteDeck: vi.fn(),
-  editRemoteDeck: vi.fn(),
-  deleteLocalCardsByDeckId: vi.fn(),
-  removeStudySession: vi.fn(),
-}));
-
-vi.mock("./firestore", () => ({
-  createDeck: mocks.createRemoteDeck,
-  deleteDeck: mocks.deleteRemoteDeck,
-  editDeck: mocks.editRemoteDeck,
-}));
-
-vi.mock("@/entities/card/@x/deck", () => ({
-  deleteLocalCardsByDeckId: mocks.deleteLocalCardsByDeckId,
-}));
-
-vi.mock("@/entities/study-session/@x/deck", () => ({
-  removeStudySession: mocks.removeStudySession,
-}));
+import { deleteDeck, editDeck } from "./mutations";
+import { deckStore } from "../model/store";
 
 describe("Deck mutations", () => {
   beforeEach(() => {
     deckStore.setState({ remoteDecks: [], localDecks: [] });
-    vi.clearAllMocks();
-  });
-
-  it("routes local Deck create, edit, and delete to local persistence", async () => {
-    const deck = createLocalDeck({ id: "local" });
-
-    await createDeck("", deck);
-    await editDeck("", { id: deck.id, name: "Renamed" });
-
-    expect(findDeckById(deck.id)).toMatchObject({ id: deck.id, name: "Renamed", localMode: true });
-    expect(mocks.createRemoteDeck).not.toHaveBeenCalled();
-    expect(mocks.editRemoteDeck).not.toHaveBeenCalled();
-
-    await deleteDeck("", deck);
-
-    expect(findDeckById(deck.id)).toBeUndefined();
-    expect(mocks.deleteLocalCardsByDeckId).toHaveBeenCalledExactlyOnceWith(deck.id);
-    expect(mocks.removeStudySession).toHaveBeenCalledExactlyOnceWith(deck.id);
-    expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
-  });
-
-  it("preserves remote Deck mutation behavior", async () => {
-    const deck = createDeckFixture({ id: "remote", localMode: false });
-    const edit = { id: deck.id, name: "Renamed" };
-    deckStore.setState({ remoteDecks: [deck] });
-
-    await createDeck("uid", deck);
-    await editDeck("uid", edit);
-    await deleteDeck("uid", deck);
-
-    expect(mocks.createRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", deck);
-    expect(mocks.editRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", edit);
-    expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("uid", { id: deck.id, uid: deck.uid });
-    expect(mocks.deleteLocalCardsByDeckId).not.toHaveBeenCalled();
-    expect(mocks.removeStudySession).toHaveBeenCalledExactlyOnceWith(deck.id);
+    localStorage.clear();
   });
 
   it("rejects edit and delete when the Deck cannot be resolved", async () => {
@@ -72,9 +18,5 @@ describe("Deck mutations", () => {
 
     await expect(editDeck("uid", { id: deck.id, name: "Renamed" })).rejects.toThrow('Deck "missing" was not found');
     await expect(deleteDeck("uid", deck)).rejects.toThrow('Deck "missing" was not found');
-
-    expect(mocks.editRemoteDeck).not.toHaveBeenCalled();
-    expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
-    expect(mocks.removeStudySession).not.toHaveBeenCalled();
   });
 });

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,9 +8,8 @@ import "@/test/initializeTestFirestore";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, subscribeCards } from "@/entities/card";
-import { createCard as createCardCommand } from "@/entities/card/api/firestore";
-import { createDeck as createDeckCommand, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
+import { deleteCard, editCard, mutateCards, subscribeCards } from "@/entities/card";
+import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture } from "@/test/factories";
@@ -34,8 +33,8 @@ describe("Query realtime subscriptions", () => {
     try {
       const deck = createDeckFixture({ id: crypto.randomUUID(), uid });
       const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid });
-      await createDeckCommand(uid, deck);
-      await createCardCommand(uid, card);
+      await createDeck(uid, deck);
+      await mutateCards(uid, [{ kind: "create", card }]);
       await vi.waitFor(() => {
         expect(deckStore.getState().remoteDecks).toContainEqual(expect.objectContaining({ id: deck.id }));
         expect(cardStore.getState().remoteCards).toContainEqual(expect.objectContaining({ id: card.id }));

--- a/test/integration/local-mutations.spec.ts
+++ b/test/integration/local-mutations.spec.ts
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { deleteCard, editCard, mutateCards, useCards } from "@/entities/card";
+import { createDeck, deleteDeck, editDeck, useDecks } from "@/entities/deck";
+import { clearStudySessions, getStudySession, startStudy } from "@/entities/study-session";
+import { createLocalCard, createLocalDeck } from "@/test/factories";
+
+vi.mock("@/shared/firebase", () => ({ db: {} }));
+
+const studyOptions = { shuffled: false, maxNumberOfCardsToLearn: 0 };
+
+describe("local Entity mutations", () => {
+  afterEach(() => {
+    clearStudySessions();
+    localStorage.clear();
+  });
+
+  it("creates, edits, and deletes a Card through its local Deck", async () => {
+    const deck = createLocalDeck({ id: "card-deck" });
+    const card = createLocalCard({ id: "edited-card", deckId: deck.id });
+    await createDeck("", deck);
+    await mutateCards("", [{ kind: "create", card }]);
+
+    await editCard("", { id: card.id, frontText: "Updated" });
+
+    const editedCards = renderHook(() => useCards());
+    expect(editedCards.result.current).toContainEqual(expect.objectContaining({ id: card.id, frontText: "Updated" }));
+    editedCards.unmount();
+
+    await deleteCard("", card);
+
+    const remainingCards = renderHook(() => useCards());
+    expect(remainingCards.result.current.find(({ id }) => id === card.id)).toBeUndefined();
+    remainingCards.unmount();
+    await deleteDeck("", deck);
+  });
+
+  it("deletes a local Deck with its Cards and study session without affecting other Decks", async () => {
+    const deck = createLocalDeck({ id: "deleted-deck" });
+    const otherDeck = createLocalDeck({ id: "kept-deck" });
+    const card = createLocalCard({ id: "deleted-card", deckId: deck.id });
+    const otherCard = createLocalCard({ id: "kept-card", deckId: otherDeck.id });
+    await createDeck("", deck);
+    await createDeck("", otherDeck);
+    await mutateCards("", [
+      { kind: "create", card },
+      { kind: "create", card: otherCard },
+    ]);
+    startStudy(deck.id, [card], studyOptions);
+    startStudy(otherDeck.id, [otherCard], studyOptions);
+
+    await editDeck("", { id: deck.id, name: "Renamed" });
+    await deleteDeck("", deck);
+
+    const decks = renderHook(() => useDecks());
+    const cards = renderHook(() => useCards());
+    expect(decks.result.current.find(({ id }) => id === deck.id)).toBeUndefined();
+    expect(cards.result.current.find(({ id }) => id === card.id)).toBeUndefined();
+    expect(getStudySession(deck.id)).toBeUndefined();
+    expect(decks.result.current).toContainEqual(expect.objectContaining({ id: otherDeck.id }));
+    expect(cards.result.current).toContainEqual(expect.objectContaining({ id: otherCard.id }));
+    expect(getStudySession(otherDeck.id)).toBeDefined();
+    decks.unmount();
+    cards.unmount();
+    await deleteDeck("", otherDeck);
+  });
+});


### PR DESCRIPTION
## Related issue

None

## Summary

- Remove Card and Deck mutation tests that assert mocked collaborator calls.
- Add local cross-Entity behavior coverage for Card CRUD and Deck deletion cascades.
- Exercise remote Card and Deck creation through the public Entity mutation APIs in the Firestore subscription flow.

## Testing

- mise run check
- mise run test-integration