### PR TITLE
[No issue] Replace subscription internals with behavior tests

### DIFF
--- a/src/entities/card/api/subscription.spec.tsx
+++ b/src/entities/card/api/subscription.spec.tsx
@@ -8,11 +8,9 @@ import { cardStore } from "../model/store";
 
 const mocks = vi.hoisted(() => ({
   collection: vi.fn((...parts: unknown[]) => parts),
-  getDocsFromServer: vi.fn(),
   onSnapshot: vi.fn(),
   query: vi.fn((...parts: unknown[]) => parts),
   where: vi.fn((...parts: unknown[]) => parts),
-  unsubscribe: vi.fn(),
 }));
 
 vi.mock("firebase/firestore", async (importOriginal) => {
@@ -20,7 +18,6 @@ vi.mock("firebase/firestore", async (importOriginal) => {
   return {
     ...actual,
     collection: mocks.collection,
-    getDocsFromServer: mocks.getDocsFromServer,
     onSnapshot: mocks.onSnapshot,
     query: mocks.query,
     where: mocks.where,
@@ -28,7 +25,7 @@ vi.mock("firebase/firestore", async (importOriginal) => {
 });
 vi.mock("@/shared/firebase", () => ({ db: "db" }));
 
-import { fetchCardReads, fetchCards, subscribeCardReads, subscribeCards } from "./firestore";
+import { subscribeCardReads, subscribeCards } from "./firestore";
 
 // Builds a Firestore-like Card document with optional field overrides.
 const cardDocument = (id: string, overrides: Record<string, unknown> = {}) => ({
@@ -59,41 +56,12 @@ describe("Card Firestore subscription", () => {
   beforeEach(() => {
     cardStore.setState({ remoteCards: [], localCards: [] });
     vi.clearAllMocks();
-    mocks.onSnapshot.mockReturnValue(mocks.unsubscribe);
-  });
-
-  it("fetches the same separated read contract as subscriptions", async () => {
-    mocks.getDocsFromServer.mockResolvedValue({
-      docs: [cardDocument("active"), cardDocument("deleted", { deletedAt: 3 })],
-    });
-
-    await expect(fetchCardReads("uid-a")).resolves.toEqual([
-      {
-        card: expect.objectContaining({ id: "active", frontText: "Remote front" }),
-        progress: expect.objectContaining({ cardId: "active", score: 3, numberOfSeen: 4 }),
-      },
-    ]);
-    expect(mocks.where).toHaveBeenCalledWith("uid", "==", "uid-a");
-  });
-
-  it("keeps combined Card fetches behind the compatibility API", async () => {
-    mocks.getDocsFromServer.mockResolvedValue({
-      docs: [cardDocument("active", { nextSeeingAt: Timestamp.fromMillis(60) })],
-    });
-
-    await expect(fetchCards("uid-a")).resolves.toEqual([
-      expect.objectContaining({
-        id: "active",
-        score: 3,
-        numberOfSeen: 4,
-        nextSeeingAt: new Date(60),
-      }),
-    ]);
+    mocks.onSnapshot.mockReturnValue(vi.fn());
   });
 
   it("exposes separate Card and StudyProgress reads from each snapshot", () => {
     const onReads = vi.fn();
-    const unsubscribe = subscribeCardReads("uid-a", onReads, vi.fn());
+    subscribeCardReads("uid-a", onReads, vi.fn());
 
     act(() =>
       getSnapshotHandler()({
@@ -134,20 +102,13 @@ describe("Card Firestore subscription", () => {
         },
       },
     ]);
-
-    unsubscribe();
-    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
-  it("subscribes by UID and fully replaces active Cards from each snapshot", () => {
+  it("fully replaces active Cards from each snapshot", () => {
     const localCard = createLocalCard({ id: "local", frontText: "Local front" });
     cardStore.setState({ localCards: [localCard] });
     const { result } = renderHook(useCards);
-    const unsubscribe = subscribeCards("uid-a", vi.fn());
-
-    expect(mocks.collection).toHaveBeenCalledWith("db", "card");
-    expect(mocks.where).toHaveBeenCalledWith("uid", "==", "uid-a");
-    expect(mocks.onSnapshot).toHaveBeenCalledWith(expect.anything(), expect.any(Function), expect.any(Function));
+    subscribeCards("uid-a", vi.fn());
 
     act(() =>
       getSnapshotHandler()({
@@ -180,9 +141,6 @@ describe("Card Firestore subscription", () => {
 
     act(() => getSnapshotHandler()({ docs: [cardDocument("replacement", { frontText: "Current" })] }));
     expect(result.current).toEqual([expect.objectContaining({ id: "replacement", frontText: "Current" }), localCard]);
-
-    unsubscribe();
-    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("reports invalid Firestore documents", () => {

--- a/src/entities/deck/api/subscription.spec.tsx
+++ b/src/entities/deck/api/subscription.spec.tsx
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => ({
   onSnapshot: vi.fn(),
   query: vi.fn((...parts: unknown[]) => parts),
   where: vi.fn((...parts: unknown[]) => parts),
-  unsubscribe: vi.fn(),
 }));
 
 vi.mock("firebase/firestore", () => ({
@@ -53,17 +52,15 @@ describe("Deck Firestore subscription", () => {
   beforeEach(() => {
     deckStore.setState({ remoteDecks: [], localDecks: [] });
     vi.clearAllMocks();
-    mocks.onSnapshot.mockReturnValue(mocks.unsubscribe);
+    mocks.onSnapshot.mockReturnValue(vi.fn());
   });
 
-  it("subscribes by UID and replaces the store with active Decks", () => {
+  it("replaces the store with active Decks", () => {
     const localDeck = createLocalDeck({ id: "local", name: "Local Deck" });
     deckStore.setState({ localDecks: [localDeck] });
     const { result } = renderHook(useDecks);
-    const unsubscribe = subscribeDecks("uid-a", vi.fn());
+    subscribeDecks("uid-a", vi.fn());
 
-    expect(mocks.collection).toHaveBeenCalledWith("db", "deck");
-    expect(mocks.where).toHaveBeenCalledWith("uid", "==", "uid-a");
     act(() =>
       getSnapshotHandler()({
         docs: [deckDocument("active", { url: "https://example.com" }), deckDocument("deleted", { deletedAt: 3 })],
@@ -74,8 +71,6 @@ describe("Deck Firestore subscription", () => {
       expect.objectContaining({ id: "active", url: "https://example.com", localMode: false }),
       localDeck,
     ]);
-    unsubscribe();
-    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("reports invalid Firestore documents", () => {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -5,11 +5,11 @@
  */
 
 import "@/test/initializeTestFirestore";
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, mutateCards, subscribeCards } from "@/entities/card";
-import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
+import { deleteCard, editCard, fetchCardReads, fetchCards, mutateCards, subscribeCards } from "@/entities/card";
+import { createDeck, deleteDeck, editDeck, fetchDecks, subscribeDecks } from "@/entities/deck";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture } from "@/test/factories";
@@ -20,8 +20,39 @@ vi.mock("@/shared/firebase", async () => ({
 }));
 
 describe("Query realtime subscriptions", () => {
+  beforeEach(() => {
+    cardStore.setState({ remoteCards: [], localCards: [] });
+    deckStore.setState({ remoteDecks: [], localDecks: [] });
+  });
+
   afterAll(async () => {
     await Promise.all(getApps().map(deleteApp));
+  });
+
+  it("fetches Cards and Decks through their public read APIs", async () => {
+    const uid = "uid";
+    const deck = createDeckFixture({ id: crypto.randomUUID(), uid, name: "Fetched Deck" });
+    const card = createCard({
+      id: crypto.randomUUID(),
+      deckId: deck.id,
+      uid,
+      frontText: "Fetched Card",
+      score: 2,
+      numberOfSeen: 3,
+    });
+    await createDeck(uid, deck);
+    await mutateCards(uid, [{ kind: "create", card }]);
+
+    const [decks, cards, reads] = await Promise.all([fetchDecks(uid), fetchCards(uid), fetchCardReads(uid)]);
+
+    expect(decks).toContainEqual(expect.objectContaining({ id: deck.id, name: "Fetched Deck" }));
+    expect(cards).toContainEqual(
+      expect.objectContaining({ id: card.id, frontText: "Fetched Card", score: 2, numberOfSeen: 3 })
+    );
+    expect(reads).toContainEqual({
+      card: expect.objectContaining({ id: card.id, frontText: "Fetched Card" }),
+      progress: expect.objectContaining({ cardId: card.id, score: 2, numberOfSeen: 3 }),
+    });
   });
 
   it("delivers initial, update, and delete snapshots without a cursor", async () => {
@@ -62,5 +93,40 @@ describe("Query realtime subscriptions", () => {
       stopCards();
       stopDecks();
     }
+  });
+
+  it("stops changing stores after unsubscribe", async () => {
+    const uid = "uid";
+    const errors: Error[] = [];
+    const stopDecks = subscribeDecks(uid, (error) => errors.push(error));
+    const stopCards = subscribeCards(uid, (error) => errors.push(error));
+    const deck = createDeckFixture({ id: crypto.randomUUID(), uid, name: "Before stop" });
+    const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid, frontText: "Before stop" });
+
+    await createDeck(uid, deck);
+    await mutateCards(uid, [{ kind: "create", card }]);
+    await vi.waitFor(() => {
+      expect(deckStore.getState().remoteDecks).toContainEqual(
+        expect.objectContaining({ id: deck.id, name: "Before stop" })
+      );
+      expect(cardStore.getState().remoteCards).toContainEqual(
+        expect.objectContaining({ id: card.id, frontText: "Before stop" })
+      );
+    });
+
+    stopCards();
+    stopDecks();
+    await editDeck(uid, { ...deck, name: "After stop" });
+    await editCard(uid, { ...card, frontText: "After stop" });
+
+    expect(await fetchDecks(uid)).toContainEqual(expect.objectContaining({ id: deck.id, name: "After stop" }));
+    expect(await fetchCards(uid)).toContainEqual(expect.objectContaining({ id: card.id, frontText: "After stop" }));
+    expect(deckStore.getState().remoteDecks).toContainEqual(
+      expect.objectContaining({ id: deck.id, name: "Before stop" })
+    );
+    expect(cardStore.getState().remoteCards).toContainEqual(
+      expect.objectContaining({ id: card.id, frontText: "Before stop" })
+    );
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Related issue\n\nNone\n\n## Summary\n\n- remove Firestore SDK call-shape, mocked fetch, and mocked unsubscribe assertions from Card and Deck subscription tests\n- verify public Card and Deck fetch results against the Firestore emulator\n- verify create, update, delete, and unsubscribe behavior through the public APIs and observable stores\n\n## Testing\n\n- Checked 391 files in 43ms. No fixes applied.
│
▲  One or more extensionless imports detected: "./vitePlugins" in file
│  "/Users/studio2022/workspace/tango/.worktrees/codex-subscription-behavior-tests/.storybook/main.ts".
│  For more information on how to resolve the issue:
│  ]8;;https://storybook.js.org/docs/faq#extensionless-imports-in-storybookmaints-and-required-ts-extensionshttps://storybook.js.org/docs/faq#extensionless-imports-in-st...]8;;

 RUN  v4.1.10 /Users/studio2022/workspace/tango/.worktrees/codex-subscription-behavior-tests

Checked 400 files in 2s. No fixes applied.
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !node_modules/** !.worktrees/**
Linting: 25 files
Summary: 0 issues in 0 files
12 files already formatted

 Test Files  104 passed (104)
      Tests  532 passed (532)
   Start at  19:32:01
   Duration  20.57s (transform 20.20s, setup 0ms, import 57.62s, tests 19.10s, environment 87.01s)

Checked 400 files in 1810ms. No fixes applied.
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !node_modules/** !.worktrees/**
Linting: 25 files
Summary: 0 issues in 0 files\n- │
▲  One or more extensionless imports detected: "./vitePlugins" in file
│  "/Users/studio2022/workspace/tango/.worktrees/codex-subscription-behavior-tests/.storybook/main.ts".
│  For more information on how to resolve the issue:
│  ]8;;https://storybook.js.org/docs/faq#extensionless-imports-in-storybookmaints-and-required-ts-extensionshttps://storybook.js.org/docs/faq#extensionless-imports-in-st...]8;;

 RUN  v4.1.10 /Users/studio2022/workspace/tango/.worktrees/codex-subscription-behavior-tests


 Test Files  5 passed (5)
      Tests  45 passed (45)
   Start at  19:32:31
   Duration  5.84s (transform 459ms, setup 0ms, import 1.04s, tests 2.74s, environment 1.64s)