### PR TITLE
[No issue] Test persisted deck filter behavior

### DIFF
--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -1,29 +1,26 @@
 /**
  * @file Verifies the "DeckFilterForm with useDeckFilterState" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "auto-submits score and tag
- * filter changes", "auto-submits score toggle and slider changes", "auto-submits individual tag,
- * all, and clear changes".
+ * The examples make the expected behavior concrete by remounting the form from its saved Deck.
  */
 
-import type { Deck } from "@/entities/deck";
+import type { Deck, DeckId } from "@/entities/deck";
 
 import type React from "react";
 
 import userEvent from "@testing-library/user-event";
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
+import { createDeck, useDeck } from "@/entities/deck";
+import { createLocalDeck } from "@/test/factories";
 import { DeckFilterForm } from "../ui/DeckFilterForm";
 import { useDeckFilterState } from "./useDeckFilterState";
-import { createDeck } from "@/test/factories";
-
-const mocks = vi.hoisted(() => ({ editDeck: vi.fn() }));
 
 vi.mock("@/entities/auth", () => ({
   useAuthUid: () => "user-id",
 }));
-vi.mock("@/entities/deck", () => ({ editDeck: mocks.editDeck }));
+vi.mock("@/shared/firebase", () => ({ db: {} }));
 
 /**
  * Renders the test-only Deck Filter Harness component with controlled state or providers.
@@ -37,21 +34,23 @@ const DeckFilterHarness: React.FC<{
   return <DeckFilterForm {...deckFilter} tags={tags} />;
 };
 
+// Connects a fresh filter form to the Deck saved by the Entity after each remount.
+const StoredDeckFilterHarness: React.FC<{ deckId: DeckId; tags: string[] }> = ({ deckId, tags }) => {
+  const deck = useDeck(deckId);
+  return deck === undefined ? null : <DeckFilterHarness deck={deck} tags={tags} />;
+};
+
 describe("DeckFilterForm with useDeckFilterState", () => {
-  const deck = createDeck({
-    scoreMax: 1,
-    scoreMin: -1,
-    tagAndFilter: false,
-    selectedTags: [],
-  });
+  const deckId = "filter-deck";
   const tags = ["tag1", "tag2", "tag3"];
 
-  beforeEach(() => {
-    mocks.editDeck.mockReset().mockResolvedValue(undefined);
-  });
-
-  it("persists score and tag filter changes", async () => {
-    render(<DeckFilterHarness deck={deck} tags={tags} />);
+  it("restores score and tag mode changes from the saved Deck", async () => {
+    await createDeck(
+      "",
+      createLocalDeck({ id: deckId, scoreMax: 1, scoreMin: -1, tagAndFilter: false, selectedTags: [] })
+    );
+    const renderFilter = () => render(<StoredDeckFilterHarness deckId={deckId} tags={tags} />);
+    const view = renderFilter();
 
     fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
       target: { value: 2 },
@@ -62,58 +61,73 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: "Match all selected tags" }));
     await userEvent.click(screen.getByRole("button", { name: /all/i }));
 
-    await waitFor(() => expect(mocks.editDeck).toHaveBeenCalledTimes(4));
-    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, scoreMax: 2 });
-    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, scoreMin: -2 });
-    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, tagAndFilter: true });
-    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deck.id, selectedTags: tags });
+    view.unmount();
+    renderFilter();
+
+    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("slider", { name: "Minimum score value" })).toHaveValue("-2");
+    expect(screen.getByRole("checkbox", { name: "Match all selected tags" })).toBeChecked();
+    expect(screen.getByText("AND")).toBeInTheDocument();
+    for (const tag of tags) expect(screen.getByRole("checkbox", { name: tag })).toBeChecked();
   });
 
-  it("persists score toggle and slider changes", async () => {
-    render(<DeckFilterHarness deck={{ ...deck, scoreMax: null, scoreMin: null }} tags={tags} />);
+  it("restores enabled score limits and later restores their removal", async () => {
+    await createDeck("", createLocalDeck({ id: deckId, scoreMax: null, scoreMin: null }));
+    const renderFilter = () => render(<StoredDeckFilterHarness deckId={deckId} tags={tags} />);
+    let view = renderFilter();
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMax: 0 });
-    });
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMin: 0 });
-    });
-
     fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
       target: { value: 2 },
     });
     fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), {
       target: { value: -2 },
     });
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMin: -2 });
-    });
+
+    view.unmount();
+    view = renderFilter();
+
+    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Enable maximum score" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Enable minimum score" })).toBeChecked();
+    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("slider", { name: "Minimum score value" })).toHaveValue("-2");
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
     await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, scoreMin: null });
-    });
+
+    view.unmount();
+    renderFilter();
+
+    expect(screen.getByText("Any score")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Enable maximum score" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Enable minimum score" })).not.toBeChecked();
+    expect(screen.getByRole("slider", { name: "Maximum score value" })).toBeDisabled();
+    expect(screen.getByRole("slider", { name: "Minimum score value" })).toBeDisabled();
   });
 
-  it("persists individual tag, all, and clear changes", async () => {
-    render(<DeckFilterHarness deck={deck} tags={tags} />);
+  it("restores individual, all, and cleared tag selections", async () => {
+    await createDeck("", createLocalDeck({ id: deckId, selectedTags: [] }));
+    const renderFilter = () => render(<StoredDeckFilterHarness deckId={deckId} tags={tags} />);
+    let view = renderFilter();
 
-    await userEvent.click(screen.getByText("tag2"));
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, selectedTags: ["tag2"] });
-    });
+    await userEvent.click(screen.getByRole("checkbox", { name: "tag2" }));
+    view.unmount();
+    view = renderFilter();
+    expect(screen.getByRole("checkbox", { name: "tag1" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "tag2" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "tag3" })).not.toBeChecked();
 
     await userEvent.click(screen.getByRole("button", { name: /all/i }));
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, selectedTags: tags });
-    });
+    view.unmount();
+    view = renderFilter();
+    for (const tag of tags) expect(screen.getByRole("checkbox", { name: tag })).toBeChecked();
 
     await userEvent.click(screen.getByRole("button", { name: /clear/i }));
-    await waitFor(() => {
-      expect(mocks.editDeck).toHaveBeenLastCalledWith("user-id", { id: deck.id, selectedTags: [] });
-    });
+    view.unmount();
+    renderFilter();
+    for (const tag of tags) expect(screen.getByRole("checkbox", { name: tag })).not.toBeChecked();
   });
 });


### PR DESCRIPTION
## Related issue\n\nNone\n\n## Summary\n\n- replace editDeck mock call assertions with real local Deck edits through the public Entity API\n- remount the filter form to verify saved score limits, tag mode, and tag selections are restored\n- cover enabling and removing score limits plus individual, all, and cleared tag selections\n\n## Testing\n\n- Checked 391 files in 46ms. No fixes applied.
│
▲  One or more extensionless imports detected: "./vitePlugins" in file
│  "/Users/studio2022/workspace/tango/.worktrees/codex-deck-filter-behavior-tests/.storybook/main.ts".
│  For more information on how to resolve the issue:
│  ]8;;https://storybook.js.org/docs/faq#extensionless-imports-in-storybookmaints-and-required-ts-extensionshttps://storybook.js.org/docs/faq#extensionless-imports-in-st...]8;;

 RUN  v4.1.10 /Users/studio2022/workspace/tango/.worktrees/codex-deck-filter-behavior-tests

Checked 400 files in 2s. No fixes applied.
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !node_modules/** !.worktrees/**
Linting: 25 files
Summary: 0 issues in 0 files
12 files already formatted

 Test Files  104 passed (104)
      Tests  532 passed (532)
   Start at  20:49:17
   Duration  20.59s (transform 21.16s, setup 0ms, import 57.41s, tests 20.47s, environment 86.61s)

Checked 400 files in 1841ms. No fixes applied.
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !node_modules/** !.worktrees/**
Linting: 25 files
Summary: 0 issues in 0 files