### PR TITLE
[No issue] Test Card and Deck UI behavior

### DIFF
--- a/src/features/card-edit/ui/CardEditForm.spec.tsx
+++ b/src/features/card-edit/ui/CardEditForm.spec.tsx
@@ -1,53 +1,90 @@
-import type { RemoteCard } from "@/entities/card";
+import type { Card, CardId } from "@/entities/card";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { createCard } from "@/test/factories";
+import { mutateCards, useCard } from "@/entities/card";
+import { createDeck } from "@/entities/deck";
+import { createLocalCard, createLocalDeck } from "@/test/factories";
 
-const mocks = vi.hoisted(() => ({
-  editCard: vi.fn(),
+const writeControls = vi.hoisted(() => ({
+  beforeWrite: undefined as (() => Promise<void>) | undefined,
+  nextError: undefined as unknown,
 }));
 
 vi.mock("@/entities/auth", () => ({
   useAuthUid: () => "user-id",
 }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
-vi.mock("@/entities/card", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/entities/card")>()),
-  editCard: mocks.editCard,
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...actual,
+    // Keep successful writes on the real local Entity path while controlling only failure and timing.
+    editCard: async (...args: Parameters<typeof actual.editCard>) => {
+      if (writeControls.nextError !== undefined) {
+        const error = writeControls.nextError;
+        writeControls.nextError = undefined;
+        throw error;
+      }
+      await writeControls.beforeWrite?.();
+      return actual.editCard(...args);
+    },
+  };
+});
+vi.mock("@/entities/deck", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/entities/deck")>()),
+  CATEGORY: ["language", "math"],
 }));
-vi.mock("@/entities/deck", () => ({ CATEGORY: ["language", "math"] }));
 
 import { CardEditForm } from "./CardEditForm";
 import { useCardEditAction } from "../model/useCardEditAction";
 import { useCardFormState } from "../model/useCardFormState";
 
-const CardEditFormHarness = (props: { card: RemoteCard; onCancel: () => void; onSaved: () => void }) => {
+const CardEditFormHarness = (props: { card: Card; onCancel: () => void; onSaved: () => void }) => {
   const editAction = useCardEditAction({ onSaved: props.onSaved });
   const form = useCardFormState({ card: props.card, onCancel: props.onCancel, onSubmit: editAction.update });
 
   return <CardEditForm form={form} saveError={editAction.error} />;
 };
 
+// A fresh Entity read after remount proves that the form displays the last successful edit.
+const StoredCardEditFormHarness = (props: { cardId: CardId; onCancel: () => void; onSaved: () => void }) => {
+  const card = useCard(props.cardId);
+  return card === undefined ? null : (
+    <CardEditFormHarness card={card} onCancel={props.onCancel} onSaved={props.onSaved} />
+  );
+};
+
 describe("CardEditForm", () => {
-  const card: RemoteCard = createCard({
-    id: "card-id",
-    uid: "user-id",
-    frontText: "Front text",
-    backText: "Back text",
-    tags: ["language"],
+  const deckId = "card-edit-deck";
+  const cardId = "card-id";
+  const renderForm = (onSaved = vi.fn(), onCancel = vi.fn()) =>
+    render(<StoredCardEditFormHarness cardId={cardId} onCancel={onCancel} onSaved={onSaved} />);
+
+  beforeEach(async () => {
+    writeControls.beforeWrite = undefined;
+    writeControls.nextError = undefined;
+    await createDeck("", createLocalDeck({ id: deckId }));
+    await mutateCards("", [
+      {
+        kind: "create",
+        card: createLocalCard({
+          id: cardId,
+          deckId,
+          frontText: "Front text",
+          backText: "Back text",
+          tags: ["language"],
+        }),
+      },
+    ]);
   });
 
-  beforeEach(() => {
-    mocks.editCard.mockReset().mockResolvedValue(undefined);
-  });
-
-  it("saves edited form values for the authenticated user and reports success", async () => {
+  it("restores successfully saved form values from the Card Entity", async () => {
     const onSaved = vi.fn();
-    render(<CardEditFormHarness card={card} onCancel={vi.fn()} onSaved={onSaved} />);
+    const view = renderForm(onSaved);
 
     const frontText = screen.getByRole("textbox", { name: "Front text" });
     const backText = screen.getByRole("textbox", { name: "Back text" });
@@ -58,38 +95,35 @@ describe("CardEditForm", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: "math" }));
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
-    await waitFor(() =>
-      expect(mocks.editCard).toHaveBeenCalledWith("user-id", {
-        id: card.id,
-        frontText: "Updated front",
-        backText: "Updated back",
-        tags: ["language", "math"],
-      })
-    );
-    expect(onSaved).toHaveBeenCalledOnce();
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    view.unmount();
+    renderForm();
+
+    expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Updated front");
+    expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Updated back");
+    expect(screen.getByRole("checkbox", { name: "language" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "math" })).toBeChecked();
   });
 
   it("uses the form submit state while saving", async () => {
-    let finishSave: (() => void) | undefined;
-    mocks.editCard.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          finishSave = resolve;
-        })
-    );
-    render(<CardEditFormHarness card={card} onCancel={vi.fn()} onSaved={vi.fn()} />);
+    let finishSave: () => void = () => undefined;
+    writeControls.beforeWrite = () =>
+      new Promise<void>((resolve) => {
+        finishSave = resolve;
+      });
+    renderForm();
 
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
-    finishSave?.();
+    finishSave();
     await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
   });
 
-  it("keeps edited values and allows another save after a failure", async () => {
-    mocks.editCard.mockRejectedValueOnce(new Error("write failed"));
+  it("keeps edited values and saves them after retrying a failure", async () => {
+    writeControls.nextError = new Error("write failed");
     const onSaved = vi.fn();
-    render(<CardEditFormHarness card={card} onCancel={vi.fn()} onSaved={onSaved} />);
+    const view = renderForm(onSaved);
     const frontText = screen.getByRole("textbox", { name: "Front text" });
     await userEvent.clear(frontText);
     await userEvent.type(frontText, "Retry front");
@@ -102,14 +136,16 @@ describe("CardEditForm", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
-    await waitFor(() => expect(mocks.editCard).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByText("Unable to save changes. Try again.")).not.toBeInTheDocument());
     expect(onSaved).toHaveBeenCalledOnce();
+    view.unmount();
+    renderForm();
+    expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Retry front");
   });
 
   it("forwards cancellation from both navigation actions", async () => {
     const onCancel = vi.fn();
-    render(<CardEditFormHarness card={card} onCancel={onCancel} onSaved={vi.fn()} />);
+    renderForm(vi.fn(), onCancel);
 
     await userEvent.click(screen.getByRole("button", { name: "Back to cards" }));
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
@@ -117,8 +153,8 @@ describe("CardEditForm", () => {
     expect(onCancel).toHaveBeenCalledTimes(2);
   });
 
-  it("validates fields before saving", async () => {
-    render(<CardEditFormHarness card={card} onCancel={vi.fn()} onSaved={vi.fn()} />);
+  it("keeps stored values unchanged when validation rejects the form", async () => {
+    const view = renderForm();
     await userEvent.clear(screen.getByRole("textbox", { name: "Front text" }));
     await userEvent.type(screen.getByRole("textbox", { name: "Front text" }), "   ");
     await userEvent.clear(screen.getByRole("textbox", { name: "Back text" }));
@@ -127,6 +163,9 @@ describe("CardEditForm", () => {
 
     expect(await screen.findByText("Front text is required.")).toBeVisible();
     expect(screen.getByText("Back text is required.")).toBeVisible();
-    expect(mocks.editCard).not.toHaveBeenCalled();
+    view.unmount();
+    renderForm();
+    expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Front text");
+    expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Back text");
   });
 });

--- a/src/features/card-list/ui/CardList.spec.tsx
+++ b/src/features/card-list/ui/CardList.spec.tsx
@@ -176,8 +176,7 @@ describe("CardList", () => {
     expect(await screen.findByText("Unable to delete this card. Check your connection and try again.")).toBeVisible();
     await userEvent.click(screen.getByRole("button", { name: "Delete card" }));
 
-    await waitFor(() => expect(mocks.deleteCard).toHaveBeenCalledTimes(2));
-    expect(screen.queryByRole("alertdialog", { name: "Delete card?" })).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole("alertdialog", { name: "Delete card?" })).not.toBeInTheDocument());
   });
 
   it("keeps score mutation feedback retryable", async () => {
@@ -189,8 +188,6 @@ describe("CardList", () => {
     expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
     swipe(article, 0, 100);
 
-    await waitFor(() => expect(mocks.editStudyProgress).toHaveBeenCalledTimes(2));
-    expect(mocks.editStudyProgress).toHaveBeenLastCalledWith("user-id", { cardId: card.id, score: 1 });
     await waitFor(() => expect(screen.queryByText("Unable to save changes. Try again.")).not.toBeInTheDocument());
   });
 });

--- a/src/features/deck-edit/ui/DeckEditForm.spec.tsx
+++ b/src/features/deck-edit/ui/DeckEditForm.spec.tsx
@@ -1,25 +1,39 @@
-import type { Deck } from "@/entities/deck";
+import type { Deck, DeckId } from "@/entities/deck";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { createDeck } from "@/test/factories";
+import { createDeck, useDeck } from "@/entities/deck";
+import { createLocalDeck } from "@/test/factories";
 
-const mocks = vi.hoisted(() => ({
-  editDeck: vi.fn(),
+const writeControls = vi.hoisted(() => ({
+  beforeWrite: undefined as (() => Promise<void>) | undefined,
+  nextError: undefined as unknown,
 }));
 
 vi.mock("@/entities/auth", () => ({
   useAuthUid: () => "user-id",
 }));
 vi.mock("@/shared/firebase", () => ({ db: {} }));
-vi.mock("@/entities/deck", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/entities/deck")>()),
-  CATEGORY: ["language", "science"],
-  editDeck: mocks.editDeck,
-}));
+vi.mock("@/entities/deck", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/deck")>();
+  return {
+    ...actual,
+    CATEGORY: ["language", "science"],
+    // Keep successful writes on the real local Entity path while controlling only failure and timing.
+    editDeck: async (...args: Parameters<typeof actual.editDeck>) => {
+      if (writeControls.nextError !== undefined) {
+        const error = writeControls.nextError;
+        writeControls.nextError = undefined;
+        throw error;
+      }
+      await writeControls.beforeWrite?.();
+      return actual.editDeck(...args);
+    },
+  };
+});
 
 import { DeckEditForm } from "./DeckEditForm";
 import { useDeckEditAction } from "../model/useDeckEditAction";
@@ -32,22 +46,36 @@ const DeckEditFormHarness = (props: { deck: Deck; onCancel: () => void; onSaved:
   return <DeckEditForm deckName={props.deck.name} form={form} saveError={editAction.error} />;
 };
 
+// A fresh Entity read after remount proves that the form displays the last successful edit.
+const StoredDeckEditFormHarness = (props: { deckId: DeckId; onCancel: () => void; onSaved: () => void }) => {
+  const deck = useDeck(props.deckId);
+  return deck === undefined ? null : (
+    <DeckEditFormHarness deck={deck} onCancel={props.onCancel} onSaved={props.onSaved} />
+  );
+};
+
 describe("DeckEditForm", () => {
-  const deck: Deck = createDeck({
-    id: "deck-id",
-    name: "Deck name",
-    url: "",
-    category: "language",
-    convertToBr: false,
+  const deckId = "deck-id";
+  const renderForm = (onSaved = vi.fn(), onCancel = vi.fn()) =>
+    render(<StoredDeckEditFormHarness deckId={deckId} onCancel={onCancel} onSaved={onSaved} />);
+
+  beforeEach(async () => {
+    writeControls.beforeWrite = undefined;
+    writeControls.nextError = undefined;
+    await createDeck(
+      "",
+      createLocalDeck({
+        id: deckId,
+        name: "Deck name",
+        category: "language",
+        convertToBr: false,
+      })
+    );
   });
 
-  beforeEach(() => {
-    mocks.editDeck.mockReset().mockResolvedValue(undefined);
-  });
-
-  it("saves edited form values for the authenticated user and reports success", async () => {
+  it("restores successfully saved form values from the Deck Entity", async () => {
     const onSaved = vi.fn();
-    render(<DeckEditFormHarness deck={deck} onCancel={vi.fn()} onSaved={onSaved} />);
+    const view = renderForm(onSaved);
 
     const name = screen.getByRole("textbox", { name: "Name" });
     await userEvent.clear(name);
@@ -57,54 +85,49 @@ describe("DeckEditForm", () => {
     await userEvent.selectOptions(screen.getByRole("combobox"), "science");
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
-    await waitFor(() =>
-      expect(mocks.editDeck).toHaveBeenCalledWith("user-id", {
-        id: deck.id,
-        name: "Updated deck",
-        url: "https://example.com/deck.csv",
-        convertToBr: true,
-        category: "science",
-      })
-    );
-    expect(onSaved).toHaveBeenCalledOnce();
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    view.unmount();
+    renderForm();
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Updated deck");
+    expect(screen.getByRole("textbox", { name: "Source URL" })).toHaveValue("https://example.com/deck.csv");
+    expect(screen.getByRole("checkbox", { name: "Convert line breaks" })).toBeChecked();
+    expect(screen.getByRole("combobox")).toHaveValue("science");
   });
 
   it("uses the form submit state while saving", async () => {
-    let finishSave: (() => void) | undefined;
-    mocks.editDeck.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          finishSave = resolve;
-        })
-    );
-    render(<DeckEditFormHarness deck={deck} onCancel={vi.fn()} onSaved={vi.fn()} />);
+    let finishSave: () => void = () => undefined;
+    writeControls.beforeWrite = () =>
+      new Promise<void>((resolve) => {
+        finishSave = resolve;
+      });
+    renderForm();
 
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
-    finishSave?.();
+    finishSave();
     await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
   });
 
-  it("submits a cleared optional URL as an explicit deletion", async () => {
-    render(
-      <DeckEditFormHarness
-        deck={{ ...deck, url: "https://example.com/deck.csv" }}
-        onCancel={vi.fn()}
-        onSaved={vi.fn()}
-      />
-    );
+  it("removes a cleared optional URL from the stored Deck", async () => {
+    await createDeck("", createLocalDeck({ id: deckId, name: "Deck name", url: "https://example.com/deck.csv" }));
+    const onSaved = vi.fn();
+    const view = renderForm(onSaved);
     await userEvent.clear(screen.getByRole("textbox", { name: "Source URL" }));
 
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
-    await waitFor(() => expect(mocks.editDeck).toHaveBeenCalledWith("user-id", expect.objectContaining({ url: null })));
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    view.unmount();
+    renderForm();
+    expect(screen.getByRole("textbox", { name: "Source URL" })).toHaveValue("");
   });
 
-  it("keeps edited values and allows another save after a failure", async () => {
-    mocks.editDeck.mockRejectedValueOnce(new Error("write failed"));
+  it("keeps edited values and saves them after retrying a failure", async () => {
+    writeControls.nextError = new Error("write failed");
     const onSaved = vi.fn();
-    render(<DeckEditFormHarness deck={deck} onCancel={vi.fn()} onSaved={onSaved} />);
+    const view = renderForm(onSaved);
     const name = screen.getByRole("textbox", { name: "Name" });
     await userEvent.clear(name);
     await userEvent.type(name, "Retry deck");
@@ -117,14 +140,16 @@ describe("DeckEditForm", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
-    await waitFor(() => expect(mocks.editDeck).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByText("Unable to save changes. Try again.")).not.toBeInTheDocument());
     expect(onSaved).toHaveBeenCalledOnce();
+    view.unmount();
+    renderForm();
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Retry deck");
   });
 
   it("forwards cancellation from both navigation actions", async () => {
     const onCancel = vi.fn();
-    render(<DeckEditFormHarness deck={deck} onCancel={onCancel} onSaved={vi.fn()} />);
+    renderForm(vi.fn(), onCancel);
 
     await userEvent.click(screen.getByRole("button", { name: "Back to decks" }));
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
@@ -132,8 +157,8 @@ describe("DeckEditForm", () => {
     expect(onCancel).toHaveBeenCalledTimes(2);
   });
 
-  it("validates fields before saving", async () => {
-    render(<DeckEditFormHarness deck={deck} onCancel={vi.fn()} onSaved={vi.fn()} />);
+  it("keeps stored values unchanged when validation rejects the form", async () => {
+    const view = renderForm();
     await userEvent.clear(screen.getByRole("textbox", { name: "Name" }));
     await userEvent.type(screen.getByRole("textbox", { name: "Source URL" }), "not-a-url");
 
@@ -141,6 +166,9 @@ describe("DeckEditForm", () => {
 
     expect(await screen.findByText("Deck name is required.")).toBeVisible();
     expect(screen.getByText("Enter a valid URL.")).toBeVisible();
-    expect(mocks.editDeck).not.toHaveBeenCalled();
+    view.unmount();
+    renderForm();
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Deck name");
+    expect(screen.getByRole("textbox", { name: "Source URL" })).toHaveValue("");
   });
 });

--- a/src/features/deck-list/ui/DeckList.spec.tsx
+++ b/src/features/deck-list/ui/DeckList.spec.tsx
@@ -140,7 +140,6 @@ describe("DeckList", () => {
     expect(await screen.findByText("Unable to delete this deck. Check your connection and try again.")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Delete deck" }));
 
-    await waitFor(() => expect(mocks.deleteDeck).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByRole("alertdialog", { name: "Delete deck?" })).not.toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Related issue

None

## Summary

- Verify Card and Deck edit forms through persisted Entity state after save, URL clearing, retry, and rejected validation.
- Keep controlled failure and pending states while successful writes use the real local mutation path.
- Replace exact retry call-count assertions in Card and Deck lists with user-visible recovery checks.

## Testing

- mise run check (104 test files, 532 tests)