### PR TITLE
[No issue] Test list, view, and study page behavior

### DIFF
--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -1,159 +1,153 @@
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 
-import * as React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import "@testing-library/jest-dom/vitest";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 
-import { createCard, createDeck, createPreferences } from "@/test/factories";
+import { mutateCards } from "@/entities/card";
+import { createDeck } from "@/entities/deck";
+import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
-  params: { id: "deck-id" as string | undefined },
   preferences: null as unknown as Preferences,
-  deck: null as Deck | null,
-  cards: [] as Card[],
-  navigate: vi.fn(),
-  onClickTag: vi.fn(),
-  cardListProps: null as null | Record<string, unknown>,
+  setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/preferences", () => ({ usePreferences: () => mocks.preferences, setDarkMode: vi.fn() }));
-vi.mock("@/entities/card", () => ({
-  useCardsByDeckId: (id: string) => {
-    const cards = mocks.cards.filter((card) => card.deckId === id);
-    return { cards, tags: [...new Set(cards.flatMap((card) => card.tags))] };
-  },
+vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/preferences", () => ({
+  usePreferences: () => mocks.preferences,
+  setDarkMode: mocks.setDarkMode,
 }));
-vi.mock("@/entities/deck", () => ({
-  filterCardsForDeck: (cards: Card[]) => cards,
-  useDeck: () => mocks.deck ?? undefined,
-}));
-vi.mock("@/features/card-list", () => ({
-  useCardListState: ({ cards }: { cards: Card[] }) => ({
-    cards,
-    answer: undefined,
-    deletionTarget: undefined,
-    mutationError: null,
-    successMessage: undefined,
-    onShowCard: vi.fn(),
-    onCloseCard: vi.fn(),
-    onSwipedLeft: vi.fn(),
-    onSwipedRight: vi.fn(),
-    onRequestDeletion: vi.fn(),
-    onCancelDeletion: vi.fn(),
-    onConfirmDeletion: vi.fn(),
-  }),
-  CardList: (props: {
-    state: { cards: Card[] };
-    filter: { selectedTags: string[]; onRemoveTag: (tag: string) => void };
-    onEditCard: (id: string) => void;
-  }) => {
-    const [shownDeckId, setShownDeckId] = React.useState<string>();
-    mocks.cardListProps = props as unknown as Record<string, unknown>;
-    return (
-      <div>
-        <span>Card list feature</span>
-        <span>{shownDeckId == null ? "No card shown" : `Card shown for ${shownDeckId}`}</span>
-        <button type="button" onClick={() => setShownDeckId(props.state.cards[0]?.deckId)}>
-          Show card
-        </button>
-        <button type="button" onClick={() => props.onEditCard(props.state.cards[0]?.id ?? "missing")}>
-          Edit card
-        </button>
-        <button type="button" onClick={() => props.filter.onRemoveTag("typescript")}>
-          Change tags
-        </button>
-      </div>
-    );
-  },
-}));
-vi.mock("@/features/deck-filter", () => ({
-  DeckFilterForm: () => <div>Filter controls</div>,
-  useDeckFilterState: () => ({
-    scoreMax: 4,
-    scoreMin: -2,
-    selectedTags: ["typescript"],
-    tagAndFilter: false,
-    setScoreMax: vi.fn(),
-    setScoreMin: vi.fn(),
-    setSelectedTags: mocks.onClickTag,
-    setTagAndFilter: vi.fn(),
-  }),
-}));
-vi.mock("react-router-dom", () => ({
-  useParams: () => mocks.params,
-  useNavigate: () => mocks.navigate,
-}));
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { CardListPage } from "./CardListPage";
 
-describe("CardListPage", () => {
-  const deck = createDeck({ id: "deck-id" });
-  const card = createCard({ id: "card-id", deckId: deck.id, tags: ["typescript"] });
-  const otherCard = createCard({ id: "other-card", deckId: "other-deck" });
+const NextDeckButton = () => {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => void navigate("/deck/next-deck")}>
+      Open next deck
+    </button>
+  );
+};
 
-  beforeEach(() => {
-    mocks.params.id = deck.id;
-    mocks.deck = deck;
-    mocks.cards = [card, otherCard];
+describe("CardListPage", () => {
+  const deckId = "deck-id";
+  const nextDeckId = "next-deck";
+  const cardId = "card-id";
+  const nextCardId = "next-card";
+  const renderPage = (path = `/deck/${deckId}`) =>
+    render(
+      <MemoryRouter initialEntries={["/previous", path]} initialIndex={1}>
+        <NextDeckButton />
+        <Routes>
+          <Route path="/previous" element={<h1>Previous page</h1>} />
+          <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/settings" element={<h1>Settings destination</h1>} />
+          <Route path="/card/:id/edit" element={<h1>Card editor destination</h1>} />
+          <Route path="/deck/:id" element={<CardListPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+  beforeEach(async () => {
     mocks.preferences = createPreferences();
-    mocks.navigate.mockReset();
-    mocks.onClickTag.mockReset();
-    mocks.cardListProps = null;
+    mocks.setDarkMode.mockReset();
+    await createDeck("", createLocalDeck({ id: deckId, name: "First deck", selectedTags: ["typescript"] }));
+    await createDeck("", createLocalDeck({ id: nextDeckId, name: "Next deck" }));
+    await mutateCards("", [
+      {
+        kind: "create",
+        card: createLocalCard({
+          id: cardId,
+          deckId,
+          frontText: "Front one",
+          backText: "Back one",
+          tags: ["typescript"],
+          uniqueKey: "card-one",
+        }),
+      },
+      {
+        kind: "create",
+        card: createLocalCard({
+          id: nextCardId,
+          deckId: nextDeckId,
+          frontText: "Front two",
+          backText: "Back two",
+          uniqueKey: "card-two",
+        }),
+      },
+    ]);
   });
 
-  it("composes the feature from the resolved route data and route callbacks", async () => {
-    render(<CardListPage />);
+  it("renders stored cards and navigates to the selected card editor", async () => {
+    renderPage();
 
-    expect(screen.getByText("Card list feature")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Cards" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "View Front one" })).toBeVisible();
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
 
-    await userEvent.click(screen.getByRole("button", { name: "Edit card" }));
-    expect(mocks.navigate).toHaveBeenCalledWith(`/card/${card.id}/edit`, undefined);
-
-    await userEvent.click(screen.getByRole("button", { name: "Change tags" }));
-    expect(mocks.onClickTag).toHaveBeenCalledExactlyOnceWith([]);
+    await userEvent.click(screen.getByRole("button", { name: "Open actions for Front one" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Card editor destination" })).toBeVisible();
   });
 
-  it("keeps route shortcuts in the page adapter", () => {
-    render(<CardListPage />);
+  it("removes a selected tag from the visible filter", async () => {
+    renderPage();
 
+    await userEvent.click(screen.getByRole("button", { name: "Remove typescript filter" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Remove typescript filter" })).not.toBeInTheDocument()
+    );
+    expect(screen.getByText("No filters")).toBeVisible();
+  });
+
+  it("navigates from both route shortcuts", async () => {
+    const view = renderPage();
     fireEvent.keyDown(window, { key: "t" });
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+
+    view.unmount();
+    renderPage();
     fireEvent.keyDown(window, { key: "s" });
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/", undefined);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/settings", undefined);
+    expect(await screen.findByRole("heading", { level: 1, name: "Settings destination" })).toBeVisible();
   });
 
-  it("resets deck-local feature state when the route deck changes", async () => {
-    const user = userEvent.setup();
-    const nextDeck = createDeck({ id: "next-deck" });
-    const nextCard = createCard({ id: "next-card", deckId: nextDeck.id });
-    const { rerender } = render(<CardListPage />);
+  it("resets the shown card when navigation changes the route deck", async () => {
+    renderPage();
 
-    await user.click(screen.getByRole("button", { name: "Show card" }));
-    expect(screen.getByText(`Card shown for ${deck.id}`)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "View Front one" }));
+    expect(screen.getByLabelText("Close card")).toHaveTextContent("Back one");
 
-    mocks.params.id = nextDeck.id;
-    mocks.deck = nextDeck;
-    mocks.cards = [nextCard];
-    rerender(<CardListPage />);
+    await userEvent.click(screen.getByRole("button", { name: "Open next deck" }));
 
-    expect(screen.getByText("No card shown")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "View Front two" })).toBeVisible();
+    expect(screen.queryByLabelText("Close card")).not.toBeInTheDocument();
   });
 
-  it("renders not-found feedback with route navigation", async () => {
-    mocks.deck = null;
-    render(<CardListPage />);
+  it("navigates with both recovery actions when the deck is unavailable", async () => {
+    const view = renderPage("/deck/missing-deck");
 
-    expect(screen.getByRole("heading", { name: "Deck not found" })).toBeInTheDocument();
-    expect(screen.queryByText("Card list feature")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Deck not found" })).toBeVisible();
     await userEvent.click(screen.getByRole("button", { name: "Go home" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+
+    view.unmount();
+    renderPage("/deck/missing-deck");
     await userEvent.click(screen.getByRole("button", { name: "Go back" }));
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/", undefined);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, -1);
+    expect(await screen.findByRole("heading", { level: 1, name: "Previous page" })).toBeVisible();
+  });
+
+  it("rejects a route without a deck id", () => {
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <CardListPage />
+        </MemoryRouter>
+      )
+    ).toThrowError("invalid deck id");
   });
 });

--- a/src/pages/card-view/ui/CardViewPage.spec.tsx
+++ b/src/pages/card-view/ui/CardViewPage.spec.tsx
@@ -1,84 +1,82 @@
+import type { Preferences } from "@/entities/preferences";
+
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
-import type { Preferences } from "@/entities/preferences";
-import { createCard, createDeck, createPreferences } from "@/test/factories";
+import { mutateCards } from "@/entities/card";
+import { createDeck } from "@/entities/deck";
+import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
-  params: { id: "card-id" as string | undefined },
-  card: null as Card | null,
-  deck: null as Deck | null,
   preferences: null as unknown as Preferences,
-  navigate: vi.fn(),
+  setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/card", () => ({
-  useCard: () => mocks.card ?? undefined,
+vi.mock("@/entities/preferences", () => ({
+  usePreferences: () => mocks.preferences,
+  setDarkMode: mocks.setDarkMode,
 }));
-vi.mock("@/entities/preferences", () => ({ usePreferences: () => mocks.preferences, setDarkMode: vi.fn() }));
-vi.mock("@/entities/deck", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/entities/deck")>();
-  return {
-    ...actual,
-    useDeck: () => mocks.deck ?? undefined,
-  };
-});
-vi.mock("@/features/card-view", () => ({
-  buildCardViewContent: (card: Card, deck: Deck) => ({ text: `Card view: ${card.id} / ${deck.id}` }),
-  CardView: ({ text }: { text: string }) => <div>{text}</div>,
-}));
-vi.mock("react-router-dom", () => ({
-  useParams: () => mocks.params,
-  useNavigate: () => mocks.navigate,
-}));
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { CardViewPage } from "./CardViewPage";
 
 describe("CardViewPage", () => {
-  const card = createCard({
-    id: "card-id",
-    deckId: "deck-id",
+  const deckId = "card-view-deck";
+  const cardId = "card-id";
+  const renderPage = (path = `/card/${cardId}`) =>
+    render(
+      <MemoryRouter initialEntries={["/previous", path]} initialIndex={1}>
+        <Routes>
+          <Route path="/previous" element={<h1>Previous page</h1>} />
+          <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/card/:id" element={<CardViewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+  beforeEach(async () => {
+    mocks.preferences = createPreferences({ appearance: { darkMode: false } });
+    mocks.setDarkMode.mockReset();
+    await createDeck("", createLocalDeck({ id: deckId, category: "raw" }));
+    await mutateCards("", [
+      {
+        kind: "create",
+        card: createLocalCard({ id: cardId, deckId, frontText: "Front text", backText: "Back text" }),
+      },
+    ]);
   });
 
-  beforeEach(() => {
-    mocks.params.id = "card-id";
-    mocks.card = card;
-    mocks.deck = createDeck({ id: "deck-id", category: "raw" });
-    mocks.preferences = createPreferences();
-    mocks.navigate.mockReset();
-  });
+  it("renders the stored card answer in the application shell", () => {
+    renderPage();
 
-  it("connects the available card and deck to the feature", () => {
-    render(<CardViewPage />);
-
-    expect(screen.getByText("Card view: card-id / deck-id")).toBeVisible();
-  });
-
-  it("renders the ready screen in the application shell", () => {
-    render(<CardViewPage />);
-
+    expect(screen.getByRole("region", { name: "Card answer" })).toHaveTextContent("Back text");
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 
-  it("shows recovery actions when the card is unavailable", async () => {
-    mocks.card = null;
-    render(<CardViewPage />);
+  it("navigates with both recovery actions when the card is unavailable", async () => {
+    const view = renderPage("/card/missing-card");
 
-    expect(screen.getByRole("heading", { level: 1, name: "Card not found" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Card not found" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Go home" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+
+    view.unmount();
+    renderPage("/card/missing-card");
     await userEvent.click(screen.getByRole("button", { name: "Go back" }));
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/", undefined);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, -1);
+    expect(await screen.findByRole("heading", { level: 1, name: "Previous page" })).toBeVisible();
   });
 
-  it("preserves the invalid route error", () => {
-    mocks.params.id = undefined;
-    expect(() => render(<CardViewPage />)).toThrowError("invalid card id");
+  it("rejects a route without a card id", () => {
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <CardViewPage />
+        </MemoryRouter>
+      )
+    ).toThrowError("invalid card id");
   });
 });

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -1,124 +1,125 @@
 import type { Preferences } from "@/entities/preferences";
-import type { ComponentProps } from "react";
-import type { DeckList } from "@/features/deck-list";
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
-import { createCard, createDeck, createPreferences } from "@/test/factories";
-
-type DeckListProps = ComponentProps<typeof DeckList>;
+import { mutateCards } from "@/entities/card";
+import { createDeck, deleteDeck } from "@/entities/deck";
+import { clearStudySessions, startStudy } from "@/entities/study-session";
+import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
-  preferences: {} as Preferences,
-  decks: [] as Deck[],
-  cards: [] as Card[],
-  useAddSampleDeck: vi.fn(),
-  requestDeletion: vi.fn(),
-  touchStudySession: vi.fn(),
-  navigate: vi.fn(),
-}));
-
-vi.mock("@/entities/preferences", () => ({
-  usePreferences: () => mocks.preferences,
+  preferences: null as unknown as Preferences,
   setDarkMode: vi.fn(),
 }));
-vi.mock("@/entities/card", () => ({
-  useCards: () => mocks.cards,
+
+vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/preferences", () => ({
+  usePreferences: () => mocks.preferences,
+  setDarkMode: mocks.setDarkMode,
 }));
-vi.mock("@/entities/deck", () => ({
-  useDecks: () => mocks.decks,
-}));
-vi.mock("@/features/deck-import", () => ({ useAddSampleDeck: mocks.useAddSampleDeck }));
-vi.mock("@/entities/study-session", () => ({
-  touchStudySession: mocks.touchStudySession,
-  useStudySessions: () => ({}),
-}));
-vi.mock("@/features/deck-list", () => ({
-  useDeckListState: ({ decks }: { decks: Deck[] }) => ({
-    sections: { studying: [], other: decks.map((deck) => ({ deck, cardCount: 0 })) },
-    deletionTarget: undefined,
-    successMessage: undefined,
-    onDownload: vi.fn(),
-    onRequestDeletion: mocks.requestDeletion,
-    onCancelDeletion: vi.fn(),
-    onConfirmDeletion: vi.fn(),
-  }),
-  DeckList: (props: DeckListProps) => {
-    const [item] = props.state.sections.other;
-    const deck = item?.deck;
-    if (deck == null) return null;
-    return (
-      <section aria-label="Deck list feature">
-        <button type="button" onClick={() => props.onViewDeck(deck.id)}>
-          View deck
-        </button>
-        <button type="button" onClick={() => props.onContinueDeck(deck.id)}>
-          Continue deck
-        </button>
-        <button type="button" onClick={() => props.onStartDeck(deck.id)}>
-          Start deck
-        </button>
-        <button type="button" onClick={() => props.onEditDeck(deck.id)}>
-          Edit deck
-        </button>
-        <button type="button" onClick={() => props.state.onRequestDeletion(deck.id)}>
-          Delete deck
-        </button>
-      </section>
-    );
-  },
-}));
-vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
+vi.mock("@/features/deck-import", () => ({ useAddSampleDeck: () => undefined }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { DeckListPage } from "./DeckListPage";
 
 describe("DeckListPage", () => {
-  const deck = createDeck({ id: "deck-1", name: "Deck" });
-  const card = createCard({ id: "card-1", deckId: deck.id });
+  const activeDeck = createLocalDeck({ id: "active-deck", name: "Active deck" });
+  const freshDeck = createLocalDeck({ id: "fresh-deck", name: "Fresh deck" });
+  const activeCard = createLocalCard({
+    id: "active-card",
+    deckId: activeDeck.id,
+    frontText: "Active front",
+    uniqueKey: "active-card",
+  });
+  const freshCard = createLocalCard({
+    id: "fresh-card",
+    deckId: freshDeck.id,
+    frontText: "Fresh front",
+    uniqueKey: "fresh-card",
+  });
+  const renderPage = () =>
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<DeckListPage />} />
+          <Route path="/settings" element={<h1>Settings destination</h1>} />
+          <Route path="/import" element={<h1>Import destination</h1>} />
+          <Route path="/deck/:id" element={<h1>Card list destination</h1>} />
+          <Route path="/deck/:id/study" element={<h1>Study destination</h1>} />
+          <Route path="/deck/:id/start" element={<h1>Study start destination</h1>} />
+          <Route path="/deck/:id/edit" element={<h1>Deck editor destination</h1>} />
+        </Routes>
+      </MemoryRouter>
+    );
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.preferences = createPreferences({ darkMode: false });
-    mocks.decks = [deck];
-    mocks.cards = [card];
+  beforeEach(async () => {
+    clearStudySessions();
+    mocks.preferences = createPreferences({ appearance: { darkMode: false } });
+    mocks.setDarkMode.mockReset();
+    await createDeck("", activeDeck);
+    await createDeck("", freshDeck);
+    await mutateCards("", [
+      { kind: "create", card: activeCard },
+      { kind: "create", card: freshCard },
+    ]);
+    startStudy(activeDeck.id, [activeCard], mocks.preferences.study);
   });
 
-  it("composes route and reusable feature actions around the Deck List Feature", () => {
-    render(<DeckListPage />);
+  it("navigates from each visible Deck action", async () => {
+    let view = renderPage();
+    await userEvent.click(screen.getByRole("button", { name: "View Active deck" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Card list destination" })).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "View deck" }));
-    fireEvent.click(screen.getByRole("button", { name: "Continue deck" }));
-    fireEvent.click(screen.getByRole("button", { name: "Start deck" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit deck" }));
-    fireEvent.click(screen.getByRole("button", { name: "Delete deck" }));
+    view.unmount();
+    view = renderPage();
+    await userEvent.click(screen.getByRole("button", { name: "Continue Active deck" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Study destination" })).toBeVisible();
 
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, `/deck/${deck.id}`, undefined);
-    expect(mocks.touchStudySession).toHaveBeenCalledExactlyOnceWith(deck.id);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, `/deck/${deck.id}/study`, undefined);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(3, `/deck/${deck.id}/start`, undefined);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(4, `/deck/${deck.id}/edit`, undefined);
-    expect(mocks.requestDeletion).toHaveBeenCalledExactlyOnceWith(deck.id);
+    view.unmount();
+    view = renderPage();
+    await userEvent.click(screen.getByRole("button", { name: "Study Fresh deck" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Study start destination" })).toBeVisible();
+
+    view.unmount();
+    renderPage();
+    await userEvent.click(screen.getByRole("button", { name: "Open actions for Fresh deck" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck editor destination" })).toBeVisible();
   });
 
-  it("keeps route shortcuts and sample Deck wiring", () => {
-    render(<DeckListPage />);
+  it("deletes a local Deck and reports the visible result", async () => {
+    renderPage();
 
+    await userEvent.click(screen.getByRole("button", { name: "Open actions for Fresh deck" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete deck" }));
+
+    expect(await screen.findByText("Deleted deck “Fresh deck”.")).toBeVisible();
+    await waitFor(() => expect(screen.queryByRole("button", { name: "View Fresh deck" })).not.toBeInTheDocument());
+  });
+
+  it("navigates from both route shortcuts", async () => {
+    const view = renderPage();
     fireEvent.keyDown(window, { key: "s" });
-    fireEvent.keyDown(window, { key: "i" });
+    expect(await screen.findByRole("heading", { level: 1, name: "Settings destination" })).toBeVisible();
 
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, "/settings", undefined);
-    expect(mocks.navigate).toHaveBeenNthCalledWith(2, "/import", undefined);
-    expect(mocks.useAddSampleDeck).toHaveBeenCalledWith();
+    view.unmount();
+    renderPage();
+    fireEvent.keyDown(window, { key: "i" });
+    expect(await screen.findByRole("heading", { level: 1, name: "Import destination" })).toBeVisible();
   });
 
-  it("renders empty list when no decks exist", () => {
-    mocks.decks = [];
-    render(<DeckListPage />);
+  it("renders an empty list after all Decks are removed", async () => {
+    await deleteDeck("", activeDeck);
+    await deleteDeck("", freshDeck);
+    renderPage();
+
+    expect(screen.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+    expect(screen.getByText("0 decks")).toBeVisible();
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
   });
 });

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -1,158 +1,138 @@
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
-import type { StudyState } from "@/features/study";
+import type { Preferences } from "@/entities/preferences";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import "@testing-library/jest-dom/vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { deleteCard, mutateCards } from "@/entities/card";
+import { createDeck } from "@/entities/deck";
+import { clearStudySessions, startStudy } from "@/entities/study-session";
+import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
-  params: { id: "deck-id" as string | undefined },
-  deck: undefined as Deck | undefined,
-  cards: [] as Card[],
-  navigate: vi.fn(),
-  studyState: undefined as StudyState | undefined,
-  studyArgs: undefined as { cards: readonly Card[]; deckId: string } | undefined,
+  preferences: null as unknown as Preferences,
+  editStudyProgress: vi.fn(),
+  setDarkMode: vi.fn(),
+  toggleShowHeader: vi.fn(),
+  toggleShowSwipeButtonList: vi.fn(),
 }));
 
-vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/deck", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/entities/deck")>();
-  return { ...actual, useDeck: () => mocks.deck };
-});
-vi.mock("@/entities/card", () => ({ useCards: () => mocks.cards }));
-vi.mock("react-router-dom", () => ({
-  useNavigate: () => mocks.navigate,
-  useParams: () => mocks.params,
+vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/preferences", () => ({
+  usePreferences: () => mocks.preferences,
+  setDarkMode: mocks.setDarkMode,
+  toggleShowHeader: mocks.toggleShowHeader,
+  toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
 }));
-vi.mock("@/features/study", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/features/study")>();
-  return {
-    ...actual,
-    useStudy: (deckId: string, cards: readonly Card[]) => {
-      mocks.studyArgs = { deckId, cards };
-      if (mocks.studyState == null) throw new Error("Study state not initialized");
-      return mocks.studyState;
-    },
-  };
-});
+// Persistence is outside Page behavior; successful writes let the real study workflow advance.
+vi.mock("@/entities/study-progress", () => ({ editStudyProgress: mocks.editStudyProgress }));
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { StudySessionPage } from "./StudySessionPage";
 
-const deck: Deck = {
-  id: "deck-id",
-  localMode: false,
-  name: "Deck",
-  isPublic: false,
-  createdAt: 0,
-  updatedAt: 0,
-  category: "raw",
-  convertToBr: false,
-  selectedTags: [],
-  tagAndFilter: false,
-  scoreMax: null,
-  scoreMin: null,
-};
-const card: Card = {
-  id: "card-id",
-  deckId: deck.id,
-  uid: "user-id",
-  frontText: "FRONT SLOT",
-  backText: "const answer = 42;",
-  tags: ["typescript"],
-  uniqueKey: "unique-key",
-  score: 2,
-  numberOfSeen: 3,
-  createdAt: 0,
-  updatedAt: 0,
-  deletedAt: null,
-  lastSeenAt: 1,
-};
-const noop = vi.fn();
-const commands = () => ({
-  swipeUp: vi.fn(),
-  swipeDown: vi.fn(),
-  swipeLeft: vi.fn(),
-  swipeRight: vi.fn(),
-  toggleBackText: vi.fn(),
-  toggleAutoPlay: vi.fn(),
-});
-const commonState = () => ({
-  ...commands(),
-  showHeader: true,
-  showBackText: false,
-  showController: true,
-  showSwipeButtonList: true,
-  autoPlay: false,
-  updateIndex: noop,
-});
-const studyingState = (): StudyState => ({
-  status: "studying",
-  ...commonState(),
-  session: {
-    sessionId: "session-id",
-    deckId: deck.id,
-    cardOrderIds: [card.id],
-    currentIndex: 0,
-    lastStudiedAt: 0,
-  },
-  card,
-});
-
 describe("StudySessionPage", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.params.id = deck.id;
-    mocks.deck = deck;
-    mocks.cards = [card];
-    mocks.studyState = studyingState();
-    mocks.studyArgs = undefined;
-    window.history.replaceState(null, document.title, document.location.href);
+  const deckId = "deck-id";
+  const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
+  const firstCard = createLocalCard({
+    id: "first-card",
+    deckId,
+    frontText: "Front one",
+    backText: "Back one",
+    uniqueKey: "first-card",
+    score: 2,
+    numberOfSeen: 3,
+  });
+  const secondCard = createLocalCard({
+    id: "second-card",
+    deckId,
+    frontText: "Front two",
+    backText: "Back two",
+    uniqueKey: "second-card",
+    score: 1,
+    numberOfSeen: 4,
+  });
+  const renderPage = (path = `/deck/${deckId}/study`) =>
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/deck/:id/study" element={<StudySessionPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+  beforeEach(async () => {
+    clearStudySessions();
+    mocks.preferences = createPreferences({ appearance: { darkMode: false } });
+    mocks.editStudyProgress.mockReset().mockResolvedValue(undefined);
+    mocks.setDarkMode.mockReset();
+    mocks.toggleShowHeader.mockReset();
+    mocks.toggleShowSwipeButtonList.mockReset();
+    await createDeck("", deck);
+    await mutateCards("", [
+      { kind: "create", card: firstCard },
+      { kind: "create", card: secondCard },
+    ]);
+    startStudy(deckId, [firstCard, secondCard], mocks.preferences.study);
   });
 
-  it("validates the route parameter", () => {
-    mocks.params.id = undefined;
-    expect(() => render(<StudySessionPage />)).toThrow("invalid deck id");
-  });
+  it("renders the active session from stored Entity state", () => {
+    renderPage();
 
-  it("passes Entity reads to useStudy and composes the application shell", () => {
-    render(<StudySessionPage />);
-
-    expect(mocks.studyArgs).toMatchObject({ deckId: deck.id, cards: [card] });
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
-    expect(screen.getByText(card.frontText)).toBeVisible();
+    expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });
 
-  it.each([
-    ["preparing", "Loading…"],
-    ["invalid", "Study session unavailable."],
-  ] as const)("renders route feedback for %s workflow state", (status, title) => {
-    mocks.studyState = { status, ...commonState() };
-    render(<StudySessionPage />);
-    expect(screen.getByRole("heading", { name: title })).toBeVisible();
+  it("reveals the current answer from the Enter shortcut", () => {
+    renderPage();
+
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(screen.getByText("Back one")).toBeVisible();
   });
 
-  it("returns to the deck list when the study session is invalid", async () => {
-    mocks.studyState = { status: "invalid", ...commonState() };
-    render(<StudySessionPage />);
+  it("shows the next stored card after the ArrowRight shortcut", async () => {
+    renderPage();
 
-    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: true }));
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    await waitFor(() => expect(screen.getByText("Front two")).toBeVisible());
+    expect(screen.queryByText("Front one")).not.toBeInTheDocument();
   });
 
-  it("delegates a representative Study shortcut to the workflow action", () => {
-    render(<StudySessionPage />);
-    const state = mocks.studyState;
-    if (state?.status !== "studying") throw new Error("expected studying workflow state");
+  it("shows loading feedback while active session cards are unavailable", async () => {
+    await deleteCard("", firstCard);
+    await deleteCard("", secondCard);
+    clearStudySessions();
+    startStudy(deckId, [firstCard], mocks.preferences.study);
 
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    renderPage();
 
-    expect(state.swipeLeft).toHaveBeenCalledOnce();
+    expect(screen.getByRole("heading", { name: "Loading…" })).toBeVisible();
+  });
+
+  it("returns to the deck list when no active session exists", async () => {
+    clearStudySessions();
+    renderPage();
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
   });
 
   it("shows route feedback when the Deck Entity is unavailable", () => {
-    mocks.deck = undefined;
-    render(<StudySessionPage />);
+    renderPage("/deck/missing-deck/study");
+
     expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
+  });
+
+  it("rejects a route without a deck id", () => {
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <StudySessionPage />
+        </MemoryRouter>
+      )
+    ).toThrowError("invalid deck id");
   });
 });


### PR DESCRIPTION
## Related issue

None

## Summary

- Exercise Card list, Card view, and Deck list pages against local Entity state, real Feature UI, and rendered router destinations.
- Verify filter removal, route-local overlay reset, Deck deletion, shortcuts, and recovery actions through visible outcomes.
- Run the real study workflow for answer reveal, session movement, loading, and invalid-session navigation while stubbing only remote progress writes.

## Testing

- mise run check (103 test files, 532 tests)