### PR TITLE
[No issue] Verify app provider behavior

### DIFF
--- a/src/app/providers/auth/index.spec.tsx
+++ b/src/app/providers/auth/index.spec.tsx
@@ -1,101 +1,106 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom/vitest";
+import type { User, UserCredential } from "firebase/auth";
+
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 
-import type { useAuthSession } from "@/entities/auth";
+import { getAuthSession, replaceAuthSession } from "@/entities/auth";
+import { clearStudySessions } from "@/entities/study-session";
 
-type AuthSessionState = ReturnType<typeof useAuthSession>;
-
-const mocks = vi.hoisted(() => ({
-  authState: { status: "initializing" } as AuthSessionState,
-  startAuthSession: vi.fn(),
-  stopAuthSession: vi.fn(),
+const firebaseAuth = vi.hoisted(() => ({
+  observer: undefined as ((user: User | null) => void) | undefined,
+  observing: false,
+  signIn: (() => new Promise<UserCredential>(() => undefined)) as () => Promise<UserCredential>,
 }));
 
-vi.mock("@/app/providers/auth/lifecycle", () => ({
-  startAuthSession: mocks.startAuthSession,
-}));
-vi.mock("@/entities/auth", () => ({
-  useAuthSession: () => mocks.authState,
+vi.mock("@/shared/firebase", () => ({ auth: {} }));
+vi.mock("firebase/auth", () => ({
+  onIdTokenChanged: (_auth: unknown, observer: (user: User | null) => void) => {
+    firebaseAuth.observer = observer;
+    firebaseAuth.observing = true;
+    return () => {
+      firebaseAuth.observing = false;
+    };
+  },
+  signInAnonymously: () => firebaseAuth.signIn(),
 }));
 
 import { AuthProvider } from "./index";
 
+const createUser = (uid: string): User => ({ uid, isAnonymous: true, providerData: [] }) as unknown as User;
+
+const publishUser = (user: User | null) => {
+  act(() => {
+    if (firebaseAuth.observing) firebaseAuth.observer?.(user);
+  });
+};
+
+const ReloadableApp = () => {
+  const [reloadRequested, setReloadRequested] = useState(false);
+  return (
+    <>
+      <AuthProvider reload={() => setReloadRequested(true)}>
+        <p>Authenticated content</p>
+      </AuthProvider>
+      {reloadRequested ? <p>Reload requested</p> : null}
+    </>
+  );
+};
+
 describe("AuthProvider", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.startAuthSession.mockReturnValue(mocks.stopAuthSession);
-    mocks.authState = { status: "authenticated", uid: "test-user", isAnonymous: true, displayName: null };
+    clearStudySessions();
+    replaceAuthSession({ status: "initializing" });
+    firebaseAuth.observer = undefined;
+    firebaseAuth.observing = false;
+    firebaseAuth.signIn = () => new Promise<UserCredential>(() => undefined);
   });
 
-  it("starts and stops the authentication lifecycle", () => {
-    const view = render(
+  it("keeps content hidden until Firebase publishes an authenticated user", () => {
+    render(
       <AuthProvider>
-        <div>Content</div>
+        <p>Authenticated content</p>
       </AuthProvider>
     );
 
-    expect(mocks.startAuthSession).toHaveBeenCalledOnce();
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeVisible();
+    expect(screen.queryByText("Authenticated content")).not.toBeInTheDocument();
+
+    publishUser(null);
+    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeVisible();
+    expect(screen.queryByText("Authenticated content")).not.toBeInTheDocument();
+
+    publishUser(createUser("user-a"));
+    expect(screen.getByText("Authenticated content")).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 1, name: "Starting Tango…" })).not.toBeInTheDocument();
+  });
+
+  it("shows bootstrap failure feedback and responds to reload", async () => {
+    firebaseAuth.signIn = () => Promise.reject(new Error("auth failed"));
+    render(<ReloadableApp />);
+
+    publishUser(null);
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Unable to start Tango" })).toBeVisible();
+    expect(screen.queryByText("Authenticated content")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(screen.getByText("Reload requested")).toBeVisible();
+  });
+
+  it("ignores Firebase updates after the provider unmounts", () => {
+    const view = render(
+      <AuthProvider>
+        <p>Authenticated content</p>
+      </AuthProvider>
+    );
+    publishUser(createUser("user-a"));
+    expect(screen.getByText("Authenticated content")).toBeVisible();
 
     view.unmount();
+    publishUser(createUser("user-b"));
 
-    expect(mocks.stopAuthSession).toHaveBeenCalledOnce();
-  });
-
-  it("shows startup feedback while authentication is in progress", () => {
-    mocks.authState = { status: "initializing" };
-    const view = render(
-      <AuthProvider>
-        <div>Content</div>
-      </AuthProvider>
-    );
-
-    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
-    expect(screen.queryByText("Content")).toBeNull();
-
-    mocks.authState = { status: "unauthenticated" };
-    view.rerender(
-      <AuthProvider>
-        <div>Content</div>
-      </AuthProvider>
-    );
-
-    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
-    expect(screen.queryByText("Content")).toBeNull();
-
-    mocks.authState = { status: "authenticating", attemptId: Symbol("attempt-a") };
-    view.rerender(
-      <AuthProvider>
-        <div>Content</div>
-      </AuthProvider>
-    );
-
-    expect(screen.getByRole("heading", { level: 1, name: "Starting Tango…" })).toBeInTheDocument();
-    expect(screen.queryByText("Content")).toBeNull();
-  });
-
-  it("shows startup errors and reloads on request", () => {
-    const reload = vi.fn();
-    mocks.authState = { status: "error", error: new Error("auth failed") };
-    render(
-      <AuthProvider reload={reload}>
-        <div>Content</div>
-      </AuthProvider>
-    );
-
-    expect(screen.getByRole("heading", { level: 1, name: "Unable to start Tango" })).toBeInTheDocument();
-    expect(screen.queryByText("Content")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
-    expect(reload).toHaveBeenCalledOnce();
-  });
-
-  it("renders children when authenticated", () => {
-    render(
-      <AuthProvider>
-        <div>Content</div>
-      </AuthProvider>
-    );
-
-    expect(screen.getByText("Content")).toBeInTheDocument();
+    expect(getAuthSession()).toMatchObject({ status: "authenticated", uid: "user-a" });
   });
 });

--- a/src/app/providers/firestore-subscriptions/index.spec.tsx
+++ b/src/app/providers/firestore-subscriptions/index.spec.tsx
@@ -1,107 +1,164 @@
-import { render, screen } from "@testing-library/react";
+interface FirestoreQuery {
+  collectionName: "card" | "deck";
+  uid: string;
+}
+
+interface FirestoreSnapshot {
+  docs: { id: string; data: () => Record<string, unknown> }[];
+}
+
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 
-const mocks = vi.hoisted(() => ({
-  authUid: "",
-  subscribeCards: vi.fn(),
-  subscribeDecks: vi.fn(),
-  operations: [] as string[],
-}));
+import { replaceAuthSession } from "@/entities/auth";
+import { clearRemoteCards, useCards } from "@/entities/card";
+import { clearRemoteDecks, useDecks } from "@/entities/deck";
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => mocks.authUid }));
-vi.mock("@/entities/card", () => ({
-  clearRemoteCards: () => mocks.operations.push("clear remote Cards"),
-  subscribeCards: mocks.subscribeCards,
-}));
-vi.mock("@/entities/deck", () => ({
-  clearRemoteDecks: () => mocks.operations.push("clear remote Decks"),
-  subscribeDecks: mocks.subscribeDecks,
-}));
+vi.mock("@/shared/firebase", () => ({ db: {} }));
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>();
+  return {
+    ...actual,
+    collection: (_database: unknown, collectionName: FirestoreQuery["collectionName"]) => ({ collectionName }),
+    where: (_field: string, _operator: string, uid: string) => ({ uid }),
+    query: (collectionReference: Pick<FirestoreQuery, "collectionName">, filter: Pick<FirestoreQuery, "uid">) => ({
+      ...collectionReference,
+      ...filter,
+    }),
+    onSnapshot: (
+      request: FirestoreQuery,
+      publishSnapshot: (snapshot: FirestoreSnapshot) => void,
+      _onError: (error: Error) => void
+    ) => {
+      const deckId = `deck-${request.uid}`;
+      const document =
+        request.collectionName === "deck"
+          ? {
+              id: deckId,
+              data: () => ({
+                name: `Deck for ${request.uid}`,
+                isPublic: false,
+                uid: request.uid,
+                createdAt: 1,
+                updatedAt: 2,
+                deletedAt: null,
+                scoreMax: null,
+                scoreMin: null,
+                selectedTags: [],
+                tagAndFilter: false,
+                category: "",
+                convertToBr: false,
+              }),
+            }
+          : {
+              id: `card-${request.uid}`,
+              data: () => ({
+                frontText: `Front for ${request.uid}`,
+                backText: `Back for ${request.uid}`,
+                tags: [],
+                uniqueKey: `key-${request.uid}`,
+                deckId,
+                uid: request.uid,
+                createdAt: 1,
+                updatedAt: 2,
+                deletedAt: null,
+                score: 0,
+                numberOfSeen: 0,
+              }),
+            };
+      publishSnapshot({ docs: [document] });
+      return () => undefined;
+    },
+  };
+});
 
 import { FirestoreSubscriptionsProvider } from ".";
 
+const authenticatedSession = (uid: string) => ({
+  status: "authenticated" as const,
+  uid,
+  isAnonymous: true,
+  displayName: null,
+});
+
+const RepositoryView = () => {
+  const cards = useCards();
+  const decks = useDecks();
+  return (
+    <>
+      <p>{decks.length === 0 ? "No remote Decks" : decks.map((deck) => deck.name).join(", ")}</p>
+      <p>{cards.length === 0 ? "No remote Cards" : cards.map((card) => card.frontText).join(", ")}</p>
+    </>
+  );
+};
+
+const renderProvider = () =>
+  render(
+    <FirestoreSubscriptionsProvider>
+      <p>Application content</p>
+      <RepositoryView />
+    </FirestoreSubscriptionsProvider>
+  );
+
 describe("FirestoreSubscriptionsProvider", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.subscribeCards.mockImplementation((uid: string) => {
-      mocks.operations.push(`start Cards ${uid}`);
-      return () => mocks.operations.push(`stop Cards ${uid}`);
-    });
-    mocks.subscribeDecks.mockImplementation((uid: string) => {
-      mocks.operations.push(`start Decks ${uid}`);
-      return () => mocks.operations.push(`stop Decks ${uid}`);
-    });
-    mocks.operations.length = 0;
-    mocks.authUid = "test-user";
+    clearRemoteCards();
+    clearRemoteDecks();
+    replaceAuthSession({ status: "initializing" });
   });
 
-  it("starts subscriptions for the authenticated UID and cleans them up on unmount", () => {
-    const view = render(<FirestoreSubscriptionsProvider>content</FirestoreSubscriptionsProvider>);
+  it("leaves application content available without remote data before authentication", () => {
+    renderProvider();
 
-    expect(mocks.operations).toEqual(["start Cards test-user", "start Decks test-user"]);
-    expect(screen.getByText("content")).toBeDefined();
+    expect(screen.getByText("Application content")).toBeVisible();
+    expect(screen.getByText("No remote Decks")).toBeVisible();
+    expect(screen.getByText("No remote Cards")).toBeVisible();
+  });
+
+  it("shows remote data for the authenticated identity", () => {
+    act(() => replaceAuthSession(authenticatedSession("user-a")));
+
+    renderProvider();
+
+    expect(screen.getByText("Deck for user-a")).toBeVisible();
+    expect(screen.getByText("Front for user-a")).toBeVisible();
+  });
+
+  it("replaces visible remote data when the authenticated identity changes", () => {
+    act(() => replaceAuthSession(authenticatedSession("user-a")));
+    renderProvider();
+    expect(screen.getByText("Deck for user-a")).toBeVisible();
+
+    act(() => replaceAuthSession(authenticatedSession("user-b")));
+
+    expect(screen.getByText("Deck for user-b")).toBeVisible();
+    expect(screen.getByText("Front for user-b")).toBeVisible();
+    expect(screen.queryByText("Deck for user-a")).not.toBeInTheDocument();
+    expect(screen.queryByText("Front for user-a")).not.toBeInTheDocument();
+  });
+
+  it("clears visible remote data on logout while preserving application content", () => {
+    act(() => replaceAuthSession(authenticatedSession("user-a")));
+    renderProvider();
+    expect(screen.getByText("Deck for user-a")).toBeVisible();
+
+    act(() => replaceAuthSession({ status: "unauthenticated" }));
+
+    expect(screen.getByText("Application content")).toBeVisible();
+    expect(screen.getByText("No remote Decks")).toBeVisible();
+    expect(screen.getByText("No remote Cards")).toBeVisible();
+  });
+
+  it("clears remote data when the provider unmounts", () => {
+    act(() => replaceAuthSession(authenticatedSession("user-a")));
+    const view = renderProvider();
+    expect(screen.getByText("Deck for user-a")).toBeVisible();
 
     view.unmount();
+    render(<RepositoryView />);
 
-    expect(mocks.operations).toEqual([
-      "start Cards test-user",
-      "start Decks test-user",
-      "stop Cards test-user",
-      "stop Decks test-user",
-      "clear remote Cards",
-      "clear remote Decks",
-    ]);
-  });
-
-  it("does not subscribe or clear remote state before authentication", () => {
-    mocks.authUid = "";
-
-    const view = render(<FirestoreSubscriptionsProvider />);
-    view.unmount();
-
-    expect(mocks.operations).toEqual([]);
-  });
-
-  it("replaces subscriptions when the authenticated UID changes", () => {
-    const view = render(<FirestoreSubscriptionsProvider />);
-    mocks.operations.length = 0;
-
-    mocks.authUid = "next-user";
-    view.rerender(<FirestoreSubscriptionsProvider />);
-
-    expect(mocks.operations).toEqual([
-      "stop Cards test-user",
-      "stop Decks test-user",
-      "clear remote Cards",
-      "clear remote Decks",
-      "start Cards next-user",
-      "start Decks next-user",
-    ]);
-  });
-
-  it("keeps subscriptions when the authenticated UID is unchanged", () => {
-    const view = render(<FirestoreSubscriptionsProvider />);
-    mocks.operations.length = 0;
-
-    view.rerender(<FirestoreSubscriptionsProvider />);
-
-    expect(mocks.operations).toEqual([]);
-    expect(mocks.subscribeCards).toHaveBeenCalledOnce();
-    expect(mocks.subscribeDecks).toHaveBeenCalledOnce();
-  });
-
-  it("stops subscriptions and clears related state on logout", () => {
-    const view = render(<FirestoreSubscriptionsProvider />);
-    mocks.operations.length = 0;
-
-    mocks.authUid = "";
-    view.rerender(<FirestoreSubscriptionsProvider />);
-
-    expect(mocks.operations).toEqual([
-      "stop Cards test-user",
-      "stop Decks test-user",
-      "clear remote Cards",
-      "clear remote Decks",
-    ]);
+    expect(screen.getByText("No remote Decks")).toBeVisible();
+    expect(screen.getByText("No remote Cards")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Related issue
None

## Summary
- replace AuthProvider lifecycle spies with observable startup, authentication, failure, reload, and cleanup behavior
- drive Firestore subscription tests through the real Auth, Card, and Deck Entity stores
- verify identity changes, logout, and unmount through the remote data visible to provider children

## Testing
- `mise run check`