### PR TITLE
[No issue] Verify authentication action behavior

### DIFF
--- a/src/features/sign-in/model/useSignIn.spec.tsx
+++ b/src/features/sign-in/model/useSignIn.spec.tsx
@@ -1,78 +1,92 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { useSignIn } from "./useSignIn";
 import { actAsync } from "@/test/act";
 
+import { useSignIn } from "./useSignIn";
+
 const deferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+
+  return { promise, reject, resolve };
 };
 
 describe("useSignIn", () => {
-  it("reports pending while sign-in is running", async () => {
+  it("reports a pending sign-in until the operation completes", async () => {
     const request = deferred<void>();
-    const signIn = vi.fn(() => request.promise);
-    const { result } = renderHook(() => useSignIn(signIn));
+    const { result } = renderHook(() => useSignIn(() => request.promise));
 
-    let attempt!: Promise<void>;
+    let operation!: Promise<void>;
     act(() => {
-      attempt = result.current.signIn();
+      operation = result.current.signIn();
     });
 
-    expect(signIn).toHaveBeenCalledOnce();
-    expect(result.current).toMatchObject({ pending: true, error: null });
+    expect(result.current.pending).toBe(true);
+    expect(result.current.error).toBeNull();
 
     await actAsync(async () => {
       request.resolve();
-      await attempt;
+      await operation;
     });
+
     expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
-  it("allows sign-in again after a failure", async () => {
-    const error = new Error("sign in failed");
-    const signIn = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+  it("clears a failed sign-in when the user retries", async () => {
+    const failure = new Error("Sign-in failed");
+    const retry = deferred<void>();
+    let firstAttempt = true;
+    const signIn = () => {
+      if (firstAttempt) {
+        firstAttempt = false;
+        return Promise.reject(failure);
+      }
+      return retry.promise;
+    };
     const { result } = renderHook(() => useSignIn(signIn));
-
-    await actAsync(async () => expect(result.current.signIn()).rejects.toBe(error));
-    expect(result.current).toMatchObject({ pending: false, error });
-
-    await actAsync(async () => expect(result.current.signIn()).resolves.toBeUndefined());
-    expect(signIn).toHaveBeenCalledTimes(2);
-    expect(result.current).toMatchObject({ pending: false, error: null });
-  });
-
-  it("clears an earlier failure when a new attempt starts", async () => {
-    const error = new Error("sign in failed");
-    const request = deferred<void>();
-    const signIn = vi.fn().mockRejectedValueOnce(error).mockReturnValueOnce(request.promise);
-    const { result } = renderHook(() => useSignIn(signIn));
-    await actAsync(async () => expect(result.current.signIn()).rejects.toBe(error));
-
-    let attempt!: Promise<void>;
-    act(() => {
-      attempt = result.current.signIn();
-    });
-    expect(result.current).toMatchObject({ pending: true, error: null });
 
     await actAsync(async () => {
-      request.resolve();
-      await attempt;
+      await expect(result.current.signIn()).rejects.toThrow("Sign-in failed");
     });
+    expect(result.current.error).toBe(failure);
+
+    let operation!: Promise<void>;
+    act(() => {
+      operation = result.current.signIn();
+    });
+
+    expect(result.current.pending).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    await actAsync(async () => {
+      retry.resolve();
+      await operation;
+    });
+
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
-  it("does not carry failures to a later mount", async () => {
-    const error = new Error("sign in failed");
-    const signIn = vi.fn().mockRejectedValue(error);
+  it("does not carry a failed sign-in into a later mount", async () => {
+    const failure = new Error("Sign-in failed");
+    const signIn = () => Promise.reject(failure);
     const { result: firstResult, unmount } = renderHook(() => useSignIn(signIn));
-    await actAsync(async () => expect(firstResult.current.signIn()).rejects.toBe(error));
+
+    await actAsync(async () => {
+      await expect(firstResult.current.signIn()).rejects.toThrow("Sign-in failed");
+    });
+    expect(firstResult.current.error).toBe(failure);
     unmount();
 
-    const { result } = renderHook(() => useSignIn(signIn));
-    expect(result.current).toMatchObject({ pending: false, error: null });
+    const { result: secondResult } = renderHook(() => useSignIn(signIn));
+
+    expect(secondResult.current.pending).toBe(false);
+    expect(secondResult.current.error).toBeNull();
   });
 });

--- a/src/features/sign-out/model/useSignOut.spec.tsx
+++ b/src/features/sign-out/model/useSignOut.spec.tsx
@@ -1,58 +1,128 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
-import { useSignOut } from "./useSignOut";
+import { replaceAuthSession } from "@/entities/auth";
 import { actAsync } from "@/test/act";
 
+import { useSignOut } from "./useSignOut";
+
 const deferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+
+  return { promise, reject, resolve };
 };
 
 describe("useSignOut", () => {
-  it("reports pending while sign-out is running", async () => {
-    const request = deferred<void>();
-    const signOut = vi.fn(() => request.promise);
-    const { result } = renderHook(() => useSignOut(signOut));
+  beforeEach(() => {
+    replaceAuthSession({ status: "initializing" });
+  });
 
-    let attempt!: Promise<void>;
+  it("reports a pending sign-out until the operation completes", async () => {
+    const request = deferred<void>();
+    const { result } = renderHook(() => useSignOut(() => request.promise));
+
+    let operation!: Promise<void>;
     act(() => {
-      attempt = result.current.signOut();
+      operation = result.current.signOut();
     });
 
-    expect(signOut).toHaveBeenCalledOnce();
-    expect(result.current).toMatchObject({ pending: true, error: null });
+    expect(result.current.pending).toBe(true);
+    expect(result.current.error).toBeNull();
 
     await actAsync(async () => {
       request.resolve();
-      await attempt;
+      await operation;
     });
+
     expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
-  it("allows sign-out again after a failure", async () => {
-    const error = new Error("sign out failed");
-    const signOut = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+  it("clears a failed sign-out when the user retries", async () => {
+    const failure = new Error("Sign-out failed");
+    const retry = deferred<void>();
+    let firstAttempt = true;
+    const signOut = () => {
+      if (firstAttempt) {
+        firstAttempt = false;
+        return Promise.reject(failure);
+      }
+      return retry.promise;
+    };
     const { result } = renderHook(() => useSignOut(signOut));
 
-    await actAsync(async () => expect(result.current.signOut()).rejects.toBe(error));
-    await actAsync(async () => expect(result.current.signOut()).resolves.toBeUndefined());
+    await actAsync(async () => {
+      await expect(result.current.signOut()).rejects.toThrow("Sign-out failed");
+    });
+    expect(result.current.error).toBe(failure);
 
-    expect(signOut).toHaveBeenCalledTimes(2);
-    expect(result.current).toMatchObject({ pending: false, error: null });
+    let operation!: Promise<void>;
+    act(() => {
+      operation = result.current.signOut();
+    });
+
+    expect(result.current.pending).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    await actAsync(async () => {
+      retry.resolve();
+      await operation;
+    });
+
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
-  it("does not carry failures to a later mount", async () => {
-    const error = new Error("sign out failed");
-    const signOut = vi.fn().mockRejectedValue(error);
+  it("does not carry a failed sign-out into a later mount", async () => {
+    const failure = new Error("Sign-out failed");
+    const signOut = () => Promise.reject(failure);
     const { result: firstResult, unmount } = renderHook(() => useSignOut(signOut));
-    await actAsync(async () => expect(firstResult.current.signOut()).rejects.toBe(error));
+
+    await actAsync(async () => {
+      await expect(firstResult.current.signOut()).rejects.toThrow("Sign-out failed");
+    });
+    expect(firstResult.current.error).toBe(failure);
     unmount();
 
-    const { result } = renderHook(() => useSignOut(signOut));
-    expect(result.current).toMatchObject({ pending: false, error: null });
+    const { result: secondResult } = renderHook(() => useSignOut(signOut));
+
+    expect(secondResult.current.pending).toBe(false);
+    expect(secondResult.current.error).toBeNull();
+  });
+
+  it("reflects the current account identity and login state", () => {
+    replaceAuthSession({
+      displayName: "Ada",
+      isAnonymous: false,
+      status: "authenticated",
+      uid: "linked-user",
+    });
+    const { result } = renderHook(() => useSignOut(() => Promise.resolve()));
+
+    expect(result.current.isLoggedIn).toBe(true);
+    expect(result.current.identity).toEqual({
+      displayName: "Ada",
+      uid: "linked-user",
+    });
+
+    act(() => {
+      replaceAuthSession({
+        displayName: null,
+        isAnonymous: true,
+        status: "authenticated",
+        uid: "anonymous-user",
+      });
+    });
+
+    expect(result.current.isLoggedIn).toBe(false);
+    expect(result.current.identity).toEqual({
+      displayName: null,
+      uid: "anonymous-user",
+    });
   });
 });

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -1,73 +1,104 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import type { useAuthAccount } from "@/entities/auth";
-import type { Preferences } from "@/entities/preferences";
+import { replaceAuthSession } from "@/entities/auth";
+import { updatePreferences } from "@/entities/preferences";
 import { createPreferences } from "@/test/factories";
-
-type AuthAccount = ReturnType<typeof useAuthAccount>;
-
-const mocks = vi.hoisted(() => ({
-  authAccount: undefined as AuthAccount,
-  authUid: "",
-  preferences: null as unknown as Preferences,
-  setDarkMode: vi.fn(),
-}));
-
-vi.mock("@/shared/firebase", () => ({ auth: {} }));
-vi.mock("@/entities/auth", () => ({
-  useAuthAccount: () => mocks.authAccount,
-  useAuthUid: () => mocks.authUid,
-}));
-vi.mock("@/entities/preferences", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/entities/preferences")>()),
-  usePreferences: () => mocks.preferences,
-  setDarkMode: mocks.setDarkMode,
-  updatePreferences: vi.fn(),
-}));
 
 import { SettingsPage } from "./SettingsPage";
 
-const renderPage = (logout = vi.fn(), login = vi.fn()) =>
-  render(
-    <MemoryRouter initialEntries={["/settings"]}>
-      <Routes>
-        <Route path="/" element={<h1>Deck list</h1>} />
-        <Route path="/settings" element={<SettingsPage login={login} logout={logout} />} />
-      </Routes>
-    </MemoryRouter>
+vi.mock("@/shared/firebase", () => ({ auth: {} }));
+
+const successfulOperation = () => Promise.resolve();
+
+const renderPage = ({
+  login = successfulOperation,
+  logout = successfulOperation,
+}: {
+  login?: () => Promise<void>;
+  logout?: () => Promise<void>;
+} = {}) => {
+  const router = createMemoryRouter(
+    [
+      { path: "/", element: <div>Home Page</div> },
+      {
+        path: "/settings",
+        element: <SettingsPage login={login} logout={logout} />,
+      },
+    ],
+    { initialEntries: ["/settings"] }
   );
+
+  return render(<RouterProvider router={router} />);
+};
 
 describe("SettingsPage", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.authAccount = undefined;
-    mocks.authUid = "";
-    mocks.preferences = createPreferences({ appearance: { darkMode: false } });
+    replaceAuthSession({ status: "initializing" });
+    updatePreferences(createPreferences({ appearance: { darkMode: false } }));
   });
 
-  it("navigates to the deck list from the route shortcut", async () => {
+  it("navigates home when the user presses the route shortcut", async () => {
     renderPage();
 
-    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     fireEvent.keyDown(window, { key: "t" });
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Deck list" })).toBeVisible();
+    expect(await screen.findByText("Home Page")).toBeVisible();
   });
 
-  it("displays an alert when sign-out fails and clears it after retrying", async () => {
-    mocks.authAccount = { uid: "retry-uid-a", displayName: "Test User" };
-    mocks.authUid = "retry-uid-a";
-    const logout = vi.fn().mockRejectedValueOnce(new Error("sign out failed")).mockResolvedValueOnce(undefined);
-    renderPage(logout);
+  it("lets a signed-in user retry a failed sign-out", async () => {
+    replaceAuthSession({
+      displayName: "Test User",
+      isAnonymous: false,
+      status: "authenticated",
+      uid: "test-user",
+    });
+    let shouldFail = true;
+    const logout = () => {
+      if (shouldFail) {
+        shouldFail = false;
+        return Promise.reject(new Error("Sign-out failed"));
+      }
+      return Promise.resolve();
+    };
+    renderPage({ logout });
 
-    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
+    await userEvent.click(screen.getByRole("button", { name: "Logout" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(screen.getByText("Test User")).toBeVisible();
 
-    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Logout" })).toBeEnabled();
+  });
+
+  it("lets a signed-out user retry a failed sign-in", async () => {
+    let shouldFail = true;
+    const login = () => {
+      if (shouldFail) {
+        shouldFail = false;
+        return Promise.reject(new Error("Sign-in failed"));
+      }
+      return Promise.resolve();
+    };
+    renderPage({ login });
+
+    await userEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign in.");
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Login" })).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Related issue
None

## Summary
- replace invocation-count assertions in sign-in and sign-out hooks with pending, failure, retry, and remount behavior
- verify sign-out identity and login state through the real auth entity store
- exercise SettingsPage sign-in and sign-out retries through rendered UI and real auth and preferences stores

## Testing
- mise run check