### PR TITLE
refactor(#1102): Move study card selection to feature owners

### DIFF
--- a/src/entities/card/@x/deck.ts
+++ b/src/entities/card/@x/deck.ts
@@ -1,2 +1,1 @@
 export { deleteLocalCardsByDeckId } from "../model/store";
-export type { Card } from "../model/types";

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -3,8 +3,8 @@ export { generateDeckId } from "./api/id";
 export { createDeck, deleteDeck, editDeck } from "./api/mutations";
 export {
   CATEGORY,
-  filterCardsForDeck,
   getCategory,
+  isDeckTagSelectionMatching,
   isHighlightLanguage,
   mustFindDeckById,
 } from "./model/rules";

--- a/src/entities/deck/model/rules.spec.ts
+++ b/src/entities/deck/model/rules.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
-import { createCard, createDeck } from "@/test/factories";
-import { CATEGORY, filterCardsForDeck, getCategory, isHighlightLanguage, mustFindDeckById } from "./rules";
+import { createDeck } from "@/test/factories";
+import { CATEGORY, getCategory, isDeckTagSelectionMatching, isHighlightLanguage, mustFindDeckById } from "./rules";
 
 describe("category", () => {
   it("defines supported categories including application categories and major languages", () => {
@@ -50,61 +50,13 @@ describe("mustFindDeckById", () => {
   });
 });
 
-describe("filterCardsForDeck", () => {
-  const now = 1000;
-  const baseDeck = createDeck({ selectedTags: [], tagAndFilter: false, scoreMax: null, scoreMin: null });
-  const basePreferences = { useCardInterval: false };
-
-  it("returns all cards when no filters are active", () => {
-    const cards = [createCard({ id: "a" }), createCard({ id: "b" })];
-    expect(filterCardsForDeck(cards, baseDeck, basePreferences, now)).toHaveLength(2);
+describe("isDeckTagSelectionMatching", () => {
+  it("accepts any tag set when the Deck has no selected tags", () => {
+    expect(isDeckTagSelectionMatching([], createDeck({ selectedTags: [] }))).toBe(true);
   });
 
-  it("filters tags with OR semantics", () => {
-    const cards = [createCard({ id: "a", tags: ["x"] }), createCard({ id: "b", tags: ["y"] })];
-    const deck = { ...baseDeck, selectedTags: ["x"], tagAndFilter: false };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
-  });
-
-  it("filters tags with AND semantics", () => {
-    const cards = [createCard({ id: "a", tags: ["x", "y"] }), createCard({ id: "b", tags: ["x"] })];
-    const deck = { ...baseDeck, selectedTags: ["x", "y"], tagAndFilter: true };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["a"]);
-  });
-
-  it("includes the configured score boundaries", () => {
-    const cards = [
-      createCard({ id: "low", score: 1 }),
-      createCard({ id: "middle", score: 2 }),
-      createCard({ id: "high", score: 3 }),
-    ];
-    const deck = { ...baseDeck, scoreMin: 1, scoreMax: 3 };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual([
-      "low",
-      "middle",
-      "high",
-    ]);
-  });
-
-  it("excludes scores outside the configured range", () => {
-    const cards = [
-      createCard({ id: "low", score: 1 }),
-      createCard({ id: "middle", score: 2 }),
-      createCard({ id: "high", score: 3 }),
-    ];
-    const deck = { ...baseDeck, scoreMin: 2, scoreMax: 2 };
-    expect(filterCardsForDeck(cards, deck, basePreferences, now).map((card) => card.id)).toEqual(["middle"]);
-  });
-
-  it("filters unavailable cards when intervals are enabled", () => {
-    const cards = [createCard({ id: "future", nextSeeingAt: new Date(now + 1) }), createCard({ id: "available" })];
-    expect(filterCardsForDeck(cards, baseDeck, { useCardInterval: true }, now).map((card) => card.id)).toEqual([
-      "available",
-    ]);
-  });
-
-  it("preserves input order while filtering", () => {
-    const cards = [createCard({ id: "seen", numberOfSeen: 5 }), createCard({ id: "new", numberOfSeen: 1 })];
-    expect(filterCardsForDeck(cards, baseDeck, basePreferences, now).map((card) => card.id)).toEqual(["seen", "new"]);
+  it("applies the Deck's OR and AND tag modes", () => {
+    expect(isDeckTagSelectionMatching(["x"], createDeck({ selectedTags: ["x", "y"], tagAndFilter: false }))).toBe(true);
+    expect(isDeckTagSelectionMatching(["x"], createDeck({ selectedTags: ["x", "y"], tagAndFilter: true }))).toBe(false);
   });
 });

--- a/src/entities/deck/model/rules.ts
+++ b/src/entities/deck/model/rules.ts
@@ -1,6 +1,3 @@
-import type { Card } from "@/entities/card/@x/deck";
-import { createStudyProgressFromCard, isStudyProgressEligible } from "@/entities/study-progress/@x/deck";
-
 import type { Category, DeckDomain, DeckId } from "./types";
 
 const APPLICATION_CATEGORIES: Category[] = ["raw", "math"];
@@ -54,33 +51,16 @@ export const getCategory = (category: Category, tags: string[]): Category => {
   return tagCategory ?? category;
 };
 
-// Applies the Deck's all-or-any tag mode; an empty selection deliberately leaves every Card eligible.
-const isCardMatchingTags = (card: Card, deck: Pick<DeckDomain, "selectedTags" | "tagAndFilter">) => {
+// Applies the Deck's all-or-any tag mode; an empty selection deliberately accepts every tag set.
+export const isDeckTagSelectionMatching = (
+  candidateTags: readonly string[],
+  deck: Pick<DeckDomain, "selectedTags" | "tagAndFilter">
+): boolean => {
   const tags = deck.selectedTags;
   if (tags.length === 0) return true;
-  if (deck.tagAndFilter) return tags.every((tag) => card.tags.includes(tag));
-  return tags.some((tag) => card.tags.includes(tag));
+  if (deck.tagAndFilter) return tags.every((tag) => candidateTags.includes(tag));
+  return tags.some((tag) => candidateTags.includes(tag));
 };
-
-// Selects Cards that satisfy tag, score, and optional due-time rules while preserving the caller's order.
-export const filterCardsForDeck = <TCard extends Card>(
-  cards: TCard[],
-  deck: Pick<DeckDomain, "selectedTags" | "tagAndFilter" | "scoreMax" | "scoreMin">,
-  study: { useCardInterval: boolean },
-  now = Date.now()
-): TCard[] =>
-  cards.filter((card) => {
-    if (!isCardMatchingTags(card, deck)) return false;
-    return isStudyProgressEligible(
-      createStudyProgressFromCard(card),
-      {
-        maximumScore: deck.scoreMax,
-        minimumScore: deck.scoreMin,
-        respectNextSeeingAt: study.useCardInterval,
-      },
-      now
-    );
-  });
 
 // Returns the requested Deck or throws when a caller's Deck reference no longer resolves.
 export const mustFindDeckById = <TDeck extends DeckDomain>(decks: readonly TDeck[], id: DeckId): TDeck => {

--- a/src/entities/study-progress/@x/deck.ts
+++ b/src/entities/study-progress/@x/deck.ts
@@ -1,1 +1,0 @@
-export { createStudyProgressFromCard, isStudyProgressEligible } from "../model/rules";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,1 +1,2 @@
 export { editStudyProgress } from "./api/firestore";
+export { createStudyProgressFromCard, isStudyProgressEligible } from "./model/rules";

--- a/src/features/card-list/model/useCardListState.ts
+++ b/src/features/card-list/model/useCardListState.ts
@@ -2,9 +2,16 @@ import * as React from "react";
 
 import { useAuthUid } from "@/entities/auth";
 import { deleteCard, mustFindCardById, type Card, type CardId, useCardsByDeckId } from "@/entities/card";
-import { type Deck, editDeck, filterCardsForDeck, getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
+import {
+  type Deck,
+  editDeck,
+  getCategory,
+  isDeckTagSelectionMatching,
+  isHighlightLanguage,
+  useDeck,
+} from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
-import { editStudyProgress } from "@/entities/study-progress";
+import { createStudyProgressFromCard, editStudyProgress, isStudyProgressEligible } from "@/entities/study-progress";
 
 type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
 
@@ -25,6 +32,8 @@ interface CardListAnswer {
 
 export interface CardListState {
   tags: string[];
+  /** Lets presentation distinguish an empty Deck from a filter with zero matches. */
+  rawCardsLength: number;
   cards: CardListItem[];
   answer: CardListAnswer | undefined;
   deletionTarget: { frontText: string; hasError: boolean } | undefined;
@@ -47,6 +56,22 @@ const buildCardListItem = (card: Card): CardListItem => ({
   tags: card.tags,
 });
 
+// Keeps multi-Entity selection in the use-case owner while each Entity supplies only its own pure rule.
+const selectStudyCards = (cards: Card[], deck: Deck, useCardInterval: boolean, now = Date.now()): Card[] =>
+  cards.filter(
+    (card) =>
+      isDeckTagSelectionMatching(card.tags, deck) &&
+      isStudyProgressEligible(
+        createStudyProgressFromCard(card),
+        {
+          maximumScore: deck.scoreMax,
+          minimumScore: deck.scoreMin,
+          respectNextSeeingAt: useCardInterval,
+        },
+        now
+      )
+  );
+
 export const useCardListState = (deckId: string) => {
   const uid = useAuthUid();
   const deck = useDeck(deckId);
@@ -61,7 +86,7 @@ export const useCardListState = (deckId: string) => {
 
   if (deck == null) return;
 
-  const cards = filterCardsForDeck(deckCards, deck, preferences.study);
+  const cards = selectStudyCards(deckCards, deck, preferences.study.useCardInterval);
   const storedFilter: DeckFilterValues = {
     scoreMax: deck.scoreMax,
     scoreMin: deck.scoreMin,
@@ -120,6 +145,7 @@ export const useCardListState = (deckId: string) => {
       setTagAndFilter: (value: boolean) => updateFilter("tagAndFilter", value),
     },
     tags,
+    rawCardsLength: deckCards.length,
     cards: cards.map(buildCardListItem),
     answer,
     deletionTarget:

--- a/src/features/card-list/ui/CardList.spec.tsx
+++ b/src/features/card-list/ui/CardList.spec.tsx
@@ -37,7 +37,10 @@ vi.mock("@/entities/preferences", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/preferences")>()),
   usePreferences: () => mocks.preferences,
 }));
-vi.mock("@/entities/study-progress", () => ({ editStudyProgress: mocks.editStudyProgress }));
+vi.mock("@/entities/study-progress", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/entities/study-progress")>()),
+  editStudyProgress: mocks.editStudyProgress,
+}));
 
 import type * as React from "react";
 import { useCardListState } from "../model/useCardListState";

--- a/src/features/study-session-start/model/useStudySessionStartState.spec.ts
+++ b/src/features/study-session-start/model/useStudySessionStartState.spec.ts
@@ -12,15 +12,20 @@ import { useStudySessionStartState } from "./useStudySessionStartState";
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
-const preferences = createPreferences({ study: { maxNumberOfCardsToLearn: 12, shuffled: false } });
+const preferences = createPreferences({
+  study: { maxNumberOfCardsToLearn: 12, shuffled: false, useCardInterval: true },
+});
 const deck = createLocalDeck({
   id: "study-start-deck",
   name: "Japanese vocabulary",
+  scoreMax: 1,
+  scoreMin: -1,
   selectedTags: ["eligible"],
 });
 const eligibleCard = createLocalCard({
   id: "eligible-card",
   deckId: deck.id,
+  score: 1,
   tags: ["eligible"],
   uniqueKey: "eligible-card",
 });
@@ -29,6 +34,20 @@ const laterCard = createLocalCard({
   deckId: deck.id,
   tags: ["later"],
   uniqueKey: "later-card",
+});
+const highScoreCard = createLocalCard({
+  id: "high-score-card",
+  deckId: deck.id,
+  score: 2,
+  tags: ["eligible"],
+  uniqueKey: "high-score-card",
+});
+const futureCard = createLocalCard({
+  id: "future-card",
+  deckId: deck.id,
+  nextSeeingAt: new Date(253_402_300_799_999),
+  tags: ["eligible"],
+  uniqueKey: "future-card",
 });
 
 describe("useStudySessionStartState", () => {
@@ -45,6 +64,8 @@ describe("useStudySessionStartState", () => {
     await mutateCards("", [
       { kind: "create", card: eligibleCard },
       { kind: "create", card: laterCard },
+      { kind: "create", card: highScoreCard },
+      { kind: "create", card: futureCard },
     ]);
   });
 
@@ -59,6 +80,7 @@ describe("useStudySessionStartState", () => {
     expect(result.current).toMatchObject({
       deckName: "Japanese vocabulary",
       maxNumberOfCardsToLearn: 12,
+      rawCardsLength: 4,
       cardsLength: 1,
       tags: ["eligible", "later"],
     });

--- a/src/features/study-session-start/model/useStudySessionStartState.ts
+++ b/src/features/study-session-start/model/useStudySessionStartState.ts
@@ -1,12 +1,29 @@
 import { useState } from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { useCardsByDeckId } from "@/entities/card";
-import { type Deck, editDeck, filterCardsForDeck, useDeck } from "@/entities/deck";
+import { type Card, useCardsByDeckId } from "@/entities/card";
+import { type Deck, editDeck, isDeckTagSelectionMatching, useDeck } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
+import { createStudyProgressFromCard, isStudyProgressEligible } from "@/entities/study-progress";
 import { startStudy } from "@/entities/study-session";
 
 type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
+
+// Keeps multi-Entity selection in the use-case owner while each Entity supplies only its own pure rule.
+const selectStudyCards = (cards: Card[], deck: Deck, useCardInterval: boolean, now = Date.now()): Card[] =>
+  cards.filter(
+    (card) =>
+      isDeckTagSelectionMatching(card.tags, deck) &&
+      isStudyProgressEligible(
+        createStudyProgressFromCard(card),
+        {
+          maximumScore: deck.scoreMax,
+          minimumScore: deck.scoreMin,
+          respectNextSeeingAt: useCardInterval,
+        },
+        now
+      )
+  );
 
 export const useStudySessionStartState = (deckId: string) => {
   const uid = useAuthUid();
@@ -17,7 +34,7 @@ export const useStudySessionStartState = (deckId: string) => {
 
   if (deck == null) return;
 
-  const cards = filterCardsForDeck(deckCards, deck, preferences.study);
+  const cards = selectStudyCards(deckCards, deck, preferences.study.useCardInterval);
   const storedFilter: DeckFilterValues = {
     scoreMax: deck.scoreMax,
     scoreMin: deck.scoreMin,
@@ -39,6 +56,8 @@ export const useStudySessionStartState = (deckId: string) => {
     },
     deckName: deck.name,
     maxNumberOfCardsToLearn: preferences.study.maxNumberOfCardsToLearn,
+    // Preserves the source count so presentation can distinguish an empty Deck from zero filter matches.
+    rawCardsLength: deckCards.length,
     cardsLength: cards.length,
     tags,
     onStart: () => startStudy(deck.id, cards, preferences.study),

--- a/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
@@ -24,7 +24,7 @@ vi.mock("@/entities/card", () => ({
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
 vi.mock("@/entities/deck", () => ({
   editDeck: vi.fn(),
-  filterCardsForDeck: (cards: Card[]) => cards,
+  isDeckTagSelectionMatching: () => true,
   useDeck: () => mocks.deck ?? undefined,
 }));
 vi.mock("@/entities/preferences", () => ({


### PR DESCRIPTION
## Related issue

Fixes #1102

## Summary

- keep Deck filtering limited to its tag-selection rule
- compose Deck, StudyProgress, Card, and Preferences rules in the Card List and Study Session Start feature models
- expose raw and filtered counts for future empty-state reasoning and remove obsolete cross-Entity exports

## Testing

- `mise run check`