### PR TITLE
[No issue] Test Storybook user behavior

### DIFF
--- a/src/app/App.stories.tsx
+++ b/src/app/App.stories.tsx
@@ -11,7 +11,6 @@ import { AppRoutes } from "@/app/routes";
 import { routes } from "@/features/navigate";
 import { type PageStoryParameters, preparePageStory, withPageStory } from "@/storybook/PageDecorator";
 import { PAGE_STORY_CARD_ID, PAGE_STORY_DECK_ID, pageStoryState } from "@/storybook/pageFixture";
-import { STORYBOOK_DECK_IMPORT_URL } from "@/storybook/handlers";
 
 const page = (path: string, overrides: Partial<Omit<PageStoryParameters, "path">> = {}): PageStoryParameters => ({
   ...pageStoryState,
@@ -71,10 +70,19 @@ export const Settings: Story = {
 
 export const Import: Story = {
   parameters: { page: page(routes.deckImport.to()) },
-  play: async () => {
-    const response = await fetch(STORYBOOK_DECK_IMPORT_URL);
-    expect(response.status).toBe(200);
-    expect(await response.text()).toContain("hello word in python");
+  play: async ({ canvas, userEvent }) => {
+    const file = new File(
+      ['"storybook prompt","storybook answer","story","storybook-import"'],
+      "storybook-import.csv",
+      { type: "text/csv" }
+    );
+
+    await userEvent.click(canvas.getByRole("radio", { name: /Local only/ }));
+    await userEvent.upload(canvas.getByLabelText("Upload a csv file"), file);
+
+    await expect(await canvas.findByRole("heading", { level: 2, name: "Review import" })).toBeVisible();
+    await expect(canvas.getByText("1 create")).toBeVisible();
+    await expect(canvas.getByText("storybook answer")).toBeVisible();
   },
 };
 

--- a/src/features/card-list/ui/CardListView.stories.tsx
+++ b/src/features/card-list/ui/CardListView.stories.tsx
@@ -88,11 +88,16 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const HoverHighlight: Story = {
-  play: async ({ canvas, userEvent }) => {
-    const [firstCard] = canvas.getAllByRole("button", { name: /^View / });
-    if (firstCard == null) throw new Error("HoverHighlight requires at least one card");
-    await userEvent.hover(firstCard);
+export const ViewCard: Story = {
+  args: { onShowCard: fn() },
+  play: async ({ args, canvas, userEvent }) => {
+    const [viewButton] = canvas.getAllByRole("button", { name: /^View / });
+    const [firstCard] = fixture.cards.default;
+    if (viewButton == null || firstCard == null) throw new Error("ViewCard requires at least one Card");
+
+    await userEvent.click(viewButton);
+
+    await expect(args.onShowCard).toHaveBeenCalledWith(firstCard.id);
   },
 };
 

--- a/src/features/deck-edit/ui/DeckEditForm.stories.tsx
+++ b/src/features/deck-edit/ui/DeckEditForm.stories.tsx
@@ -19,7 +19,7 @@ const createForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
   },
   fields: {
     name: { defaultValue: deck.name },
-    convertToBr: { checked: deck.convertToBr },
+    convertToBr: { checked: deck.convertToBr, onChange: () => undefined },
     url: { defaultValue: deck.url },
     category: { defaultValue: deck.category, options: [{ label: deck.category, value: deck.category }] },
   },

--- a/src/features/deck-list/ui/DeckListView.stories.tsx
+++ b/src/features/deck-list/ui/DeckListView.stories.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn } from "storybook/test";
 
 import type { Deck } from "@/entities/deck";
 import type { DeckListState } from "../model/useDeckListState";
@@ -65,11 +66,16 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const HoverHighlight: Story = {
-  play: async ({ canvas, userEvent }) => {
-    const [firstDeck] = canvas.getAllByRole("button", { name: /^View / });
-    if (firstDeck == null) throw new Error("HoverHighlight requires at least one deck");
-    await userEvent.hover(firstDeck);
+export const ViewDeck: Story = {
+  args: { deckCard: { onClickName: fn() } },
+  play: async ({ args, canvas, userEvent }) => {
+    const [viewButton] = canvas.getAllByRole("button", { name: /^View / });
+    const [firstDeck] = mixed.studying;
+    if (viewButton == null || firstDeck == null) throw new Error("ViewDeck requires at least one Deck");
+
+    await userEvent.click(viewButton);
+
+    await expect(args.deckCard?.onClickName).toHaveBeenCalledWith(firstDeck.deck.id);
   },
 };
 


### PR DESCRIPTION
## Related issue
None

## Summary

- Exercise the import page through local CSV selection and its rendered preview instead of fetching the MSW fixture directly.
- Replace assertion-free hover plays with observable Card and Deck view actions.
- Complete the Deck form story fixture controlled-field contract to avoid React warnings.

## Testing

- mise run check
- mise run test-storybook (47 files, 260 tests)