### PR TITLE
refactor(#728): Move Settings auth actions into features

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -15,8 +15,6 @@ vi.mock("@/app/providers/auth", () => ({
 vi.mock("@/app/providers/firestore-subscriptions", () => ({
   FirestoreSubscriptionsProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
-vi.mock("@/features/sign-in", () => ({ loginGoogle: vi.fn() }));
-vi.mock("@/features/sign-out", () => ({ signOutCurrentUser: vi.fn() }));
 vi.mock("@/pages/card-form", () => ({ CardFormPage: () => null }));
 vi.mock("@/pages/card-list", () => ({ CardListPage: () => null }));
 vi.mock("@/pages/card-view", () => ({ CardViewPage: () => null }));

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -1,15 +1,13 @@
 /**
  * @file Defines Tango's route tree.
- * Each URL is connected to a page component while route-level authentication actions and unknown
- * route recovery stay at the application boundary.
+ * Each URL is connected to a page component while unknown route recovery stays at the application
+ * boundary.
  */
 
 import type React from "react";
 import { Route, Routes } from "react-router-dom";
 
 import { routes, useNavigation } from "@/features/navigate";
-import { loginGoogle } from "@/features/sign-in";
-import { signOutCurrentUser } from "@/features/sign-out";
 import { CardFormPage } from "@/pages/card-form";
 import { CardListPage } from "@/pages/card-list";
 import { CardViewPage } from "@/pages/card-view";
@@ -38,10 +36,6 @@ const UnknownRoute = () => {
   );
 };
 
-const login = async () => {
-  await loginGoogle();
-};
-
 /**
  * Renders Tango's route tree inside the router supplied by the caller.
  * Production uses BrowserRouter while Storybook can provide MemoryRouter for isolated page stories.
@@ -55,7 +49,7 @@ export const AppRoutes: React.FC = () => (
     <Route path={routes.deckStudy.path} element={<StudySessionPage />} />
     <Route path={routes.cardView.path} element={<CardViewPage />} />
     <Route path={routes.cardForm.path} element={<CardFormPage />} />
-    <Route path={routes.settings.path} element={<SettingsPage login={login} logout={signOutCurrentUser} />} />
+    <Route path={routes.settings.path} element={<SettingsPage />} />
     <Route path={routes.deckImport.path} element={<DeckImportPage />} />
     <Route path={routes.notFound.path} element={<UnknownRoute />} />
   </Routes>

--- a/src/features/sign-in/index.ts
+++ b/src/features/sign-in/index.ts
@@ -1,2 +1,1 @@
-export { loginGoogle } from "./model/signIn";
 export { useSignIn } from "./model/useSignIn";

--- a/src/features/sign-in/model/useSignIn.spec.tsx
+++ b/src/features/sign-in/model/useSignIn.spec.tsx
@@ -1,7 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
+
+const mocks = vi.hoisted(() => ({
+  loginGoogle: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock("./signIn", () => ({ loginGoogle: mocks.loginGoogle }));
 
 import { useSignIn } from "./useSignIn";
 
@@ -17,9 +23,15 @@ const deferred = <T,>() => {
 };
 
 describe("useSignIn", () => {
+  beforeEach(() => {
+    mocks.loginGoogle.mockReset();
+    mocks.loginGoogle.mockResolvedValue(undefined);
+  });
+
   it("reports a pending sign-in until the operation completes", async () => {
     const request = deferred<void>();
-    const { result } = renderHook(() => useSignIn(() => request.promise));
+    mocks.loginGoogle.mockReturnValue(request.promise);
+    const { result } = renderHook(() => useSignIn());
 
     let operation!: Promise<void>;
     act(() => {
@@ -41,15 +53,8 @@ describe("useSignIn", () => {
   it("clears a failed sign-in when the user retries", async () => {
     const failure = new Error("Sign-in failed");
     const retry = deferred<void>();
-    let firstAttempt = true;
-    const signIn = () => {
-      if (firstAttempt) {
-        firstAttempt = false;
-        return Promise.reject(failure);
-      }
-      return retry.promise;
-    };
-    const { result } = renderHook(() => useSignIn(signIn));
+    mocks.loginGoogle.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
+    const { result } = renderHook(() => useSignIn());
 
     await actAsync(async () => {
       await expect(result.current.signIn()).rejects.toThrow("Sign-in failed");
@@ -75,8 +80,8 @@ describe("useSignIn", () => {
 
   it("does not carry a failed sign-in into a later mount", async () => {
     const failure = new Error("Sign-in failed");
-    const signIn = () => Promise.reject(failure);
-    const { result: firstResult, unmount } = renderHook(() => useSignIn(signIn));
+    mocks.loginGoogle.mockRejectedValue(failure);
+    const { result: firstResult, unmount } = renderHook(() => useSignIn());
 
     await actAsync(async () => {
       await expect(firstResult.current.signIn()).rejects.toThrow("Sign-in failed");
@@ -84,7 +89,7 @@ describe("useSignIn", () => {
     expect(firstResult.current.error).toBe(failure);
     unmount();
 
-    const { result: secondResult } = renderHook(() => useSignIn(signIn));
+    const { result: secondResult } = renderHook(() => useSignIn());
 
     expect(secondResult.current.pending).toBe(false);
     expect(secondResult.current.error).toBeNull();

--- a/src/features/sign-in/model/useSignIn.ts
+++ b/src/features/sign-in/model/useSignIn.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
-export const useSignIn = (signIn: () => Promise<void>) => {
+import { loginGoogle } from "./signIn";
+
+export const useSignIn = () => {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<unknown>(null);
 
@@ -8,7 +10,7 @@ export const useSignIn = (signIn: () => Promise<void>) => {
     setPending(true);
     setError(null);
     try {
-      await signIn();
+      await loginGoogle();
     } catch (nextError) {
       setError(nextError);
       throw nextError;

--- a/src/features/sign-out/index.ts
+++ b/src/features/sign-out/index.ts
@@ -1,2 +1,1 @@
-export { signOutCurrentUser } from "./model/signOut";
 export { useSignOut } from "./model/useSignOut";

--- a/src/features/sign-out/model/useSignOut.spec.tsx
+++ b/src/features/sign-out/model/useSignOut.spec.tsx
@@ -1,8 +1,14 @@
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { replaceAuthSession } from "@/entities/auth";
 import { actAsync } from "@/test/act";
+
+const mocks = vi.hoisted(() => ({
+  signOutCurrentUser: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("./signOut", () => ({ signOutCurrentUser: mocks.signOutCurrentUser }));
 
 import { useSignOut } from "./useSignOut";
 
@@ -19,12 +25,15 @@ const deferred = <T,>() => {
 
 describe("useSignOut", () => {
   beforeEach(() => {
+    mocks.signOutCurrentUser.mockReset();
+    mocks.signOutCurrentUser.mockResolvedValue(undefined);
     replaceAuthSession({ status: "initializing" });
   });
 
   it("reports a pending sign-out until the operation completes", async () => {
     const request = deferred<void>();
-    const { result } = renderHook(() => useSignOut(() => request.promise));
+    mocks.signOutCurrentUser.mockReturnValue(request.promise);
+    const { result } = renderHook(() => useSignOut());
 
     let operation!: Promise<void>;
     act(() => {
@@ -46,15 +55,8 @@ describe("useSignOut", () => {
   it("clears a failed sign-out when the user retries", async () => {
     const failure = new Error("Sign-out failed");
     const retry = deferred<void>();
-    let firstAttempt = true;
-    const signOut = () => {
-      if (firstAttempt) {
-        firstAttempt = false;
-        return Promise.reject(failure);
-      }
-      return retry.promise;
-    };
-    const { result } = renderHook(() => useSignOut(signOut));
+    mocks.signOutCurrentUser.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
+    const { result } = renderHook(() => useSignOut());
 
     await actAsync(async () => {
       await expect(result.current.signOut()).rejects.toThrow("Sign-out failed");
@@ -80,8 +82,8 @@ describe("useSignOut", () => {
 
   it("does not carry a failed sign-out into a later mount", async () => {
     const failure = new Error("Sign-out failed");
-    const signOut = () => Promise.reject(failure);
-    const { result: firstResult, unmount } = renderHook(() => useSignOut(signOut));
+    mocks.signOutCurrentUser.mockRejectedValue(failure);
+    const { result: firstResult, unmount } = renderHook(() => useSignOut());
 
     await actAsync(async () => {
       await expect(firstResult.current.signOut()).rejects.toThrow("Sign-out failed");
@@ -89,7 +91,7 @@ describe("useSignOut", () => {
     expect(firstResult.current.error).toBe(failure);
     unmount();
 
-    const { result: secondResult } = renderHook(() => useSignOut(signOut));
+    const { result: secondResult } = renderHook(() => useSignOut());
 
     expect(secondResult.current.pending).toBe(false);
     expect(secondResult.current.error).toBeNull();
@@ -102,7 +104,7 @@ describe("useSignOut", () => {
       status: "authenticated",
       uid: "linked-user",
     });
-    const { result } = renderHook(() => useSignOut(() => Promise.resolve()));
+    const { result } = renderHook(() => useSignOut());
 
     expect(result.current.isLoggedIn).toBe(true);
     expect(result.current.identity).toEqual({

--- a/src/features/sign-out/model/useSignOut.ts
+++ b/src/features/sign-out/model/useSignOut.ts
@@ -2,7 +2,9 @@ import { useState } from "react";
 
 import { useAuthAccount, useAuthUid } from "@/entities/auth";
 
-export const useSignOut = (signOut: () => Promise<void>) => {
+import { signOutCurrentUser } from "./signOut";
+
+export const useSignOut = () => {
   const account = useAuthAccount();
   const uid = useAuthUid();
   const [pending, setPending] = useState(false);
@@ -12,7 +14,7 @@ export const useSignOut = (signOut: () => Promise<void>) => {
     setPending(true);
     setError(null);
     try {
-      await signOut();
+      await signOutCurrentUser();
     } catch (nextError) {
       setError(nextError);
       throw nextError;

--- a/src/pages/settings/ui/SettingsPage.spec.tsx
+++ b/src/pages/settings/ui/SettingsPage.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { linkWithPopup, signOut } from "firebase/auth";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -10,23 +11,20 @@ import { createPreferences } from "@/test/factories";
 
 import { SettingsPage } from "./SettingsPage";
 
-vi.mock("@/shared/firebase", () => ({ auth: {} }));
+const mocks = vi.hoisted(() => ({
+  auth: { currentUser: { isAnonymous: true } },
+}));
 
-const successfulOperation = () => Promise.resolve();
+vi.mock("@/shared/firebase", () => ({ auth: mocks.auth }));
+vi.mock("firebase/auth");
 
-const renderPage = ({
-  login = successfulOperation,
-  logout = successfulOperation,
-}: {
-  login?: () => Promise<void>;
-  logout?: () => Promise<void>;
-} = {}) => {
+const renderPage = () => {
   const router = createMemoryRouter(
     [
       { path: "/", element: <div>Home Page</div> },
       {
         path: "/settings",
-        element: <SettingsPage login={login} logout={logout} />,
+        element: <SettingsPage />,
       },
     ],
     { initialEntries: ["/settings"] }
@@ -37,6 +35,10 @@ const renderPage = ({
 
 describe("SettingsPage", () => {
   beforeEach(() => {
+    vi.mocked(linkWithPopup).mockReset();
+    vi.mocked(linkWithPopup).mockResolvedValue({ user: {} } as never);
+    vi.mocked(signOut).mockReset();
+    vi.mocked(signOut).mockResolvedValue(undefined);
     replaceAuthSession({ status: "initializing" });
     updatePreferences(createPreferences({ appearance: { darkMode: false } }));
   });
@@ -56,15 +58,8 @@ describe("SettingsPage", () => {
       status: "authenticated",
       uid: "test-user",
     });
-    let shouldFail = true;
-    const logout = () => {
-      if (shouldFail) {
-        shouldFail = false;
-        return Promise.reject(new Error("Sign-out failed"));
-      }
-      return Promise.resolve();
-    };
-    renderPage({ logout });
+    vi.mocked(signOut).mockRejectedValueOnce(new Error("Sign-out failed")).mockResolvedValueOnce(undefined);
+    renderPage();
 
     await userEvent.click(screen.getByRole("button", { name: "Logout" }));
 
@@ -80,15 +75,10 @@ describe("SettingsPage", () => {
   });
 
   it("lets a signed-out user retry a failed sign-in", async () => {
-    let shouldFail = true;
-    const login = () => {
-      if (shouldFail) {
-        shouldFail = false;
-        return Promise.reject(new Error("Sign-in failed"));
-      }
-      return Promise.resolve();
-    };
-    renderPage({ login });
+    vi.mocked(linkWithPopup)
+      .mockRejectedValueOnce(new Error("Sign-in failed"))
+      .mockResolvedValueOnce({ user: {} } as never);
+    renderPage();
 
     await userEvent.click(screen.getByRole("button", { name: "Login" }));
 

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -8,16 +8,11 @@ import { routes, useNavigation } from "@/features/navigate";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
 import { AppLayout } from "@/widgets/app-layout";
 
-interface SettingsPageProps {
-  login: () => Promise<void>;
-  logout: () => Promise<void>;
-}
-
-export const SettingsPage: React.FC<SettingsPageProps> = ({ login, logout }) => {
+export const SettingsPage: React.FC = () => {
   const navigation = useNavigation();
 
-  const signIn = useSignIn(login);
-  const signOut = useSignOut(logout);
+  const signIn = useSignIn();
+  const signOut = useSignOut();
   const { isLoggedIn } = signOut;
   const accountOperation = isLoggedIn
     ? {

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -33,6 +33,8 @@ export default defineConfig([
       "./src/features/card-list/**",
       "./src/features/deck-edit/**",
       "./src/features/preferences-edit/**",
+      "./src/features/sign-in/**",
+      "./src/features/sign-out/**",
       "./src/features/study/**",
       "./src/features/study-session-start/**",
     ],


### PR DESCRIPTION
## Related issue

Fixes #728

## Summary

- Remove login and logout callback props from SettingsPage and the route-level auth wiring from AppRoutes.
- Let the sign-in and sign-out feature hooks own their Firebase commands, pending state, and errors behind their public boundaries.
- Preserve retry feedback coverage and document the route-specific feature slices in the FSD lint configuration.

## Testing

- mise run check