### PR TITLE
fix(#512): Own Deck import operation failures

### DIFF
--- a/src/features/deck-import/model/useDeckImport.spec.tsx
+++ b/src/features/deck-import/model/useDeckImport.spec.tsx
@@ -224,7 +224,6 @@ describe("useDeckImport", () => {
     expect(result.current.deckImport.error).toEqual(new Error("card mutation failed"));
     expect(result.current.deckImport.preview).toBeUndefined();
     expect(result.current.deckImport.fileName).toBe(name);
-    expect(result.current.deckImport.fileReselectionRequired).toBe(true);
     await actAsync(async () => {
       expect(await result.current.deckImport.importPreview()).toBeUndefined();
     });
@@ -232,7 +231,6 @@ describe("useDeckImport", () => {
 
     await actAsync(async () => result.current.deckImport.selectFile(file));
     expect(result.current.deckImport.error).toBeNull();
-    expect(result.current.deckImport.fileReselectionRequired).toBe(false);
     expect(result.current.deckImport.preview?.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
     await actAsync(async () => result.current.deckImport.importPreview());
 

--- a/src/features/deck-import/model/useDeckImport.spec.tsx
+++ b/src/features/deck-import/model/useDeckImport.spec.tsx
@@ -222,10 +222,17 @@ describe("useDeckImport", () => {
     expect(savedDeck).toBeDefined();
     expect(result.current.cards.filter((card) => card.deckId === savedDeck?.id)).toEqual([]);
     expect(result.current.deckImport.error).toEqual(new Error("card mutation failed"));
-    await expect(result.current.deckImport.importPreview()).rejects.toThrow("prepared Deck import is not available");
+    expect(result.current.deckImport.preview).toBeUndefined();
+    expect(result.current.deckImport.fileName).toBe(name);
+    expect(result.current.deckImport.fileReselectionRequired).toBe(true);
+    await actAsync(async () => {
+      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+    });
+    expect(result.current.deckImport.previewError).toEqual(new Error("Select a CSV file before importing"));
 
     await actAsync(async () => result.current.deckImport.selectFile(file));
     expect(result.current.deckImport.error).toBeNull();
+    expect(result.current.deckImport.fileReselectionRequired).toBe(false);
     expect(result.current.deckImport.preview?.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
     await actAsync(async () => result.current.deckImport.importPreview());
 

--- a/src/features/deck-import/model/useDeckImport.spec.tsx
+++ b/src/features/deck-import/model/useDeckImport.spec.tsx
@@ -144,7 +144,10 @@ describe("useDeckImport", () => {
         issues: [expect.objectContaining({ rowNumber: 1, message: "Expected 4 columns, found 2." })],
       },
     });
-    await expect(result.current.deckImport.importPreview()).rejects.toThrow("Fix invalid CSV rows");
+    await actAsync(async () => {
+      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+    });
+    expect(result.current.deckImport.previewError).toEqual(new Error("Fix invalid CSV rows before importing"));
     expect(findDeck(result.current.decks, name)).toBeUndefined();
   });
 
@@ -157,7 +160,10 @@ describe("useDeckImport", () => {
 
     expect(result.current.deckImport.storageMode).toBe("remote");
     expect(result.current.deckImport.preview).toBeUndefined();
-    await expect(result.current.deckImport.importPreview()).rejects.toThrow("Select a CSV file");
+    await actAsync(async () => {
+      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+    });
+    expect(result.current.deckImport.previewError).toEqual(new Error("Select a CSV file before importing"));
   });
 
   it("builds a remote preview from current server data instead of stale local state", async () => {
@@ -190,9 +196,10 @@ describe("useDeckImport", () => {
     const { result } = renderDeckImport();
 
     await actAsync(async () => {
-      await expect(result.current.deckImport.selectFile(csvFile(name))).rejects.toThrow("server read failed");
+      expect(await result.current.deckImport.selectFile(csvFile(name))).toEqual({ status: "failure" });
     });
 
+    expect(result.current.deckImport.fileName).toBe(name);
     expect(result.current.deckImport.preview).toBeUndefined();
     expect(result.current.deckImport.previewError).toEqual(new Error("server read failed"));
     expect(result.current.deckImport.error).toBeNull();
@@ -208,7 +215,7 @@ describe("useDeckImport", () => {
     controls.nextMutationError = new Error("card mutation failed");
 
     await actAsync(async () => {
-      await expect(result.current.deckImport.importPreview()).rejects.toThrow("card mutation failed");
+      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
     });
 
     const savedDeck = findDeck(result.current.decks, name);
@@ -224,5 +231,16 @@ describe("useDeckImport", () => {
 
     expect(result.current.deckImport.result).toMatchObject({ created: 1, updated: 0, skipped: 0 });
     expect(result.current.cards.filter((card) => card.deckId === savedDeck?.id)).toHaveLength(1);
+  });
+
+  it("makes a sample preparation failure observable without rejecting", async () => {
+    const { result } = renderDeckImport();
+
+    await actAsync(async () => {
+      expect(await result.current.deckImport.addSample()).toEqual({ status: "failure" });
+    });
+
+    expect(result.current.deckImport.error).toEqual(new Error("A confirmed user is required for remote imports"));
+    expect(result.current.deckImport.pending).toBe(false);
   });
 });

--- a/src/features/deck-import/model/useDeckImport.spec.tsx
+++ b/src/features/deck-import/model/useDeckImport.spec.tsx
@@ -145,7 +145,7 @@ describe("useDeckImport", () => {
       },
     });
     await actAsync(async () => {
-      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+      expect(await result.current.deckImport.importPreview()).toBeUndefined();
     });
     expect(result.current.deckImport.previewError).toEqual(new Error("Fix invalid CSV rows before importing"));
     expect(findDeck(result.current.decks, name)).toBeUndefined();
@@ -161,7 +161,7 @@ describe("useDeckImport", () => {
     expect(result.current.deckImport.storageMode).toBe("remote");
     expect(result.current.deckImport.preview).toBeUndefined();
     await actAsync(async () => {
-      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+      expect(await result.current.deckImport.importPreview()).toBeUndefined();
     });
     expect(result.current.deckImport.previewError).toEqual(new Error("Select a CSV file before importing"));
   });
@@ -196,7 +196,7 @@ describe("useDeckImport", () => {
     const { result } = renderDeckImport();
 
     await actAsync(async () => {
-      expect(await result.current.deckImport.selectFile(csvFile(name))).toEqual({ status: "failure" });
+      expect(await result.current.deckImport.selectFile(csvFile(name))).toBeUndefined();
     });
 
     expect(result.current.deckImport.fileName).toBe(name);
@@ -215,7 +215,7 @@ describe("useDeckImport", () => {
     controls.nextMutationError = new Error("card mutation failed");
 
     await actAsync(async () => {
-      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+      expect(await result.current.deckImport.importPreview()).toBeUndefined();
     });
 
     const savedDeck = findDeck(result.current.decks, name);
@@ -226,7 +226,7 @@ describe("useDeckImport", () => {
     expect(result.current.deckImport.fileName).toBe(name);
     expect(result.current.deckImport.fileReselectionRequired).toBe(true);
     await actAsync(async () => {
-      expect(await result.current.deckImport.importPreview()).toEqual({ status: "failure" });
+      expect(await result.current.deckImport.importPreview()).toBeUndefined();
     });
     expect(result.current.deckImport.previewError).toEqual(new Error("Select a CSV file before importing"));
 
@@ -244,7 +244,7 @@ describe("useDeckImport", () => {
     const { result } = renderDeckImport();
 
     await actAsync(async () => {
-      expect(await result.current.deckImport.addSample()).toEqual({ status: "failure" });
+      expect(await result.current.deckImport.addSample()).toBeUndefined();
     });
 
     expect(result.current.deckImport.error).toEqual(new Error("A confirmed user is required for remote imports"));

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -21,11 +21,9 @@ export const useDeckImport = () => {
   const execution = useDeckImportExecution(uid);
   const preview = useDeckImportPreview({ uid, cards, decks });
   const [status, setStatus] = useState<DeckImportStatus>("idle");
-  const [fileReselectionRequired, setFileReselectionRequired] = useState(false);
 
   const selectFile = async (file: File) => {
     execution.clear();
-    setFileReselectionRequired(false);
     setStatus("validating");
     try {
       return await preview.selectFile(file);
@@ -35,29 +33,23 @@ export const useDeckImport = () => {
   };
 
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
-    if (preview.setStorageMode(storageMode)) {
-      execution.clear();
-      setFileReselectionRequired(false);
-    }
+    if (preview.setStorageMode(storageMode)) execution.clear();
   };
 
-  const runImport = async (prepare: () => PreparedDeckImport | undefined, onExecutionFailure?: () => void) => {
+  const runImport = async (prepare: () => PreparedDeckImport | undefined) => {
     const preparedImport = prepare();
     if (preparedImport === undefined) return;
 
     preview.clearError();
     setStatus("importing");
     try {
-      const importResult = await execution.run(preparedImport);
-      if (importResult === undefined) onExecutionFailure?.();
-      return importResult;
+      return await execution.run(preparedImport);
     } finally {
       setStatus("idle");
     }
   };
 
   const addSample = () => {
-    setFileReselectionRequired(false);
     if (uid === "") {
       execution.fail(new Error("A confirmed user is required for remote imports"));
       return Promise.resolve();
@@ -65,24 +57,16 @@ export const useDeckImport = () => {
     return runImport(() => prepareSampleDeck(uid, { cards, decks, generateCardId }));
   };
 
-  const importPreview = () =>
-    runImport(preview.takePreparedImport, () => {
-      // Persistence can fail after creating the Deck, so retry must rebuild a plan from current destination data.
-      preview.invalidate();
-      setFileReselectionRequired(true);
-    });
-
   return {
     selectFile,
     setStorageMode,
-    importPreview,
+    importPreview: () => runImport(preview.takePreparedImport),
     addSample,
     storageMode: preview.storageMode,
     fileName: preview.fileName,
     preview: preview.preview,
     validating: status === "validating",
     pending: status === "importing",
-    fileReselectionRequired,
     error: execution.error,
     previewError: preview.error,
     result: execution.result,

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -5,13 +5,17 @@ import { generateCardId, useCards } from "@/entities/card";
 import { useDecks } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
 import { prepareSampleDeck } from "./useAddSampleDeck";
-import type { DeckImportStorageMode, PreparedDeckImport } from "./useDeckImportExecution";
+import type { DeckImportResult, DeckImportStorageMode, PreparedDeckImport } from "./useDeckImportExecution";
 import { useDeckImportExecution } from "./useDeckImportExecution";
 import { useDeckImportPreview } from "./useDeckImportPreview";
 
 export type { DeckImportPreview } from "./useDeckImportPreview";
 
 type DeckImportStatus = "idle" | "validating" | "importing";
+type DeckImportOperationResult<Value> = { status: "success"; value: Value } | { status: "failure" };
+
+const operationSucceeded = <Value>(value: Value): DeckImportOperationResult<Value> => ({ status: "success", value });
+const operationFailed = { status: "failure" } as const;
 
 export const useDeckImport = () => {
   const uid = useAuthUid();
@@ -26,7 +30,8 @@ export const useDeckImport = () => {
     execution.clear();
     setStatus("validating");
     try {
-      return await preview.selectFile(file);
+      const selectedPreview = await preview.selectFile(file);
+      return selectedPreview === undefined ? operationFailed : operationSucceeded(selectedPreview);
     } finally {
       setStatus("idle");
     }
@@ -36,23 +41,37 @@ export const useDeckImport = () => {
     if (preview.setStorageMode(storageMode)) execution.clear();
   };
 
-  const runImport = async (prepare: () => PreparedDeckImport) => {
+  const runImport = async (
+    prepare: () => PreparedDeckImport | undefined
+  ): Promise<DeckImportOperationResult<DeckImportResult>> => {
     const preparedImport = prepare();
+    if (preparedImport === undefined) return operationFailed;
+
     preview.clearError();
     setStatus("importing");
     try {
-      return await execution.run(preparedImport);
+      const importResult = await execution.run(preparedImport);
+      return importResult === undefined ? operationFailed : operationSucceeded(importResult);
     } finally {
       setStatus("idle");
     }
+  };
+
+  const addSample = () => {
+    if (uid === "") {
+      execution.fail(new Error("A confirmed user is required for remote imports"));
+      return Promise.resolve(operationFailed);
+    }
+    return runImport(() => prepareSampleDeck(uid, { cards, decks, generateCardId }));
   };
 
   return {
     selectFile,
     setStorageMode,
     importPreview: () => runImport(preview.takePreparedImport),
-    addSample: () => runImport(() => prepareSampleDeck(uid, { cards, decks, generateCardId })),
+    addSample,
     storageMode: preview.storageMode,
+    fileName: preview.fileName,
     preview: preview.preview,
     validating: status === "validating",
     pending: status === "importing",

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -25,9 +25,11 @@ export const useDeckImport = () => {
   const execution = useDeckImportExecution(uid);
   const preview = useDeckImportPreview({ uid, cards, decks });
   const [status, setStatus] = useState<DeckImportStatus>("idle");
+  const [fileReselectionRequired, setFileReselectionRequired] = useState(false);
 
   const selectFile = async (file: File) => {
     execution.clear();
+    setFileReselectionRequired(false);
     setStatus("validating");
     try {
       const selectedPreview = await preview.selectFile(file);
@@ -38,11 +40,15 @@ export const useDeckImport = () => {
   };
 
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
-    if (preview.setStorageMode(storageMode)) execution.clear();
+    if (preview.setStorageMode(storageMode)) {
+      execution.clear();
+      setFileReselectionRequired(false);
+    }
   };
 
   const runImport = async (
-    prepare: () => PreparedDeckImport | undefined
+    prepare: () => PreparedDeckImport | undefined,
+    onExecutionFailure?: () => void
   ): Promise<DeckImportOperationResult<DeckImportResult>> => {
     const preparedImport = prepare();
     if (preparedImport === undefined) return operationFailed;
@@ -51,13 +57,18 @@ export const useDeckImport = () => {
     setStatus("importing");
     try {
       const importResult = await execution.run(preparedImport);
-      return importResult === undefined ? operationFailed : operationSucceeded(importResult);
+      if (importResult === undefined) {
+        onExecutionFailure?.();
+        return operationFailed;
+      }
+      return operationSucceeded(importResult);
     } finally {
       setStatus("idle");
     }
   };
 
   const addSample = () => {
+    setFileReselectionRequired(false);
     if (uid === "") {
       execution.fail(new Error("A confirmed user is required for remote imports"));
       return Promise.resolve(operationFailed);
@@ -65,16 +76,24 @@ export const useDeckImport = () => {
     return runImport(() => prepareSampleDeck(uid, { cards, decks, generateCardId }));
   };
 
+  const importPreview = () =>
+    runImport(preview.takePreparedImport, () => {
+      // Persistence can fail after creating the Deck, so retry must rebuild a plan from current destination data.
+      preview.invalidate();
+      setFileReselectionRequired(true);
+    });
+
   return {
     selectFile,
     setStorageMode,
-    importPreview: () => runImport(preview.takePreparedImport),
+    importPreview,
     addSample,
     storageMode: preview.storageMode,
     fileName: preview.fileName,
     preview: preview.preview,
     validating: status === "validating",
     pending: status === "importing",
+    fileReselectionRequired,
     error: execution.error,
     previewError: preview.error,
     result: execution.result,

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -5,17 +5,13 @@ import { generateCardId, useCards } from "@/entities/card";
 import { useDecks } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
 import { prepareSampleDeck } from "./useAddSampleDeck";
-import type { DeckImportResult, DeckImportStorageMode, PreparedDeckImport } from "./useDeckImportExecution";
+import type { DeckImportStorageMode, PreparedDeckImport } from "./useDeckImportExecution";
 import { useDeckImportExecution } from "./useDeckImportExecution";
 import { useDeckImportPreview } from "./useDeckImportPreview";
 
 export type { DeckImportPreview } from "./useDeckImportPreview";
 
 type DeckImportStatus = "idle" | "validating" | "importing";
-type DeckImportOperationResult<Value> = { status: "success"; value: Value } | { status: "failure" };
-
-const operationSucceeded = <Value>(value: Value): DeckImportOperationResult<Value> => ({ status: "success", value });
-const operationFailed = { status: "failure" } as const;
 
 export const useDeckImport = () => {
   const uid = useAuthUid();
@@ -32,8 +28,7 @@ export const useDeckImport = () => {
     setFileReselectionRequired(false);
     setStatus("validating");
     try {
-      const selectedPreview = await preview.selectFile(file);
-      return selectedPreview === undefined ? operationFailed : operationSucceeded(selectedPreview);
+      return await preview.selectFile(file);
     } finally {
       setStatus("idle");
     }
@@ -46,22 +41,16 @@ export const useDeckImport = () => {
     }
   };
 
-  const runImport = async (
-    prepare: () => PreparedDeckImport | undefined,
-    onExecutionFailure?: () => void
-  ): Promise<DeckImportOperationResult<DeckImportResult>> => {
+  const runImport = async (prepare: () => PreparedDeckImport | undefined, onExecutionFailure?: () => void) => {
     const preparedImport = prepare();
-    if (preparedImport === undefined) return operationFailed;
+    if (preparedImport === undefined) return;
 
     preview.clearError();
     setStatus("importing");
     try {
       const importResult = await execution.run(preparedImport);
-      if (importResult === undefined) {
-        onExecutionFailure?.();
-        return operationFailed;
-      }
-      return operationSucceeded(importResult);
+      if (importResult === undefined) onExecutionFailure?.();
+      return importResult;
     } finally {
       setStatus("idle");
     }
@@ -71,7 +60,7 @@ export const useDeckImport = () => {
     setFileReselectionRequired(false);
     if (uid === "") {
       execution.fail(new Error("A confirmed user is required for remote imports"));
-      return Promise.resolve(operationFailed);
+      return Promise.resolve();
     }
     return runImport(() => prepareSampleDeck(uid, { cards, decks, generateCardId }));
   };

--- a/src/features/deck-import/model/useDeckImportExecution.ts
+++ b/src/features/deck-import/model/useDeckImportExecution.ts
@@ -154,11 +154,15 @@ export const prepareDeckImport = (
   };
 };
 
+const assertPreparedImportOwner = (preparedImport: PreparedDeckImport, uid: string) => {
+  if (preparedImport.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
+};
+
 export const executePreparedDeckImport = async (
   preparedImport: PreparedDeckImport,
   { uid, createDeck, mutateCards }: DeckImportExecutionDependencies
 ) => {
-  if (preparedImport.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
+  assertPreparedImportOwner(preparedImport, uid);
   if (preparedImport.needsDeckCreation) await createDeck(preparedImport.destination);
   if (preparedImport.mutations.length > 0) await mutateCards(preparedImport.mutations);
 
@@ -186,23 +190,26 @@ export const useDeckImportExecution = (uid: string) => {
   };
 
   const run = async (preparedImport: PreparedDeckImport) => {
+    // Ownership mismatch is an invariant, so check it before the expected persistence failure boundary.
+    assertPreparedImportOwner(preparedImport, uid);
     updateState({ error: null });
+    let importResult: DeckImportResult | undefined;
     try {
-      const importResult = await executePreparedDeckImport(preparedImport, {
+      importResult = await executePreparedDeckImport(preparedImport, {
         uid,
         createDeck: (deck) => persistDeck(uid, deck),
         mutateCards: (mutations) => persistCardMutations(uid, mutations),
       });
       updateState({ result: importResult });
-      return importResult;
     } catch (caughtError) {
       updateState({ result: undefined, error: caughtError });
-      throw caughtError;
     }
+    return importResult;
   };
 
   return {
     run,
+    fail: (error: unknown) => updateState({ result: undefined, error }),
     clear: () => updateState({ error: null, result: undefined }),
     error: state.error,
     result: state.result,

--- a/src/features/deck-import/model/useDeckImportPreview.ts
+++ b/src/features/deck-import/model/useDeckImportPreview.ts
@@ -17,6 +17,7 @@ export interface DeckImportPreview {
 
 interface DeckImportPreviewState {
   storageMode: DeckImportStorageMode;
+  fileName: string | undefined;
   preview: DeckImportPreview | undefined;
   error: unknown;
 }
@@ -33,6 +34,7 @@ interface UseDeckImportPreviewOptions {
 
 const initialState = (): DeckImportPreviewState => ({
   storageMode: "remote",
+  fileName: undefined,
   preview: undefined,
   error: null,
 });
@@ -60,39 +62,64 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
   const selectFile = async (file: File) => {
     const { storageMode } = state;
     preparedImportRef.current.preparedImport = undefined;
-    updateState({ preview: undefined, error: null });
+    updateState({ fileName: file.name, preview: undefined, error: null });
 
+    let analysis: DeckImportAnalysis;
     try {
-      const analysis = await parseCsv(await file.text());
-      const destinationData = await loadDestinationData(storageMode, uid, { decks, cards });
-
-      const preparedImport = prepareDeckImport(
-        { name: file.name, rows: analysis.rows, storageMode },
-        { uid, ...destinationData, generateCardId }
-      );
-      const preview = { deckName: file.name, analysis, plan: preparedImport.plan };
-      preparedImportRef.current.preparedImport = preparedImport;
-      updateState({ preview });
-      return preview;
+      analysis = await parseCsv(await file.text());
     } catch (caughtError) {
       updateState({ error: caughtError });
-      throw caughtError;
+      return;
     }
+
+    let destinationData: { decks: Deck[]; cards: Card[] };
+    try {
+      destinationData = await loadDestinationData(storageMode, uid, { decks, cards });
+    } catch (caughtError) {
+      updateState({ error: caughtError });
+      return;
+    }
+
+    if (storageMode === "remote" && uid === "") {
+      updateState({ error: new Error("A confirmed user is required for remote imports") });
+      return;
+    }
+
+    // Preparation runs outside the expected I/O failure boundaries so schema and programming invariants still reject.
+    const preparedImport = prepareDeckImport(
+      { name: file.name, rows: analysis.rows, storageMode },
+      { uid, ...destinationData, generateCardId }
+    );
+    const preview = { deckName: file.name, analysis, plan: preparedImport.plan };
+    preparedImportRef.current.preparedImport = preparedImport;
+    updateState({ preview });
+    return preview;
   };
 
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
     if (state.storageMode === storageMode) return false;
 
     preparedImportRef.current.preparedImport = undefined;
-    updateState({ storageMode, preview: undefined, error: null });
+    updateState({ storageMode, fileName: undefined, preview: undefined, error: null });
     return true;
   };
 
   const takePreparedImport = () => {
     const { preview } = state;
-    if (preview == null) throw new Error("Select a CSV file before importing");
-    if (preview.analysis.invalidCount > 0) throw new Error("Fix invalid CSV rows before importing");
-    if (preview.analysis.rows.length === 0) throw new Error("The CSV file has no valid rows");
+    const preconditionError =
+      preview == null
+        ? new Error("Select a CSV file before importing")
+        : preview.analysis.invalidCount > 0
+          ? new Error("Fix invalid CSV rows before importing")
+          : preview.analysis.rows.length === 0
+            ? new Error("The CSV file has no valid rows")
+            : undefined;
+    if (preconditionError !== undefined) {
+      updateState({ error: preconditionError });
+      return;
+    }
+
+    // A valid preview must always retain its one-shot prepared import until execution starts.
     if (preparedImportRef.current.preparedImport == null) {
       throw new Error("The prepared Deck import is not available");
     }
@@ -108,6 +135,7 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
     takePreparedImport,
     clearError: () => updateState({ error: null }),
     storageMode: state.storageMode,
+    fileName: state.fileName,
     preview: state.preview,
     error: state.error,
   };

--- a/src/features/deck-import/model/useDeckImportPreview.ts
+++ b/src/features/deck-import/model/useDeckImportPreview.ts
@@ -133,6 +133,10 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
     selectFile,
     setStorageMode,
     takePreparedImport,
+    invalidate: () => {
+      preparedImportRef.current.preparedImport = undefined;
+      updateState({ preview: undefined });
+    },
     clearError: () => updateState({ error: null }),
     storageMode: state.storageMode,
     fileName: state.fileName,

--- a/src/features/deck-import/model/useDeckImportPreview.ts
+++ b/src/features/deck-import/model/useDeckImportPreview.ts
@@ -106,16 +106,16 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
 
   const takePreparedImport = () => {
     const { preview } = state;
-    const preconditionError =
-      preview == null
-        ? new Error("Select a CSV file before importing")
-        : preview.analysis.invalidCount > 0
-          ? new Error("Fix invalid CSV rows before importing")
-          : preview.analysis.rows.length === 0
-            ? new Error("The CSV file has no valid rows")
-            : undefined;
-    if (preconditionError !== undefined) {
-      updateState({ error: preconditionError });
+    if (preview == null) {
+      updateState({ error: new Error("Select a CSV file before importing") });
+      return;
+    }
+    if (preview.analysis.invalidCount > 0) {
+      updateState({ error: new Error("Fix invalid CSV rows before importing") });
+      return;
+    }
+    if (preview.analysis.rows.length === 0) {
+      updateState({ error: new Error("The CSV file has no valid rows") });
       return;
     }
 
@@ -125,7 +125,9 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
     }
 
     const { preparedImport } = preparedImportRef.current;
+    // Execution may persist only part of the plan, so every retry must prepare again from current destination data.
     preparedImportRef.current.preparedImport = undefined;
+    updateState({ preview: undefined });
     return preparedImport;
   };
 
@@ -133,10 +135,6 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
     selectFile,
     setStorageMode,
     takePreparedImport,
-    invalidate: () => {
-      preparedImportRef.current.preparedImport = undefined;
-      updateState({ preview: undefined });
-    },
     clearError: () => updateState({ error: null }),
     storageMode: state.storageMode,
     fileName: state.fileName,

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -24,6 +24,7 @@ interface DeckImportViewProps {
   previewError?: unknown;
   storageMode?: DeckImportStorageMode;
   fileName?: string;
+  fileReselectionRequired?: boolean;
 }
 
 const resultCounts = (result: DeckImportResult) => (
@@ -38,6 +39,7 @@ interface ImportResultProps {
   result: DeckImportResult | undefined;
   error: unknown;
   onBack: (() => void) | undefined;
+  fileReselectionRequired: boolean | undefined;
 }
 
 const ImportResult = (props: ImportResultProps) => {
@@ -47,6 +49,9 @@ const ImportResult = (props: ImportResultProps) => {
       <section role="alert" className="rounded-surface border border-danger bg-surface-muted p-4 text-ink">
         <h2 className="font-bold">Import failed</h2>
         <p className="mt-1 break-words text-caption text-ink-muted">{message}</p>
+        {props.fileReselectionRequired ? (
+          <p className="mt-2 text-caption text-ink-muted">Choose the CSV file again to rebuild the import preview.</p>
+        ) : null}
       </section>
     );
   }
@@ -211,7 +216,12 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
             Importing…
           </p>
         ) : null}
-        <ImportResult result={props.result} error={props.error} onBack={props.onBack} />
+        <ImportResult
+          result={props.result}
+          error={props.error}
+          onBack={props.onBack}
+          fileReselectionRequired={props.fileReselectionRequired}
+        />
         <PreviewError error={props.previewError} />
         <section className="space-y-4">
           <h2 className="mb-3 break-words text-title font-bold text-ink">Choose a CSV file</h2>

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -23,6 +23,7 @@ interface DeckImportViewProps {
   error?: unknown;
   previewError?: unknown;
   storageMode?: DeckImportStorageMode;
+  fileName?: string;
 }
 
 const resultCounts = (result: DeckImportResult) => (
@@ -195,6 +196,7 @@ const ImportPreview = (props: ImportPreviewProps) => {
 export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
   const busy = Boolean(props.pending || props.validating);
   const storageMode = props.storageMode ?? "remote";
+  const fileName = props.fileName ?? props.preview?.deckName;
 
   return (
     <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
@@ -244,7 +246,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
           </fieldset>
           <Upload
             disabled={busy}
-            {...(props.preview !== undefined ? { fileName: props.preview.deckName } : {})}
+            {...(fileName !== undefined ? { fileName } : {})}
             {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
           />
         </section>

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -24,7 +24,6 @@ interface DeckImportViewProps {
   previewError?: unknown;
   storageMode?: DeckImportStorageMode;
   fileName?: string;
-  fileReselectionRequired?: boolean;
 }
 
 const resultCounts = (result: DeckImportResult) => (
@@ -220,7 +219,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
           result={props.result}
           error={props.error}
           onBack={props.onBack}
-          fileReselectionRequired={props.fileReselectionRequired}
+          fileReselectionRequired={props.error != null && fileName !== undefined && props.preview === undefined}
         />
         <PreviewError error={props.previewError} />
         <section className="space-y-4">

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -137,4 +137,14 @@ describe("DeckImportPage", () => {
     expect(screen.getByText(name)).toBeVisible();
     expect(screen.getByText("front: retry back")).toBeVisible();
   });
+
+  it("shows a sample preparation failure in place", async () => {
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add sample deck" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Import failed");
+    expect(screen.getByRole("alert")).toHaveTextContent("A confirmed user is required for remote imports");
+    expect(screen.getByRole("heading", { level: 1, name: "Import decks" })).toBeVisible();
+  });
 });

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -122,7 +122,10 @@ describe("DeckImportPage", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Import failed");
     expect(screen.getByRole("alert")).toHaveTextContent("card mutation failed");
+    expect(screen.getByRole("alert")).toHaveTextContent("Choose the CSV file again to rebuild the import preview");
     expect(screen.getByRole("heading", { level: 1, name: "Import decks" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Import" })).not.toBeInTheDocument();
+    expect(screen.getByText(name)).toBeVisible();
 
     fireEvent.change(screen.getByLabelText(/Upload a csv file/), {
       target: {

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -23,8 +23,8 @@ export const DeckImportPage: React.FC = () => {
           void deckImport.addSample();
         }}
         onImport={() => {
-          void deckImport.importPreview().then((operation) => {
-            if (operation.status === "success") return navigation.to(routes.deckList.to());
+          void deckImport.importPreview().then((result) => {
+            if (result !== undefined) return navigation.to(routes.deckList.to());
           });
         }}
         onBack={() => void navigation.back()}

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -31,7 +31,6 @@ export const DeckImportPage: React.FC = () => {
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}
-        fileReselectionRequired={deckImport.fileReselectionRequired}
         {...(deckImport.fileName !== undefined ? { fileName: deckImport.fileName } : {})}
         preview={deckImport.preview}
         result={deckImport.result}

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -31,6 +31,7 @@ export const DeckImportPage: React.FC = () => {
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}
+        fileReselectionRequired={deckImport.fileReselectionRequired}
         {...(deckImport.fileName !== undefined ? { fileName: deckImport.fileName } : {})}
         preview={deckImport.preview}
         result={deckImport.result}

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -17,21 +17,21 @@ export const DeckImportPage: React.FC = () => {
         storageMode={deckImport.storageMode}
         onStorageModeChange={deckImport.setStorageMode}
         onChange={(file) => {
-          void deckImport.selectFile(file).catch(() => undefined);
+          void deckImport.selectFile(file);
         }}
         onAddSample={() => {
-          void deckImport.addSample().catch(() => undefined);
+          void deckImport.addSample();
         }}
         onImport={() => {
-          void deckImport
-            .importPreview()
-            .then(() => navigation.to(routes.deckList.to()))
-            .catch(() => undefined);
+          void deckImport.importPreview().then((operation) => {
+            if (operation.status === "success") return navigation.to(routes.deckList.to());
+          });
         }}
         onBack={() => void navigation.back()}
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}
+        {...(deckImport.fileName !== undefined ? { fileName: deckImport.fileName } : {})}
         preview={deckImport.preview}
         result={deckImport.result}
         error={deckImport.error}


### PR DESCRIPTION
## Related issue

Fixes #512

## Summary

- Return explicit success or failure statuses from Deck import UI operations.
- Keep expected preview and execution failures in Feature state while preserving developer-visible invariant rejections.
- Navigate only after a successful import and cover preview, execution, and sample failure behavior.

## Testing

- mise run check