### PR TITLE
No issue: Move study session state resolution to entity

### DIFF
--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -1,5 +1,11 @@
 export { useStudySession, useStudySessions } from "./model/hooks";
-export { canMoveStudySession, compareActiveDecks, groupDecksByStudyStatus, planStudySessionSwipe } from "./model/rules";
+export {
+  canMoveStudySession,
+  compareActiveDecks,
+  groupDecksByStudyStatus,
+  planStudySessionSwipe,
+  resolveStudySession,
+} from "./model/rules";
 export type { StudySession } from "./model/types";
 export {
   clearStudySessions,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -7,6 +7,7 @@ import {
   groupDecksByStudyStatus,
   isStudySessionPositionUnchanged,
   planStudySessionSwipe,
+  resolveStudySession,
 } from "./rules";
 import type { StudySession } from "./types";
 
@@ -68,6 +69,30 @@ describe("canMoveStudySession", () => {
     expect(canMoveStudySession(session, "next")).toBe(true);
     expect(canMoveStudySession({ ...session, currentIndex: 0 }, "previous")).toBe(false);
     expect(canMoveStudySession({ ...session, currentIndex: 2 }, "next")).toBe(false);
+  });
+});
+
+describe("resolveStudySession", () => {
+  const cards = [{ id: "card-1", frontText: "front" }];
+
+  it("resolves the Card at the active session position", () => {
+    const activeSession = { ...session, currentIndex: 0 };
+
+    expect(resolveStudySession(activeSession, cards)).toEqual({
+      status: "studying",
+      session: activeSession,
+      card: cards[0],
+    });
+  });
+
+  it("waits while Cards have not loaded", () => {
+    expect(resolveStudySession(session, [])).toEqual({ status: "preparing" });
+  });
+
+  it("rejects a missing session, empty position, or absent loaded Card", () => {
+    expect(resolveStudySession(undefined, cards)).toEqual({ status: "invalid" });
+    expect(resolveStudySession({ ...session, cardOrderIds: [] }, [])).toEqual({ status: "invalid" });
+    expect(resolveStudySession(session, cards)).toEqual({ status: "invalid" });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -2,6 +2,7 @@ import type { SwipeAction } from "@/entities/preferences/@x/study-session";
 import { type CardProgressFields, recordCardStudyProgress } from "@/entities/study-progress/@x/study-session";
 
 import type {
+  ResolvedStudySession,
   StudySession,
   StudySessionCard,
   StudySessionMovement,
@@ -62,13 +63,21 @@ export const groupDecksByStudyStatus = <TDeck extends StudySessionDeck>(
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
-// Finds the loaded Card at the active session position for swipe planning.
-const findCurrentStudySessionCard = <Card extends StudySessionCard>(
-  session: StudySession,
+// Resolves whether an active session can study now, is waiting for Cards, or is invalid.
+export const resolveStudySession = <Card extends StudySessionCard>(
+  session: StudySession | undefined,
   cards: readonly Card[]
-): Card | undefined => {
+): ResolvedStudySession<Card> => {
+  if (session == null) return { status: "invalid" };
+
   const cardId = getCurrentStudySessionCardId(session);
-  return cardId == null ? undefined : cards.find(({ id }) => id === cardId);
+  if (cardId == null) return { status: "invalid" };
+
+  const card = cards.find(({ id }) => id === cardId);
+  if (card != null) return { status: "studying", session, card };
+
+  // An empty collection can still be an in-flight read; loaded Cards prove that the persisted Card is absent.
+  return { status: cards.length === 0 ? "preparing" : "invalid" };
 };
 
 // Collapses control actions into the movement, exit, or no-op effects understood by a study session.
@@ -90,13 +99,13 @@ export const planStudySessionSwipe = (
   const effect = resolveStudySessionSwipeEffect(swipeAction);
   if (effect === "none" || effect === "exit") return { effect };
 
-  const card = findCurrentStudySessionCard(session, cards);
-  if (card == null) return { effect: "none" };
+  const resolvedSession = resolveStudySession(session, cards);
+  if (resolvedSession.status !== "studying") return { effect: "none" };
 
   return {
     effect,
     session,
-    progress: recordCardStudyProgress(card, swipeAction, studiedAt),
+    progress: recordCardStudyProgress(resolvedSession.card, swipeAction, studiedAt),
   };
 };
 

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -49,3 +49,8 @@ export type StudySessionSwipePlan =
 
 /** Minimal Card identity needed to resolve a study session position. */
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
+
+/** Resolution of an active study session against the currently loaded Cards. */
+export type ResolvedStudySession<Card extends StudySessionCard> =
+  | { status: "preparing" | "invalid" }
+  | { status: "studying"; session: StudySession; card: Card };

--- a/src/features/study/model/useStudySessionState.ts
+++ b/src/features/study/model/useStudySessionState.ts
@@ -1,30 +1,21 @@
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
-import { removeStudySession, type StudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+import { removeStudySession, resolveStudySession, touchStudySession, useStudySession } from "@/entities/study-session";
 
 import * as React from "react";
 
-export type StudySessionState =
-  | { status: "preparing" | "invalid" }
-  | { status: "studying"; session: StudySession; card: Card };
+export type StudySessionState = ReturnType<typeof resolveStudySession<Card>>;
 
 export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
   const session = useStudySession(deckId);
-  const cardId = session?.cardOrderIds[session.currentIndex];
-  const card = cardId == null ? undefined : cards.find(({ id }) => id === cardId);
-
-  let sessionState: StudySessionState;
-  if (session == null || cardId == null) sessionState = { status: "invalid" };
-  else if (card != null) sessionState = { status: "studying", session, card };
-  else sessionState = { status: cards.length === 0 ? "preparing" : "invalid" };
+  const sessionState = resolveStudySession(session, cards);
 
   React.useEffect(() => {
-    if (sessionState.status !== "studying") return;
-    touchStudySession(deckId);
-  }, [deckId, sessionState.status]);
-
-  React.useEffect(() => {
-    if (sessionState.status !== "invalid") return;
+    if (sessionState.status === "studying") {
+      touchStudySession(deckId);
+      return;
+    }
+    if (sessionState.status === "preparing") return;
 
     // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
     removeStudySession(deckId);


### PR DESCRIPTION
## Summary

- move study session status resolution into the study-session entity
- consolidate study session touch and invalidation handling into one effect
- reuse the entity resolver for swipe planning and cover its states with unit tests

## Testing

- mise run check