### PR TITLE
refactor: move study card selection into domain

### DIFF
--- a/src/entities/deck/@x/study-session.ts
+++ b/src/entities/deck/@x/study-session.ts
@@ -1,1 +1,2 @@
+export { isDeckTagSelectionMatching } from "../model/rules";
 export type { DeckId } from "../model/types";

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,13 +1,7 @@
 export { fetchDecks, subscribeDecks } from "./api/firestore";
 export { generateDeckId } from "./api/id";
 export { createDeck, deleteDeck, editDeck } from "./api/mutations";
-export {
-  CATEGORY,
-  getCategory,
-  isDeckTagSelectionMatching,
-  isHighlightLanguage,
-  mustFindDeckById,
-} from "./model/rules";
+export { CATEGORY, getCategory, isHighlightLanguage, mustFindDeckById } from "./model/rules";
 export { useDeck, useDecks } from "./model/hooks";
 export { deckFormSchema } from "./model/schema";
 export { clearRemoteDecks } from "./model/store";

--- a/src/entities/study-progress/@x/study-session.ts
+++ b/src/entities/study-progress/@x/study-session.ts
@@ -1,2 +1,7 @@
-export { buildStudyCardOrder, recordCardStudyProgress } from "../model/rules";
+export {
+  buildStudyCardOrder,
+  createStudyProgressFromCard,
+  isStudyProgressEligible,
+  recordCardStudyProgress,
+} from "../model/rules";
 export type { CardProgressFields, StudyCardOrderOptions, StudyProgressEdit } from "../model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,2 +1,1 @@
 export { editStudyProgress } from "./api/firestore";
-export { createStudyProgressFromCard, isStudyProgressEligible } from "./model/rules";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -5,6 +5,7 @@ export {
   groupDecksByStudyStatus,
   planStudySessionSwipe,
   resolveStudySession,
+  selectStudyCards,
 } from "./model/rules";
 export type { StudySession } from "./model/types";
 export {

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -1,5 +1,11 @@
+import { isDeckTagSelectionMatching } from "@/entities/deck/@x/study-session";
 import type { SwipeAction } from "@/entities/preferences/@x/study-session";
-import { type CardProgressFields, recordCardStudyProgress } from "@/entities/study-progress/@x/study-session";
+import {
+  type CardProgressFields,
+  createStudyProgressFromCard,
+  isStudyProgressEligible,
+  recordCardStudyProgress,
+} from "@/entities/study-progress/@x/study-session";
 
 import type {
   ResolvedStudySession,
@@ -33,6 +39,19 @@ interface DecksByStudyStatus<TDeck> {
   inactive: TDeck[];
 }
 
+/** Card fields needed to decide whether the Card belongs in a study session. */
+interface StudyCardSelectionCard extends CardProgressFields {
+  tags: readonly string[];
+}
+
+/** Deck-owned filters that define the study-session candidate set. */
+interface StudyCardSelectionDeck {
+  scoreMax: number | null;
+  scoreMin: number | null;
+  selectedTags: readonly string[];
+  tagAndFilter: boolean;
+}
+
 // Compares Deck names with locale-aware ascending order for deterministic presentation ties.
 const compareDeckNames = (left: NamedDeck, right: NamedDeck): number => left.name.localeCompare(right.name);
 
@@ -58,6 +77,27 @@ export const groupDecksByStudyStatus = <TDeck extends StudySessionDeck>(
 
   return { active, inactive };
 };
+
+// Selects the Cards allowed by the Deck's tag filters and current StudyProgress eligibility rules.
+export const selectStudyCards = <TCard extends StudyCardSelectionCard>(
+  cards: readonly TCard[],
+  deck: StudyCardSelectionDeck,
+  respectNextSeeingAt: boolean,
+  now = Date.now()
+): TCard[] =>
+  cards.filter(
+    (card) =>
+      isDeckTagSelectionMatching(card.tags, deck.selectedTags, deck.tagAndFilter) &&
+      isStudyProgressEligible(
+        createStudyProgressFromCard(card),
+        {
+          maximumScore: deck.scoreMax,
+          minimumScore: deck.scoreMin,
+          respectNextSeeingAt,
+        },
+        now
+      )
+  );
 
 // Reads the Card id at the session cursor, returning undefined for an empty or out-of-range position.
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>

--- a/src/features/card-list/model/useCardListState.ts
+++ b/src/features/card-list/model/useCardListState.ts
@@ -2,16 +2,10 @@ import * as React from "react";
 
 import { useAuthUid } from "@/entities/auth";
 import { deleteCard, mustFindCardById, type Card, type CardId, useCardsByDeckId } from "@/entities/card";
-import {
-  type Deck,
-  editDeck,
-  getCategory,
-  isDeckTagSelectionMatching,
-  isHighlightLanguage,
-  useDeck,
-} from "@/entities/deck";
+import { type Deck, editDeck, getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
-import { createStudyProgressFromCard, editStudyProgress, isStudyProgressEligible } from "@/entities/study-progress";
+import { editStudyProgress } from "@/entities/study-progress";
+import { selectStudyCards } from "@/entities/study-session";
 
 type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
 
@@ -55,22 +49,6 @@ const buildCardListItem = (card: Card): CardListItem => ({
   numberOfSeen: card.numberOfSeen,
   tags: card.tags,
 });
-
-// Keeps multi-Entity selection in the use-case owner while each Entity supplies only its own pure rule.
-const selectStudyCards = (cards: Card[], deck: Deck, useCardInterval: boolean, now = Date.now()): Card[] =>
-  cards.filter(
-    (card) =>
-      isDeckTagSelectionMatching(card.tags, deck.selectedTags, deck.tagAndFilter) &&
-      isStudyProgressEligible(
-        createStudyProgressFromCard(card),
-        {
-          maximumScore: deck.scoreMax,
-          minimumScore: deck.scoreMin,
-          respectNextSeeingAt: useCardInterval,
-        },
-        now
-      )
-  );
 
 export const useCardListState = (deckId: string) => {
   const uid = useAuthUid();

--- a/src/features/study-session-start/model/useStudySessionStartState.ts
+++ b/src/features/study-session-start/model/useStudySessionStartState.ts
@@ -1,29 +1,12 @@
 import { useState } from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { type Card, useCardsByDeckId } from "@/entities/card";
-import { type Deck, editDeck, isDeckTagSelectionMatching, useDeck } from "@/entities/deck";
+import { useCardsByDeckId } from "@/entities/card";
+import { type Deck, editDeck, useDeck } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
-import { createStudyProgressFromCard, isStudyProgressEligible } from "@/entities/study-progress";
-import { startStudy } from "@/entities/study-session";
+import { selectStudyCards, startStudy } from "@/entities/study-session";
 
 type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
-
-// Keeps multi-Entity selection in the use-case owner while each Entity supplies only its own pure rule.
-const selectStudyCards = (cards: Card[], deck: Deck, useCardInterval: boolean, now = Date.now()): Card[] =>
-  cards.filter(
-    (card) =>
-      isDeckTagSelectionMatching(card.tags, deck.selectedTags, deck.tagAndFilter) &&
-      isStudyProgressEligible(
-        createStudyProgressFromCard(card),
-        {
-          maximumScore: deck.scoreMax,
-          minimumScore: deck.scoreMin,
-          respectNextSeeingAt: useCardInterval,
-        },
-        now
-      )
-  );
 
 export const useStudySessionStartState = (deckId: string) => {
   const uid = useAuthUid();


### PR DESCRIPTION
## Summary

- move `selectStudyCards` from feature-local hooks into `entities/study-session` domain rules
- expose only the Deck and StudyProgress rules needed by `study-session` through `@x/study-session`
- reuse the same selector from `card-list` and `study-session-start` instead of duplicating the rule

## Rationale

Choosing which Cards are eligible for a study session combines Deck tag filters, score bounds, and StudyProgress due-time rules. That is shared cross-entity domain logic rather than feature-specific presentation/use-case code.

## Testing

- not run locally; CI will validate the change
