### PR TITLE
refactor(#1127): Always create new Decks on import

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -4,7 +4,8 @@
  * normal containers, hooks, and route parameters.
  */
 
-import type { CardId, RemoteCard } from "@/entities/card";
+import type { CardId } from "@/entities/card";
+import type { RemoteCard } from "@/entities/card/model/types";
 import { replaceRemoteCards } from "@/entities/card/model/store";
 import type { Deck, DeckId } from "@/entities/deck";
 import { replaceRemoteDecks } from "@/entities/deck/model/store";

--- a/.storybook/support/pageFixture.ts
+++ b/.storybook/support/pageFixture.ts
@@ -1,6 +1,7 @@
 /** @file Defines deterministic application data shared by route-level Storybook stories. */
 
-import type { CardId, RemoteCard } from "@/entities/card";
+import type { CardId } from "@/entities/card";
+import type { RemoteCard } from "@/entities/card/model/types";
 import type { Deck, DeckId } from "@/entities/deck";
 
 import { createCard, createDeck, createPreferences } from "@/test/factories";

--- a/src/app/App.stories.tsx
+++ b/src/app/App.stories.tsx
@@ -81,7 +81,7 @@ export const Import: Story = {
     await userEvent.upload(canvas.getByLabelText("Upload a csv file"), file);
 
     await expect(await canvas.findByRole("heading", { level: 2, name: "Review import" })).toBeVisible();
-    await expect(canvas.getByText("1 create")).toBeVisible();
+    await expect(canvas.getByText("1 valid")).toBeVisible();
     await expect(canvas.getByText("storybook answer")).toBeVisible();
   },
 };

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -83,10 +83,6 @@ export const fetchCardReads = async (uid: string): Promise<CardRead[]> => {
   return mapActiveCardReads(snapshot.docs);
 };
 
-/** Keeps existing authoritative fetch consumers on the combined read model until #604. */
-export const fetchCards = async (uid: string): Promise<RemoteCard[]> =>
-  (await fetchCardReads(uid)).map(combineCardRead);
-
 /** Writes a new physical Card document with synchronized creation and update timestamps. */
 const createCardDocument = async (card: CardCreate): Promise<void> => {
   const createdAt = getCurrentTimeMillis();

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,4 +1,4 @@
-export { fetchCards, subscribeCards } from "./api/firestore";
+export { subscribeCards } from "./api/firestore";
 /** @public Separated read operations for the cross-Entity Card document boundary. */
 export { fetchCardReads, subscribeCardReads } from "./api/firestore";
 /** @public Separated read contract for the cross-Entity Card document boundary. */
@@ -13,13 +13,10 @@ export type {
   CardId,
   CardMutation,
   CardRaw,
-  RemoteCard,
 } from "./model/types";
 export {
   countCardsByDeckId,
   filterCardsByDeckId,
   getCardContentValidationErrors,
-  hasSameEditableCardContent,
-  indexCardsByUniqueKey,
   mustFindCardById,
 } from "./model/rules";

--- a/src/entities/card/model/rules.spec.ts
+++ b/src/entities/card/model/rules.spec.ts
@@ -6,8 +6,6 @@ import {
   filterCardsByDeckId,
   filterTagsByDeckId,
   getCardContentValidationErrors,
-  hasSameEditableCardContent,
-  indexCardsByUniqueKey,
   mustFindCardById,
 } from "./rules";
 
@@ -51,30 +49,6 @@ describe("filterCardsByDeckId", () => {
     const card3 = createCard({ id: "card-3", deckId: "deck-a" });
 
     expect(filterCardsByDeckId([card1, card2, card3], "deck-a")).toEqual([card1, card3]);
-  });
-});
-
-describe("indexCardsByUniqueKey", () => {
-  it("indexes Cards by their domain key", () => {
-    const target = createCard({ uniqueKey: "target" });
-
-    expect(indexCardsByUniqueKey([target]).get("target")).toBe(target);
-  });
-});
-
-describe("hasSameEditableCardContent", () => {
-  it("ignores persistence fields while comparing editable content", () => {
-    const left = createCard({ id: "left", frontText: "front", backText: "back", tags: ["tag"] });
-    const right = createCard({ id: "right", frontText: "front", backText: "back", tags: ["tag"] });
-
-    expect(hasSameEditableCardContent(left, right)).toBe(true);
-  });
-
-  it("detects changed editable content", () => {
-    const left = createCard({ backText: "before" });
-    const right = createCard({ backText: "after" });
-
-    expect(hasSameEditableCardContent(left, right)).toBe(false);
   });
 });
 

--- a/src/entities/card/model/rules.ts
+++ b/src/entities/card/model/rules.ts
@@ -31,16 +31,6 @@ export const getCardContentValidationErrors = (card: CardRaw): Partial<Record<ke
 export const filterCardsByDeckId = (cards: Card[], deckId: string): Card[] =>
   cards.filter((card) => card.deckId === deckId);
 
-// Indexes Cards by import identity; when keys repeat, the last Card intentionally becomes the lookup result.
-export const indexCardsByUniqueKey = <T extends Card>(cards: readonly T[]): Map<string, T> =>
-  new Map(cards.map((card) => [card.uniqueKey, card]));
-
-// Compares imported content only; uniqueKey identifies the target rather than content that an import can change.
-export const hasSameEditableCardContent = (left: CardRaw, right: CardRaw): boolean =>
-  left.frontText === right.frontText &&
-  left.backText === right.backText &&
-  left.tags.join("\0") === right.tags.join("\0");
-
 // Collects unique tags for one Deck and sorts them so filter controls receive a deterministic order.
 export const filterTagsByDeckId = (cards: Card[], deckId: string): string[] =>
   [...new Set(filterCardsByDeckId(cards, deckId).flatMap((card) => card.tags))].sort();

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { Deck, DeckCreateInput, DeckId } from "../model/types";
+import type { DeckCreateInput, DeckId } from "../model/types";
 
 import {
   collection,
@@ -7,7 +7,6 @@ import {
   deleteField,
   doc,
   getDocs,
-  getDocsFromServer,
   onSnapshot,
   query,
   setDoc,
@@ -54,15 +53,6 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
     },
     onError
   );
-
-// Fetches an authoritative snapshot of active Deck views owned by one user.
-export const fetchDecks = async (uid: string): Promise<Deck[]> => {
-  const snapshot = await getDocsFromServer(query(collection(db, DECK_COLLECTION), where("uid", "==", uid)));
-  return snapshot.docs.flatMap((document) => {
-    const deck = readActiveRemoteDeck(document.id, document.data());
-    return deck === undefined ? [] : [deck];
-  });
-};
 
 // Writes a new Deck document with synchronized creation and update timestamps.
 const createDeckDocument = async (deck: z.infer<typeof createDeckSchema>["deck"]): Promise<void> => {

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -1,4 +1,4 @@
-export { fetchDecks, subscribeDecks } from "./api/firestore";
+export { subscribeDecks } from "./api/firestore";
 export { generateDeckId } from "./api/id";
 export { createDeck, deleteDeck, editDeck } from "./api/mutations";
 export { CATEGORY, getCategory, isHighlightLanguage, mustFindDeckById } from "./model/rules";

--- a/src/features/deck-import/model/useAddSampleDeck.ts
+++ b/src/features/deck-import/model/useAddSampleDeck.ts
@@ -1,10 +1,9 @@
-import type { Card } from "@/entities/card";
-import type { Deck, DeckId } from "@/entities/deck";
+import type { DeckId } from "@/entities/deck";
 
 import { useEffect } from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { generateCardId, mutateCards, useCards } from "@/entities/card";
+import { generateCardId, mutateCards } from "@/entities/card";
 import { createDeck, useDecks } from "@/entities/deck";
 import sampleCards from "../../../../sample/build/output.json";
 import { executePreparedDeckImport, prepareDeckImport } from "./useDeckImportExecution";
@@ -15,8 +14,7 @@ const SAMPLE_VERSION = 1;
 const sampleDeckId = (uid: string): DeckId => `sample-v${String(SAMPLE_VERSION)}-${uid}`;
 
 interface SampleDeckPreparationOptions {
-  cards: Card[];
-  decks: Deck[];
+  generateDeckId: () => DeckId;
   generateCardId: () => string;
 }
 
@@ -24,7 +22,6 @@ export const prepareSampleDeck = (uid: string, options: SampleDeckPreparationOpt
   prepareDeckImport(
     {
       name: SAMPLE_DECK_NAME,
-      preferredDeckId: sampleDeckId(uid),
       rows: sampleCards.map((card, index) => ({ rowNumber: index + 1, card })),
     },
     { uid, ...options }
@@ -32,21 +29,23 @@ export const prepareSampleDeck = (uid: string, options: SampleDeckPreparationOpt
 
 export const useAddSampleDeck = () => {
   const uid = useAuthUid();
-  const cards = useCards();
   const decks = useDecks();
 
   useEffect(() => {
     if (uid === "" || decks.length > 0) return;
 
-    // Bootstrap is opportunistic; subscription changes provide another attempt without blocking the Deck list.
-    void executePreparedDeckImport(prepareSampleDeck(uid, { cards, decks, generateCardId }), {
-      uid,
-      createDeck: (deck) => {
-        // Samples remain account-synced even when CSV imports support a local destination.
-        if (deck.localMode === true) throw new Error("The sample Deck cannot use local storage");
-        return createDeck(uid, deck);
-      },
-      mutateCards: (mutations) => mutateCards(uid, mutations),
-    }).catch(() => undefined);
-  }, [cards, decks, uid]);
+    // A stable ID prevents repeated bootstrap effects from creating multiple sample Decks before subscriptions catch up.
+    void executePreparedDeckImport(
+      prepareSampleDeck(uid, { generateDeckId: () => sampleDeckId(uid), generateCardId }),
+      {
+        uid,
+        createDeck: (deck) => {
+          // Samples remain account-synced even when CSV imports support a local destination.
+          if (deck.localMode === true) throw new Error("The sample Deck cannot use local storage");
+          return createDeck(uid, deck);
+        },
+        mutateCards: (mutations) => mutateCards(uid, mutations),
+      }
+    ).catch(() => undefined);
+  }, [decks, uid]);
 };

--- a/src/features/deck-import/model/useDeckImport.spec.tsx
+++ b/src/features/deck-import/model/useDeckImport.spec.tsx
@@ -1,4 +1,3 @@
-import type { Card } from "@/entities/card";
 import type { Deck } from "@/entities/deck";
 
 import { act, renderHook } from "@testing-library/react";
@@ -7,13 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCards } from "@/entities/card";
 import { useDecks } from "@/entities/deck";
 import { actAsync } from "@/test/act";
-import { createCard, createDeck } from "@/test/factories";
 
 const controls = vi.hoisted(() => ({
   uid: "",
-  remoteDecks: [] as Deck[],
-  remoteCards: [] as Card[],
-  remoteReadError: undefined as unknown,
   nextMutationError: undefined as unknown,
 }));
 
@@ -23,10 +18,6 @@ vi.mock("@/entities/card", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/card")>();
   return {
     ...actual,
-    fetchCards: () => {
-      if (controls.remoteReadError !== undefined) return Promise.reject(controls.remoteReadError);
-      return Promise.resolve(controls.remoteCards);
-    },
     mutateCards: (...arguments_: Parameters<typeof actual.mutateCards>) => {
       if (controls.nextMutationError !== undefined) {
         const error = controls.nextMutationError;
@@ -34,16 +25,6 @@ vi.mock("@/entities/card", async (importOriginal) => {
         return Promise.reject(error);
       }
       return actual.mutateCards(...arguments_);
-    },
-  };
-});
-vi.mock("@/entities/deck", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/entities/deck")>();
-  return {
-    ...actual,
-    fetchDecks: () => {
-      if (controls.remoteReadError !== undefined) return Promise.reject(controls.remoteReadError);
-      return Promise.resolve(controls.remoteDecks);
     },
   };
 });
@@ -65,9 +46,6 @@ const findDeck = (decks: Deck[], name: string) => decks.find((deck) => deck.name
 describe("useDeckImport", () => {
   beforeEach(() => {
     controls.uid = "";
-    controls.remoteDecks = [];
-    controls.remoteCards = [];
-    controls.remoteReadError = undefined;
     controls.nextMutationError = undefined;
   });
 
@@ -81,7 +59,6 @@ describe("useDeckImport", () => {
     expect(result.current.deckImport.preview).toMatchObject({
       deckName: name,
       analysis: { invalidCount: 0 },
-      plan: { created: 1, updated: 0, unchanged: 0 },
     });
     expect(findDeck(result.current.decks, name)).toBeUndefined();
 
@@ -98,10 +75,10 @@ describe("useDeckImport", () => {
       }),
     ]);
     expect(result.current.cards.find((card) => card.deckId === savedDeck?.id)).not.toHaveProperty("uid");
-    expect(result.current.deckImport.result).toMatchObject({ created: 1, updated: 0, skipped: 0 });
+    expect(result.current.deckImport.result).toMatchObject({ created: 1 });
   });
 
-  it("updates a local Card and then skips an identical re-import", async () => {
+  it("creates a new local Deck without changing a same-name Deck or its Cards", async () => {
     const name = "behavior-reimport.csv";
     const { result } = renderDeckImport();
     act(() => result.current.deckImport.setStorageMode("local"));
@@ -112,20 +89,17 @@ describe("useDeckImport", () => {
     const originalCard = result.current.cards.find((card) => card.deckId === originalDeck?.id);
 
     await actAsync(async () => result.current.deckImport.selectFile(csvFile(name, "new back")));
-    expect(result.current.deckImport.preview?.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
     await actAsync(async () => result.current.deckImport.importPreview());
 
-    expect(result.current.decks.filter((deck) => deck.name === name)).toHaveLength(1);
+    const matchingDecks = result.current.decks.filter((deck) => deck.name === name);
+    expect(matchingDecks).toHaveLength(2);
     expect(result.current.cards.filter((card) => card.deckId === originalDeck?.id)).toEqual([
-      expect.objectContaining({ id: originalCard?.id, backText: "new back" }),
+      expect.objectContaining({ id: originalCard?.id, backText: "old back" }),
     ]);
-
-    await actAsync(async () => result.current.deckImport.selectFile(csvFile(name, "new back")));
-    expect(result.current.deckImport.preview?.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
-    await actAsync(async () => result.current.deckImport.importPreview());
-
-    expect(result.current.deckImport.result).toMatchObject({ created: 0, updated: 0, skipped: 1 });
-    expect(result.current.cards.filter((card) => card.deckId === originalDeck?.id)).toHaveLength(1);
+    const newDeck = matchingDecks.find((deck) => deck.id !== originalDeck?.id);
+    expect(result.current.cards.filter((card) => card.deckId === newDeck?.id)).toEqual([
+      expect.objectContaining({ backText: "new back" }),
+    ]);
   });
 
   it("keeps an invalid CSV in preview without creating a Deck", async () => {
@@ -160,46 +134,7 @@ describe("useDeckImport", () => {
     await expect(result.current.deckImport.importPreview()).rejects.toThrow("Select a CSV file");
   });
 
-  it("builds a remote preview from current server data instead of stale local state", async () => {
-    controls.uid = "uid-a";
-    const serverDeck = createDeck({ id: "remote-preview-deck", name: "behavior-remote.csv", uid: controls.uid });
-    controls.remoteDecks = [serverDeck];
-    controls.remoteCards = [
-      createCard({
-        id: "remote-preview-card",
-        deckId: serverDeck.id,
-        uid: controls.uid,
-        frontText: "front",
-        backText: "old back",
-        tags: ["tag"],
-        uniqueKey: "key",
-      }),
-    ];
-    const { result } = renderDeckImport();
-
-    await actAsync(async () => result.current.deckImport.selectFile(csvFile("behavior-remote.csv", "new back")));
-
-    expect(result.current.deckImport.preview?.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(findDeck(result.current.decks, "behavior-remote.csv")).toBeUndefined();
-  });
-
-  it("exposes a remote preview failure without changing stored data", async () => {
-    controls.uid = "uid-a";
-    controls.remoteReadError = new Error("server read failed");
-    const name = "behavior-read-failure.csv";
-    const { result } = renderDeckImport();
-
-    await actAsync(async () => {
-      await expect(result.current.deckImport.selectFile(csvFile(name))).rejects.toThrow("server read failed");
-    });
-
-    expect(result.current.deckImport.preview).toBeUndefined();
-    expect(result.current.deckImport.previewError).toEqual(new Error("server read failed"));
-    expect(result.current.deckImport.error).toBeNull();
-    expect(findDeck(result.current.decks, name)).toBeUndefined();
-  });
-
-  it("requires a fresh preview after a failed save and then completes the retry", async () => {
+  it("retries a failed save with the same new Deck", async () => {
     const name = "behavior-retry.csv";
     const file = csvFile(name);
     const { result } = renderDeckImport();
@@ -215,14 +150,10 @@ describe("useDeckImport", () => {
     expect(savedDeck).toBeDefined();
     expect(result.current.cards.filter((card) => card.deckId === savedDeck?.id)).toEqual([]);
     expect(result.current.deckImport.error).toEqual(new Error("card mutation failed"));
-    await expect(result.current.deckImport.importPreview()).rejects.toThrow("prepared Deck import is not available");
-
-    await actAsync(async () => result.current.deckImport.selectFile(file));
-    expect(result.current.deckImport.error).toBeNull();
-    expect(result.current.deckImport.preview?.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
     await actAsync(async () => result.current.deckImport.importPreview());
 
-    expect(result.current.deckImport.result).toMatchObject({ created: 1, updated: 0, skipped: 0 });
+    expect(result.current.deckImport.result).toMatchObject({ created: 1 });
+    expect(result.current.decks.filter((deck) => deck.name === name)).toHaveLength(1);
     expect(result.current.cards.filter((card) => card.deckId === savedDeck?.id)).toHaveLength(1);
   });
 });

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 import { useAuthUid } from "@/entities/auth";
-import { generateCardId, useCards } from "@/entities/card";
-import { useDecks } from "@/entities/deck";
+import { generateCardId } from "@/entities/card";
+import { generateDeckId } from "@/entities/deck";
 import { usePreferences } from "@/entities/preferences";
 import { prepareSampleDeck } from "./useAddSampleDeck";
 import type { DeckImportStorageMode, PreparedDeckImport } from "./useDeckImportExecution";
@@ -15,11 +15,9 @@ type DeckImportStatus = "idle" | "validating" | "importing";
 
 export const useDeckImport = () => {
   const uid = useAuthUid();
-  const cards = useCards();
-  const decks = useDecks();
   const preferences = usePreferences();
   const execution = useDeckImportExecution(uid);
-  const preview = useDeckImportPreview({ uid, cards, decks });
+  const preview = useDeckImportPreview(uid);
   const [status, setStatus] = useState<DeckImportStatus>("idle");
 
   const selectFile = async (file: File) => {
@@ -47,11 +45,18 @@ export const useDeckImport = () => {
     }
   };
 
+  const importPreview = async () => {
+    const result = await runImport(preview.getPreparedImport);
+    // Preserve generated IDs after a failed write so retrying cannot create another partial Deck.
+    preview.completePreparedImport();
+    return result;
+  };
+
   return {
     selectFile,
     setStorageMode,
-    importPreview: () => runImport(preview.takePreparedImport),
-    addSample: () => runImport(() => prepareSampleDeck(uid, { cards, decks, generateCardId })),
+    importPreview,
+    addSample: () => runImport(() => prepareSampleDeck(uid, { generateDeckId, generateCardId })),
     storageMode: preview.storageMode,
     preview: preview.preview,
     validating: status === "validating",

--- a/src/features/deck-import/model/useDeckImportExecution.spec.ts
+++ b/src/features/deck-import/model/useDeckImportExecution.spec.ts
@@ -2,8 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
-import { createCard, createDeck, createLocalCard, createLocalDeck } from "@/test/factories";
-import { prepareDeckImport } from "./useDeckImportExecution";
+import { executePreparedDeckImport, prepareDeckImport } from "./useDeckImportExecution";
 
 describe("prepareDeckImport", () => {
   const row = {
@@ -12,93 +11,101 @@ describe("prepareDeckImport", () => {
   };
   const rows = [row];
 
-  it("prepares a Card creation and its preview action together", () => {
+  it("prepares a new remote Deck and Card creations", () => {
     const preparedImport = prepareDeckImport(
       { name: "deck.csv", rows },
-      { uid: "uid", decks: [], cards: [], generateCardId: vi.fn(() => "card") }
+      {
+        uid: "uid",
+        generateDeckId: vi.fn(() => "deck"),
+        generateCardId: vi.fn(() => "card"),
+      }
     );
 
-    expect(preparedImport.plan).toMatchObject({ created: 1, updated: 0, unchanged: 0 });
+    expect(preparedImport.destination).toEqual({ id: "deck", uid: "uid", name: "deck.csv" });
     expect(preparedImport.mutations).toEqual([
-      { kind: "create", card: expect.objectContaining({ id: "card", uniqueKey: "key-1" }) },
+      {
+        kind: "create",
+        card: { ...row.card, id: "card", deckId: "deck", uid: "uid" },
+      },
     ]);
   });
 
-  it("prepares an update from the Card with the same unique key", () => {
-    const deck = createDeck({ id: "deck", name: "deck.csv", uid: "uid" });
-    const existing = createCard({
-      id: "existing",
-      deckId: deck.id,
-      uid: deck.uid,
-      frontText: "before",
-      uniqueKey: "key-1",
-    });
-    const preparedImport = prepareDeckImport(
-      { name: deck.name, rows },
-      { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn() }
-    );
+  it("generates a new destination for every preparation", () => {
+    const generateDeckId = vi.fn().mockReturnValueOnce("deck-1").mockReturnValueOnce("deck-2");
+    const dependencies = {
+      uid: "uid",
+      generateDeckId,
+      generateCardId: vi.fn().mockReturnValueOnce("card-1").mockReturnValueOnce("card-2"),
+    };
 
-    expect(preparedImport.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(preparedImport.mutations).toEqual([
-      { kind: "edit", card: expect.objectContaining({ id: existing.id, frontText: "front" }) },
-    ]);
-  });
+    const first = prepareDeckImport({ name: "same.csv", rows }, dependencies);
+    const second = prepareDeckImport({ name: "same.csv", rows }, dependencies);
 
-  it("skips a Card with identical editable content", () => {
-    const deck = createDeck({ id: "deck", name: "deck.csv", uid: "uid" });
-    const existing = createCard({ ...row.card, deckId: deck.id, uid: deck.uid });
-    const preparedImport = prepareDeckImport(
-      { name: deck.name, rows },
-      { uid: deck.uid, decks: [deck], cards: [existing], generateCardId: vi.fn() }
-    );
-
-    expect(preparedImport.plan).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
-    expect(preparedImport.mutations).toEqual([]);
+    expect(first.destination.id).toBe("deck-1");
+    expect(second.destination.id).toBe("deck-2");
+    expect(first.mutations[0]).toMatchObject({ kind: "create", card: { id: "card-1", deckId: "deck-1" } });
+    expect(second.mutations[0]).toMatchObject({ kind: "create", card: { id: "card-2", deckId: "deck-2" } });
   });
 
   it("prepares local Deck and Card creation without an account owner", () => {
     const preparedImport = prepareDeckImport(
       { name: "local.csv", rows, storageMode: "local" },
-      { uid: "", decks: [], cards: [], generateCardId: vi.fn(() => "local-card") }
+      {
+        uid: "",
+        generateDeckId: vi.fn(() => "local-deck"),
+        generateCardId: vi.fn(() => "local-card"),
+      }
     );
 
-    expect(preparedImport.destination).toEqual({ id: expect.any(String), name: "local.csv", localMode: true });
+    expect(preparedImport.destination).toEqual({ id: "local-deck", name: "local.csv", localMode: true });
     expect(preparedImport.mutations).toEqual([
       {
         kind: "create",
-        card: {
-          ...row.card,
-          id: "local-card",
-          deckId: preparedImport.destination.id,
-        },
+        card: { ...row.card, id: "local-card", deckId: "local-deck" },
       },
     ]);
   });
 
-  it("plans a local re-import from only the matching local Deck", () => {
-    const remoteDeck = createDeck({ id: "remote", name: "shared.csv", uid: "uid" });
-    const localDeck = createLocalDeck({ id: "local", name: "shared.csv" });
-    const remoteCard = createCard({ ...row.card, id: "remote-card", deckId: remoteDeck.id, uid: remoteDeck.uid });
-    const localCard = createLocalCard({
-      ...row.card,
-      id: "local-card",
-      deckId: localDeck.id,
-      frontText: "before",
-    });
-    const preparedImport = prepareDeckImport(
-      { name: localDeck.name, rows, storageMode: "local" },
-      {
-        uid: "uid",
-        decks: [remoteDeck, localDeck],
-        cards: [remoteCard, localCard],
-        generateCardId: vi.fn(),
-      }
-    );
+  it("requires a confirmed user for a remote import", () => {
+    expect(() =>
+      prepareDeckImport(
+        { name: "remote.csv", rows },
+        { uid: "", generateDeckId: vi.fn(() => "deck"), generateCardId: vi.fn(() => "card") }
+      )
+    ).toThrow("A confirmed user is required for remote imports");
+  });
+});
 
-    expect(preparedImport.destination.id).toBe(localDeck.id);
-    expect(preparedImport.plan).toMatchObject({ created: 0, updated: 1, unchanged: 0 });
-    expect(preparedImport.mutations).toEqual([
-      { kind: "edit", card: expect.objectContaining({ id: localCard.id, frontText: "front" }) },
-    ]);
+describe("executePreparedDeckImport", () => {
+  it("creates the prepared Deck before its Cards", async () => {
+    const preparedImport = prepareDeckImport(
+      {
+        name: "deck.csv",
+        rows: [
+          {
+            rowNumber: 1,
+            card: { frontText: "front", backText: "back", tags: [], uniqueKey: "key" },
+          },
+        ],
+      },
+      { uid: "uid", generateDeckId: () => "deck", generateCardId: () => "card" }
+    );
+    const calls: string[] = [];
+    const createDeck = vi.fn(() => {
+      calls.push("deck");
+      return Promise.resolve();
+    });
+    const mutateCards = vi.fn(() => {
+      calls.push("cards");
+      return Promise.resolve();
+    });
+
+    await expect(executePreparedDeckImport(preparedImport, { uid: "uid", createDeck, mutateCards })).resolves.toEqual({
+      created: 1,
+      deckId: "deck",
+    });
+    expect(calls).toEqual(["deck", "cards"]);
+    expect(createDeck).toHaveBeenCalledWith(preparedImport.destination);
+    expect(mutateCards).toHaveBeenCalledWith(preparedImport.mutations);
   });
 });

--- a/src/features/deck-import/model/useDeckImportExecution.ts
+++ b/src/features/deck-import/model/useDeckImportExecution.ts
@@ -1,46 +1,31 @@
-import type { Card, CardMutation, RemoteCard } from "@/entities/card";
-import type { Deck, DeckCreateInput, DeckId, LocalDeckCreateInput } from "@/entities/deck";
+import type { CardMutation } from "@/entities/card";
+import type { DeckCreateInput, DeckId, LocalDeckCreateInput } from "@/entities/deck";
 
 import { useState } from "react";
 
-import {
-  hasSameEditableCardContent,
-  indexCardsByUniqueKey,
-  mutateCards as persistCardMutations,
-} from "@/entities/card";
-import { createDeck as persistDeck, generateDeckId } from "@/entities/deck";
+import { mutateCards as persistCardMutations } from "@/entities/card";
+import { createDeck as persistDeck } from "@/entities/deck";
 
 import type { DeckImportRow } from "../lib/cardCsv";
 
 type DeckImportCreateInput = DeckCreateInput | LocalDeckCreateInput;
 export type DeckImportStorageMode = "local" | "remote";
 
-type DeckImportAction = "create" | "update" | "unchanged";
-
 export interface PreparedDeckImport {
   uid: string;
   destination: DeckImportCreateInput;
-  needsDeckCreation: boolean;
   mutations: CardMutation[];
-  plan: {
-    rows: (DeckImportRow & { action: DeckImportAction })[];
-    created: number;
-    updated: number;
-    unchanged: number;
-  };
 }
 
 interface DeckImportSource {
   name: string;
-  preferredDeckId?: DeckId;
   rows: DeckImportRow[];
   storageMode?: DeckImportStorageMode;
 }
 
 interface DeckImportPreparationDependencies {
   uid: string;
-  decks: Deck[];
-  cards: Card[];
+  generateDeckId: () => DeckId;
   generateCardId: () => string;
 }
 
@@ -50,101 +35,50 @@ interface DeckImportExecutionDependencies {
   mutateCards: (mutations: CardMutation[]) => Promise<unknown>;
 }
 
-const isRemoteCard = (card: Card): card is RemoteCard => "uid" in card;
-
-const usesStorageMode = (card: Card, storageMode: DeckImportStorageMode): boolean =>
-  storageMode === "remote" ? isRemoteCard(card) : !isRemoteCard(card);
-
-const matchesDestination = (candidate: Deck, source: DeckImportSource, storageMode: DeckImportStorageMode): boolean => {
-  if (candidate.localMode !== (storageMode === "local")) return false;
-  return source.preferredDeckId === undefined
-    ? candidate.name === source.name
-    : candidate.id === source.preferredDeckId;
-};
-
 const createDestination = (
   source: DeckImportSource,
   uid: string,
-  storageMode: DeckImportStorageMode
+  storageMode: DeckImportStorageMode,
+  generateDeckId: () => DeckId
 ): DeckImportCreateInput => {
-  const id = source.preferredDeckId ?? generateDeckId();
+  const id = generateDeckId();
   return storageMode === "local" ? { id, name: source.name, localMode: true } : { id, uid, name: source.name };
 };
 
-const reuseDestination = (deck: Deck): DeckImportCreateInput =>
-  deck.localMode ? { id: deck.id, name: deck.name, localMode: true } : { id: deck.id, uid: deck.uid, name: deck.name };
-
-const actionFor = (existing: Card | undefined, row: DeckImportRow): DeckImportAction => {
-  if (existing == null) return "create";
-  return hasSameEditableCardContent(existing, row.card) ? "unchanged" : "update";
-};
-
-const prepareCardMutations = ({
+const prepareCardCreations = ({
   rows,
-  existing,
   destinationId,
   uid,
   storageMode,
   generateCardId,
 }: {
   rows: DeckImportRow[];
-  existing: Card[];
   destinationId: DeckId;
   uid: string;
   storageMode: DeckImportStorageMode;
   generateCardId: () => string;
-}): Pick<PreparedDeckImport, "plan" | "mutations"> => {
-  const byUniqueKey = indexCardsByUniqueKey(existing);
-  const planRows: PreparedDeckImport["plan"]["rows"] = [];
-  const mutations: CardMutation[] = [];
-  const counts: Record<DeckImportAction, number> = { create: 0, update: 0, unchanged: 0 };
-
-  for (const row of rows) {
-    const current = byUniqueKey.get(row.card.uniqueKey);
-    const action = actionFor(current, row);
-    counts[action] += 1;
-    planRows.push({ ...row, action });
-
-    if (action === "create") {
-      const cardFields = { ...row.card, id: generateCardId(), deckId: destinationId };
-      // Local persistence stays account-agnostic; Card mutation routing follows the parent Deck's localMode.
-      const card = storageMode === "local" ? cardFields : { ...cardFields, uid };
-      mutations.push({ kind: "create", card });
-    } else if (action === "update" && current != null) {
-      mutations.push({ kind: "edit", card: { ...current, ...row.card } });
-    }
-  }
-
-  return {
-    mutations,
-    plan: {
-      rows: planRows,
-      created: counts.create,
-      updated: counts.update,
-      unchanged: counts.unchanged,
-    },
-  };
-};
+}): CardMutation[] =>
+  rows.map((row) => {
+    const cardFields = { ...row.card, id: generateCardId(), deckId: destinationId };
+    // Local persistence stays account-agnostic; Card mutation routing follows the parent Deck's localMode.
+    const card = storageMode === "local" ? cardFields : { ...cardFields, uid };
+    return { kind: "create", card };
+  });
 
 export const prepareDeckImport = (
   source: DeckImportSource,
-  { uid, decks, cards, generateCardId }: DeckImportPreparationDependencies
+  { uid, generateDeckId, generateCardId }: DeckImportPreparationDependencies
 ): PreparedDeckImport => {
   const storageMode = source.storageMode ?? "remote";
   if (storageMode === "remote" && uid === "") throw new Error("A confirmed user is required for remote imports");
 
-  const existingDeck = decks.find((candidate) => matchesDestination(candidate, source, storageMode));
-  const destination =
-    existingDeck == null ? createDestination(source, uid, storageMode) : reuseDestination(existingDeck);
+  const destination = createDestination(source, uid, storageMode, generateDeckId);
 
-  const existing = cards.filter((card) => card.deckId === destination.id && usesStorageMode(card, storageMode));
   return {
     uid,
     destination,
-    needsDeckCreation: existingDeck == null,
-    ...prepareCardMutations({
+    mutations: prepareCardCreations({
       rows: source.rows,
-      existing,
       destinationId: destination.id,
       uid,
       storageMode,
@@ -158,13 +92,11 @@ export const executePreparedDeckImport = async (
   { uid, createDeck, mutateCards }: DeckImportExecutionDependencies
 ) => {
   if (preparedImport.uid !== uid) throw new Error("The prepared Deck import belongs to a different user");
-  if (preparedImport.needsDeckCreation) await createDeck(preparedImport.destination);
+  await createDeck(preparedImport.destination);
   if (preparedImport.mutations.length > 0) await mutateCards(preparedImport.mutations);
 
   return {
-    created: preparedImport.plan.created,
-    updated: preparedImport.plan.updated,
-    skipped: preparedImport.plan.unchanged,
+    created: preparedImport.mutations.length,
     deckId: preparedImport.destination.id,
   };
 };

--- a/src/features/deck-import/model/useDeckImportPreview.ts
+++ b/src/features/deck-import/model/useDeckImportPreview.ts
@@ -1,10 +1,7 @@
-import type { Card } from "@/entities/card";
-import type { Deck } from "@/entities/deck";
-
 import { useRef, useState } from "react";
 
-import { fetchCards, generateCardId } from "@/entities/card";
-import { fetchDecks } from "@/entities/deck";
+import { generateCardId } from "@/entities/card";
+import { generateDeckId } from "@/entities/deck";
 import { type DeckImportAnalysis, parseCsv } from "../lib/cardCsv";
 import type { DeckImportStorageMode, PreparedDeckImport } from "./useDeckImportExecution";
 import { prepareDeckImport } from "./useDeckImportExecution";
@@ -12,7 +9,6 @@ import { prepareDeckImport } from "./useDeckImportExecution";
 export interface DeckImportPreview {
   deckName: string;
   analysis: DeckImportAnalysis;
-  plan: PreparedDeckImport["plan"];
 }
 
 interface DeckImportPreviewState {
@@ -25,12 +21,6 @@ interface PreparedDeckImportState {
   preparedImport: PreparedDeckImport | undefined;
 }
 
-interface UseDeckImportPreviewOptions {
-  uid: string;
-  decks: Deck[];
-  cards: Card[];
-}
-
 const initialState = (): DeckImportPreviewState => ({
   storageMode: "remote",
   preview: undefined,
@@ -38,19 +28,7 @@ const initialState = (): DeckImportPreviewState => ({
 });
 const createPreparedImportState = (): PreparedDeckImportState => ({ preparedImport: undefined });
 
-const loadDestinationData = async (
-  storageMode: DeckImportStorageMode,
-  uid: string,
-  localData: { decks: Deck[]; cards: Card[] }
-) => {
-  if (storageMode === "local") return localData;
-
-  // Listener-backed stores may lag, so remote plans must use authoritative server reads.
-  const [decks, cards] = await Promise.all([fetchDecks(uid), fetchCards(uid)]);
-  return { decks, cards };
-};
-
-export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreviewOptions) => {
+export const useDeckImportPreview = (uid: string) => {
   const preparedImportRef = useRef<PreparedDeckImportState>(createPreparedImportState());
   const [state, setState] = useState<DeckImportPreviewState>(initialState);
   const updateState = (update: Partial<DeckImportPreviewState>) => {
@@ -64,13 +42,11 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
 
     try {
       const analysis = await parseCsv(await file.text());
-      const destinationData = await loadDestinationData(storageMode, uid, { decks, cards });
-
       const preparedImport = prepareDeckImport(
         { name: file.name, rows: analysis.rows, storageMode },
-        { uid, ...destinationData, generateCardId }
+        { uid, generateDeckId, generateCardId }
       );
-      const preview = { deckName: file.name, analysis, plan: preparedImport.plan };
+      const preview = { deckName: file.name, analysis };
       preparedImportRef.current.preparedImport = preparedImport;
       updateState({ preview });
       return preview;
@@ -88,7 +64,7 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
     return true;
   };
 
-  const takePreparedImport = () => {
+  const getPreparedImport = () => {
     const { preview } = state;
     if (preview == null) throw new Error("Select a CSV file before importing");
     if (preview.analysis.invalidCount > 0) throw new Error("Fix invalid CSV rows before importing");
@@ -97,15 +73,16 @@ export const useDeckImportPreview = ({ uid, decks, cards }: UseDeckImportPreview
       throw new Error("The prepared Deck import is not available");
     }
 
-    const { preparedImport } = preparedImportRef.current;
-    preparedImportRef.current.preparedImport = undefined;
-    return preparedImport;
+    return preparedImportRef.current.preparedImport;
   };
 
   return {
     selectFile,
     setStorageMode,
-    takePreparedImport,
+    getPreparedImport,
+    completePreparedImport: () => {
+      preparedImportRef.current.preparedImport = undefined;
+    },
     clearError: () => updateState({ error: null }),
     storageMode: state.storageMode,
     preview: state.preview,

--- a/src/features/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/features/deck-import/ui/DeckImportView.spec.tsx
@@ -21,18 +21,6 @@ const preview = {
     issues: [],
     invalidCount: 0,
   },
-  plan: {
-    rows: [
-      {
-        rowNumber: 1,
-        card: { frontText: "front", backText: "back", tags: ["tag"], uniqueKey: "key-1" },
-        action: "create",
-      },
-    ],
-    created: 1,
-    updated: 0,
-    unchanged: 0,
-  },
 } satisfies DeckImportPreview;
 
 describe("DeckImportView", () => {
@@ -97,7 +85,7 @@ describe("DeckImportView", () => {
     render(<DeckImportView sampleText={sampleText} onAddSample={onAddSample} onDownloadSample={onDownloadSample} />);
 
     expect(screen.getByText(/Four columns without a header/)).toHaveTextContent("uniqueKey");
-    expect(screen.getByText(/uniqueKey is required/)).toBeInTheDocument();
+    expect(screen.getByText(/uniqueKey is required/)).toHaveTextContent("must be unique within the CSV file");
     expect(screen.getAllByText("front").length).toBeGreaterThan(0);
 
     await userEvent.click(screen.getByRole("button", { name: "Add sample deck" }));
@@ -118,7 +106,7 @@ describe("DeckImportView", () => {
     expect(onDownloadSample).toHaveBeenCalledOnce();
   });
 
-  it("shows validation, planned changes, row content, and waits for explicit import", async () => {
+  it("shows validation and row content, and waits for explicit import", async () => {
     const onImport = vi.fn();
     render(<DeckImportView sampleText="front,back,,key" preview={preview} onImport={onImport} />);
 
@@ -126,9 +114,8 @@ describe("DeckImportView", () => {
     expect(screen.getByText("1 valid")).toBeVisible();
     expect(screen.getByText("1 skipped")).toBeVisible();
     expect(screen.getByText("0 invalid")).toBeVisible();
-    expect(screen.getByText("1 create")).toBeVisible();
-    expect(screen.getByText("0 update")).toBeVisible();
-    expect(screen.getByText("0 unchanged")).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Planned changes" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Action" })).not.toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "front" })).toBeVisible();
     expect(screen.getByRole("cell", { name: "key-1" })).toBeVisible();
     expect(onImport).not.toHaveBeenCalled();
@@ -153,7 +140,6 @@ describe("DeckImportView", () => {
           },
         ],
       },
-      plan: { rows: [], created: 0, updated: 0, unchanged: 0 },
     };
     render(<DeckImportView sampleText="front,back,,key" preview={invalidPreview} />);
 
@@ -178,16 +164,14 @@ describe("DeckImportView", () => {
     const onBack = vi.fn();
     const success = {
       created: 2,
-      updated: 1,
-      skipped: 3,
       deckId: "deck",
     } satisfies DeckImportResult;
     const view = render(<DeckImportView sampleText="front,back,,key" result={success} onBack={onBack} />);
 
     expect(screen.getByRole("status")).toHaveTextContent("Import complete");
     expect(screen.getByRole("status")).toHaveTextContent("2 created");
-    expect(screen.getByRole("status")).toHaveTextContent("1 updated");
-    expect(screen.getByRole("status")).toHaveTextContent("3 skipped");
+    expect(screen.getByRole("status")).not.toHaveTextContent("updated");
+    expect(screen.getByRole("status")).not.toHaveTextContent("skipped");
     await userEvent.click(screen.getByRole("button", { name: "Back to decks" }));
     expect(onBack).toHaveBeenCalledOnce();
 

--- a/src/features/deck-import/ui/DeckImportView.stories.tsx
+++ b/src/features/deck-import/ui/DeckImportView.stories.tsx
@@ -23,23 +23,6 @@ const preview = {
     issues: [],
     invalidCount: 0,
   },
-  plan: {
-    rows: [
-      {
-        rowNumber: 1,
-        card: { frontText: "hello", backText: "hola", tags: ["greeting"], uniqueKey: "hello-es" },
-        action: "update",
-      },
-      {
-        rowNumber: 2,
-        card: { frontText: "goodbye", backText: "adiós", tags: ["greeting"], uniqueKey: "goodbye-es" },
-        action: "create",
-      },
-    ],
-    created: 1,
-    updated: 1,
-    unchanged: 0,
-  },
 } satisfies DeckImportPreview;
 
 const meta = {
@@ -83,7 +66,6 @@ export const Invalid: Story = {
           },
         ],
       },
-      plan: { rows: [], created: 0, updated: 0, unchanged: 0 },
     },
   },
 };
@@ -98,7 +80,7 @@ export const Pending: Story = {
 export const Success: Story = {
   args: {
     preview,
-    result: { created: 1, updated: 1, skipped: 0, deckId: "spanish-basics" },
+    result: { created: 2, deckId: "spanish-basics" },
   },
 };
 

--- a/src/features/deck-import/ui/DeckImportView.tsx
+++ b/src/features/deck-import/ui/DeckImportView.tsx
@@ -28,8 +28,6 @@ interface DeckImportViewProps {
 const resultCounts = (result: DeckImportResult) => (
   <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption">
     <li>{result.created} created</li>
-    <li>{result.updated} updated</li>
-    <li>{result.skipped} skipped</li>
   </ul>
 );
 
@@ -91,8 +89,8 @@ const ImportPreview = (props: ImportPreviewProps) => {
 
   const busy = Boolean(props.pending || props.validating);
   const canImport = preview.analysis.rows.length > 0 && preview.analysis.invalidCount === 0 && !busy;
-  const visibleRows = preview.plan.rows.slice(0, 10);
-  const hiddenRowCount = preview.plan.rows.length - visibleRows.length;
+  const visibleRows = preview.analysis.rows.slice(0, 10);
+  const hiddenRowCount = preview.analysis.rows.length - visibleRows.length;
 
   return (
     <section aria-labelledby="import-preview-heading" className="space-y-4">
@@ -105,21 +103,13 @@ const ImportPreview = (props: ImportPreviewProps) => {
         </p>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div>
         <div className="rounded-surface border border-border bg-surface-muted p-3">
           <h3 className="font-semibold text-ink">Validation</h3>
           <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption text-ink-muted">
             <li>{preview.analysis.rows.length} valid</li>
             <li>{preview.analysis.skippedRows.length} skipped</li>
             <li>{preview.analysis.invalidCount} invalid</li>
-          </ul>
-        </div>
-        <div className="rounded-surface border border-border bg-surface-muted p-3">
-          <h3 className="font-semibold text-ink">Planned changes</h3>
-          <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-caption text-ink-muted">
-            <li>{preview.plan.created} create</li>
-            <li>{preview.plan.updated} update</li>
-            <li>{preview.plan.unchanged} unchanged</li>
           </ul>
         </div>
       </div>
@@ -149,7 +139,6 @@ const ImportPreview = (props: ImportPreviewProps) => {
             <thead className="bg-surface-muted">
               <tr>
                 <th className="px-3 py-2">Row</th>
-                <th className="px-3 py-2">Action</th>
                 <th className="px-3 py-2">Front</th>
                 <th className="px-3 py-2">Back</th>
                 <th className="px-3 py-2">Tags</th>
@@ -160,7 +149,6 @@ const ImportPreview = (props: ImportPreviewProps) => {
               {visibleRows.map((row) => (
                 <tr key={row.rowNumber} className="border-t border-border">
                   <td className="px-3 py-2">{row.rowNumber}</td>
-                  <td className="px-3 py-2 capitalize">{row.action}</td>
                   <td className="max-w-64 break-words px-3 py-2">{row.card.frontText}</td>
                   <td className="max-w-64 break-words px-3 py-2">{row.card.backText}</td>
                   <td className="px-3 py-2">{row.card.tags.join(", ")}</td>
@@ -260,9 +248,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
             <Description>
               Four columns without a header: front text, back text, tags (optional), and uniqueKey.
             </Description>
-            <Description>
-              uniqueKey is required. Keep it stable to update the same card and avoid duplicates when importing again.
-            </Description>
+            <Description>uniqueKey is required and must be unique within the CSV file.</Description>
           </div>
         </section>
         <section>

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -103,7 +103,7 @@ describe("DeckImportPage", () => {
 
     await selectLocalFile(name, "saved back");
 
-    expect(screen.getByText("1 create")).toBeVisible();
+    expect(screen.getByText("1 valid")).toBeVisible();
     expect(screen.queryByRole("heading", { level: 1, name: "Deck list destination" })).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Import" }));
 
@@ -112,7 +112,7 @@ describe("DeckImportPage", () => {
     expect(screen.getByText("front: saved back")).toBeVisible();
   });
 
-  it("shows a failed save in place and completes after the file is selected again", async () => {
+  it("shows a failed save in place and retries the same import", async () => {
     const name = "page-behavior-retry.csv";
     renderPage();
     await selectLocalFile(name, "retry back");
@@ -124,13 +124,6 @@ describe("DeckImportPage", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("card mutation failed");
     expect(screen.getByRole("heading", { level: 1, name: "Import decks" })).toBeVisible();
 
-    fireEvent.change(screen.getByLabelText(/Upload a csv file/), {
-      target: {
-        files: [new File(['"front","retry back","tag","key"'], name, { type: "text/csv" })],
-      },
-    });
-    expect(await screen.findByRole("heading", { level: 2, name: "Review import" })).toBeVisible();
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Import" }));
 
     expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();

--- a/test/e2e/deck-import-local.spec.ts
+++ b/test/e2e/deck-import-local.spec.ts
@@ -12,7 +12,7 @@ test("restores an imported local-only Deck for list and study flows", async ({ p
     mimeType: "text/csv",
     buffer: Buffer.from('"local front","local back","tag","local-key"'),
   });
-  await expect(page.getByText("1 create")).toBeVisible();
+  await expect(page.getByText("1 valid")).toBeVisible();
   await page.getByRole("button", { name: "Import", exact: true }).click();
 
   await expect(page).toHaveURL(/\/$/);

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -4,8 +4,7 @@
  * objects.
  */
 
-import type { RemoteCard } from "@/entities/card";
-import type { LocalCard } from "@/entities/card/model/types";
+import type { LocalCard, RemoteCard } from "@/entities/card/model/types";
 import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preferences";
 

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -4,8 +4,8 @@
  * "should update a card", and "should import cards".
  */
 
-import { mutateCards, type Card, type RemoteCard } from "@/entities/card";
-import type { CardCreateInput } from "@/entities/card/model/types";
+import { mutateCards, type Card } from "@/entities/card";
+import type { CardCreateInput, RemoteCard } from "@/entities/card/model/types";
 
 import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,8 +8,8 @@ import "@/test/initializeTestFirestore";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, fetchCardReads, fetchCards, mutateCards, subscribeCards } from "@/entities/card";
-import { createDeck, deleteDeck, editDeck, fetchDecks, subscribeDecks } from "@/entities/deck";
+import { deleteCard, editCard, fetchCardReads, mutateCards, subscribeCards } from "@/entities/card";
+import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture } from "@/test/factories";
@@ -29,7 +29,7 @@ describe("Query realtime subscriptions", () => {
     await Promise.all(getApps().map(deleteApp));
   });
 
-  it("fetches Cards and Decks through their public read APIs", async () => {
+  it("fetches separated Card reads through the public read API", async () => {
     const uid = "uid";
     const deck = createDeckFixture({ id: crypto.randomUUID(), uid, name: "Fetched Deck" });
     const card = createCard({
@@ -43,12 +43,8 @@ describe("Query realtime subscriptions", () => {
     await createDeck(uid, deck);
     await mutateCards(uid, [{ kind: "create", card }]);
 
-    const [decks, cards, reads] = await Promise.all([fetchDecks(uid), fetchCards(uid), fetchCardReads(uid)]);
+    const reads = await fetchCardReads(uid);
 
-    expect(decks).toContainEqual(expect.objectContaining({ id: deck.id, name: "Fetched Deck" }));
-    expect(cards).toContainEqual(
-      expect.objectContaining({ id: card.id, frontText: "Fetched Card", score: 2, numberOfSeen: 3 })
-    );
     expect(reads).toContainEqual({
       card: expect.objectContaining({ id: card.id, frontText: "Fetched Card" }),
       progress: expect.objectContaining({ cardId: card.id, score: 2, numberOfSeen: 3 }),
@@ -119,8 +115,6 @@ describe("Query realtime subscriptions", () => {
     await editDeck(uid, { ...deck, name: "After stop" });
     await editCard(uid, { ...card, frontText: "After stop" });
 
-    expect(await fetchDecks(uid)).toContainEqual(expect.objectContaining({ id: deck.id, name: "After stop" }));
-    expect(await fetchCards(uid)).toContainEqual(expect.objectContaining({ id: card.id, frontText: "After stop" }));
     expect(deckStore.getState().remoteDecks).toContainEqual(
       expect.objectContaining({ id: deck.id, name: "Before stop" })
     );


### PR DESCRIPTION
## Related issue

Fixes #1127

## Summary

- Always generate a new Deck destination for every CSV import, even when a same-name Deck exists.
- Remove existing Deck and Card lookups together with Card update and unchanged planning.
- Create only new Cards during import and simplify the preview and result UI accordingly.
- Preserve prepared IDs across a failed write so retrying the same import does not create another partial Deck.

## Testing

- mise run check
- mise run test-integration