### PR TITLE
[No issue] Enforce Steiger import locality

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,25 +83,6 @@ export default [
     },
     rules: {
       ...boundariesRecommended.rules,
-      "boundaries/dependencies": [
-        "error",
-        {
-          checkInternals: true,
-          default: "allow",
-          rules: [
-            {
-              from: { type: sliceLayers },
-              disallow: {
-                dependency: {
-                  relationship: { to: "internal" },
-                  source: "@/**",
-                },
-              },
-              message: "Use a relative import within the same slice.",
-            },
-          ],
-        },
-      ],
       "boundaries/no-unknown-files": "error",
     },
   }),

--- a/src/app/App.stories.tsx
+++ b/src/app/App.stories.tsx
@@ -7,10 +7,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect } from "storybook/test";
 
-import { AppRoutes } from "@/app/routes";
 import { routes } from "@/features/navigate";
 import { type PageStoryParameters, preparePageStory, withPageStory } from "@/storybook/PageDecorator";
 import { PAGE_STORY_CARD_ID, PAGE_STORY_DECK_ID, pageStoryState } from "@/storybook/pageFixture";
+
+import { AppRoutes } from "./routes";
 
 const page = (path: string, overrides: Partial<Omit<PageStoryParameters, "path">> = {}): PageStoryParameters => ({
   ...pageStoryState,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,10 +7,11 @@
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
 
-import { AuthProvider } from "@/app/auth";
-import { FirestoreSubscriptionsProvider } from "@/app/firestore-subscriptions";
-import { AppRoutes } from "@/app/routes";
 import { usePreferences } from "@/entities/preference";
+
+import { AuthProvider } from "./auth";
+import { FirestoreSubscriptionsProvider } from "./firestore-subscriptions";
+import { AppRoutes } from "./routes";
 
 /**
  * Renders the App user interface.

--- a/src/app/auth/index.tsx
+++ b/src/app/auth/index.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 
-import { startAuthSession } from "@/app/auth/lifecycle";
 import { useAuthSession } from "@/entities/auth";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
+
+import { startAuthSession } from "./lifecycle";
 
 export interface AuthProviderProps {
   children: React.ReactNode;

--- a/src/shared/files/downloadTextFile.spec.ts
+++ b/src/shared/files/downloadTextFile.spec.ts
@@ -1,8 +1,9 @@
 import saveAs from "file-saver";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { downloadTextFile } from "@/shared/files";
 import { createBlobConstructor } from "@/test/factories";
+
+import { downloadTextFile } from ".";
 
 vi.mock("file-saver", () => ({ default: vi.fn() }));
 

--- a/src/shared/ui/actions-menu/ActionsMenu.tsx
+++ b/src/shared/ui/actions-menu/ActionsMenu.tsx
@@ -7,7 +7,7 @@
 import type * as React from "react";
 import { AiOutlineMore } from "react-icons/ai";
 
-import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
+import { focusableElementSelector } from "../../lib/focusableElementSelector";
 
 export interface ActionsMenuItem {
   key: string;

--- a/src/shared/ui/content/Code.stories.tsx
+++ b/src/shared/ui/content/Code.stories.tsx
@@ -6,8 +6,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Code as Template } from "@/shared/ui/content/Code";
 import * as fixture from "@/storybook/fixture";
+
+import { Code as Template } from "./Code";
 
 const meta = {
   title: "Shared/Content/Code",

--- a/src/shared/ui/content/Code.tsx
+++ b/src/shared/ui/content/Code.tsx
@@ -6,10 +6,11 @@
 
 import cx from "classnames";
 import * as React from "react";
-import { Style } from "@/shared/ui/content/Style";
 // biome-ignore lint/correctness/noUnresolvedImports: highlight.js exposes this default through its ESM export map.
 import hljs from "highlight.js";
+
 import "./Code.scss";
+import { Style } from "./Style";
 
 /**
  * Renders the Highlight user interface.

--- a/src/shared/ui/content/ContentHierarchy.spec.tsx
+++ b/src/shared/ui/content/ContentHierarchy.spec.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
-import { Description, Style, Title } from "@/shared/ui/content";
+import { Description, Style, Title } from ".";
 
 describe("shared content hierarchy", () => {
   it("activates an interactive title from the keyboard", () => {

--- a/src/shared/ui/content/Description.stories.tsx
+++ b/src/shared/ui/content/Description.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Description as Template } from "@/shared/ui/content/Description";
+import { Description as Template } from "./Description";
 
 const meta = {
   title: "Shared/Content/Description",

--- a/src/shared/ui/content/Math.stories.tsx
+++ b/src/shared/ui/content/Math.stories.tsx
@@ -6,8 +6,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { MathContent as Template } from "@/shared/ui/content/Math";
 import * as fixture from "@/storybook/fixture";
+
+import { MathContent as Template } from "./Math";
 
 // github-markdown-css follows the browser preference, so the story canvas must use the same theme.
 const preferredTheme = globalThis.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";

--- a/src/shared/ui/content/Math.tsx
+++ b/src/shared/ui/content/Math.tsx
@@ -4,14 +4,15 @@
  * and interaction rules.
  */
 
+import "github-markdown-css/github-markdown.css";
+import "katex/dist/katex.min.css";
 import type * as React from "react";
-import { Style } from "@/shared/ui/content/Style";
 import Markdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
-import remarkMath from "remark-math";
 import remarkGfm from "remark-gfm";
-import "katex/dist/katex.min.css";
-import "github-markdown-css/github-markdown.css";
+import remarkMath from "remark-math";
+
+import { Style } from "./Style";
 
 /**
  * Renders the Math Content user interface.

--- a/src/shared/ui/content/RemovableTag.tsx
+++ b/src/shared/ui/content/RemovableTag.tsx
@@ -6,7 +6,7 @@
 
 import type * as React from "react";
 
-import { TagMarker, tagClassName } from "@/shared/ui/content/tagStyles";
+import { TagMarker, tagClassName } from "./tagStyles";
 
 export interface RemovableTagProps {
   className?: string;

--- a/src/shared/ui/content/RichContent.spec.tsx
+++ b/src/shared/ui/content/RichContent.spec.tsx
@@ -9,8 +9,8 @@ import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 
-import { Code } from "@/shared/ui/content/Code";
-import { MathContent } from "@/shared/ui/content/Math";
+import { Code } from "./Code";
+import { MathContent } from "./Math";
 
 describe("shared rich content", () => {
   it("keeps code copyable, categorized, and horizontally scrollable", async () => {

--- a/src/shared/ui/content/Score.stories.tsx
+++ b/src/shared/ui/content/Score.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Score as Template } from "@/shared/ui/content/Score";
+import { Score as Template } from "./Score";
 
 const meta = {
   title: "Shared/Content/Score",

--- a/src/shared/ui/content/StatusContent.spec.tsx
+++ b/src/shared/ui/content/StatusContent.spec.tsx
@@ -8,9 +8,9 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 
-import { Score } from "@/shared/ui/content/Score";
-import { Feedback } from "@/shared/ui/feedback";
-import type { FeedbackTone } from "@/shared/ui/feedback/Feedback";
+import { Feedback } from "../feedback";
+import type { FeedbackTone } from "../feedback/Feedback";
+import { Score } from "./Score";
 
 describe("shared status content", () => {
   it.each([

--- a/src/shared/ui/content/TagLabel.stories.tsx
+++ b/src/shared/ui/content/TagLabel.stories.tsx
@@ -6,8 +6,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { RemovableTag } from "@/shared/ui/content/RemovableTag";
-import { TagLabel } from "@/shared/ui/content/TagLabel";
+import { RemovableTag } from "./RemovableTag";
+import { TagLabel } from "./TagLabel";
 
 const meta = {
   title: "Shared/Content/TagLabel",

--- a/src/shared/ui/content/TagLabel.tsx
+++ b/src/shared/ui/content/TagLabel.tsx
@@ -6,7 +6,7 @@
 
 import type * as React from "react";
 
-import { TagMarker, tagClassName } from "@/shared/ui/content/tagStyles";
+import { TagMarker, tagClassName } from "./tagStyles";
 
 export interface TagLabelProps {
   className?: string;

--- a/src/shared/ui/content/TagList.stories.tsx
+++ b/src/shared/ui/content/TagList.stories.tsx
@@ -6,9 +6,10 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Tag } from "@/shared/ui/forms";
-import { TagList as Template } from "@/shared/ui/content/TagList";
 import * as fixture from "@/storybook/fixture";
+
+import { Tag } from "../forms";
+import { TagList as Template } from "./TagList";
 
 const meta = {
   title: "Shared/Content/TagList",

--- a/src/shared/ui/content/TagPresentation.spec.tsx
+++ b/src/shared/ui/content/TagPresentation.spec.tsx
@@ -5,8 +5,8 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
-import { RemovableTag } from "@/shared/ui/content/RemovableTag";
-import { TagLabel } from "@/shared/ui/content/TagLabel";
+import { RemovableTag } from "./RemovableTag";
+import { TagLabel } from "./TagLabel";
 
 describe("tag presentation", () => {
   it("renders compact read-only tag content outside the tab order", () => {

--- a/src/shared/ui/content/Title.stories.tsx
+++ b/src/shared/ui/content/Title.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Title as Template } from "@/shared/ui/content/Title";
+import { Title as Template } from "./Title";
 
 const meta = {
   title: "Shared/Content/Title",

--- a/src/shared/ui/content/Title.tsx
+++ b/src/shared/ui/content/Title.tsx
@@ -6,7 +6,8 @@
 
 import cx from "classnames";
 import type * as React from "react";
-import { useButtonInteraction } from "@/shared/ui/button-interaction";
+
+import { useButtonInteraction } from "../button-interaction";
 
 /**
  * Renders the Title user interface.

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
-import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
-import { Button } from "@/shared/ui/button";
+import { focusableElementSelector } from "../../lib/focusableElementSelector";
+import { Button } from "../button";
 
 export interface DestructiveActionDialogProps {
   title: string;

--- a/src/shared/ui/feedback/Overlay.spec.tsx
+++ b/src/shared/ui/feedback/Overlay.spec.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
-import { Overlay } from "@/shared/ui/feedback/Overlay";
+import { Overlay } from "./Overlay";
 
 describe("shared overlay surface", () => {
   it("reports clicks from an accessibly named overlay", () => {

--- a/src/shared/ui/feedback/Overlay.stories.tsx
+++ b/src/shared/ui/feedback/Overlay.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Overlay as Template } from "@/shared/ui/feedback/Overlay";
+import { Overlay as Template } from "./Overlay";
 
 const meta = {
   title: "Shared/Feedback/Overlay",

--- a/src/shared/ui/feedback/Overlay.tsx
+++ b/src/shared/ui/feedback/Overlay.tsx
@@ -6,7 +6,8 @@
 
 import cx from "classnames";
 import type * as React from "react";
-import { useButtonInteraction } from "@/shared/ui/button-interaction";
+
+import { useButtonInteraction } from "../button-interaction";
 
 /**
  * Renders the Overlay user interface.

--- a/src/shared/ui/forms/ActionControl.spec.tsx
+++ b/src/shared/ui/forms/ActionControl.spec.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
-import { Button } from "@/shared/ui/button";
+import { Button } from "../button";
 
 describe("Button action control", () => {
   it("does not activate while disabled", () => {

--- a/src/shared/ui/forms/Form.stories.tsx
+++ b/src/shared/ui/forms/Form.stories.tsx
@@ -6,10 +6,10 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Form as Template } from "@/shared/ui/forms/Form";
-import { FormItem } from "@/shared/ui/forms/FormItem";
-import { Input } from "@/shared/ui/forms/Input";
-import { Switch } from "@/shared/ui/forms/Switch";
+import { Form as Template } from "./Form";
+import { FormItem } from "./FormItem";
+import { Input } from "./Input";
+import { Switch } from "./Switch";
 
 /**
  * Prepares review form data for the Storybook examples in this file.

--- a/src/shared/ui/forms/FormItem.stories.tsx
+++ b/src/shared/ui/forms/FormItem.stories.tsx
@@ -6,12 +6,12 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Button } from "@/shared/ui/button";
-import { FormItem as Template } from "@/shared/ui/forms/FormItem";
-import { Input } from "@/shared/ui/forms/Input";
-import { Select } from "@/shared/ui/forms/Select";
-import { Slider } from "@/shared/ui/forms/Slider";
-import { Switch } from "@/shared/ui/forms/Switch";
+import { Button } from "../button";
+import { FormItem as Template } from "./FormItem";
+import { Input } from "./Input";
+import { Select } from "./Select";
+import { Slider } from "./Slider";
+import { Switch } from "./Switch";
 
 const meta = {
   title: "Shared/Forms/FormItem",

--- a/src/shared/ui/forms/FormItem.tsx
+++ b/src/shared/ui/forms/FormItem.tsx
@@ -6,7 +6,8 @@
 
 import cx from "classnames";
 import type React from "react";
-import { Description } from "@/shared/ui/content";
+
+import { Description } from "../content";
 
 /**
  * Renders the Form Item user interface.

--- a/src/shared/ui/forms/FormLayout.spec.tsx
+++ b/src/shared/ui/forms/FormLayout.spec.tsx
@@ -4,8 +4,8 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 
-import { Form } from "@/shared/ui/forms/Form";
-import { FormItem } from "@/shared/ui/forms/FormItem";
+import { Form } from "./Form";
+import { FormItem } from "./FormItem";
 
 const appearsBefore = (first: Node, second: Node): boolean => {
   // biome-ignore lint/suspicious/noBitwiseOperators: compareDocumentPosition returns a DOM bitmask by contract.

--- a/src/shared/ui/forms/Input.stories.tsx
+++ b/src/shared/ui/forms/Input.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Input as Template } from "@/shared/ui/forms/Input";
+import { Input as Template } from "./Input";
 
 const meta = {
   title: "Shared/Forms/Input",

--- a/src/shared/ui/forms/Select.stories.tsx
+++ b/src/shared/ui/forms/Select.stories.tsx
@@ -6,8 +6,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Select as Template } from "@/shared/ui/forms/Select";
 import * as fixture from "@/storybook/fixture";
+
+import { Select as Template } from "./Select";
 
 const meta = {
   title: "Shared/Forms/Select",

--- a/src/shared/ui/forms/SelectionControl.spec.tsx
+++ b/src/shared/ui/forms/SelectionControl.spec.tsx
@@ -11,10 +11,10 @@ import "@testing-library/jest-dom/vitest";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { Slider } from "@/shared/ui/forms/Slider";
-import { Switch } from "@/shared/ui/forms/Switch";
-import { Tag } from "@/shared/ui/forms/Tag";
-import { Upload } from "@/shared/ui/forms/Upload";
+import { Slider } from "./Slider";
+import { Switch } from "./Switch";
+import { Tag } from "./Tag";
+import { Upload } from "./Upload";
 
 describe("shared selection controls", () => {
   it("forwards accessible naming props to the switch input", () => {

--- a/src/shared/ui/forms/Slider.stories.tsx
+++ b/src/shared/ui/forms/Slider.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { expect, fireEvent, fn } from "storybook/test";
 
-import { Slider as Template } from "@/shared/ui/forms/Slider";
+import { Slider as Template } from "./Slider";
 
 const meta = {
   title: "Shared/Forms/Slider",

--- a/src/shared/ui/forms/Switch.stories.tsx
+++ b/src/shared/ui/forms/Switch.stories.tsx
@@ -7,7 +7,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, fn } from "storybook/test";
 
-import { Switch as Template } from "@/shared/ui/forms/Switch";
+import { Switch as Template } from "./Switch";
 
 const meta = {
   title: "Shared/Forms/Switch",

--- a/src/shared/ui/forms/Tag.stories.tsx
+++ b/src/shared/ui/forms/Tag.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Tag as Template } from "@/shared/ui/forms/Tag";
+import { Tag as Template } from "./Tag";
 
 const meta = {
   title: "Shared/Forms/Tag",

--- a/src/shared/ui/forms/Tag.tsx
+++ b/src/shared/ui/forms/Tag.tsx
@@ -7,7 +7,7 @@
 import cx from "classnames";
 import type * as React from "react";
 
-import { tagClassName } from "@/shared/ui/content";
+import { tagClassName } from "../content";
 
 /**
  * Renders the Tag user interface.

--- a/src/shared/ui/forms/TextControl.spec.tsx
+++ b/src/shared/ui/forms/TextControl.spec.tsx
@@ -10,9 +10,9 @@ import "@testing-library/jest-dom/vitest";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { Input } from "@/shared/ui/forms/Input";
-import { Select } from "@/shared/ui/forms/Select";
-import { Textarea } from "@/shared/ui/forms/Textarea";
+import { Input } from "./Input";
+import { Select } from "./Select";
+import { Textarea } from "./Textarea";
 
 describe("shared text controls", () => {
   it("forwards an id so external labels can name the input", () => {

--- a/src/shared/ui/forms/Textarea.stories.tsx
+++ b/src/shared/ui/forms/Textarea.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Textarea as Template } from "@/shared/ui/forms/Textarea";
+import { Textarea as Template } from "./Textarea";
 
 const meta = {
   title: "Shared/Forms/Textarea",

--- a/src/shared/ui/forms/Upload.stories.tsx
+++ b/src/shared/ui/forms/Upload.stories.tsx
@@ -6,7 +6,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Upload as Template } from "@/shared/ui/forms/Upload";
+import { Upload as Template } from "./Upload";
 
 const meta = {
   title: "Shared/Forms/Upload",

--- a/src/shared/ui/full-screen/FullScreen.tsx
+++ b/src/shared/ui/full-screen/FullScreen.tsx
@@ -6,7 +6,8 @@
 
 import cx from "classnames";
 import type * as React from "react";
-import { useButtonInteraction } from "@/shared/ui/button-interaction";
+
+import { useButtonInteraction } from "../button-interaction";
 
 /**
  * Renders the Full Screen user interface.

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -8,7 +8,8 @@ import cx from "classnames";
 import type * as React from "react";
 import { IconContext } from "react-icons";
 import { AiFillSetting, AiOutlineUpload, AiOutlineSun, AiFillMoon } from "react-icons/ai";
-import { Logo } from "@/shared/ui/logo";
+
+import { Logo } from "../logo";
 
 export interface HeaderProps {
   fixed?: boolean;

--- a/src/shared/ui/layout/Layout.tsx
+++ b/src/shared/ui/layout/Layout.tsx
@@ -5,10 +5,11 @@
  */
 
 import type * as React from "react";
-import { FullScreen } from "@/shared/ui/full-screen";
-import { Header, type HeaderProps } from "@/shared/ui/header";
-import { Main } from "@/shared/ui/main";
-import { Outer } from "@/shared/ui/outer";
+
+import { FullScreen } from "../full-screen";
+import { Header, type HeaderProps } from "../header";
+import { Main } from "../main";
+import { Outer } from "../outer";
 
 /**
  * Renders the Footer user interface.

--- a/src/shared/ui/logo/Logo.tsx
+++ b/src/shared/ui/logo/Logo.tsx
@@ -6,7 +6,8 @@
 
 import cx from "classnames";
 import type * as React from "react";
-import { useButtonInteraction } from "@/shared/ui/button-interaction";
+
+import { useButtonInteraction } from "../button-interaction";
 
 /**
  * Renders the Logo user interface.

--- a/src/shared/ui/remote-mutation-notice/RemoteMutationNotice.tsx
+++ b/src/shared/ui/remote-mutation-notice/RemoteMutationNotice.tsx
@@ -4,7 +4,7 @@
  * and interaction rules.
  */
 
-import { Button } from "@/shared/ui/button";
+import { Button } from "../button";
 
 export interface RemoteMutationNoticeProps {
   pending: boolean;

--- a/src/shared/ui/route-feedback/RouteFeedback.tsx
+++ b/src/shared/ui/route-feedback/RouteFeedback.tsx
@@ -6,8 +6,8 @@
 
 import type * as React from "react";
 
-import { Button, type ButtonVariant } from "@/shared/ui/button";
-import { Layout } from "@/shared/ui/layout";
+import { Button, type ButtonVariant } from "../button";
+import { Layout } from "../layout";
 
 type RouteFeedbackTone = "loading" | "error" | "not-found";
 

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -6,9 +6,7 @@ export default defineConfig([
   ...fsd.configs.recommended,
   {
     rules: {
-      "fsd/forbidden-imports": "error",
-      "fsd/no-public-api-sidestep": "error",
-      "fsd/public-api": "error",
+      "fsd/import-locality": "error",
     },
   },
 ]);


### PR DESCRIPTION
## Related issue

None

## Summary

- Enable `fsd/import-locality` as an error on top of the FSD recommended Steiger rules.
- Remove the redundant ESLint `boundaries/dependencies` rule that enforced relative imports within the same slice.
- Keep the remaining ESLint boundary and presentation-specific rules because they cover project-specific concerns outside Steiger import locality.
- Remove redundant explicit Steiger overrides already enabled by the recommended config.

## Testing

- GitHub Actions CI