### PR TITLE
[No issue] Show deck deletion on deck form

### DIFF
--- a/src/features/deck-deletion/index.ts
+++ b/src/features/deck-deletion/index.ts
@@ -1,0 +1,2 @@
+export { useDeckDeletion } from "./model/useDeckDeletion";
+export { DeckDeletionDialog } from "./ui/DeckDeletionDialog";

--- a/src/features/deck-deletion/model/useDeckDeletion.ts
+++ b/src/features/deck-deletion/model/useDeckDeletion.ts
@@ -9,7 +9,17 @@ interface DeckDeletionTarget {
   cardCount: number;
 }
 
-export const useDeckDeletion = () => {
+export interface DeckDeletionTargetView {
+  deckName: string;
+  cardCount: number;
+  hasError: boolean;
+}
+
+interface UseDeckDeletionOptions {
+  onDeleted?: () => void;
+}
+
+export const useDeckDeletion = ({ onDeleted }: UseDeckDeletionOptions = {}) => {
   const uid = useAuthUid();
   const cards = useCards();
   const decks = useDecks();
@@ -34,6 +44,7 @@ export const useDeckDeletion = () => {
       await deleteDeck(uid, target.deck.id);
       setTarget(undefined);
       setSuccessMessage(`Deleted deck “${target.deck.name}”.`);
+      onDeleted?.();
     } catch {
       // Keep the target open so a transient write failure can be retried without losing user intent.
       setHasError(true);

--- a/src/features/deck-deletion/ui/DeckDeletionDialog.tsx
+++ b/src/features/deck-deletion/ui/DeckDeletionDialog.tsx
@@ -1,0 +1,32 @@
+import type * as React from "react";
+
+import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
+
+import type { DeckDeletionTargetView } from "../model/useDeckDeletion";
+
+interface DeckDeletionDialogProps {
+  target: DeckDeletionTargetView;
+  onCancel: () => void;
+  onConfirm: () => Promise<void>;
+}
+
+export const DeckDeletionDialog: React.FC<DeckDeletionDialogProps> = ({ target, onCancel, onConfirm }) => (
+  <DestructiveActionDialog
+    title="Delete deck?"
+    targetLabel="Deck"
+    targetName={target.deckName}
+    confirmLabel="Delete deck"
+    {...(target.hasError ? { errorMessage: "Unable to delete this deck. Check your connection and try again." } : {})}
+    description={
+      <>
+        <p>
+          This permanently deletes {target.cardCount} {target.cardCount === 1 ? "card" : "cards"} in this deck.
+        </p>
+        <p>Any in-progress study session for this deck will also end.</p>
+        <p>This action cannot be undone.</p>
+      </>
+    }
+    onCancel={onCancel}
+    onConfirm={onConfirm}
+  />
+);

--- a/src/pages/deck-form/ui/DeckEditor.spec.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.spec.tsx
@@ -43,7 +43,9 @@ const DeckEditorHarness = (props: { deckId: string; onCancel: () => void; onSave
   const editor = useDeckFormState({ deckId: props.deckId, onCancel: props.onCancel, onSaved: props.onSaved });
 
   if (editor == null) return null;
-  return <DeckEditor deckName={editor.deckName} form={editor.form} saveError={editor.saveError} />;
+  return (
+    <DeckEditor deckName={editor.deckName} form={editor.form} saveError={editor.saveError} onDelete={() => undefined} />
+  );
 };
 
 // A fresh Entity read after remount proves that the form displays the last successful edit.

--- a/src/pages/deck-form/ui/DeckEditor.stories.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.stories.tsx
@@ -40,6 +40,7 @@ const meta = {
   args: {
     deckName: fixture.deck.default.name,
     form: createForm(fixture.deck.default),
+    onDelete: () => undefined,
   },
 } satisfies Meta<typeof DeckEditor>;
 

--- a/src/pages/deck-form/ui/DeckEditor.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 import { AiOutlineArrowLeft } from "react-icons/ai";
 
+import { Button } from "@/shared/ui/button";
 import { Feedback } from "@/shared/ui/feedback";
 
 import type { DeckFormProps } from "../model/useDeckFormState";
@@ -10,9 +11,10 @@ export interface DeckEditorProps {
   deckName: string;
   form: DeckFormProps;
   saveError?: unknown;
+  onDelete: () => void;
 }
 
-export const DeckEditor: React.FC<DeckEditorProps> = ({ deckName, form, saveError }) => (
+export const DeckEditor: React.FC<DeckEditorProps> = ({ deckName, form, saveError, onDelete }) => (
   <section className="mx-auto w-full max-w-reading overflow-hidden rounded-surface border border-border bg-surface p-4 md:p-6">
     <header className="mb-section-gap">
       <button
@@ -29,5 +31,17 @@ export const DeckEditor: React.FC<DeckEditorProps> = ({ deckName, form, saveErro
     </header>
     <Feedback tone="error">{saveError == null ? null : "Unable to save changes. Try again."}</Feedback>
     <DeckForm {...form} />
+    <section
+      aria-labelledby="delete-deck-heading"
+      className="mt-section-gap rounded-surface border border-danger p-4 md:p-5"
+    >
+      <h2 id="delete-deck-heading" className="text-title font-semibold text-danger">
+        Danger zone
+      </h2>
+      <p className="mt-1 text-body text-ink-muted">Permanently delete this deck, its cards, and study session.</p>
+      <Button className="mt-4" variant="destructive" onClick={onDelete}>
+        Delete deck
+      </Button>
+    </section>
   </section>
 );

--- a/src/pages/deck-form/ui/DeckFormContainer.tsx
+++ b/src/pages/deck-form/ui/DeckFormContainer.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 
+import { DeckDeletionDialog, useDeckDeletion } from "@/features/deck-deletion";
 import { routes, useNavigation } from "@/features/navigate";
 import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
@@ -11,6 +12,7 @@ export const DeckFormContainer: React.FC<{ deckId: string }> = ({ deckId }) => {
   const navigation = useNavigation();
   const goToList = () => void navigation.to(routes.deckList.to(), { replace: true });
   const editor = useDeckFormState({ deckId, onCancel: goToList, onSaved: goToList });
+  const deletion = useDeckDeletion({ onDeleted: goToList });
 
   if (editor == null) {
     return (
@@ -20,7 +22,15 @@ export const DeckFormContainer: React.FC<{ deckId: string }> = ({ deckId }) => {
 
   return (
     <AppLayout showHeader>
-      <DeckEditor deckName={editor.deckName} form={editor.form} saveError={editor.saveError} />
+      {deletion.target != null && (
+        <DeckDeletionDialog target={deletion.target} onCancel={deletion.cancel} onConfirm={deletion.confirm} />
+      )}
+      <DeckEditor
+        deckName={editor.deckName}
+        form={editor.form}
+        saveError={editor.saveError}
+        onDelete={() => deletion.request(editor.form.deckInfo.id)}
+      />
     </AppLayout>
   );
 };

--- a/src/pages/deck-form/ui/DeckFormPage.spec.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.spec.tsx
@@ -1,6 +1,6 @@
 import type { Preferences } from "@/entities/preference";
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -75,6 +75,25 @@ describe("DeckFormPage", () => {
     renderPage();
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck list" })).toBeVisible();
+  });
+
+  it("deletes the deck from its settings page after confirmation", async () => {
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete deck" }));
+    const dialog = screen.getByRole("alertdialog", { name: "Delete deck?" });
+    expect(dialog).toHaveTextContent("Deck name");
+    expect(dialog).toHaveTextContent("This permanently deletes 0 cards in this deck.");
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Deck name" })).toBeVisible();
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete deck" }));
+    await userEvent.click(
+      within(screen.getByRole("alertdialog", { name: "Delete deck?" })).getByRole("button", { name: "Delete deck" })
+    );
 
     expect(await screen.findByRole("heading", { level: 1, name: "Deck list" })).toBeVisible();
   });

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -2,13 +2,12 @@ import type * as React from "react";
 import { useKey } from "react-use";
 
 import { touchStudySession } from "@/entities/study-session";
+import { DeckDeletionDialog, useDeckDeletion } from "@/features/deck-deletion";
 import { useAddSampleDeck } from "@/features/deck-import";
 import { routes, useNavigation } from "@/features/navigate";
-import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 import { Feedback } from "@/shared/ui/feedback";
 import { AppLayout } from "@/widgets/app-layout";
 
-import { useDeckDeletion } from "../model/useDeckDeletion";
 import { useDeckExport } from "../model/useDeckExport";
 import { useDeckListState } from "../model/useDeckListState";
 import { DeckList } from "./DeckList";
@@ -33,27 +32,7 @@ export const DeckListPage: React.FC = () => {
     <AppLayout showHeader>
       <Feedback tone="success">{deletion.successMessage}</Feedback>
       {deletion.target != null && (
-        <DestructiveActionDialog
-          title="Delete deck?"
-          targetLabel="Deck"
-          targetName={deletion.target.deckName}
-          confirmLabel="Delete deck"
-          {...(deletion.target.hasError
-            ? { errorMessage: "Unable to delete this deck. Check your connection and try again." }
-            : {})}
-          description={
-            <>
-              <p>
-                This permanently deletes {deletion.target.cardCount}{" "}
-                {deletion.target.cardCount === 1 ? "card" : "cards"} in this deck.
-              </p>
-              <p>Any in-progress study session for this deck will also end.</p>
-              <p>This action cannot be undone.</p>
-            </>
-          }
-          onCancel={deletion.cancel}
-          onConfirm={deletion.confirm}
-        />
+        <DeckDeletionDialog target={deletion.target} onCancel={deletion.cancel} onConfirm={deletion.confirm} />
       )}
       <DeckList
         sections={deckList.sections}


### PR DESCRIPTION
## Related issue

None.

## Summary

- show a destructive delete action on the deck settings page
- reuse the deck deletion confirmation and workflow across deck list and deck form pages
- return to the deck list after a successful deletion

## Testing

- `mise run check`