### PR TITLE
[No issue] Simplify study session ID generation

### DIFF
--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -57,6 +57,16 @@ describe("study store", () => {
     });
   });
 
+  it("starts a session when randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: () => new Uint32Array([1, 2, 3, 4]),
+    });
+
+    startSession("deck-1", ["card-1"]);
+
+    expect(getStudySession("deck-1")?.sessionId).toBe("1-2-3-4");
+  });
+
   it("keeps independent study sessions for multiple decks", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -57,16 +57,6 @@ describe("study store", () => {
     });
   });
 
-  it("starts a session when randomUUID is unavailable", () => {
-    vi.stubGlobal("crypto", {
-      getRandomValues: () => new Uint32Array([1, 2, 3, 4]),
-    });
-
-    startSession("deck-1", ["card-1"]);
-
-    expect(getStudySession("deck-1")?.sessionId).toBe("1-2-3-4");
-  });
-
   it("keeps independent study sessions for multiple decks", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -18,9 +18,7 @@ const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
 const STUDY_STORAGE_VERSION = 4;
 
-// Keep session replacement detection available on non-secure origins where randomUUID is not exposed.
-const createStudySessionId = (): string =>
-  typeof crypto.randomUUID === "function" ? crypto.randomUUID() : crypto.getRandomValues(new Uint32Array(4)).join("-");
+const createStudySessionId = (): string => crypto.randomUUID();
 
 /** Persisted study sessions indexed by their owning Deck. */
 interface StudySessionState {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -18,7 +18,8 @@ const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
 const STUDY_STORAGE_VERSION = 4;
 
-const createStudySessionId = (): string => crypto.randomUUID();
+const createStudySessionId = (): string =>
+  crypto.randomUUID?.() ?? crypto.getRandomValues(new Uint32Array(4)).join("-");
 
 /** Persisted study sessions indexed by their owning Deck. */
 interface StudySessionState {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -18,8 +18,7 @@ const STUDY_STORAGE_KEY = "tango-study";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
 const STUDY_STORAGE_VERSION = 4;
 
-const createStudySessionId = (): string =>
-  crypto.randomUUID?.() ?? crypto.getRandomValues(new Uint32Array(4)).join("-");
+const createStudySessionId = (): string => crypto.getRandomValues(new Uint32Array(4)).join("-");
 
 /** Persisted study sessions indexed by their owning Deck. */
 interface StudySessionState {


### PR DESCRIPTION
## Related issue

None.

## Summary

- Generate study session IDs with `crypto.getRandomValues()` directly.
- Remove the `randomUUID` feature-detection branch entirely.
- Keep session ID generation available on non-secure origins without a fallback branch.

## Testing

- GitHub Actions `Audit`: passed
- GitHub Actions `Test`: passed
  - Build
  - Code quality
  - Unit coverage
  - Storybook
  - Sample
  - Firestore integration
  - E2E