### PR TITLE
fix(#512): Simplify deck import UI operations

### DIFF
--- a/src/features/deck-import/model/useDeckImport.spec.tsx
+++ b/src/features/deck-import/model/useDeckImport.spec.tsx
@@ -121,8 +121,20 @@ describe("useDeckImport", () => {
         issues: [expect.objectContaining({ rowNumber: 1, message: "Expected 4 columns, found 2." })],
       },
     });
-    await expect(result.current.deckImport.importPreview()).rejects.toThrow("Fix invalid CSV rows");
+    await expect(result.current.deckImport.importPreview()).resolves.toBeUndefined();
     expect(findDeck(result.current.decks, name)).toBeUndefined();
+  });
+
+  it("exposes a file read failure without rejecting the UI operation", async () => {
+    const { result } = renderDeckImport();
+    const file = csvFile("unreadable.csv");
+    vi.spyOn(file, "text").mockRejectedValue(new Error("file read failed"));
+
+    await actAsync(async () => {
+      await expect(result.current.deckImport.selectFile(file)).resolves.toBeUndefined();
+    });
+
+    expect(result.current.deckImport.previewError).toEqual(new Error("file read failed"));
   });
 
   it("clears a prepared preview when the destination changes", async () => {
@@ -134,7 +146,7 @@ describe("useDeckImport", () => {
 
     expect(result.current.deckImport.storageMode).toBe("remote");
     expect(result.current.deckImport.preview).toBeUndefined();
-    await expect(result.current.deckImport.importPreview()).rejects.toThrow("Select a CSV file");
+    await expect(result.current.deckImport.importPreview()).resolves.toBeUndefined();
   });
 
   it("retries a failed save with the same new Deck", async () => {
@@ -146,7 +158,7 @@ describe("useDeckImport", () => {
     controls.nextMutationError = new Error("card mutation failed");
 
     await actAsync(async () => {
-      await expect(result.current.deckImport.importPreview()).rejects.toThrow("card mutation failed");
+      await expect(result.current.deckImport.importPreview()).resolves.toBeUndefined();
     });
 
     const savedDeck = findDeck(result.current.decks, name);
@@ -172,6 +184,18 @@ describe("useDeckImport", () => {
       result.current.cards.filter((card) => card.deckId === sampleDeck?.id).every((card) => !("uid" in card))
     ).toBe(true);
     expect(result.current.preferences.loadSample).toBe(false);
+  });
+
+  it("keeps the sample bootstrap enabled and exposes an add failure", async () => {
+    const { result } = renderDeckImport();
+    controls.nextMutationError = new Error("sample mutation failed");
+
+    await actAsync(async () => {
+      await expect(result.current.deckImport.addSample()).resolves.toBeUndefined();
+    });
+
+    expect(result.current.deckImport.error).toEqual(new Error("sample mutation failed"));
+    expect(result.current.preferences.loadSample).toBe(true);
   });
 
   it("keeps repeated sample imports idempotent", async () => {

--- a/src/features/deck-import/model/useDeckImport.ts
+++ b/src/features/deck-import/model/useDeckImport.ts
@@ -22,7 +22,7 @@ export const useDeckImport = () => {
     execution.clear();
     setStatus("validating");
     try {
-      return await preview.selectFile(file);
+      await preview.selectFile(file);
     } finally {
       setStatus("idle");
     }
@@ -33,11 +33,10 @@ export const useDeckImport = () => {
   };
 
   const runImport = async (prepare: () => PreparedDeckImport) => {
-    const preparedImport = prepare();
     preview.clearError();
     setStatus("importing");
     try {
-      return await execution.run(preparedImport);
+      return await execution.run(prepare);
     } finally {
       setStatus("idle");
     }
@@ -45,13 +44,15 @@ export const useDeckImport = () => {
 
   const importPreview = async () => {
     const result = await runImport(preview.getPreparedImport);
-    // Preserve generated IDs after a failed write so retrying cannot create another partial Deck.
+    if (result === undefined) return;
+    // Failed writes retain generated IDs so retrying cannot create another partial Deck.
     preview.completePreparedImport();
     return result;
   };
 
   const addSample = async () => {
     const result = await runImport(() => prepareSampleDeck(uid));
+    if (result === undefined) return;
     // Explicit imports remain available, but a successful one also satisfies the automatic bootstrap permanently.
     updatePreferences({ loadSample: false });
     return result;

--- a/src/features/deck-import/model/useDeckImportExecution.ts
+++ b/src/features/deck-import/model/useDeckImportExecution.ts
@@ -116,20 +116,20 @@ export const useDeckImportExecution = (uid: string) => {
     setState((current) => ({ ...current, ...update }));
   };
 
-  const run = async (preparedImport: PreparedDeckImport) => {
+  const run = async (prepare: () => PreparedDeckImport): Promise<DeckImportResult | undefined> => {
     updateState({ error: null });
+    let importResult: DeckImportResult | undefined;
     try {
-      const importResult = await executePreparedDeckImport(preparedImport, {
+      importResult = await executePreparedDeckImport(prepare(), {
         uid,
         createDeck: (deck) => persistDeck(uid, deck),
         mutateCards: (mutations) => persistCardMutations(uid, mutations),
       });
       updateState({ result: importResult });
-      return importResult;
     } catch (caughtError) {
       updateState({ result: undefined, error: caughtError });
-      throw caughtError;
     }
+    return importResult;
   };
 
   return {

--- a/src/features/deck-import/model/useDeckImportPreview.ts
+++ b/src/features/deck-import/model/useDeckImportPreview.ts
@@ -49,10 +49,8 @@ export const useDeckImportPreview = (uid: string) => {
       const preview = { deckName: file.name, analysis };
       preparedImportRef.current.preparedImport = preparedImport;
       updateState({ preview });
-      return preview;
     } catch (caughtError) {
       updateState({ error: caughtError });
-      throw caughtError;
     }
   };
 

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -130,4 +130,15 @@ describe("DeckImportPage", () => {
     expect(screen.getByText(name)).toBeVisible();
     expect(screen.getByText("front: retry back")).toBeVisible();
   });
+
+  it("shows a failed sample add in place", async () => {
+    renderPage();
+    controls.nextMutationError = new Error("sample mutation failed");
+
+    await userEvent.click(screen.getByRole("button", { name: "Add sample deck" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Import failed");
+    expect(screen.getByRole("alert")).toHaveTextContent("sample mutation failed");
+    expect(screen.getByRole("heading", { level: 1, name: "Import decks" })).toBeVisible();
+  });
 });

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -18,16 +18,15 @@ export const DeckImportPage: React.FC = () => {
         storageMode={deckImport.storageMode}
         onStorageModeChange={deckImport.setStorageMode}
         onChange={(file) => {
-          void deckImport.selectFile(file).catch(() => undefined);
+          void deckImport.selectFile(file);
         }}
         onAddSample={() => {
-          void deckImport.addSample().catch(() => undefined);
+          void deckImport.addSample();
         }}
         onImport={() => {
-          void deckImport
-            .importPreview()
-            .then(() => navigate(routes.deckList.to()))
-            .catch(() => undefined);
+          void deckImport.importPreview().then((result) => {
+            if (result !== undefined) void navigate(routes.deckList.to());
+          });
         }}
         onBack={() => void navigate(-1)}
         onDownloadSample={downloadSampleCsv}


### PR DESCRIPTION
## Related issue

Fixes #512

## Summary

- Resolve Deck import UI operations through the existing error states instead of rejected promises.
- Navigate to the Deck list only after a successful preview import.
- Cover file read, import, and sample add failures with behavior tests.

## Testing

- mise run check