### PR TITLE
[No issue] Make card text use available width

### DIFF
--- a/src/features/card-view/ui/BackText.tsx
+++ b/src/features/card-view/ui/BackText.tsx
@@ -23,7 +23,7 @@ export interface BackTextProps {
 export const BackText: React.FC<BackTextProps> = (props) => (
   <Style
     div
-    className="mx-auto h-full w-full max-w-reading overflow-x-hidden p-section-gap"
+    className="mx-auto h-full w-full overflow-x-hidden p-section-gap"
     {...(props.onClick !== undefined ? { onClick: props.onClick } : {})}
   >
     {props.category === "math" ? (

--- a/src/features/card-view/ui/CardView.tsx
+++ b/src/features/card-view/ui/CardView.tsx
@@ -27,7 +27,7 @@ export const CardView: React.FC<CardViewProps> = ({ text, category, code, dark, 
   return (
     <section
       aria-label="Card answer"
-      className="mx-auto w-full max-w-reading rounded-surface bg-surface-elevated text-ink shadow-surface"
+      className="mx-auto w-full rounded-surface bg-surface-elevated text-ink shadow-surface"
     >
       {content}
     </section>

--- a/src/features/card-view/ui/FrontText.tsx
+++ b/src/features/card-view/ui/FrontText.tsx
@@ -37,7 +37,7 @@ export const FrontText: React.FC<FrontTextProps> = (props) => {
     <div
       id="frontText"
       className={cx(
-        "mx-auto flex h-full w-full max-w-reading min-w-0 items-center justify-center break-words p-section-gap text-ink"
+        "mx-auto flex h-full w-full min-w-0 items-center justify-center break-words p-section-gap text-ink"
       )}
       {...clickInteraction}
       {...handlers}


### PR DESCRIPTION
## Related issue

None.

## Summary

- Remove the reading-width cap from the front text, back text, and card answer surface.
- Let card content use the available viewport or page width on larger screens while retaining responsive mobile sizing.

## Testing

- mise run check
- Storybook width verification at 1440px and 390px