### PR TITLE
feat(#951): Add session-preserving Study exit

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 
@@ -10,6 +10,7 @@ describe("StudySession", () => {
   it("gives swipe overlays accessible names", () => {
     render(
       <StudySession
+        onExit={vi.fn()}
         showBackText
         backTextSlot={<div>Back</div>}
         swipeOverlay={{
@@ -26,5 +27,17 @@ describe("StudySession", () => {
     expect(screen.getByRole("button", { name: "Swipe up" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Swipe down" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
+  });
+
+  it("reports the explicit Exit action through a plain callback", () => {
+    const onExit = vi.fn();
+    render(<StudySession onExit={onExit} frontTextSlot={<div>Front</div>} />);
+
+    const exit = screen.getByRole("button", { name: "Exit" });
+    expect(exit).toBeVisible();
+
+    fireEvent.click(exit);
+
+    expect(onExit).toHaveBeenCalledOnce();
   });
 });

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -31,10 +31,15 @@ describe("StudySession", () => {
 
   it("reports the explicit Exit action through a plain callback", () => {
     const onExit = vi.fn();
-    render(<StudySession onExit={onExit} frontTextSlot={<div>Front</div>} />);
+    render(
+      <StudySession onExit={onExit} cardOverlaySlot={<div>Card metadata</div>} frontTextSlot={<div>Front</div>} />
+    );
 
     const exit = screen.getByRole("button", { name: "Exit" });
+    const actions = screen.getByRole("toolbar", { name: "Study actions" });
     expect(exit).toBeVisible();
+    expect(actions).toContainElement(exit);
+    expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
     fireEvent.click(exit);
 

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
 
 import * as fixture from "@/storybook/fixture";
 
@@ -18,6 +19,7 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
+    onExit: fn(),
     showSwipeButtonList: true,
     frontTextSlot: <div>front text</div>,
   },

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -15,6 +15,7 @@ const SWIPE_FEEDBACK_LABEL: Record<SwipeDirection, string> = {
 };
 
 export interface StudySessionProps {
+  showHeader?: boolean;
   showBackText?: boolean;
   showSwipeButtonList?: boolean;
   showController?: boolean;
@@ -29,9 +30,16 @@ export interface StudySessionProps {
   onExit: () => void;
 }
 
-const ExitAction: React.FC<{ onExit: () => void }> = ({ onExit }) => (
-  // Keep Exit below the optional Header's footprint so it remains usable in either Header state.
-  <div className="fixed left-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] top-[calc(var(--spacing-touch)+1.5rem+env(safe-area-inset-top))] z-40">
+const ExitAction: React.FC<{ showHeader: boolean | undefined; onExit: () => void }> = ({ showHeader, onExit }) => (
+  // This row reserves space above card metadata; safe-area padding is needed only when Header does not provide it.
+  <div
+    role="toolbar"
+    aria-label="Study actions"
+    className={cx(
+      "relative z-40 flex shrink-0 pb-2 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]",
+      showHeader ? "pt-2" : "pt-[calc(0.5rem+env(safe-area-inset-top))]"
+    )}
+  >
     <Button size="sm" variant="quiet" onClick={onExit}>
       Exit
     </Button>
@@ -118,17 +126,19 @@ const Controls: React.FC<{
 };
 
 export const StudySession: React.FC<StudySessionProps> = (props) => (
-  <>
+  <div className="flex h-full min-h-0 flex-col">
     {props.feedbackSlot}
-    <ExitAction onExit={props.onExit} />
+    <ExitAction showHeader={props.showHeader} onExit={props.onExit} />
     <SwipeFeedback swipeFeedback={props.swipeFeedback} />
-    <CardContent
-      showBackText={props.showBackText}
-      backTextSlot={props.backTextSlot}
-      frontTextSlot={props.frontTextSlot}
-      cardOverlaySlot={props.cardOverlaySlot}
-      swipeOverlay={props.swipeOverlay}
-    />
+    <div className="relative min-h-0 flex-1">
+      <CardContent
+        showBackText={props.showBackText}
+        backTextSlot={props.backTextSlot}
+        frontTextSlot={props.frontTextSlot}
+        cardOverlaySlot={props.cardOverlaySlot}
+        swipeOverlay={props.swipeOverlay}
+      />
+    </div>
     <Controls
       showBackText={props.showBackText}
       showSwipeButtonList={props.showSwipeButtonList}
@@ -136,5 +146,5 @@ export const StudySession: React.FC<StudySessionProps> = (props) => (
       swipeButtonList={props.swipeButtonList}
       controller={props.controller}
     />
-  </>
+  </div>
 );

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import type * as React from "react";
 import type { SwipeDirection } from "@/entities/preference";
+import { Button } from "@/shared/ui/button";
 import { Overlay } from "@/shared/ui/feedback";
 
 import { Controller, type ControllerProps } from "./Controller";
@@ -25,7 +26,17 @@ export interface StudySessionProps {
   controller?: ControllerProps;
   swipeButtonList?: SwipeButtonListProps;
   feedbackSlot?: React.ReactNode;
+  onExit: () => void;
 }
+
+const ExitAction: React.FC<{ onExit: () => void }> = ({ onExit }) => (
+  // Keep Exit below the optional Header's footprint so it remains usable in either Header state.
+  <div className="fixed left-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] top-[calc(var(--spacing-touch)+1.5rem+env(safe-area-inset-top))] z-40">
+    <Button size="sm" variant="quiet" onClick={onExit}>
+      Exit
+    </Button>
+  </div>
+);
 
 const SwipeFeedback: React.FC<{ swipeFeedback: SwipeDirection | undefined }> = ({ swipeFeedback }) => {
   if (swipeFeedback === undefined) return null;
@@ -109,6 +120,7 @@ const Controls: React.FC<{
 export const StudySession: React.FC<StudySessionProps> = (props) => (
   <>
     {props.feedbackSlot}
+    <ExitAction onExit={props.onExit} />
     <SwipeFeedback swipeFeedback={props.swipeFeedback} />
     <CardContent
       showBackText={props.showBackText}

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -21,7 +21,7 @@ type StudyShortcutAction =
   | "toggleSwipeButtonList"
   | "toggleAutoPlay";
 
-const renderStudyScreen = (state: StudyState | undefined) => {
+const renderStudyScreen = (state: StudyState | undefined, onExit: () => void) => {
   if (state == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
 
   if (state.status !== "studying") {
@@ -43,6 +43,7 @@ const renderStudyScreen = (state: StudyState | undefined) => {
   return (
     <AppLayout fullscreen scroll={state.showBackText} showHeader={state.showHeader}>
       <StudySession
+        onExit={onExit}
         showController={state.showController}
         showBackText={state.showBackText}
         showSwipeButtonList={state.showSwipeButtonList}
@@ -84,6 +85,7 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
   const navigate = useNavigate();
   const study = useStudy(deckId);
   const latestStudy = useLatest(study);
+  const exit = () => void navigate(routes.cardList.to(deckId));
   const runWhileStudying = (action: StudyShortcutAction) => () => {
     const currentStudy = latestStudy.current;
     if (currentStudy?.status === "studying") void currentStudy[action]();
@@ -104,7 +106,7 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
     void navigate(routes.deckList.to(), { replace: true });
   }, [navigate, study?.status]);
 
-  return renderStudyScreen(study);
+  return renderStudyScreen(study, exit);
 };
 
 export const StudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) => {

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -44,6 +44,7 @@ const renderStudyScreen = (state: StudyState | undefined, onExit: () => void) =>
     <AppLayout fullscreen scroll={state.showBackText} showHeader={state.showHeader}>
       <StudySession
         onExit={onExit}
+        showHeader={state.showHeader}
         showController={state.showController}
         showBackText={state.showBackText}
         showSwipeButtonList={state.showSwipeButtonList}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -1,13 +1,13 @@
 import type { Preferences } from "@/entities/preference";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 import { deleteCard, mutateCards } from "@/entities/card";
 import { createDeck } from "@/entities/deck";
-import { clearStudySessions, startStudy } from "@/entities/study-session";
+import { clearStudySessions, getStudySession, startStudy } from "@/entities/study-session";
 import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -47,6 +47,11 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { StudySessionPage } from "./StudySessionPage";
 
+const CardListDestination = () => {
+  const { id } = useParams();
+  return <h1>Cards for {id}</h1>;
+};
+
 describe("StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
@@ -73,6 +78,7 @@ describe("StudySessionPage", () => {
       <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/deck/:id" element={<CardListDestination />} />
           <Route path="/deck/:id/study" element={<StudySessionPage />} />
         </Routes>
       </MemoryRouter>
@@ -118,6 +124,26 @@ describe("StudySessionPage", () => {
 
     await waitFor(() => expect(screen.getByText("Front two")).toBeVisible());
     expect(screen.queryByText("Front one")).not.toBeInTheDocument();
+  });
+
+  it("exits a deep-linked Study to the same Deck without changing the resumable session", () => {
+    renderPage();
+    const sessionBeforeExit = getStudySession(deckId);
+
+    fireEvent.click(screen.getByRole("button", { name: "Exit" }));
+
+    expect(screen.getByRole("heading", { level: 1, name: `Cards for ${deckId}` })).toBeVisible();
+    expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
+    expect(mocks.removeStudySession).not.toHaveBeenCalled();
+  });
+
+  it("keeps Exit available when the Header is hidden", () => {
+    mocks.preferences = createPreferences({ appearance: { darkMode: false, showHeader: false } });
+
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Exit" })).toBeVisible();
   });
 
   it("shows loading feedback while active session cards are unavailable", async () => {

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -105,6 +105,7 @@ describe("StudySessionPage", () => {
     renderPage();
 
     expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
+    expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
     expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });
@@ -143,7 +144,10 @@ describe("StudySessionPage", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
+    expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Exit" })).toBeVisible();
+    expect(screen.getByLabelText("Score 2, positive")).toBeVisible();
+    expect(screen.getByText(/3 times/)).toBeVisible();
   });
 
   it("shows loading feedback while active session cards are unavailable", async () => {


### PR DESCRIPTION
## Related issue

Fixes #951

## Summary

- Add an always-available, touch-sized Exit action to the Study presentation.
- Navigate to the current Deck card list without removing or completing the resumable Study session.
- Cover the plain callback, hidden Header state, deep-link destination, and session preservation.

## Testing

- `mise run check`