### PR TITLE
No issue: Configure reviewer subagent workflow

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,24 +1,18 @@
 name = "reviewer"
-description = "Read-only final reviewer for correctness, regressions, security, architecture, and missing tests."
+description = "Non-editing reviewer for correctness, security, architecture, and tests."
 model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
-Review the current task's changes like a repository owner. Do not edit files.
+Review the current task's changes. Do not edit files.
 
-Start from the user's request and every applicable AGENTS.md instruction. Inspect all
-changes relative to origin/main, including committed, staged, unstaged, and untracked
-files. Read the surrounding code needed to verify behavior rather than reviewing the
-diff in isolation.
+Read the request and applicable AGENTS.md files. Review the three-dot diff against
+origin/main, plus staged, unstaged, and untracked changes. Inspect surrounding code.
 
-Prioritize concrete defects: incorrect behavior, regressions, security or privacy
-risks, unsafe asynchronous ordering, broken compatibility, Feature-Sliced Design
-violations, missing intent comments for non-obvious constraints, and tests that are
-missing or coupled to implementation details. Ignore style-only preferences unless
-they hide a real maintenance or correctness risk.
+Find concrete correctness, regression, security, privacy, concurrency, compatibility,
+Feature-Sliced Design, intent-comment, and test issues. Ignore style-only or
+speculative concerns.
 
-For each finding, report a P0-P3 severity, a concise title, the exact file and narrow
-line range, evidence, user impact, and a practical direction for fixing it. Do not
-report speculative concerns without a plausible failure mode. If there are no
-findings, say so explicitly and mention any residual validation gaps.
+For each finding, report P0-P3 severity, the file and narrow line range, evidence,
+impact, and fix direction. If none, say so and note validation gaps.
 """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -5,6 +5,7 @@ model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 Review the current task's changes. Do not edit files.
+Do not delegate work to other agents.
 
 Read the request and applicable AGENTS.md files. Review the three-dot diff against
 origin/main, plus staged, unstaged, and untracked changes. Inspect surrounding code.
@@ -13,6 +14,6 @@ Find concrete correctness, regression, security, privacy, concurrency, compatibi
 Feature-Sliced Design, intent-comment, and test issues. Ignore style-only or
 speculative concerns.
 
-For each finding, report P0-P3 severity, the file and narrow line range, evidence,
+For each finding, report P0-P2 severity, the file and narrow line range, evidence,
 impact, and fix direction. If none, say so and note validation gaps.
 """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,24 @@
+name = "reviewer"
+description = "Read-only final reviewer for correctness, regressions, security, architecture, and missing tests."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review the current task's changes like a repository owner. Do not edit files.
+
+Start from the user's request and every applicable AGENTS.md instruction. Inspect all
+changes relative to origin/main, including committed, staged, unstaged, and untracked
+files. Read the surrounding code needed to verify behavior rather than reviewing the
+diff in isolation.
+
+Prioritize concrete defects: incorrect behavior, regressions, security or privacy
+risks, unsafe asynchronous ordering, broken compatibility, Feature-Sliced Design
+violations, missing intent comments for non-obvious constraints, and tests that are
+missing or coupled to implementation details. Ignore style-only preferences unless
+they hide a real maintenance or correctness risk.
+
+For each finding, report a P0-P3 severity, a concise title, the exact file and narrow
+line range, evidence, user impact, and a practical direction for fixing it. Do not
+report speculative concerns without a plausible failure mode. If there are no
+findings, say so explicitly and mention any residual validation gaps.
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -14,6 +14,7 @@ Find concrete correctness, regression, security, privacy, concurrency, compatibi
 Feature-Sliced Design, intent-comment, and test issues. Ignore style-only or
 speculative concerns.
 
-For each finding, report P0-P2 severity, the file and narrow line range, evidence,
-impact, and fix direction. If none, say so and note validation gaps.
+Classify findings as P0 (must), P1 (recommend), or P2 (nit). For each finding,
+report the file and narrow line range, evidence, impact, and fix direction. If none,
+say so and note validation gaps.
 """

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@
 
 ## Review Workflow
 
-- After implementing non-documentation changes and running the required checks, delegate a final review to the project-scoped `reviewer` subagent.
-- Ask the reviewer to inspect every change relative to `origin/main`, including committed, staged, unstaged, and untracked files, then wait for its result before finishing.
-- Resolve every concrete finding or explain with evidence why it does not apply. After any non-documentation fix, rerun the relevant checks and the reviewer.
-- Keep the reviewer non-editing. It must not modify files.
+- After non-documentation changes pass the required checks, delegate a final review to `reviewer`.
+- Have it review the three-dot diff against `origin/main`, plus staged, unstaged, and untracked changes. Wait for the result.
+- Resolve each finding or reject it with evidence. After any non-documentation fix, rerun relevant checks and the review.
+- The reviewer must not edit files.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@
 - If `gh` fails in the sandbox, rerun it outside the sandbox.
 - Before finishing non-documentation changes, run `mise run check`.
 
+## Review Workflow
+
+- After implementing non-documentation changes and running the required checks, delegate a final review to the project-scoped `reviewer` subagent.
+- Ask the reviewer to inspect every change relative to `origin/main`, including committed, staged, unstaged, and untracked files, then wait for its result before finishing.
+- Resolve every concrete finding or explain with evidence why it does not apply. If a fix materially changes behavior, rerun the relevant checks and the reviewer.
+- Keep the reviewer read-only. It reports findings but does not edit files.
+
 ## Architecture
 
 - Follow the current official Feature-Sliced Design guidance before repository-specific placement preferences.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@
 
 - After implementing non-documentation changes and running the required checks, delegate a final review to the project-scoped `reviewer` subagent.
 - Ask the reviewer to inspect every change relative to `origin/main`, including committed, staged, unstaged, and untracked files, then wait for its result before finishing.
-- Resolve every concrete finding or explain with evidence why it does not apply. If a fix materially changes behavior, rerun the relevant checks and the reviewer.
-- Keep the reviewer read-only. It reports findings but does not edit files.
+- Resolve every concrete finding or explain with evidence why it does not apply. After any non-documentation fix, rerun the relevant checks and the reviewer.
+- Keep the reviewer non-editing. It must not modify files.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,11 @@
 
 ## Review Workflow
 
-- After non-documentation changes pass the required checks, delegate a final review to `reviewer`.
-- Have it review the three-dot diff against `origin/main`, plus staged, unstaged, and untracked changes. Wait for the result.
-- Resolve each finding or reject it with evidence. After any non-documentation fix, rerun relevant checks and the review.
-- The reviewer must not edit files.
+1. Delegate a review to the `reviewer` subagent.
+2. Fix every P0 finding. P1 and P2 findings are optional.
+3. After fixes, delegate another review.
+4. Stop when there are no P0 findings or after three review rounds.
+5. Report any unresolved findings to the user.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add a project-scoped, read-only reviewer subagent for correctness, regression, security, architecture, and test coverage checks.
- Require a final reviewer pass after implementation and validation, with concrete findings resolved before completion.

## Testing

- `mise run check`
- Parsed `.codex/agents/reviewer.toml` with Python `tomllib`
- Reviewer subagent reported no P0-P3 findings