### PR TITLE
feat(#204): Use native play/pause button in Study

### DIFF
--- a/src/pages/study-session/ui/Controller.spec.tsx
+++ b/src/pages/study-session/ui/Controller.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { Controller } from "./Controller";
@@ -9,7 +10,7 @@ describe("Controller", () => {
     const onToggleAutoPlay = vi.fn();
     render(<Controller autoPlay={false} onToggleAutoPlay={onToggleAutoPlay} />);
 
-    fireEvent.click(screen.getByTestId("play"));
+    fireEvent.click(screen.getByRole("button", { name: "Play" }));
 
     expect(onToggleAutoPlay).toHaveBeenCalledOnce();
   });
@@ -17,9 +18,22 @@ describe("Controller", () => {
   it("reflects the controlled autoplay value", () => {
     const { rerender } = render(<Controller autoPlay={false} />);
 
+    expect(screen.getByRole("button", { name: "Play" })).toHaveAttribute("type", "button");
+
     rerender(<Controller autoPlay />);
 
-    expect(screen.getByTestId("pause")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+  });
+
+  it("supports native keyboard activation", async () => {
+    const user = userEvent.setup();
+    const onToggleAutoPlay = vi.fn();
+    render(<Controller autoPlay={false} onToggleAutoPlay={onToggleAutoPlay} />);
+
+    screen.getByRole("button", { name: "Play" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(onToggleAutoPlay).toHaveBeenCalledOnce();
   });
 
   it("delegates manual index changes", () => {

--- a/src/pages/study-session/ui/Controller.tsx
+++ b/src/pages/study-session/ui/Controller.tsx
@@ -19,12 +19,19 @@ export const Controller: React.FC<ControllerProps> = (props) => {
 
   return (
     <IconContext.Provider value={{ className: "dark:text-gray-200 text-2xl" }}>
-      <div className="flex px-4 items-center">
-        {!autoPlay ? (
-          <AiOutlineCaretRight data-testid="play" onClick={props.onToggleAutoPlay} className="text-xl" />
-        ) : (
-          <AiOutlinePause data-testid="pause" onClick={props.onToggleAutoPlay} className="text-xl" />
-        )}
+      <div className="flex items-center px-4">
+        <button
+          type="button"
+          aria-label={autoPlay ? "Pause" : "Play"}
+          className="inline-flex size-touch shrink-0 items-center justify-center rounded-control text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          onClick={props.onToggleAutoPlay}
+        >
+          {autoPlay ? (
+            <AiOutlinePause aria-hidden="true" className="text-xl" />
+          ) : (
+            <AiOutlineCaretRight aria-hidden="true" className="text-xl" />
+          )}
+        </button>
         <div className="flex-1 px-2">
           <Slider
             min={0}


### PR DESCRIPTION
## Related issue

Fixes #204

## Summary

- Render the Study autoplay control as a native button with state-specific accessible names.
- Keep the play and pause icons decorative while matching existing touch-target and focus-visible styles.
- Query the control by role and accessible name and cover native keyboard activation in component tests.

## Testing

- mise run check