### PR TITLE
refactor(#342): Stabilize Storybook fixtures

### DIFF
--- a/.storybook/support/fixture.ts
+++ b/.storybook/support/fixture.ts
@@ -11,6 +11,9 @@ import type { Preferences } from "@/entities/preference";
 import type { Option } from "@/shared/ui/forms/Select";
 import { createCard, createDeck, createPreferences } from "@/test/factories";
 
+// Keeps time-based Storybook inputs stable without coupling production code to a Storybook clock.
+export const timestamp = Date.UTC(2026, 6, 1, 12, 0, 0);
+
 export const form = {
   options: {
     default: [
@@ -73,7 +76,7 @@ export const card = {
     score: 3,
     numberOfSeen: 5,
     tags: ["tag1", "tag2"],
-    lastSeenAt: Date.now(),
+    lastSeenAt: timestamp,
   }),
   long: createCard({
     frontText: "too long front text ".repeat(20),
@@ -81,7 +84,7 @@ export const card = {
     score: 3,
     numberOfSeen: 5,
     tags: ["tag1", "tag2"],
-    lastSeenAt: Date.now(),
+    lastSeenAt: timestamp,
   }),
   toolong: createCard({
     frontText: "too long front text ".repeat(20),
@@ -89,7 +92,7 @@ export const card = {
     score: 3,
     numberOfSeen: 5,
     tags: ["tag1", "tag2"],
-    lastSeenAt: Date.now(),
+    lastSeenAt: timestamp,
   }),
   longTags: createCard({
     frontText: "front text",
@@ -97,7 +100,7 @@ export const card = {
     score: 3,
     numberOfSeen: 5,
     tags: tags.toolong,
-    lastSeenAt: Date.now(),
+    lastSeenAt: timestamp,
   }),
 } as const satisfies Record<string, Card>;
 

--- a/src/features/card-view/ui/CardOverlay.stories.tsx
+++ b/src/features/card-view/ui/CardOverlay.stories.tsx
@@ -6,6 +6,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
+import * as fixture from "@/storybook/fixture";
+
 import { CardOverlay as Template } from "./CardOverlay";
 
 const meta = {
@@ -18,7 +20,7 @@ const meta = {
   args: {
     score: 1,
     numberOfSeen: 4,
-    lastSeenAt: Date.now(),
+    lastSeenAt: fixture.timestamp,
   },
 } satisfies Meta<typeof Template>;
 

--- a/src/pages/deck-list/ui/DeckList.stories.tsx
+++ b/src/pages/deck-list/ui/DeckList.stories.tsx
@@ -32,7 +32,7 @@ const studyingItems = (decks: Deck[]) =>
     studyProgress: {
       currentIndex: index + 1,
       cardCount: 12 + index * 7,
-      lastStudiedAt: Date.now() - index * 24 * 60 * 60 * 1000,
+      lastStudiedAt: fixture.timestamp - index * 24 * 60 * 60 * 1000,
     },
   }));
 
@@ -87,13 +87,9 @@ export const WithStudyProgress: Story = {
   args: { sections: { studying: studyingItems(fixture.decks.default), other: [] } },
 };
 
-export const Active: Story = WithStudyProgress;
-
 export const Empty: Story = {
   args: { sections: { studying: [], other: [] } },
 };
-
-export const EmptyComposition: Story = Empty;
 
 export const Long: Story = {
   args: { sections: longSections },
@@ -106,8 +102,6 @@ export const IphoneX: Story = {
     },
   },
 };
-
-export const MobileLight: Story = IphoneX;
 
 export const Dark: Story = {
   globals: {

--- a/src/pages/deck-list/ui/DeckListCard.stories.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.stories.tsx
@@ -31,27 +31,21 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Inactive: Story = {};
-
 export const WithStudyProgress: Story = {
   args: {
     studyProgress: {
       currentIndex: 0,
       cardCount: 3,
-      lastStudiedAt: Date.now() - 5 * 60 * 1000,
+      lastStudiedAt: fixture.timestamp - 5 * 60 * 1000,
     },
   },
 };
-
-export const Active: Story = WithStudyProgress;
 
 export const TooLongName: Story = {
   args: {
     deck: fixture.deck.tooLongName,
   },
 };
-
-export const LongTitle: Story = TooLongName;
 
 export const IphoneX: Story = {
   parameters: {
@@ -60,8 +54,6 @@ export const IphoneX: Story = {
     },
   },
 };
-
-export const MobileLight: Story = IphoneX;
 
 export const Dark: Story = {
   globals: {


### PR DESCRIPTION
## Related issue

Fixes #342

## Summary

- replace current-time Storybook fixture values with one fixed timestamp
- preserve meaningful timestamp offsets from the fixed base value
- remove duplicate Deck List and Deck List Card alias stories

## Testing

- npm run build:storybook
- npm run test:storybook
- mise run check