### PR TITLE
fix(#385): Stop autoplay at terminal Card

### DIFF
--- a/src/pages/study-session/model/useAutoPlay.ts
+++ b/src/pages/study-session/model/useAutoPlay.ts
@@ -16,13 +16,20 @@ export const useAutoPlay = (
 ) => {
   const [autoPlay, setAutoPlay] = React.useState(defaultAutoPlay);
   const onAdvanceEvent = React.useEffectEvent(onAdvance);
+  const activeAutoPlaySession =
+    sessionState.status === "studying" && autoPlay && cardInterval > 0 ? sessionState.session : undefined;
   const autoPlaySession =
-    sessionState.status === "studying" &&
-    autoPlay &&
-    cardInterval > 0 &&
-    canMoveStudySession(sessionState.session, "next")
-      ? sessionState.session
+    activeAutoPlaySession !== undefined && canMoveStudySession(activeAutoPlaySession, "next")
+      ? activeAutoPlaySession
       : undefined;
+
+  React.useEffect(() => {
+    if (activeAutoPlaySession === undefined || autoPlaySession !== undefined) return;
+
+    // A terminal Card ends playback without completing or moving the StudySession.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- The session is an external-store snapshot.
+    setAutoPlay(false);
+  }, [activeAutoPlaySession, autoPlaySession]);
 
   React.useEffect(() => {
     if (autoPlaySession === undefined) return;

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -153,7 +153,34 @@ describe("useStudy", () => {
       status: "studying",
       card: { frontText: "card-2" },
       showBackText: false,
+      autoPlay: false,
     });
+    expect(getStudySession(deckId)).toMatchObject({ currentIndex: 1 });
+
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(getStudySession(deckId)).toMatchObject({ currentIndex: 1 });
+  });
+
+  it("stops autoplay on a one-Card session without completing or moving it", () => {
+    vi.useFakeTimers();
+    mocks.cards = cards.slice(0, 1);
+    mocks.preferences = createPreferences({ cardInterval: 1, defaultAutoPlay: true });
+    clearStudySessions();
+    startStudy(deckId, mocks.cards, { shuffled: false, maxNumberOfCardsToLearn: 0 });
+
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current).toMatchObject({
+      status: "studying",
+      session: { currentIndex: 0, cardCount: 1 },
+      autoPlay: false,
+    });
+    expect(getStudySession(deckId)).toMatchObject({ currentIndex: 0, cardOrderIds: ["card-1"] });
+
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(getStudySession(deckId)).toMatchObject({ currentIndex: 0, cardOrderIds: ["card-1"] });
   });
 
   it("does not advance a restarted session with an old autoplay timer", () => {


### PR DESCRIPTION
## Related issue

Fixes #385

## Summary

- Stop Page-local autoplay when the active StudySession reaches its terminal Card.
- Preserve the terminal session and index without treating the stop as completion.
- Add regression coverage for terminal transitions and one-Card sessions.

## Testing

- mise run check