### PR TITLE
ci(#228): harden CI/CD reliability and security

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,25 +8,124 @@ on:
 permissions:
   contents: read
 
+# Serialize production candidates; the freshness job below rejects a stale candidate before deployment.
+concurrency:
+  group: production
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+    with:
+      upload-hosting-artifact: true
+    secrets:
+      VITE_PROJECT_ID: ${{ secrets.VITE_PROJECT_ID }}
+      VITE_WEB_API_KEY: ${{ secrets.VITE_WEB_API_KEY }}
+
+  freshness:
+    needs: [test]
+    name: Check Production Freshness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      current: ${{ steps.main.outputs.current }}
+    steps:
+      - name: Compare candidate with current main
+        id: main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_sha="$(
+            curl --fail --silent --show-error --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/commits/main" |
+              jq --exit-status --raw-output '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))'
+          )"
+          if [ "$current_sha" = "$GITHUB_SHA" ]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping stale deployment candidate $GITHUB_SHA; main is $current_sha."
+          fi
 
   deploy:
-    needs: [test]
+    needs: [test, freshness]
+    if: ${{ needs.freshness.outputs.current == 'true' }}
     name: Deploy To Firebase
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://tango-ts.web.app
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
-      - run: echo VITE_PROJECT_ID="${{ secrets.VITE_PROJECT_ID }}" >> .env
-      - run: echo VITE_WEB_API_KEY="${{ secrets.VITE_WEB_API_KEY }}" >> .env
-
       - run: mise run init
 
-      - run: mise run build
+      - name: Download tested Hosting build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: firebase-hosting-${{ github.sha }}
 
-      - run: npx firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}" --only hosting,firestore:rules
+      - name: Verify Hosting build identity and contents
+        run: |
+          test "$(cat hosting-source-sha)" = "$GITHUB_SHA"
+          test -s build/index.html
+          test -n "$(find build/assets -type f -print -quit)"
+          sha256sum --check hosting-files.sha256
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: tango-ts
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Deploy tested Hosting build and Firestore Rules
+        run: npx firebase deploy --project tango-ts --non-interactive --only hosting,firestore:rules
+
+  smoke:
+    needs: [deploy]
+    name: Production Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          cache: npm
+
+      - name: Install npm
+        run: npm install --global npm@12.0.1
+
+      - run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run production smoke
+        env:
+          PLAYWRIGHT_BASE_URL: https://tango-ts.web.app
+        run: npm run e2e:production
+
+      - name: Upload production smoke diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-smoke-${{ github.sha }}
+          path: |
+            playwright-report/production/
+            test-results/production/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,39 @@ name: Test
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      upload-hosting-artifact:
+        description: Upload the production Hosting build for the calling workflow
+        type: boolean
+        default: false
+    secrets:
+      VITE_PROJECT_ID:
+        required: false
+      VITE_WEB_API_KEY:
+        required: false
   pull_request:
     branches:
       - "**"
+
+# Only superseded runs for the same PR share a group. Reusable and manual runs remain unique.
+concurrency:
+  group: test-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 jobs:
+  dependency-review:
+    name: Dependency Review
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
   e2e:
     name: E2E
     uses: ./.github/workflows/e2e.yaml
@@ -58,7 +83,35 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run ${{ matrix.name }}
+        env:
+          VITE_PROJECT_ID: ${{ matrix.name == 'Build' && inputs.upload-hosting-artifact && secrets.VITE_PROJECT_ID || '' }}
+          VITE_WEB_API_KEY: ${{ matrix.name == 'Build' && inputs.upload-hosting-artifact && secrets.VITE_WEB_API_KEY || '' }}
         run: ${{ matrix.command }}
+
+      - name: Validate production Hosting build
+        if: ${{ matrix.name == 'Build' && inputs.upload-hosting-artifact }}
+        env:
+          VITE_PROJECT_ID: ${{ secrets.VITE_PROJECT_ID }}
+          VITE_WEB_API_KEY: ${{ secrets.VITE_WEB_API_KEY }}
+        run: |
+          test -n "$VITE_PROJECT_ID"
+          test -n "$VITE_WEB_API_KEY"
+          test -s build/index.html
+          test -n "$(find build/assets -type f -print -quit)"
+          printf '%s\n' "$GITHUB_SHA" > hosting-source-sha
+          find build -type f -print0 | sort -z | xargs -0 sha256sum > hosting-files.sha256
+
+      - name: Upload production Hosting build
+        if: ${{ matrix.name == 'Build' && inputs.upload-hosting-artifact }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: firebase-hosting-${{ github.sha }}
+          path: |
+            build/
+            hosting-source-sha
+            hosting-files.sha256
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Upload Vitest coverage report
         id: coverage
@@ -99,10 +152,22 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: checks
+    needs: [checks, dependency-review, e2e, integration]
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         env:
-          RESULT: ${{ needs.checks.result }}
-        run: test "$RESULT" = success
+          CHECKS_RESULT: ${{ needs.checks.result }}
+          DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+        run: |
+          test "$CHECKS_RESULT" = success
+          test "$E2E_RESULT" = success
+          test "$INTEGRATION_RESULT" = success
+          if [ "$EVENT_NAME" = pull_request ]; then
+            test "$DEPENDENCY_REVIEW_RESULT" = success
+          else
+            test "$DEPENDENCY_REVIEW_RESULT" = skipped
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules
 
 # firebase
 .firebase/
+gha-creds-*.json
 
 storybook-static/
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,32 @@ npm run e2e:ui
 
 The initial E2E suite seeds local browser storage and does not require a real Firebase project or emulator.
 
-## Get Firebase Token
+## Production deployment identity
 
-get a new token if old one expired
+The production workflow deploys with short-lived Google Application Default Credentials from GitHub OIDC. It
+does not use a Firebase CLI token or a service account key.
 
-```bash
-npx firebase login:ci
+Configure a Google Cloud Workload Identity Provider with this attribute mapping:
+
+```text
+google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.ref=assertion.ref
 ```
 
-paste the new token here
-https://github.com/her0e1c1/tango/settings/secrets/actions
+Restrict the provider to this repository's immutable numeric ID, the main branch, and the production environment:
+
+```text
+attribute.repository_id=='118316857' && attribute.ref=='refs/heads/main' && assertion.sub=='repo:her0e1c1/tango:environment:production'
+```
+
+Grant that principal `roles/iam.workloadIdentityUser` on a dedicated deploy service account. The deploy account
+needs `roles/firebasehosting.admin`, `roles/firebaserules.admin`, and `roles/serviceusage.serviceUsageConsumer`;
+do not grant Owner or Editor.
+
+Create a GitHub `production` environment restricted to the `main` branch and add these environment variables:
+
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`: full provider resource name, including the numeric Google Cloud project number
+- `GCP_DEPLOY_SERVICE_ACCOUNT`: dedicated deploy service account email
+
+After the first successful OIDC deployment, delete the repository `FIREBASE_TOKEN` secret and revoke the old
+Firebase CLI token at its issuing account. Keep `VITE_PROJECT_ID` and `VITE_WEB_API_KEY` as repository secrets;
+the reusable Test workflow consumes them only while producing the tested Hosting artifact for a main deployment.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ci": "npm run build:sample && npm run build && npm run build:storybook && npm run fmt && npm run fmt:sample && npm run lint && npm run test:coverage && npm run test:sample",
     "db": "firebase emulators:start",
     "e2e": "playwright test",
+    "e2e:production": "playwright test --config playwright.production.config.ts",
     "e2e:ui": "playwright test --ui",
     "test": "npm run test:unit",
     "test:coverage": "vitest run --project=unit --coverage",

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./test/production-smoke",
+  fullyParallel: true,
+  forbidOnly: true,
+  retries: 2,
+  reporter: [["github"], ["html", { open: "never", outputFolder: "playwright-report/production" }]],
+  outputDir: "test-results/production",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "https://tango-ts.web.app",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/test/production-smoke/hosting.spec.ts
+++ b/test/production-smoke/hosting.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type ConsoleMessage, type Page } from "@playwright/test";
+import { routeAnonymousAuth, seedConfig } from "../e2e/fixtures";
+
+interface ProductionIsolation {
+  firestoreRequests: number;
+}
+
+const isExpectedIsolationError = (message: ConsoleMessage, isolation: ProductionIsolation) => {
+  if (isolation.firestoreRequests === 0) return false;
+  if (message.text().includes("status of 418")) {
+    return message.location().url.startsWith("https://firestore.googleapis.com/");
+  }
+  const text = message.text();
+  return (
+    text.includes("@firebase/firestore: Firestore") &&
+    text.includes("Could not reach Cloud Firestore backend.") &&
+    text.includes("FirebaseError: [code=unavailable]") &&
+    text.includes("The client will operate in offline mode")
+  );
+};
+
+const isolateProductionData = async (page: Page, isolation: ProductionIsolation) => {
+  await routeAnonymousAuth(page, "production-smoke");
+  await seedConfig(page);
+
+  // Hosting smoke must exercise production assets without reading or mutating production user data.
+  await page.route("https://firestore.googleapis.com/**", async (route) => {
+    isolation.firestoreRequests += 1;
+    await route.fulfill({
+      status: 418,
+      contentType: "application/json",
+      body: JSON.stringify({ error: { code: 418, message: "Production data is isolated from smoke tests." } }),
+    });
+  });
+};
+
+test.beforeEach(async ({ page }) => {
+  const unexpectedErrors: string[] = [];
+  const isolation = { firestoreRequests: 0 };
+  page.on("console", (message) => {
+    if (message.type() === "error" && !isExpectedIsolationError(message, isolation)) {
+      unexpectedErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => unexpectedErrors.push(error.message));
+
+  await isolateProductionData(page, isolation);
+  await page.exposeFunction("assertNoBrowserErrors", () => expect(unexpectedErrors).toEqual([]));
+});
+
+test("serves the application shell and hashed assets", async ({ page, request }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  const assetPaths = await page
+    .locator('script[src^="/assets/"], link[href^="/assets/"]')
+    .evaluateAll((elements) => elements.map((element) => element.getAttribute("src") ?? element.getAttribute("href")));
+  expect(assetPaths.length).toBeGreaterThan(0);
+  const responses = await Promise.all(
+    assetPaths.map((assetPath) => {
+      expect(assetPath).not.toBeNull();
+      return request.get(assetPath ?? "");
+    })
+  );
+  for (const response of responses) {
+    expect(response.ok()).toBe(true);
+  }
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});
+
+test("renders a representative read-only route", async ({ page }) => {
+  await page.goto("/settings");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Settings" })).toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});
+
+test("serves the SPA fallback and recovers from an unknown route", async ({ page }) => {
+  const response = await page.goto("/production-smoke-unknown-route");
+
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole("heading", { level: 1, name: "Page not found" })).toBeVisible();
+  await page.getByRole("button", { name: "Go home" }).click();
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await page.evaluate(() => window.assertNoBrowserErrors());
+});


### PR DESCRIPTION
## Related issue

Relates to #228

Related work: #229, #230, #233, #234, #235

## Summary

- aggregate all canonical Test, E2E, Integration, and Dependency Review results behind the stable Test check, with same-PR cancellation
- promote a SHA-bound, checksummed Hosting artifact from the tested build instead of rebuilding during deployment
- replace Firebase CLI token authentication with least-privilege GitHub OIDC/ADC and reject stale deployment candidates
- add read-only production Hosting smoke coverage with failure diagnostics
- document the WIF trust condition, IAM roles, GitHub variables, and legacy token cleanup

## Testing

- mise run check
- npm run e2e:production (3 passed against https://tango-ts.web.app)
- three reviewer rounds; no unresolved code P0 findings

## Pre-merge requirements

- [ ] Create a production GitHub environment restricted to main
- [ ] Provision the documented WIF provider and deploy service account/IAM bindings
- [ ] Set production variables GCP_WORKLOAD_IDENTITY_PROVIDER and GCP_DEPLOY_SERVICE_ACCOUNT
- [ ] Confirm the aggregate Test check identity on this PR, then enable one active ruleset that requires only that stable context
- [ ] Validate one representative OIDC production deployment before deleting and revoking FIREBASE_TOKEN

This PR remains draft because the external environment, WIF variables, and active required-check ruleset are not configured yet.