### PR TITLE
[No issue] Fix study session swipe gestures

### DIFF
--- a/src/features/card-view/ui/FrontText.spec.tsx
+++ b/src/features/card-view/ui/FrontText.spec.tsx
@@ -8,25 +8,7 @@ import "@testing-library/jest-dom/vitest";
 
 import { FrontText } from "./FrontText";
 
-const swipeLeft = (target: HTMLElement) => {
-  const start = { identifier: 1, target, clientX: 200, clientY: 24 };
-  const end = { identifier: 1, target, clientX: 20, clientY: 24 };
-
-  fireEvent.touchStart(target, { touches: [start], targetTouches: [start], changedTouches: [start] });
-  fireEvent.touchMove(target, { touches: [end], targetTouches: [end], changedTouches: [end] });
-  fireEvent.touchEnd(target, { touches: [], targetTouches: [], changedTouches: [end] });
-};
-
 describe("FrontText", () => {
-  it("reports a left swipe", () => {
-    const onSwipeLeft = vi.fn();
-    render(<FrontText text="Front" onSwipeLeft={onSwipeLeft} />);
-
-    swipeLeft(screen.getByText("Front"));
-
-    expect(onSwipeLeft).toHaveBeenCalledOnce();
-  });
-
   it("preserves content and click interaction", () => {
     const onClick = vi.fn();
     render(<FrontText text="A very long front without spaces: abcdefghijklmnopqrstuvwxyz" onClick={onClick} />);

--- a/src/features/card-view/ui/FrontText.stories.tsx
+++ b/src/features/card-view/ui/FrontText.stories.tsx
@@ -13,12 +13,6 @@ const meta = {
   title: "Card/FrontText",
   component: Template,
   tags: ["autodocs"],
-  argTypes: {
-    onSwipeUp: { action: "onSwipeUp" },
-    onSwipeDown: { action: "onSwipeDown" },
-    onSwipeLeft: { action: "onSwipeLeft" },
-    onSwipeRight: { action: "onSwipeRight" },
-  },
   args: {},
 } satisfies Meta<typeof Template>;
 

--- a/src/features/card-view/ui/FrontText.tsx
+++ b/src/features/card-view/ui/FrontText.tsx
@@ -8,15 +8,10 @@ import cx from "classnames";
 import type * as React from "react";
 import { useButtonInteraction } from "@/shared/ui/button-interaction";
 import { MathContent, Title } from "@/shared/ui/content";
-import { useSwipeable } from "react-swipeable";
 
 export interface FrontTextProps {
   text: string;
   category?: string;
-  onSwipeLeft?: () => void;
-  onSwipeUp?: () => void;
-  onSwipeRight?: () => void;
-  onSwipeDown?: () => void;
   onClick?: () => void;
 }
 
@@ -26,12 +21,6 @@ export interface FrontTextProps {
  * notation.
  */
 export const FrontText: React.FC<FrontTextProps> = (props) => {
-  const handlers = useSwipeable({
-    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: props.onSwipeLeft } : {}),
-    ...(props.onSwipeUp !== undefined ? { onSwipedUp: props.onSwipeUp } : {}),
-    ...(props.onSwipeRight !== undefined ? { onSwipedRight: props.onSwipeRight } : {}),
-    ...(props.onSwipeDown !== undefined ? { onSwipedDown: props.onSwipeDown } : {}),
-  });
   const clickInteraction = useButtonInteraction<HTMLDivElement>(props.onClick);
   return (
     <div
@@ -40,7 +29,6 @@ export const FrontText: React.FC<FrontTextProps> = (props) => {
         "mx-auto flex h-full w-full min-w-0 items-center justify-center break-words p-section-gap text-ink"
       )}
       {...clickInteraction}
-      {...handlers}
     >
       {props.category === "math" ? <MathContent text={props.text} /> : <Title>{props.text}</Title>}
     </div>

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -6,6 +6,24 @@ vi.mock("@/shared/firebase", () => ({ auth: {} }));
 
 import { StudySession } from "./StudySession";
 
+const swipeLeft = (target: HTMLElement) => {
+  const start = { identifier: 1, target, clientX: 200, clientY: 24 };
+  const end = { identifier: 1, target, clientX: 20, clientY: 24 };
+
+  fireEvent.touchStart(target, { touches: [start], targetTouches: [start], changedTouches: [start] });
+  fireEvent.touchMove(target, { touches: [end], targetTouches: [end], changedTouches: [end] });
+  fireEvent.touchEnd(target, { touches: [], targetTouches: [], changedTouches: [end] });
+};
+
+const swipeUp = (target: HTMLElement) => {
+  const start = { identifier: 1, target, clientX: 24, clientY: 200 };
+  const end = { identifier: 1, target, clientX: 24, clientY: 20 };
+
+  fireEvent.touchStart(target, { touches: [start], targetTouches: [start], changedTouches: [start] });
+  fireEvent.touchMove(target, { touches: [end], targetTouches: [end], changedTouches: [end] });
+  fireEvent.touchEnd(target, { touches: [], targetTouches: [], changedTouches: [end] });
+};
+
 describe("StudySession", () => {
   it("gives swipe overlays accessible names", () => {
     render(
@@ -44,5 +62,32 @@ describe("StudySession", () => {
     fireEvent.click(exit);
 
     expect(onExit).toHaveBeenCalledOnce();
+  });
+
+  it("reports a swipe performed on the back text", () => {
+    const onSwipeLeft = vi.fn();
+    render(<StudySession onExit={vi.fn()} showBackText backTextSlot={<div>Back</div>} onSwipeLeft={onSwipeLeft} />);
+
+    swipeLeft(screen.getByText("Back"));
+
+    expect(onSwipeLeft).toHaveBeenCalledOnce();
+  });
+
+  it("reserves vertical drags on the back text for scrolling", () => {
+    const onSwipeUp = vi.fn();
+    render(<StudySession onExit={vi.fn()} showBackText backTextSlot={<div>Long back</div>} onSwipeUp={onSwipeUp} />);
+
+    swipeUp(screen.getByText("Long back"));
+
+    expect(onSwipeUp).not.toHaveBeenCalled();
+  });
+
+  it("reports a vertical swipe performed on the front text", () => {
+    const onSwipeUp = vi.fn();
+    render(<StudySession onExit={vi.fn()} frontTextSlot={<div>Front</div>} onSwipeUp={onSwipeUp} />);
+
+    swipeUp(screen.getByText("Front"));
+
+    expect(onSwipeUp).toHaveBeenCalledOnce();
   });
 });

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import type * as React from "react";
+import { useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
 import { Button } from "@/shared/ui/button";
 import { Overlay } from "@/shared/ui/feedback";
@@ -27,6 +28,10 @@ export interface StudySessionProps {
   controller?: ControllerProps;
   swipeButtonList?: SwipeButtonListProps;
   feedbackSlot?: React.ReactNode;
+  onSwipeLeft?: () => void;
+  onSwipeUp?: () => void;
+  onSwipeRight?: () => void;
+  onSwipeDown?: () => void;
   onExit: () => void;
 }
 
@@ -125,26 +130,36 @@ const Controls: React.FC<{
   );
 };
 
-export const StudySession: React.FC<StudySessionProps> = (props) => (
-  <div className="flex h-full min-h-0 flex-col">
-    {props.feedbackSlot}
-    <ExitAction showHeader={props.showHeader} onExit={props.onExit} />
-    <SwipeFeedback swipeFeedback={props.swipeFeedback} />
-    <div className="relative min-h-0 flex-1">
-      <CardContent
+export const StudySession: React.FC<StudySessionProps> = (props) => {
+  // Keep horizontal gestures above face-specific content, but reserve vertical drags on the Back for scrolling.
+  const swipeHandlers = useSwipeable({
+    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: props.onSwipeLeft } : {}),
+    ...(!props.showBackText && props.onSwipeUp !== undefined ? { onSwipedUp: props.onSwipeUp } : {}),
+    ...(props.onSwipeRight !== undefined ? { onSwipedRight: props.onSwipeRight } : {}),
+    ...(!props.showBackText && props.onSwipeDown !== undefined ? { onSwipedDown: props.onSwipeDown } : {}),
+  });
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {props.feedbackSlot}
+      <ExitAction showHeader={props.showHeader} onExit={props.onExit} />
+      <SwipeFeedback swipeFeedback={props.swipeFeedback} />
+      <div className="relative min-h-0 flex-1" {...swipeHandlers}>
+        <CardContent
+          showBackText={props.showBackText}
+          backTextSlot={props.backTextSlot}
+          frontTextSlot={props.frontTextSlot}
+          cardOverlaySlot={props.cardOverlaySlot}
+          swipeOverlay={props.swipeOverlay}
+        />
+      </div>
+      <Controls
         showBackText={props.showBackText}
-        backTextSlot={props.backTextSlot}
-        frontTextSlot={props.frontTextSlot}
-        cardOverlaySlot={props.cardOverlaySlot}
-        swipeOverlay={props.swipeOverlay}
+        showSwipeButtonList={props.showSwipeButtonList}
+        showController={props.showController}
+        swipeButtonList={props.swipeButtonList}
+        controller={props.controller}
       />
     </div>
-    <Controls
-      showBackText={props.showBackText}
-      showSwipeButtonList={props.showSwipeButtonList}
-      showController={props.showController}
-      swipeButtonList={props.swipeButtonList}
-      controller={props.controller}
-    />
-  </div>
-);
+  );
+};

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -48,17 +48,13 @@ const renderStudyScreen = (state: StudyState | undefined, onExit: () => void) =>
         showController={state.showController}
         showBackText={state.showBackText}
         showSwipeButtonList={state.showSwipeButtonList}
+        onSwipeUp={swipeActions.onClickUp}
+        onSwipeDown={swipeActions.onClickDown}
+        onSwipeLeft={swipeActions.onClickLeft}
+        onSwipeRight={swipeActions.onClickRight}
         {...(state.swipeFeedback !== undefined ? { swipeFeedback: state.swipeFeedback } : {})}
         frontTextSlot={
-          <FrontText
-            category={state.card.category}
-            text={state.card.frontText}
-            onSwipeUp={swipeActions.onClickUp}
-            onSwipeDown={swipeActions.onClickDown}
-            onSwipeLeft={swipeActions.onClickLeft}
-            onSwipeRight={swipeActions.onClickRight}
-            onClick={state.toggleBackText}
-          />
+          <FrontText category={state.card.category} text={state.card.frontText} onClick={state.toggleBackText} />
         }
         cardOverlaySlot={
           <CardOverlay


### PR DESCRIPTION
## Related issue

None

## Summary

- Keep swipe gesture handling mounted across study card face changes.
- Enable horizontal swipes on the scrollable back face while reserving vertical drags for scrolling.
- Add regression coverage for back-face horizontal swipes, back-face vertical scrolling, and front-face vertical swipes.

## Testing

- `mise run check`