### PR TITLE
No issue: Clarify deck list section mapping

### DIFF
--- a/src/pages/deck-list/model/useDeckListState.spec.tsx
+++ b/src/pages/deck-list/model/useDeckListState.spec.tsx
@@ -59,9 +59,10 @@ describe("useDeckListState", () => {
     const { sections } = result.current;
 
     expect(sections.studying.map((item) => item.deck.id)).toEqual(["active-new", "active-old"]);
-    expect(sections.studying[0]?.studyProgress).toEqual({
+    expect(sections.studying[0]?.studySession).toMatchObject({
+      deckId: "active-new",
       currentIndex: 0,
-      cardCount: 3,
+      cardOrderIds: cardsForDeck("active-new").map((card) => card.id),
       lastStudiedAt: 200,
     });
     expect(sections.other.map((item) => item.deck.id)).toEqual(["other-a", "other-z"]);

--- a/src/pages/deck-list/model/useDeckListState.ts
+++ b/src/pages/deck-list/model/useDeckListState.ts
@@ -9,28 +9,13 @@ import {
 
 const compareDeckNames = (left: Deck, right: Deck): number => left.name.localeCompare(right.name);
 
-type StudyProgress = {
-  currentIndex: number;
-  cardCount: number;
-  lastStudiedAt: StudySession["lastStudiedAt"];
-};
-
 type DeckListItem = {
-  deck: Pick<Deck, "id" | "name" | "category" | "isPublic">;
+  deck: Deck;
   cardCount: number;
-  studyProgress?: StudyProgress;
+  studyProgress?: Pick<StudySession, "currentIndex" | "lastStudiedAt"> & { cardCount: number };
 };
 
-type StudyingDeckListItem = DeckListItem & {
-  studyProgress: StudyProgress;
-};
-
-type DeckListSections = {
-  studying: StudyingDeckListItem[];
-  other: DeckListItem[];
-};
-
-const toStudyProgress = (session: StudySession): StudyProgress => ({
+const toStudyProgress = (session: StudySession) => ({
   currentIndex: session.currentIndex,
   cardCount: session.cardOrderIds.length,
   lastStudiedAt: session.lastStudiedAt,
@@ -40,7 +25,7 @@ const buildDeckListSections = (
   decks: Deck[],
   cards: Card[],
   sessionsByDeckId: Partial<Record<DeckId, StudySession>>
-): DeckListSections => {
+) => {
   const cardCounts = countCardsByDeckId(cards);
   const { active, inactive } = groupDecksByStudyStatus(decks, sessionsByDeckId);
 
@@ -49,7 +34,7 @@ const buildDeckListSections = (
     cardCount: cardCounts.get(deck.id) ?? 0,
     studyProgress: toStudyProgress(session),
   }));
-  const other = inactive.sort(compareDeckNames).map((deck) => ({
+  const other: DeckListItem[] = inactive.sort(compareDeckNames).map((deck) => ({
     deck,
     cardCount: cardCounts.get(deck.id) ?? 0,
   }));

--- a/src/pages/deck-list/model/useDeckListState.ts
+++ b/src/pages/deck-list/model/useDeckListState.ts
@@ -9,33 +9,52 @@ import {
 
 const compareDeckNames = (left: Deck, right: Deck): number => left.name.localeCompare(right.name);
 
+type StudyProgress = {
+  currentIndex: number;
+  cardCount: number;
+  lastStudiedAt: StudySession["lastStudiedAt"];
+};
+
+type DeckListItem = {
+  deck: Pick<Deck, "id" | "name" | "category" | "isPublic">;
+  cardCount: number;
+  studyProgress?: StudyProgress;
+};
+
+type StudyingDeckListItem = DeckListItem & {
+  studyProgress: StudyProgress;
+};
+
+type DeckListSections = {
+  studying: StudyingDeckListItem[];
+  other: DeckListItem[];
+};
+
+const toStudyProgress = (session: StudySession): StudyProgress => ({
+  currentIndex: session.currentIndex,
+  cardCount: session.cardOrderIds.length,
+  lastStudiedAt: session.lastStudiedAt,
+});
+
 const buildDeckListSections = (
   decks: Deck[],
   cards: Card[],
   sessionsByDeckId: Partial<Record<DeckId, StudySession>>
-) => {
+): DeckListSections => {
   const cardCounts = countCardsByDeckId(cards);
-  const createItem = (deck: Pick<Deck, "id" | "name" | "category" | "isPublic">, session?: StudySession) => ({
+  const { active, inactive } = groupDecksByStudyStatus(decks, sessionsByDeckId);
+
+  const studying = active.sort(compareActiveDecks).map(({ deck, session }) => ({
     deck,
     cardCount: cardCounts.get(deck.id) ?? 0,
-    ...(session == null
-      ? {}
-      : {
-          studyProgress: {
-            currentIndex: session.currentIndex,
-            cardCount: session.cardOrderIds.length,
-            lastStudiedAt: session.lastStudiedAt,
-          },
-        }),
-  });
-  const { active: studyingDecks, inactive: otherDecks } = groupDecksByStudyStatus(decks, sessionsByDeckId);
-  studyingDecks.sort(compareActiveDecks);
-  otherDecks.sort(compareDeckNames);
+    studyProgress: toStudyProgress(session),
+  }));
+  const other = inactive.sort(compareDeckNames).map((deck) => ({
+    deck,
+    cardCount: cardCounts.get(deck.id) ?? 0,
+  }));
 
-  return {
-    studying: studyingDecks.map(({ deck, session }) => createItem(deck, session)),
-    other: otherDecks.map((deck) => createItem(deck)),
-  };
+  return { studying, other };
 };
 
 export const useDeckListState = () => {

--- a/src/pages/deck-list/model/useDeckListState.ts
+++ b/src/pages/deck-list/model/useDeckListState.ts
@@ -12,14 +12,8 @@ const compareDeckNames = (left: Deck, right: Deck): number => left.name.localeCo
 type DeckListItem = {
   deck: Deck;
   cardCount: number;
-  studyProgress?: Pick<StudySession, "currentIndex" | "lastStudiedAt"> & { cardCount: number };
+  studySession?: StudySession;
 };
-
-const toStudyProgress = (session: StudySession) => ({
-  currentIndex: session.currentIndex,
-  cardCount: session.cardOrderIds.length,
-  lastStudiedAt: session.lastStudiedAt,
-});
 
 const buildDeckListSections = (
   decks: Deck[],
@@ -32,7 +26,7 @@ const buildDeckListSections = (
   const studying = active.sort(compareActiveDecks).map(({ deck, session }) => ({
     deck,
     cardCount: cardCounts.get(deck.id) ?? 0,
-    studyProgress: toStudyProgress(session),
+    studySession: session,
   }));
   const other: DeckListItem[] = inactive.sort(compareDeckNames).map((deck) => ({
     deck,

--- a/src/pages/deck-list/ui/DeckList.spec.tsx
+++ b/src/pages/deck-list/ui/DeckList.spec.tsx
@@ -22,7 +22,13 @@ const sections = {
     {
       deck: activeDeck,
       cardCount: 10,
-      studyProgress: { currentIndex: 1, cardCount: 4, lastStudiedAt: Date.now() },
+      studySession: {
+        sessionId: "active-session",
+        deckId: activeDeck.id,
+        cardOrderIds: ["card-1", "card-2", "card-3", "card-4"],
+        currentIndex: 1,
+        lastStudiedAt: Date.now(),
+      },
     },
   ],
   other: [{ deck: otherDeck, cardCount: 7 }],

--- a/src/pages/deck-list/ui/DeckList.stories.tsx
+++ b/src/pages/deck-list/ui/DeckList.stories.tsx
@@ -29,9 +29,11 @@ const studyingItems = (decks: Deck[]) =>
   decks.map((deck, index) => ({
     deck,
     cardCount: 30 + index,
-    studyProgress: {
+    studySession: {
+      sessionId: `session-${deck.id}`,
+      deckId: deck.id,
+      cardOrderIds: Array.from({ length: 12 + index * 7 }, (_, cardIndex) => `${deck.id}-card-${String(cardIndex)}`),
       currentIndex: index + 1,
-      cardCount: 12 + index * 7,
       lastStudiedAt: fixture.timestamp - index * 24 * 60 * 60 * 1000,
     },
   }));

--- a/src/pages/deck-list/ui/DeckList.tsx
+++ b/src/pages/deck-list/ui/DeckList.tsx
@@ -52,7 +52,7 @@ const DeckListSection: React.FC<{
             key={item.deck.id}
             deck={item.deck}
             cardCount={item.cardCount}
-            {...(item.studyProgress != null ? { studyProgress: item.studyProgress } : {})}
+            {...(item.studySession != null ? { studySession: item.studySession } : {})}
             {...actions}
             openMenuDeckId={openMenuDeckId}
             onToggleMenu={onToggleMenu}

--- a/src/pages/deck-list/ui/DeckListCard.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.spec.tsx
@@ -54,9 +54,11 @@ describe("DeckListCard", () => {
       <DeckListCard
         deck={deck}
         cardCount={8}
-        studyProgress={{
+        studySession={{
+          sessionId: "study-session",
+          deckId: deck.id,
+          cardOrderIds: ["card-1", "card-2", "card-3"],
           currentIndex: 1,
-          cardCount: 3,
           lastStudiedAt: new Date("2026-07-18T00:05:00Z").getTime(),
         }}
       />
@@ -97,7 +99,13 @@ describe("DeckListCard", () => {
       <ControlledDeckListCard
         deck={deck}
         cardCount={8}
-        studyProgress={{ currentIndex: 0, cardCount: 3, lastStudiedAt: Date.now() }}
+        studySession={{
+          sessionId: "study-session",
+          deckId: deck.id,
+          cardOrderIds: ["card-1", "card-2", "card-3"],
+          currentIndex: 0,
+          lastStudiedAt: Date.now(),
+        }}
         {...actions}
       />
     );

--- a/src/pages/deck-list/ui/DeckListCard.stories.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.stories.tsx
@@ -33,9 +33,11 @@ export const Default: Story = {};
 
 export const WithStudyProgress: Story = {
   args: {
-    studyProgress: {
+    studySession: {
+      sessionId: "study-session",
+      deckId: fixture.deck.default.id,
+      cardOrderIds: ["card-1", "card-2", "card-3"],
       currentIndex: 0,
-      cardCount: 3,
       lastStudiedAt: fixture.timestamp - 5 * 60 * 1000,
     },
   },

--- a/src/pages/deck-list/ui/DeckListCard.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.tsx
@@ -58,11 +58,11 @@ const primaryActionClassName =
 const DeckListCardStatus: React.FC<{
   deck: DeckListCardProps["deck"];
   active: boolean;
-  studyProgress: DeckListCardProps["studyProgress"];
+  studySession: DeckListCardProps["studySession"];
   progressValue: number;
   cardCount: number;
   statusId: string;
-}> = ({ deck, active, studyProgress, progressValue, cardCount, statusId }) => (
+}> = ({ deck, active, studySession, progressValue, cardCount, statusId }) => (
   <span id={statusId} className="mt-1 flex min-w-0 items-center gap-2 text-caption text-ink-muted">
     {deck.category !== "" && (
       <span className="max-w-28 truncate rounded-pill bg-surface-muted px-2 py-0.5 text-xs font-medium text-ink">
@@ -70,8 +70,8 @@ const DeckListCardStatus: React.FC<{
       </span>
     )}
     <span className="truncate">
-      {active && studyProgress
-        ? `${String(progressValue)} / ${String(studyProgress.cardCount)} · ${formatLastStudied(studyProgress.lastStudiedAt)}`
+      {active && studySession
+        ? `${String(progressValue)} / ${String(studySession.cardOrderIds.length)} · ${formatLastStudied(studySession.lastStudiedAt)}`
         : `${String(cardCount)} ${cardCount === 1 ? "card" : "cards"}`}
     </span>
   </span>
@@ -105,10 +105,11 @@ const DeckListCardProgressBar: React.FC<{
  * operations.
  */
 export const DeckListCard: React.FC<DeckListCardProps> = (props) => {
-  const { deck, studyProgress } = props;
-  const active = studyProgress != null;
-  const progressValue = active ? studyProgress.currentIndex + 1 : 0;
-  const progressPercent = active ? Math.min(100, (progressValue / studyProgress.cardCount) * 100) : 0;
+  const { deck, studySession } = props;
+  const active = studySession != null;
+  const studyCardCount = studySession?.cardOrderIds.length ?? 0;
+  const progressValue = active ? studySession.currentIndex + 1 : 0;
+  const progressPercent = active ? Math.min(100, (progressValue / studyCardCount) * 100) : 0;
   const pending = props.isPending?.(deck.id) ?? false;
   /**
    * Wraps an optional action so it receives the current item's identifier when invoked.
@@ -146,7 +147,7 @@ export const DeckListCard: React.FC<DeckListCardProps> = (props) => {
         <DeckListCardStatus
           deck={deck}
           active={active}
-          studyProgress={studyProgress}
+          studySession={studySession}
           progressValue={progressValue}
           cardCount={props.cardCount}
           statusId={statusId}
@@ -156,7 +157,7 @@ export const DeckListCard: React.FC<DeckListCardProps> = (props) => {
           active={active}
           progressValue={progressValue}
           progressPercent={progressPercent}
-          cardCount={studyProgress?.cardCount ?? 0}
+          cardCount={studyCardCount}
           deckName={deck.name}
         />
       </div>


### PR DESCRIPTION
## Summary
- replace the optional deck-list item factory with explicit studying and other mappings
- pass the existing StudySession through the Deck List page and derive display progress in DeckListCard
- remove the intermediate progress projection and its custom types

## Testing
- npm run test:unit -- src/pages/deck-list/model/useDeckListState.spec.tsx src/pages/deck-list/ui/DeckList.spec.tsx src/pages/deck-list/ui/DeckListCard.spec.tsx
- mise run check