### PR TITLE
[No issue] Fix study session mouse swipes

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -1,10 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
-
-afterEach(() => vi.useRealTimers());
 
 import { StudySession } from "./StudySession";
 
@@ -26,10 +24,15 @@ const swipeUp = (target: HTMLElement) => {
   fireEvent.touchEnd(target, { touches: [], targetTouches: [], changedTouches: [end] });
 };
 
-const swipeUpWithMouse = (target: HTMLElement) => {
-  fireEvent.mouseDown(target, { clientX: 24, clientY: 200 });
-  fireEvent.mouseMove(document, { clientX: 24, clientY: 20 });
-  fireEvent.mouseUp(document, { clientX: 24, clientY: 20 });
+const swipeWithMouse = (
+  target: HTMLElement,
+  start: { clientX: number; clientY: number },
+  end: { clientX: number; clientY: number },
+  button = 0
+) => {
+  fireEvent.mouseDown(target, { ...start, button });
+  fireEvent.mouseMove(document, { ...end, button });
+  fireEvent.mouseUp(document, { ...end, button });
 };
 
 describe("StudySession", () => {
@@ -99,8 +102,7 @@ describe("StudySession", () => {
     expect(onSwipeUp).toHaveBeenCalledOnce();
   });
 
-  it("treats a mouse swipe as only a swipe and allows a later card click", () => {
-    vi.useFakeTimers();
+  it("treats a primary-button mouse swipe as only a swipe", () => {
     const onSwipeUp = vi.fn();
     const onFrontClick = vi.fn();
     render(
@@ -116,14 +118,45 @@ describe("StudySession", () => {
     );
     const front = screen.getByRole("button", { name: "Front" });
 
-    swipeUpWithMouse(front);
+    swipeWithMouse(front, { clientX: 24, clientY: 200 }, { clientX: 24, clientY: 20 });
     fireEvent.click(front);
 
     expect(onSwipeUp).toHaveBeenCalledOnce();
     expect(onFrontClick).not.toHaveBeenCalled();
+  });
 
-    vi.runAllTimers();
-    fireEvent.click(front);
-    expect(onFrontClick).toHaveBeenCalledOnce();
+  it("ignores non-primary mouse drags on the front text", () => {
+    const onSwipeUp = vi.fn();
+    render(<StudySession onExit={vi.fn()} frontTextSlot={<div>Front</div>} onSwipeUp={onSwipeUp} />);
+    const front = screen.getByText("Front");
+
+    swipeWithMouse(front, { clientX: 24, clientY: 200 }, { clientX: 24, clientY: 20 }, 1);
+    swipeWithMouse(front, { clientX: 24, clientY: 200 }, { clientX: 24, clientY: 20 }, 2);
+
+    expect(onSwipeUp).not.toHaveBeenCalled();
+  });
+
+  it("keeps a mouse drag from swiping or clicking the back text", () => {
+    const onSwipeLeft = vi.fn();
+    const onBackClick = vi.fn();
+    render(
+      <StudySession
+        onExit={vi.fn()}
+        showBackText
+        backTextSlot={
+          <button type="button" onClick={onBackClick}>
+            Back
+          </button>
+        }
+        onSwipeLeft={onSwipeLeft}
+      />
+    );
+    const back = screen.getByRole("button", { name: "Back" });
+
+    swipeWithMouse(back, { clientX: 200, clientY: 24 }, { clientX: 20, clientY: 24 });
+    fireEvent.click(back);
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onBackClick).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -1,8 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
+
+afterEach(() => vi.useRealTimers());
 
 import { StudySession } from "./StudySession";
 
@@ -22,6 +24,12 @@ const swipeUp = (target: HTMLElement) => {
   fireEvent.touchStart(target, { touches: [start], targetTouches: [start], changedTouches: [start] });
   fireEvent.touchMove(target, { touches: [end], targetTouches: [end], changedTouches: [end] });
   fireEvent.touchEnd(target, { touches: [], targetTouches: [], changedTouches: [end] });
+};
+
+const swipeUpWithMouse = (target: HTMLElement) => {
+  fireEvent.mouseDown(target, { clientX: 24, clientY: 200 });
+  fireEvent.mouseMove(document, { clientX: 24, clientY: 20 });
+  fireEvent.mouseUp(document, { clientX: 24, clientY: 20 });
 };
 
 describe("StudySession", () => {
@@ -89,5 +97,33 @@ describe("StudySession", () => {
     swipeUp(screen.getByText("Front"));
 
     expect(onSwipeUp).toHaveBeenCalledOnce();
+  });
+
+  it("treats a mouse swipe as only a swipe and allows a later card click", () => {
+    vi.useFakeTimers();
+    const onSwipeUp = vi.fn();
+    const onFrontClick = vi.fn();
+    render(
+      <StudySession
+        onExit={vi.fn()}
+        frontTextSlot={
+          <button type="button" onClick={onFrontClick}>
+            Front
+          </button>
+        }
+        onSwipeUp={onSwipeUp}
+      />
+    );
+    const front = screen.getByRole("button", { name: "Front" });
+
+    swipeUpWithMouse(front);
+    fireEvent.click(front);
+
+    expect(onSwipeUp).toHaveBeenCalledOnce();
+    expect(onFrontClick).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+    fireEvent.click(front);
+    expect(onFrontClick).toHaveBeenCalledOnce();
   });
 });

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type * as React from "react";
+import * as React from "react";
 import { useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
 import { Button } from "@/shared/ui/button";
@@ -150,13 +150,50 @@ const Controls: React.FC<{
 };
 
 export const StudySession: React.FC<StudySessionProps> = (props) => {
-  // Keep horizontal gestures above face-specific content, but reserve vertical drags on the Back for scrolling.
+  const suppressCardClick = React.useRef(false);
+  const suppressCardClickTimer = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  React.useEffect(
+    () => () => {
+      if (suppressCardClickTimer.current !== undefined) clearTimeout(suppressCardClickTimer.current);
+    },
+    []
+  );
+
+  const withTrailingClickSuppression = (action: () => void) => () => {
+    // Browsers emit a click after a mouse drag; keep that click from also flipping the study card.
+    suppressCardClick.current = true;
+    if (suppressCardClickTimer.current !== undefined) clearTimeout(suppressCardClickTimer.current);
+    suppressCardClickTimer.current = setTimeout(() => {
+      suppressCardClick.current = false;
+      suppressCardClickTimer.current = undefined;
+    }, 0);
+    action();
+  };
+
+  // Desktop drags and touch gestures share these Page-owned handlers; the Back still reserves vertical drags for scrolling.
   const swipeHandlers = useSwipeable({
-    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: props.onSwipeLeft } : {}),
-    ...(!props.showBackText && props.onSwipeUp !== undefined ? { onSwipedUp: props.onSwipeUp } : {}),
-    ...(props.onSwipeRight !== undefined ? { onSwipedRight: props.onSwipeRight } : {}),
-    ...(!props.showBackText && props.onSwipeDown !== undefined ? { onSwipedDown: props.onSwipeDown } : {}),
+    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: withTrailingClickSuppression(props.onSwipeLeft) } : {}),
+    ...(!props.showBackText && props.onSwipeUp !== undefined
+      ? { onSwipedUp: withTrailingClickSuppression(props.onSwipeUp) }
+      : {}),
+    ...(props.onSwipeRight !== undefined ? { onSwipedRight: withTrailingClickSuppression(props.onSwipeRight) } : {}),
+    ...(!props.showBackText && props.onSwipeDown !== undefined
+      ? { onSwipedDown: withTrailingClickSuppression(props.onSwipeDown) }
+      : {}),
+    trackMouse: true,
   });
+
+  const stopTrailingCardClick: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    // biome-ignore lint/suspicious/noUnnecessaryConditions: React refs are mutable; remove after biomejs/biome#11174.
+    if (!suppressCardClick.current) return;
+
+    suppressCardClick.current = false;
+    if (suppressCardClickTimer.current !== undefined) clearTimeout(suppressCardClickTimer.current);
+    suppressCardClickTimer.current = undefined;
+    event.preventDefault();
+    event.stopPropagation();
+  };
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 flex-col bg-canvas text-ink">
@@ -166,6 +203,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       <div
         className={cx("relative min-h-0 flex-1", props.showBackText ? "overflow-y-auto" : "overflow-hidden")}
         {...swipeHandlers}
+        onClickCapture={stopTrailingCardClick}
       >
         <CardContent
           showBackText={props.showBackText}

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import * as React from "react";
-import { useSwipeable } from "react-swipeable";
+import { type SwipeEventData, useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
 import { Button } from "@/shared/ui/button";
 import { Overlay } from "@/shared/ui/feedback";
@@ -160,7 +160,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
     []
   );
 
-  const withTrailingClickSuppression = (action: () => void) => () => {
+  const suppressTrailingCardClick = () => {
     // Browsers emit a click after a mouse drag; keep that click from also flipping the study card.
     suppressCardClick.current = true;
     if (suppressCardClickTimer.current !== undefined) clearTimeout(suppressCardClickTimer.current);
@@ -168,21 +168,30 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       suppressCardClick.current = false;
       suppressCardClickTimer.current = undefined;
     }, 0);
-    action();
   };
 
-  // Desktop drags and touch gestures share these Page-owned handlers; the Back still reserves vertical drags for scrolling.
+  const runSwipeAction =
+    (action: () => void) =>
+    ({ event }: SwipeEventData) => {
+      // Back mouse drags are tracked only to suppress their trailing click; touch swipes still change progress.
+      if (!(props.showBackText && "button" in event)) action();
+    };
+
   const swipeHandlers = useSwipeable({
-    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: withTrailingClickSuppression(props.onSwipeLeft) } : {}),
-    ...(!props.showBackText && props.onSwipeUp !== undefined
-      ? { onSwipedUp: withTrailingClickSuppression(props.onSwipeUp) }
-      : {}),
-    ...(props.onSwipeRight !== undefined ? { onSwipedRight: withTrailingClickSuppression(props.onSwipeRight) } : {}),
+    onSwiped: suppressTrailingCardClick,
+    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: runSwipeAction(props.onSwipeLeft) } : {}),
+    ...(!props.showBackText && props.onSwipeUp !== undefined ? { onSwipedUp: runSwipeAction(props.onSwipeUp) } : {}),
+    ...(props.onSwipeRight !== undefined ? { onSwipedRight: runSwipeAction(props.onSwipeRight) } : {}),
     ...(!props.showBackText && props.onSwipeDown !== undefined
-      ? { onSwipedDown: withTrailingClickSuppression(props.onSwipeDown) }
+      ? { onSwipedDown: runSwipeAction(props.onSwipeDown) }
       : {}),
     trackMouse: true,
   });
+
+  const startPrimaryMouseSwipe: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    // react-swipeable tracks every mouse button by default, but only the primary button may change study progress.
+    if (event.button === 0) swipeHandlers.onMouseDown?.(event);
+  };
 
   const stopTrailingCardClick: React.MouseEventHandler<HTMLDivElement> = (event) => {
     // biome-ignore lint/suspicious/noUnnecessaryConditions: React refs are mutable; remove after biomejs/biome#11174.
@@ -195,6 +204,12 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
     event.stopPropagation();
   };
 
+  const cardGestureHandlers = {
+    ...swipeHandlers,
+    onClickCapture: stopTrailingCardClick,
+    onMouseDown: startPrimaryMouseSwipe,
+  };
+
   return (
     <div className="relative flex h-full min-h-0 flex-1 flex-col bg-canvas text-ink">
       {props.feedbackSlot}
@@ -202,8 +217,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       <SwipeFeedback showHeader={props.showHeader} swipeFeedback={props.swipeFeedback} />
       <div
         className={cx("relative min-h-0 flex-1", props.showBackText ? "overflow-y-auto" : "overflow-hidden")}
-        {...swipeHandlers}
-        onClickCapture={stopTrailingCardClick}
+        {...cardGestureHandlers}
       >
         <CardContent
           showBackText={props.showBackText}

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { getDocument, routeAnonymousAuth, seedConfig, seedDeckAndCards } from "./fixtures";
+import { e2eConfig, getDocument, routeAnonymousAuth, seedConfig, seedDeckAndCards } from "./fixtures";
 
 type SeedCard = Record<string, unknown> & { id: string };
 
@@ -67,9 +67,14 @@ const persistedStudy = {
   version: 4,
 };
 
-const seedSwipeSession = async (page: Page) => {
+const keepBodyAfterCardChangedConfig = {
+  ...e2eConfig,
+  appearance: { ...e2eConfig.appearance, hideBodyWhenCardChanged: false },
+};
+
+const seedSwipeSession = async (page: Page, config = e2eConfig) => {
   await routeAnonymousAuth(page, e2eDeck.uid);
-  await seedConfig(page);
+  await seedConfig(page, config);
   await seedDeckAndCards(e2eDeck, e2eCards);
   await page.goto("/");
   await expect(page.getByText(e2eDeck.name)).toBeVisible();
@@ -91,6 +96,18 @@ const persistedCard = async (cardId: string) => {
 const persistedStudyEnvelope = async (page: Page) =>
   page.evaluate(() => JSON.parse(window.localStorage.getItem("tango-study") ?? "{}"));
 
+const swipeFrontUp = async (page: Page) => {
+  const box = await page.getByRole("button", { name: "apple", exact: true }).boundingBox();
+  if (box == null) throw new Error("Study card front is not visible");
+
+  const x = box.x + box.width / 2;
+  // Start near the center so responsive edge spacing cannot move the drag outside the card surface.
+  await page.mouse.move(x, box.y + box.height * 0.5);
+  await page.mouse.down();
+  await page.mouse.move(x, box.y + box.height * 0.2, { steps: 5 });
+  await page.mouse.up();
+};
+
 const persistedStateBoundaries = async (page: Page) =>
   page.evaluate(() => {
     const root = JSON.parse(window.localStorage.getItem("tango-config") ?? "{}");
@@ -106,59 +123,86 @@ const persistedStateBoundaries = async (page: Page) =>
     };
   });
 
-test.describe.configure({ mode: "serial" });
-
-test.beforeEach(async ({ page }) => {
+const prepareSwipeSession = async (page: Page, config = e2eConfig) => {
   const errors: string[] = [];
   page.on("console", (message) => {
     if (message.type() === "error") errors.push(message.text());
   });
   page.on("pageerror", (error) => errors.push(error.message));
 
-  await seedSwipeSession(page);
+  await seedSwipeSession(page, config);
   await page.exposeFunction("assertNoBrowserErrors", () => expect(errors).toEqual([]));
-});
+};
 
-test("shows the front and back text in the deck study screen", async ({ page }) => {
-  await page.goto(`/deck/${e2eDeck.id}/study`);
+test.describe.configure({ mode: "serial" });
 
-  await expect(page.getByText("apple")).toBeVisible();
-  await page.keyboard.press("Enter");
+test.describe("study session", () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareSwipeSession(page);
+  });
 
-  await expect(page.getByText("りんご")).toBeVisible();
-  await page.evaluate(() => window.assertNoBrowserErrors());
-});
+  test("shows the front and back text in the deck study screen", async ({ page }) => {
+    await page.goto(`/deck/${e2eDeck.id}/study`);
 
-test("updates study progress with a mastered deck swipe", async ({ page }) => {
-  await page.goto(`/deck/${e2eDeck.id}/study`);
+    await expect(page.getByText("apple")).toBeVisible();
+    await page.keyboard.press("Enter");
 
-  await expect(page.getByText("apple")).toBeVisible();
-  await page.getByRole("button", { name: "Swipe up" }).click();
+    await expect(page.getByText("りんご")).toBeVisible();
+    await page.evaluate(() => window.assertNoBrowserErrors());
+  });
 
-  await expect(page.getByText("banana")).toBeVisible();
-  await expect.poll(async () => persistedCard(e2eCards[0].id)).toMatchObject({ score: 1, numberOfSeen: 1 });
-  await expect
-    .poll(async () => persistedStudyEnvelope(page))
-    .toMatchObject({
-      state: {
-        sessionsByDeckId: {
-          [e2eDeck.id]: {
-            deckId: e2eDeck.id,
-            cardOrderIds: e2eCards.map((card) => card.id),
-            currentIndex: 1,
+  test("updates study progress with a mastered deck swipe", async ({ page }) => {
+    await page.goto(`/deck/${e2eDeck.id}/study`);
+
+    await expect(page.getByText("apple")).toBeVisible();
+    await page.getByRole("button", { name: "Swipe up" }).click();
+
+    await expect(page.getByText("banana")).toBeVisible();
+    await expect.poll(async () => persistedCard(e2eCards[0].id)).toMatchObject({ score: 1, numberOfSeen: 1 });
+    await expect
+      .poll(async () => persistedStudyEnvelope(page))
+      .toMatchObject({
+        state: {
+          sessionsByDeckId: {
+            [e2eDeck.id]: {
+              deckId: e2eDeck.id,
+              cardOrderIds: e2eCards.map((card) => card.id),
+              currentIndex: 1,
+            },
           },
         },
-      },
-      version: 4,
-    });
-  await expect
-    .poll(async () => persistedStateBoundaries(page))
-    .toEqual({
-      rootDeck: false,
-      rootCard: false,
-      preferencesShowBackText: false,
-      preferencesAutoPlay: false,
-      preferencesLastSwipe: false,
-    });
-  await page.evaluate(() => window.assertNoBrowserErrors());
+        version: 4,
+      });
+    await expect
+      .poll(async () => persistedStateBoundaries(page))
+      .toEqual({
+        rootDeck: false,
+        rootCard: false,
+        preferencesShowBackText: false,
+        preferencesAutoPlay: false,
+        preferencesLastSwipe: false,
+      });
+    await page.evaluate(() => window.assertNoBrowserErrors());
+  });
+});
+
+test.describe("mouse swipe regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareSwipeSession(page, keepBodyAfterCardChangedConfig);
+  });
+
+  test("advances with an upward drag without flipping the next card", async ({ page }) => {
+    await page.goto(`/deck/${e2eDeck.id}/study`);
+
+    await expect(page.getByText("apple")).toBeVisible();
+    await swipeFrontUp(page);
+
+    await expect(page.getByText("banana")).toBeVisible();
+    await expect(page.getByText("バナナ")).toBeHidden();
+    await expect.poll(async () => persistedCard(e2eCards[0].id)).toMatchObject({ score: 1, numberOfSeen: 1 });
+
+    await page.getByRole("button", { name: "banana", exact: true }).click();
+    await expect(page.getByText("バナナ")).toBeVisible();
+    await page.evaluate(() => window.assertNoBrowserErrors());
+  });
 });

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -96,15 +96,29 @@ const persistedCard = async (cardId: string) => {
 const persistedStudyEnvelope = async (page: Page) =>
   page.evaluate(() => JSON.parse(window.localStorage.getItem("tango-study") ?? "{}"));
 
-const swipeFrontUp = async (page: Page) => {
+const swipeFrontUp = async (page: Page, button: "left" | "middle" | "right" = "left") => {
   const box = await page.getByRole("button", { name: "apple", exact: true }).boundingBox();
   if (box == null) throw new Error("Study card front is not visible");
 
   const x = box.x + box.width / 2;
   // Start near the center so responsive edge spacing cannot move the drag outside the card surface.
   await page.mouse.move(x, box.y + box.height * 0.5);
-  await page.mouse.down();
+  await page.mouse.down({ button });
   await page.mouse.move(x, box.y + box.height * 0.2, { steps: 5 });
+  await page.mouse.up({ button });
+};
+
+const selectBackText = async (page: Page) => {
+  const textRect = await page.getByText("りんご", { exact: true }).evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const rect = range.getBoundingClientRect();
+    return { left: rect.left, right: rect.right, y: rect.top + rect.height / 2 };
+  });
+
+  await page.mouse.move(textRect.left + 1, textRect.y);
+  await page.mouse.down();
+  await page.mouse.move(textRect.right - 1, textRect.y, { steps: 5 });
   await page.mouse.up();
 };
 
@@ -203,6 +217,31 @@ test.describe("mouse swipe regression", () => {
 
     await page.getByRole("button", { name: "banana", exact: true }).click();
     await expect(page.getByText("バナナ")).toBeVisible();
+    await page.evaluate(() => window.assertNoBrowserErrors());
+  });
+
+  test("ignores non-primary mouse drags", async ({ page }) => {
+    await page.goto(`/deck/${e2eDeck.id}/study`);
+
+    await expect(page.getByText("apple")).toBeVisible();
+    await swipeFrontUp(page, "right");
+    await swipeFrontUp(page, "middle");
+
+    await expect(page.getByText("apple")).toBeVisible();
+    await expect.poll(async () => persistedCard(e2eCards[0].id)).toMatchObject({ score: 0, numberOfSeen: 0 });
+    await page.evaluate(() => window.assertNoBrowserErrors());
+  });
+
+  test("keeps the back visible while selecting its text", async ({ page }) => {
+    await page.goto(`/deck/${e2eDeck.id}/study`);
+    await page.getByRole("button", { name: "apple", exact: true }).click();
+
+    await expect(page.getByText("りんご", { exact: true })).toBeVisible();
+    await selectBackText(page);
+
+    await expect(page.getByText("りんご", { exact: true })).toBeVisible();
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() ?? "")).toContain("りんご");
+    await expect.poll(async () => persistedCard(e2eCards[0].id)).toMatchObject({ score: 0, numberOfSeen: 0 });
     await page.evaluate(() => window.assertNoBrowserErrors());
   });
 });


### PR DESCRIPTION
## Related issue

None

## Summary

- Enable mouse tracking for study-session swipe gestures.
- Suppress the trailing click after a drag so swiping does not also flip the card.
- Add unit and Playwright regression coverage for mouse swipes and subsequent card clicks.

## Testing

- npm run test:unit -- src/pages/study-session/ui/StudySession.spec.tsx
- Playwright swipe.spec.ts: 3 passed
- mise run check: 518 unit tests passed