### PR TITLE
No issue: Define UI props ownership rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Treat the recommended `@feature-sliced/steiger-plugin` rules as architectural constraints. Resolve violations structurally instead of disabling a recommended rule unless the user explicitly requests an exception.
 - Do not retain a Feature or Entity slice solely because the code is conceptually a user action or domain concept when it has only one Page consumer; prefer colocating insignificant slices with that Page.
 - Move reusable cross-Page workflows to Features, reusable domain concepts and rules to Entities, and broadly reusable technical or UI primitives to Shared.
+- UI components must define their own props instead of reusing model return types.
 
 ## Coding Style
 


### PR DESCRIPTION
## Summary

- require UI components to define their own props
- avoid coupling UI contracts to model return types

## Testing

- not run (documentation-only change)