### PR TITLE
[No issue] Let Deck List UI own its props

### DIFF
--- a/src/pages/deck-list/model/useDeckListState.ts
+++ b/src/pages/deck-list/model/useDeckListState.ts
@@ -45,5 +45,3 @@ export const useDeckListState = () => {
     sections: buildDeckListSections(decks, cards, sessionsByDeckId),
   };
 };
-
-export type DeckListState = ReturnType<typeof useDeckListState>;

--- a/src/pages/deck-list/ui/DeckList.spec.tsx
+++ b/src/pages/deck-list/ui/DeckList.spec.tsx
@@ -4,15 +4,13 @@
  * both compact sections", "omits empty sections", "opens one deck actions menu at a time".
  */
 
-import type { DeckListState } from "../model/useDeckListState";
-
 import { fireEvent, render, within, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it } from "vitest";
 
 import { createDeck } from "@/test/factories";
 
-import { DeckList } from "./DeckList";
+import { DeckList, type DeckListProps } from "./DeckList";
 
 const activeDeck = createDeck({ id: "active", name: "Active deck", category: "math" });
 const otherDeck = createDeck({ id: "other", name: "Other deck", category: "history" });
@@ -32,7 +30,7 @@ const sections = {
     },
   ],
   other: [{ deck: otherDeck, cardCount: 7 }],
-} satisfies DeckListState["sections"];
+} satisfies DeckListProps["sections"];
 
 describe("DeckList", () => {
   it("renders the page count and both compact sections", () => {

--- a/src/pages/deck-list/ui/DeckList.stories.tsx
+++ b/src/pages/deck-list/ui/DeckList.stories.tsx
@@ -8,11 +8,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { expect, fn } from "storybook/test";
 
 import type { Deck } from "@/entities/deck";
-import type { DeckListState } from "../model/useDeckListState";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
-import { DeckList as Template } from "./DeckList";
+import { DeckList as Template, type DeckListProps } from "./DeckList";
 
 /**
  * Prepares other items data for the Storybook examples in this file.
@@ -41,11 +40,11 @@ const studyingItems = (decks: Deck[]) =>
 const mixed = {
   studying: studyingItems(fixture.decks.default.slice(0, 3)),
   other: otherItems(fixture.decks.default.slice(3)),
-} satisfies DeckListState["sections"];
+} satisfies DeckListProps["sections"];
 const longSections = {
   studying: studyingItems(fixture.decks.long.slice(0, 4)),
   other: otherItems(fixture.decks.long.slice(4)),
-} satisfies DeckListState["sections"];
+} satisfies DeckListProps["sections"];
 
 const meta = {
   title: "Pages/Deck List/DeckList",

--- a/src/pages/deck-list/ui/DeckList.tsx
+++ b/src/pages/deck-list/ui/DeckList.tsx
@@ -4,14 +4,26 @@
 
 import * as React from "react";
 
-import type { DeckId } from "@/entities/deck";
-
-import type { DeckListState } from "../model/useDeckListState";
+import type { Deck, DeckId } from "@/entities/deck";
+import type { StudySession } from "@/entities/study-session";
 
 import { DeckListCard, type DeckListCardActions } from "./DeckListCard";
 
+interface DeckListItem {
+  deck: Deck;
+  cardCount: number;
+  studySession?: StudySession;
+}
+
+interface StudyingDeckListItem extends DeckListItem {
+  studySession: StudySession;
+}
+
 export interface DeckListProps {
-  sections: DeckListState["sections"];
+  sections: {
+    studying: StudyingDeckListItem[];
+    other: DeckListItem[];
+  };
   deckCard?: DeckListCardActions;
 }
 
@@ -27,7 +39,7 @@ const countLabel = (count: number) => `${String(count)} ${count === 1 ? "deck" :
 const DeckListSection: React.FC<{
   title: string;
   note: string;
-  items: DeckListState["sections"]["other"];
+  items: DeckListItem[];
   actions: DeckListCardActions | undefined;
   openMenuDeckId: DeckId | undefined;
   onToggleMenu: (id: DeckId) => void;

--- a/src/pages/deck-list/ui/DeckListCard.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.tsx
@@ -8,8 +8,8 @@ import cx from "classnames";
 import * as React from "react";
 import { AiFillCaretRight, AiOutlineCloud } from "react-icons/ai";
 
-import type { DeckId } from "@/entities/deck";
-import type { DeckListState } from "../model/useDeckListState";
+import type { Deck, DeckId } from "@/entities/deck";
+import type { StudySession } from "@/entities/study-session";
 
 import { DeckActionsMenu } from "./DeckActionsMenu";
 
@@ -30,9 +30,11 @@ interface DeckListCardMenuState {
   onCloseMenu?: () => void;
 }
 
-export type DeckListCardProps = DeckListCardActions &
-  DeckListCardMenuState &
-  DeckListState["sections"]["other"][number];
+export interface DeckListCardProps extends DeckListCardActions, DeckListCardMenuState {
+  deck: Deck;
+  cardCount: number;
+  studySession?: StudySession;
+}
 
 /**
  * Formats a deck's last-study time for display in the deck list.


### PR DESCRIPTION
## Related issue

None.

## Summary

- Define Deck List presentation contracts within the UI components
- Remove UI dependencies on the useDeckListState return type
- Type tests and Storybook fixtures against DeckListProps

## Testing

- mise run check