### PR TITLE
[No issue] Let Card Form UI own its props

### DIFF
--- a/src/pages/card-form/model/useCardFormState.ts
+++ b/src/pages/card-form/model/useCardFormState.ts
@@ -5,36 +5,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
 import { useAuthUid } from "@/entities/auth";
-import { cardContentSchema, editCard, type CardId, useCard } from "@/entities/card";
+import { cardContentSchema, editCard, useCard } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
-import type { Form, Option, Tag, Textarea } from "@/shared/ui/forms";
-
-interface CardFormTagField extends Option {
-  input: React.ComponentProps<typeof Tag>;
-}
-
-interface CardFormFields {
-  frontText: React.ComponentProps<typeof Textarea>;
-  backText: React.ComponentProps<typeof Textarea>;
-  tags: CardFormTagField[];
-}
-
-export interface CardFormProps {
-  cardInfo: {
-    uniqueKey: string;
-    id: CardId;
-    createdAt?: string;
-    lastSeenAt?: string;
-  };
-  fields: CardFormFields;
-  errors: {
-    frontText: string | undefined;
-    backText: string | undefined;
-  };
-  isSubmitting: boolean;
-  onCancel: () => void;
-  onSubmit: NonNullable<React.ComponentProps<typeof Form>["onSubmit"]>;
-}
 
 const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
 type CardFormValues = z.infer<typeof cardFormSchema>;
@@ -75,7 +47,7 @@ export const useCardFormState = ({ cardId, onCancel, onSaved }: UseCardFormState
     void submit(event);
   };
 
-  const form: CardFormProps = {
+  const form = {
     cardInfo: {
       id: card.id,
       uniqueKey: card.uniqueKey,

--- a/src/pages/card-form/ui/CardEditor.stories.tsx
+++ b/src/pages/card-form/ui/CardEditor.stories.tsx
@@ -3,8 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import * as fixture from "@/storybook/fixture";
 import { INITIAL_VIEWPORTS } from "@/storybook/storybookViewports";
 
-import type { CardFormProps } from "../model/useCardFormState";
 import { CardEditor } from "./CardEditor";
+import type { CardFormProps } from "./CardForm";
 
 const longCard = {
   ...fixture.card.long,

--- a/src/pages/card-form/ui/CardEditor.tsx
+++ b/src/pages/card-form/ui/CardEditor.tsx
@@ -3,8 +3,7 @@ import { AiOutlineArrowLeft } from "react-icons/ai";
 
 import { Feedback } from "@/shared/ui/feedback";
 
-import type { CardFormProps } from "../model/useCardFormState";
-import { CardForm } from "./CardForm";
+import { CardForm, type CardFormProps } from "./CardForm";
 
 export interface CardEditorProps {
   form: CardFormProps;

--- a/src/pages/card-form/ui/CardForm.tsx
+++ b/src/pages/card-form/ui/CardForm.tsx
@@ -1,10 +1,38 @@
 import type * as React from "react";
 import { useId } from "react";
 
+import type { CardId } from "@/entities/card";
 import { Button } from "@/shared/ui/button";
 import { TagList } from "@/shared/ui/content";
 import { Form, FormItem, Tag, Textarea } from "@/shared/ui/forms";
-import type { CardFormProps } from "../model/useCardFormState";
+import type { Option } from "@/shared/ui/forms";
+
+interface CardFormTagField extends Option {
+  input: React.ComponentProps<typeof Tag>;
+}
+
+interface CardFormFields {
+  frontText: React.ComponentProps<typeof Textarea>;
+  backText: React.ComponentProps<typeof Textarea>;
+  tags: CardFormTagField[];
+}
+
+export interface CardFormProps {
+  cardInfo: {
+    uniqueKey: string;
+    id: CardId;
+    createdAt?: string;
+    lastSeenAt?: string;
+  };
+  fields: CardFormFields;
+  errors: {
+    frontText: string | undefined;
+    backText: string | undefined;
+  };
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onSubmit: NonNullable<React.ComponentProps<typeof Form>["onSubmit"]>;
+}
 
 export const CardForm: React.FC<CardFormProps> = (props) => {
   const sectionHeadingIdPrefix = useId();


### PR DESCRIPTION
## Related issue

None.

## Summary

- Move CardFormProps and its supporting field types into the Card Form UI
- Let useCardFormState infer its return shape without depending on UI props
- Type CardEditor and Storybook fixtures against the UI-owned contract

## Testing

- mise run check