### PR TITLE
[No issue] Expand E2E acceptance test coverage

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -1,37 +1,119 @@
 # E2E テスト仕様書
 
+## カテゴリ
+
+- `read`: テスト中に永続データを変更しない。
+- `write`: 1つの論理操作による変更を永続化する。
+- `batch`: Deck / Card 群、保存先、認証スコープなど複数のリソースを一括で変更する。
+
+並列実行時のデータ競合を避けるため、カテゴリごとにテストを分ける。`write` と `batch` は、
+テストケース間で所有ユーザーや対象データを共有しない。
+
+## 共通の期待結果
+
+- `browser error` は、処理されていない page error または予期しない console error を指す。
+- 正常系では browser error が発生しないことを確認する。
+- 異常系では想定したエラーが画面上で処理され、browser error として残らないことを確認する。
+
 ## テストケース
+
+### App
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| APP-01 | batch | [Sample Deck を一度だけ初期生成できる](./app.md#app-01) |
+| APP-02 | read | [存在しない route から Deck 一覧へ復帰できる](./app.md#app-02) |
+| APP-03 | read | [認証初期化失敗から Reload で復帰できる](./app.md#app-03) |
+
+### Account
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| ACCOUNT-01 | batch | [匿名アカウントを Google アカウントに連携してデータを維持できる](./account.md#account-01) |
+| ACCOUNT-02 | write | [Google sign-in 失敗後に再試行できる](./account.md#account-02) |
+| ACCOUNT-03 | batch | [sign-out 後に新しい匿名アカウントへ切り替えられる](./account.md#account-03) |
+
+### Settings
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| SETTINGS-01 | write | [Dark mode を自動保存して reload 後も反映できる](./settings.md#settings-01) |
+| SETTINGS-02 | write | [Maximum cards 設定を次の学習 session に反映できる](./settings.md#settings-02) |
+
+### Import
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| IMPORT-01 | read | [有効な CSV を永続化せずに preview できる](./import.md#import-01) |
+| IMPORT-02 | read | [不正な行を含む CSV の import を阻止できる](./import.md#import-02) |
+| IMPORT-03 | batch | [CSV を remote に import して reload 後も利用できる](./import.md#import-03) |
+| IMPORT-04 | batch | [CSV を local-only に import して reload 後に学習できる](./import.md#import-04) |
+| IMPORT-05 | batch | [失敗した import を同じ保存先へ重複なく再試行できる](./import.md#import-05) |
+| IMPORT-06 | batch | [Sample Deck を繰り返し追加しても重複しない](./import.md#import-06) |
 
 ### Deck
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| DECK-01 | read | [Deck 一覧から詳細へ遷移できる](./deck.md#deck-01) |
-| DECK-02 | write | [Deck 編集内容を保存して一覧に戻れる](./deck.md#deck-02) |
-| DECK-03 | write | [Deck を削除できる](./deck.md#deck-03) |
+| DECK-01 | read | [Deck 一覧から Card 一覧へ遷移できる](./deck.md#deck-01) |
+| DECK-02 | write | [Deck 編集内容を保存して reload 後も確認できる](./deck.md#deck-02) |
+| DECK-03 | batch | [Deck と関連データをまとめて削除できる](./deck.md#deck-03) |
+| DECK-04 | read | [Deck の削除を取り消せる](./deck.md#deck-04) |
+| DECK-05 | batch | [Deck の削除失敗後に再試行できる](./deck.md#deck-05) |
+| DECK-06 | read | [存在しない Deck から復帰できる](./deck.md#deck-06) |
+| DECK-07 | batch | [local-only Deck と Card を remote storage へ移行できる](./deck.md#deck-07) |
+| DECK-08 | read | [Deck の Card を CSV で export できる](./deck.md#deck-08) |
 
 ### Card
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| CARD-01 | read | [Card 一覧を表示できる](./card.md#card-01) |
-| CARD-02 | read | [Card の裏面を overlay で確認できる](./card.md#card-02) |
-| CARD-03 | write | [Card 編集内容を保存して前画面に戻れる](./card.md#card-03) |
+| CARD-01 | read | [Card 一覧に学習情報を表示できる](./card.md#card-01) |
+| CARD-02 | read | [Card の裏面 overlay を開ける](./card.md#card-02) |
+| CARD-03 | write | [Card 編集内容を保存して reload 後も確認できる](./card.md#card-03) |
 | CARD-04 | write | [Card を削除できる](./card.md#card-04) |
-| CARD-05 | write | [Card の swipe 操作で score を更新できる](./card.md#card-05) |
+| CARD-05 | write | [Card の右 swipe で score を増やせる](./card.md#card-05) |
+| CARD-06 | write | [Card の左 swipe で score を減らせる](./card.md#card-06) |
+| CARD-07 | read | [開いている Card の裏面 overlay を閉じられる](./card.md#card-07) |
+| CARD-08 | read | [Card の削除を取り消せる](./card.md#card-08) |
+| CARD-09 | write | [Card の編集失敗後に再試行できる](./card.md#card-09) |
+| CARD-10 | write | [score と tag の filter を保存して Card 一覧へ反映できる](./card.md#card-10) |
+| CARD-11 | read | [Card view を直接開ける](./card.md#card-11) |
+| CARD-12 | read | [存在しない Card から復帰できる](./card.md#card-12) |
 
 ### Swipe
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| SWIPE-01 | read | [Deck 学習画面で card の表面と裏面を表示できる](./swipe.md#swipe-01) |
-| SWIPE-02 | write | [Deck 学習画面で mastered swipe を実行できる](./swipe.md#swipe-02) |
+| SWIPE-01 | read | [学習中の Card を表面から裏面へ切り替えられる](./swipe.md#swipe-01) |
+| SWIPE-02 | write | [mastered action で学習結果を保存して次の Card へ進める](./swipe.md#swipe-02) |
+| SWIPE-03 | write | [non-mastered action で学習結果を保存して次の Card へ進める](./swipe.md#swipe-03) |
+| SWIPE-04 | write | [next-card action で次の Card へ進める](./swipe.md#swipe-04) |
+| SWIPE-05 | write | [previous-card action で前の Card へ戻れる](./swipe.md#swipe-05) |
+| SWIPE-06 | write | [filter と学習上限を反映して session を開始できる](./swipe.md#swipe-06) |
+| SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](./swipe.md#swipe-07) |
+| SWIPE-08 | write | [Exit 後に同じ位置から Continue できる](./swipe.md#swipe-08) |
+| SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](./swipe.md#swipe-09) |
+| SWIPE-10 | write | [最後の Card を完了して session を終了できる](./swipe.md#swipe-10) |
+| SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](./swipe.md#swipe-11) |
+| SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](./swipe.md#swipe-12) |
+| SWIPE-13 | write | [primary mouse の上方向 drag で次の Card へ進める](./swipe.md#swipe-13) |
+| SWIPE-14 | read | [non-primary mouse の drag を無視できる](./swipe.md#swipe-14) |
+| SWIPE-15 | read | [裏面 text を選択しても Card の状態を維持できる](./swipe.md#swipe-15) |
+
+### Persistence
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| PERSIST-01 | read | [UID ごとに remote data を分離して reload 後も表示できる](./persistence.md#persist-01) |
+| PERSIST-02 | batch | [offline cache の変更を再接続後に remote へ同期できる](./persistence.md#persist-02) |
 
 ## 前提
 
 - Playwright で実行する。
 - 実行コマンドは `mise run e2e`。
-- Deck / Card は Firestore emulator に保存する。
-- Config / Study session は必要に応じて localStorage に保存する。
+- Deck / Card は Firestore emulator または localStorage の選択された保存先に保存する。
+- Config / Study session は localStorage に保存する。
 - Firebase Auth API は mock し、Firebase 実環境には依存しない。
-- 並列実行時のデータ競合を避けるため、read のテストと write のテストは分ける。
+- CSV の各 validation rule、全 Settings 項目、全入力手段の組み合わせは unit / component test で確認し、
+  E2E では代表的な利用者導線を確認する。

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -1,13 +1,24 @@
 # E2E テスト仕様書
 
+## 前提
+
+- この仕様書は、Playwright で確認する画面上の振る舞いと、永続化・認証境界で観測する結果を定義する。
+- 実行コマンドは `mise run e2e`。
+- 具体的な fixture 値はテスト実装を正とし、この仕様書には重複して記載しない。
+- Deck / Card は、選択された保存先に応じて Firestore emulator または localStorage に保存する。
+- Config / Study session は localStorage に保存する。
+- Firebase Auth API は mock し、Firebase 実環境には依存しない。
+- CSV の各 validation rule、全 Settings 項目、全入力手段の組み合わせは unit / component test で確認し、
+  E2E では代表的な利用者導線を確認する。
+
 ## カテゴリ
 
 - `read`: テスト中に永続データを変更しない。
 - `write`: 1つの論理操作による変更を永続化する。
 - `batch`: Deck / Card 群、保存先、認証スコープなど複数のリソースを一括で変更する。
 
-並列実行時のデータ競合を避けるため、カテゴリごとにテストを分ける。`write` と `batch` は、
-テストケース間で所有ユーザーや対象データを共有しない。
+カテゴリは、永続化の変更範囲を示す。共有状態が競合する場合は、テストケースごとに一意な fixture を使うか、
+同じデータを扱うテストを serial 実行する。
 
 ## 共通の期待結果
 
@@ -107,13 +118,3 @@
 | --- | --- | --- |
 | PERSIST-01 | read | [UID ごとに remote data を分離して reload 後も表示できる](./persistence.md#persist-01) |
 | PERSIST-02 | batch | [offline cache の変更を再接続後に remote へ同期できる](./persistence.md#persist-02) |
-
-## 前提
-
-- Playwright で実行する。
-- 実行コマンドは `mise run e2e`。
-- Deck / Card は Firestore emulator または localStorage の選択された保存先に保存する。
-- Config / Study session は localStorage に保存する。
-- Firebase Auth API は mock し、Firebase 実環境には依存しない。
-- CSV の各 validation rule、全 Settings 項目、全入力手段の組み合わせは unit / component test で確認し、
-  E2E では代表的な利用者導線を確認する。

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -2,14 +2,12 @@
 
 ## 前提
 
-- この仕様書は、Playwright で確認する画面上の振る舞いと、永続化・認証境界で観測する結果を定義する。
-- 実行コマンドは `mise run e2e`。
-- 具体的な fixture 値はテスト実装を正とし、この仕様書には重複して記載しない。
-- Deck / Card は、選択された保存先に応じて Firestore emulator または localStorage に保存する。
-- Config / Study session は localStorage に保存する。
-- Firebase Auth API は mock し、Firebase 実環境には依存しない。
-- CSV の各 validation rule、全 Settings 項目、全入力手段の組み合わせは unit / component test で確認し、
-  E2E では代表的な利用者導線を確認する。
+- `mise run e2e` で Playwright を実行する。
+- 具体的な fixture 値はテスト実装を正とし、仕様書には記載しない。
+- Deck / Card は Firestore emulator または localStorage、Config / Study session は localStorage に保存し、
+  Firebase Auth API は mock する。
+- E2E は代表的な利用者導線を対象とし、各 validation rule や設定・入力手段の組み合わせは
+  unit / component test で確認する。
 
 ## カテゴリ
 

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -3,7 +3,6 @@
 ## 前提
 
 - `mise run e2e` で Playwright を実行する。
-- 具体的な fixture 値はテスト実装を正とし、仕様書には記載しない。
 - Deck / Card は Firestore emulator または localStorage、Config / Study session は localStorage に保存し、
   Firebase Auth API は mock する。
 - E2E は代表的な利用者導線を対象とし、各 validation rule や設定・入力手段の組み合わせは
@@ -11,12 +10,9 @@
 
 ## カテゴリ
 
-- `read`: テスト中に永続データを変更しない。
-- `write`: 1つの論理操作による変更を永続化する。
+- `read`: 永続データを変更せず、並列実行の対象とする。
+- `write`: ケースごとに分離したデータへ1つの論理操作を永続化し、並列実行の対象とする。
 - `batch`: Deck / Card 群、保存先、認証スコープなど複数のリソースを一括で変更する。
-
-カテゴリは、永続化の変更範囲を示す。共有状態が競合する場合は、テストケースごとに一意な fixture を使うか、
-同じデータを扱うテストを serial 実行する。
 
 ## 共通の期待結果
 

--- a/docs/e2e/account.md
+++ b/docs/e2e/account.md
@@ -1,0 +1,80 @@
+# Account E2E テスト仕様書
+
+## 目的
+
+匿名アカウントと Google アカウントの切り替えが、認証情報、ユーザーデータ、cache、学習 session の境界を保つことを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| ACCOUNT-01 | batch | [匿名アカウントを Google アカウントに連携してデータを維持できる](#account-01) |
+| ACCOUNT-02 | write | [Google sign-in 失敗後に再試行できる](#account-02) |
+| ACCOUNT-03 | batch | [sign-out 後に新しい匿名アカウントへ切り替えられる](#account-03) |
+
+<a id="account-01"></a>
+
+### ACCOUNT-01 匿名アカウントを Google アカウントに連携してデータを維持できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 匿名アカウントに Deck と Card が存在する。
+- 対象 Deck に進行中の学習 session が存在する。
+- 連携する Google アカウントは別の Firebase Auth ユーザーに紐づいていない。
+
+When:
+
+- Account 画面から Google アカウントへ sign-in する。
+
+Then:
+
+- Account 画面に Google アカウントとの連携状態が表示される。
+- 匿名アカウントと同じ UID が維持される。
+- 連携前の Deck、Card、学習 session を引き続き利用できる。
+- browser error が発生しない。
+
+<a id="account-02"></a>
+
+### ACCOUNT-02 Google sign-in 失敗後に再試行できる
+
+カテゴリ: `write`
+
+Given:
+
+- 匿名アカウントで Account 画面を開いている。
+- Google sign-in の失敗が画面内で処理され、`Retry` が表示されている。
+- 再試行では Google sign-in に成功できる。
+
+When:
+
+- `Retry` を選択して Google sign-in を再試行する。
+
+Then:
+
+- 再試行後にエラー表示が残らない。
+- Account 画面に Google アカウントとの連携状態が表示される。
+- 未処理の browser error が発生しない。
+
+<a id="account-03"></a>
+
+### ACCOUNT-03 sign-out 後に新しい匿名アカウントへ切り替えられる
+
+カテゴリ: `batch`
+
+Given:
+
+- Google アカウントに連携したユーザーの remote Deck と Card が query cache に存在する。
+- 対象ユーザーに進行中の学習 session が存在する。
+
+When:
+
+- Account 画面から sign-out し、匿名認証の完了を待つ。
+
+Then:
+
+- Account 画面に新しい匿名アカウントと連携前とは異なる UID が表示される。
+- 前の UID に属する remote Deck と Card が query cache や画面に残らない。
+- 前の UID で開始した学習 session を利用できない。
+- browser error が発生しない。

--- a/docs/e2e/app.md
+++ b/docs/e2e/app.md
@@ -1,0 +1,74 @@
+# App E2E テスト仕様書
+
+## 目的
+
+アプリケーションの初期化と route recovery が、複数の永続資源や認証失敗を含む状況でも破綻しないことを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| APP-01 | batch | [Sample Deck を一度だけ初期生成できる](#app-01) |
+| APP-02 | read | [存在しない route から Deck 一覧へ復帰できる](#app-02) |
+| APP-03 | read | [認証初期化失敗から Reload で復帰できる](#app-03) |
+
+<a id="app-01"></a>
+
+### APP-01 Sample Deck を一度だけ初期生成できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 認証済みユーザーに Deck がなく、Sample Deck の初期生成が有効である。
+
+When:
+
+- Deck 一覧を開いて初期生成の完了を待ち、ページを reload する。
+
+Then:
+
+- Sample Deck とその Card 群が利用できる。
+- Sample Deck とその Card 群は reload 後も重複しない。
+- browser error が発生しない。
+
+<a id="app-02"></a>
+
+### APP-02 存在しない route から Deck 一覧へ復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーがアプリケーションにアクセスできる。
+- Sample Deck の自動生成が無効である。
+
+When:
+
+- 存在しない route を直接開き、`Go home` を選択する。
+
+Then:
+
+- Deck 一覧へ遷移する。
+- not-found 表示が残らない。
+- browser error が発生しない。
+
+<a id="app-03"></a>
+
+### APP-03 認証初期化失敗から Reload で復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証初期化失敗が画面内で処理され、認証初期化失敗画面に `Reload` が表示されている。
+- 次の認証初期化は成功でき、Sample Deck の自動生成は無効である。
+
+When:
+
+- 認証初期化失敗画面に表示された `Reload` を選択する。
+
+Then:
+
+- 再初期化が完了し、Deck 一覧を利用できる。
+- 未処理の browser error が発生しない。

--- a/docs/e2e/card.md
+++ b/docs/e2e/card.md
@@ -2,42 +2,48 @@
 
 ## 目的
 
-Card 管理の主要導線が、ブラウザ上で表示・編集・削除・状態更新まで破綻しないことを確認する。
+Card 管理の主要導線が、ブラウザ上で表示・編集・削除・filter・学習状態更新まで破綻しないことを確認する。
 
 ## テストケース
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| CARD-01 | read | [Card 一覧を表示できる](#card-01) |
-| CARD-02 | read | [Card の裏面を overlay で確認できる](#card-02) |
-| CARD-03 | write | [Card 編集内容を保存して前画面に戻れる](#card-03) |
+| CARD-01 | read | [Card 一覧に学習情報を表示できる](#card-01) |
+| CARD-02 | read | [Card の裏面 overlay を開ける](#card-02) |
+| CARD-03 | write | [Card 編集内容を保存して reload 後も確認できる](#card-03) |
 | CARD-04 | write | [Card を削除できる](#card-04) |
-| CARD-05 | write | [Card の swipe 操作で score を更新できる](#card-05) |
+| CARD-05 | write | [Card の右 swipe で score を増やせる](#card-05) |
+| CARD-06 | write | [Card の左 swipe で score を減らせる](#card-06) |
+| CARD-07 | read | [開いている Card の裏面 overlay を閉じられる](#card-07) |
+| CARD-08 | read | [Card の削除を取り消せる](#card-08) |
+| CARD-09 | write | [Card の編集失敗後に再試行できる](#card-09) |
+| CARD-10 | write | [score と tag の filter を保存して Card 一覧へ反映できる](#card-10) |
+| CARD-11 | read | [Card view を直接開ける](#card-11) |
+| CARD-12 | read | [存在しない Card から復帰できる](#card-12) |
 
 <a id="card-01"></a>
 
-### CARD-01 Card 一覧を表示できる
+### CARD-01 Card 一覧に学習情報を表示できる
 
 カテゴリ: `read`
 
 Given:
 
 - 認証済みユーザーが所有する Deck が存在する。
-- 対象 Deck に未学習の Card が存在する。
+- 対象 Deck に score、学習回数、tags を持つ Card が存在する。
 
 When:
 
-- 対象 deck の詳細画面を開く。
+- 対象 Deck の Card 一覧を開く。
 
 Then:
 
-- card の front text が表示される。
-- score と学習回数が表示される。
+- 対象 Card の front text、score、学習回数、tags が表示される。
 - browser error が発生しない。
 
 <a id="card-02"></a>
 
-### CARD-02 Card の裏面を overlay で確認できる
+### CARD-02 Card の裏面 overlay を開ける
 
 カテゴリ: `read`
 
@@ -48,17 +54,16 @@ Given:
 
 When:
 
-- 対象 deck の詳細画面を開き、card の裏面を表示して閉じる。
+- Card 一覧で対象 Card を選択する。
 
 Then:
 
-- overlay で card の back text を確認できる。
-- overlay を閉じられる。
+- 対象 Card の back text が overlay に表示される。
 - browser error が発生しない。
 
 <a id="card-03"></a>
 
-### CARD-03 Card 編集内容を保存して前画面に戻れる
+### CARD-03 Card 編集内容を保存して reload 後も確認できる
 
 カテゴリ: `write`
 
@@ -69,13 +74,11 @@ Given:
 
 When:
 
-- Card の front text、back text、tags を編集して保存し、変更後の裏面を確認する。
+- 対象 Card の front text、back text、tags を変更して保存し、画面を reload して編集画面を再度開く。
 
 Then:
 
-- Deck 詳細画面に戻る。
-- card 一覧に変更後の front text が表示される。
-- overlay に変更後の back text が表示される。
+- 編集画面に変更後の front text、back text、tags が表示される。
 - browser error が発生しない。
 
 <a id="card-04"></a>
@@ -91,16 +94,17 @@ Given:
 
 When:
 
-- 対象 deck の詳細画面から card を削除する。
+- Card 一覧から対象 Card の削除を確定し、画面を reload する。
 
 Then:
 
-- card 一覧に削除した card が表示されない。
+- Card 一覧に対象 Card が表示されない。
+- 対象 Card が active Card として保存先から読み込まれない。
 - browser error が発生しない。
 
 <a id="card-05"></a>
 
-### CARD-05 Card の swipe 操作で score を更新できる
+### CARD-05 Card の右 swipe で score を増やせる
 
 カテゴリ: `write`
 
@@ -111,10 +115,158 @@ Given:
 
 When:
 
-- 対象 deck の詳細画面で card を右方向に swipe した後、左方向に swipe する。
+- Card 一覧で対象 Card を右方向に swipe し、保存完了後に画面を reload する。
 
 Then:
 
-- 右方向の swipe で card の score が増える。
-- 左方向の swipe で card の score が減る。
+- 対象 Card の score が swipe 前より 1 増えて表示される。
+- browser error が発生しない。
+
+<a id="card-06"></a>
+
+### CARD-06 Card の左 swipe で score を減らせる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 対象 Deck に score を持つ Card が存在する。
+
+When:
+
+- Card 一覧で対象 Card を左方向に swipe し、保存完了後に画面を reload する。
+
+Then:
+
+- 対象 Card の score が swipe 前より 1 減って表示される。
+- browser error が発生しない。
+
+<a id="card-07"></a>
+
+### CARD-07 開いている Card の裏面 overlay を閉じられる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 対象 Deck の Card 一覧で、対象 Card の back text overlay が開いている。
+
+When:
+
+- overlay の close action を実行する。
+
+Then:
+
+- back text overlay が閉じる。
+- Card 一覧に対象 Card の front text が表示される。
+- Card の永続データが変更されない。
+- browser error が発生しない。
+
+<a id="card-08"></a>
+
+### CARD-08 Card の削除を取り消せる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 削除対象 Card の action menu trigger から削除 dialog を開いている。
+- dialog に対象 Card と削除を取り消せない旨が表示されている。
+
+When:
+
+- Cancel を選択する。
+
+Then:
+
+- 削除 dialog が閉じる。
+- focus が対象 Card の action menu trigger に戻る。
+- 対象 Card の永続データが変更されない。
+- browser error が発生しない。
+
+<a id="card-09"></a>
+
+### CARD-09 Card の編集失敗後に再試行できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 対象 Deck に編集対象の Card が存在する。
+- 編集要求の失敗が編集画面内で処理され、変更内容が維持されている。
+- 次の編集要求は成功できる。
+
+When:
+
+- 同じ変更内容の保存を再試行し、Card 一覧を reload する。
+
+Then:
+
+- Card 一覧へ戻る。
+- reload 後も対象 Card に変更内容が表示される。
+- 最初の編集失敗に伴う未処理の browser error が発生しない。
+
+<a id="card-10"></a>
+
+### CARD-10 score と tag の filter を保存して Card 一覧へ反映できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 対象 Deck に score と tags の組み合わせが異なる複数の Card が存在する。
+
+When:
+
+- Card 一覧で score 範囲と tag filter を設定し、保存完了後に画面を reload する。
+
+Then:
+
+- reload 前に設定した score 範囲と tag filter が表示される。
+- 両方の filter 条件に一致する Card だけが一覧に表示される。
+- browser error が発生しない。
+
+<a id="card-11"></a>
+
+### CARD-11 Card view を直接開ける
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 対象 Deck に back text を持つ Card が存在する。
+
+When:
+
+- 対象 Card の view route を直接開く。
+
+Then:
+
+- 対象 Card の back text が Card answer として表示される。
+- application shell が表示される。
+- browser error が発生しない。
+
+<a id="card-12"></a>
+
+### CARD-12 存在しない Card から復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーの保存先に、route が参照する Card が存在しない。
+
+When:
+
+- 存在しない Card の view route を直接開き、Card が利用できない旨の画面から home recovery action を実行する。
+
+Then:
+
+- Deck 一覧が表示される。
 - browser error が発生しない。

--- a/docs/e2e/deck.md
+++ b/docs/e2e/deck.md
@@ -2,19 +2,24 @@
 
 ## 目的
 
-Deck 管理の主要導線が、ブラウザ上で画面遷移・状態更新まで破綻しないことを確認する。
+Deck 管理の主要導線が、ブラウザ上で表示・編集・削除・保存先の移行・export まで破綻しないことを確認する。
 
 ## テストケース
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| DECK-01 | read | [Deck 一覧から詳細へ遷移できる](#deck-01) |
-| DECK-02 | write | [Deck 編集内容を保存して一覧に戻れる](#deck-02) |
-| DECK-03 | write | [Deck を削除できる](#deck-03) |
+| DECK-01 | read | [Deck 一覧から Card 一覧へ遷移できる](#deck-01) |
+| DECK-02 | write | [Deck 編集内容を保存して reload 後も確認できる](#deck-02) |
+| DECK-03 | batch | [Deck と関連データをまとめて削除できる](#deck-03) |
+| DECK-04 | read | [Deck の削除を取り消せる](#deck-04) |
+| DECK-05 | batch | [Deck の削除失敗後に再試行できる](#deck-05) |
+| DECK-06 | read | [存在しない Deck から復帰できる](#deck-06) |
+| DECK-07 | batch | [local-only Deck と Card を remote storage へ移行できる](#deck-07) |
+| DECK-08 | read | [Deck の Card を CSV で export できる](#deck-08) |
 
 <a id="deck-01"></a>
 
-### DECK-01 Deck 一覧から詳細へ遷移できる
+### DECK-01 Deck 一覧から Card 一覧へ遷移できる
 
 カテゴリ: `read`
 
@@ -25,18 +30,17 @@ Given:
 
 When:
 
-- Deck 一覧を開き、deck 名を選択する。
+- Deck 一覧を開き、対象 Deck を選択する。
 
 Then:
 
-- 一覧に deck 名が表示される。
-- deck 詳細画面に遷移する。
-- card 一覧に card が表示される。
+- 対象 Deck の Card 一覧へ遷移する。
+- 対象 Card の front text が表示される。
 - browser error が発生しない。
 
 <a id="deck-02"></a>
 
-### DECK-02 Deck 編集内容を保存して一覧に戻れる
+### DECK-02 Deck 編集内容を保存して reload 後も確認できる
 
 カテゴリ: `write`
 
@@ -46,29 +50,139 @@ Given:
 
 When:
 
-- deck name を編集して保存する。
+- 対象 Deck の name と category を変更して保存し、画面を reload して編集画面を再度開く。
 
 Then:
 
-- Deck 一覧に戻る。
-- 一覧に変更後の deck 名が表示される。
+- 編集画面に変更後の name と category が表示される。
 - browser error が発生しない。
 
 <a id="deck-03"></a>
 
-### DECK-03 Deck を削除できる
+### DECK-03 Deck と関連データをまとめて削除できる
 
-カテゴリ: `write`
+カテゴリ: `batch`
 
 Given:
 
 - 認証済みユーザーが所有する削除対象の Deck が存在する。
+- 対象 Deck に複数の Card と再開可能な学習 session が存在する。
 
 When:
 
-- Deck 一覧から deck を削除する。
+- Deck 一覧から対象 Deck の削除を確定し、画面を reload する。
 
 Then:
 
-- 一覧に deck が表示されない。
+- Deck 一覧に対象 Deck が表示されない。
+- 対象 Deck と関連するすべての Card が保存先から削除されている。
+- 対象 Deck の学習 session を再開できない。
+- browser error が発生しない。
+
+<a id="deck-04"></a>
+
+### DECK-04 Deck の削除を取り消せる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する削除対象の Deck が存在する。
+- 対象 Deck の action menu trigger から削除 dialog を開いている。
+- dialog に対象 Deck、関連 Card と学習 session への影響、削除を取り消せない旨が表示されている。
+
+When:
+
+- Cancel を選択する。
+
+Then:
+
+- 削除 dialog が閉じる。
+- focus が対象 Deck の action menu trigger に戻る。
+- 対象 Deck と関連する Card および学習 session が変更されない。
+- browser error が発生しない。
+
+<a id="deck-05"></a>
+
+### DECK-05 Deck の削除失敗後に再試行できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 認証済みユーザーが所有する削除対象の Deck が存在する。
+- 対象 Deck に Card と再開可能な学習 session が存在する。
+- 削除要求の失敗が dialog 内で処理され、同じ削除対象が維持されている。
+- 次の削除要求は成功できる。
+
+When:
+
+- dialog から同じ Deck の削除を再試行する。
+
+Then:
+
+- 削除 dialog が閉じる。
+- Deck 一覧に対象 Deck が表示されない。
+- 対象 Deck と関連する Card および学習 session が削除される。
+- 最初の削除失敗に伴う未処理の browser error が発生しない。
+
+<a id="deck-06"></a>
+
+### DECK-06 存在しない Deck から復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーの保存先に、route が参照する Deck が存在しない。
+
+When:
+
+- 存在しない Deck の Card 一覧を直接開き、Deck が利用できない旨の画面から home recovery action を実行する。
+
+Then:
+
+- Deck 一覧が表示される。
+- browser error が発生しない。
+
+<a id="deck-07"></a>
+
+### DECK-07 local-only Deck と Card を remote storage へ移行できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 認証済みユーザーの browser storage に local-only Deck が存在する。
+- 対象 Deck に複数の local-only Card が存在する。
+
+When:
+
+- 対象 Deck の Local only を無効にして保存し、画面を reload する。
+
+Then:
+
+- 対象 Deck とすべての Card が remote storage から読み込まれて表示される。
+- browser storage に移行前の Deck と Card の duplicate が残らない。
+- browser error が発生しない。
+
+<a id="deck-08"></a>
+
+### DECK-08 Deck の Card を CSV で export できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck が存在する。
+- 対象 Deck に front text、back text、tags、unique key を持つ Card が複数存在する。
+
+When:
+
+- Deck 一覧から対象 Deck の CSV download を実行する。
+
+Then:
+
+- 対象 Deck の name に対応する CSV file が download される。
+- CSV に各 Card の front text、back text、tags、unique key が Card ごとの row として含まれる。
 - browser error が発生しない。

--- a/docs/e2e/import.md
+++ b/docs/e2e/import.md
@@ -1,0 +1,148 @@
+# Import E2E テスト仕様書
+
+## 目的
+
+CSV の検証から保存先別の import、失敗後の再試行、Sample Deck の追加までが、重複や意図しない永続化を起こさずに完了することを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| IMPORT-01 | read | [有効な CSV を永続化せずに preview できる](#import-01) |
+| IMPORT-02 | read | [不正な行を含む CSV の import を阻止できる](#import-02) |
+| IMPORT-03 | batch | [CSV を remote に import して reload 後も利用できる](#import-03) |
+| IMPORT-04 | batch | [CSV を local-only に import して reload 後に学習できる](#import-04) |
+| IMPORT-05 | batch | [失敗した import を同じ保存先へ重複なく再試行できる](#import-05) |
+| IMPORT-06 | batch | [Sample Deck を繰り返し追加しても重複しない](#import-06) |
+
+<a id="import-01"></a>
+
+### IMPORT-01 有効な CSV を永続化せずに preview できる
+
+カテゴリ: `read`
+
+Given:
+
+- 必須の列と一意な uniqueKey を持つ有効な CSV がある。
+- CSV に対応する Deck と Card は選択する保存先に存在しない。
+
+When:
+
+- Import 画面で CSV を選択し、Import を実行せずに検証の完了を待つ。
+
+Then:
+
+- Deck 名、検証件数、Card の内容を含む preview が表示される。
+- Import 操作が有効になる。
+- 選択した保存先に Deck と Card は作成されない。
+- 未処理の browser error が発生しない。
+
+<a id="import-02"></a>
+
+### IMPORT-02 不正な行を含む CSV の import を阻止できる
+
+カテゴリ: `read`
+
+Given:
+
+- 必須の uniqueKey が空の行を含む CSV がある。
+- CSV に対応する Deck と Card は選択する保存先に存在しない。
+
+When:
+
+- Import 画面で CSV を選択し、検証の完了を待つ。
+
+Then:
+
+- 不正な行と理由が validation error として画面内に表示される。
+- Import 操作は無効のままになる。
+- 選択した保存先に Deck と Card は作成されない。
+- 未処理の browser error が発生しない。
+
+<a id="import-03"></a>
+
+### IMPORT-03 CSV を remote に import して reload 後も利用できる
+
+カテゴリ: `batch`
+
+Given:
+
+- ユーザーとして認証されている。
+- 学習可能な Card を含む有効な CSV がある。
+- CSV に対応する remote の Deck と Card は現在の UID に存在しない。
+
+When:
+
+- Import 画面で remote の保存先を選択し、CSV の preview を確認して import した後、Deck 一覧を reload して import した Deck を開く。
+
+Then:
+
+- preview に含まれていた Deck とすべての Card が現在の UID の remote data として表示される。
+- reload 後も Deck と Card の内容が維持される。
+- 未処理の browser error が発生しない。
+
+<a id="import-04"></a>
+
+### IMPORT-04 CSV を local-only に import して reload 後に学習できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 学習可能な Card を含む有効な CSV がある。
+- CSV に対応する Deck と Card は local storage に存在しない。
+
+When:
+
+- Import 画面で local-only の保存先を選択し、CSV の preview を確認して import した後、reload して import した Deck の学習を開始する。
+
+Then:
+
+- import した Deck とすべての Card が local storage に維持される。
+- 対応する Deck と Card は remote data に作成されない。
+- 学習画面に import した Card が表示される。
+- 未処理の browser error が発生しない。
+
+<a id="import-05"></a>
+
+### IMPORT-05 失敗した import を同じ保存先へ重複なく再試行できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 有効な CSV の最初の import で、保存先の Deck を作成した後に Card の保存が失敗している。
+- import の失敗が画面内で処理され、同じ preview と保存先が維持されている。
+- 次の import では Card を保存できる。
+
+When:
+
+- CSV と保存先を変更せずに Import を再度実行する。
+
+Then:
+
+- 再試行は最初の試行で作成された Deck を保存先として完了する。
+- 選択した保存先には Deck が一つだけ存在し、preview に含まれていた Card が重複なく保存される。
+- 未処理の browser error が発生しない。
+
+<a id="import-06"></a>
+
+### IMPORT-06 Sample Deck を繰り返し追加しても重複しない
+
+カテゴリ: `batch`
+
+Given:
+
+- Sample Deck が明示的な追加操作によって local storage に保存されている。
+- Sample Deck とその Card の識別子および件数が記録されている。
+- Deck 一覧から Import 画面を開いている。
+
+When:
+
+- Import 画面から Sample Deck を再度追加し、`Back to decks` で Deck 一覧へ戻った後、画面を reload して Sample Deck を開く。
+
+Then:
+
+- local storage に存在する Sample Deck は一つだけである。
+- Sample Deck の Card の識別子と件数は追加前から変わらず、重複していない。
+- 未処理の browser error が発生しない。

--- a/docs/e2e/persistence.md
+++ b/docs/e2e/persistence.md
@@ -1,0 +1,57 @@
+# Persistence E2E テスト仕様書
+
+## 目的
+
+remote data が認証 UID ごとに分離され、永続 cache と queued write が network 状態の変化を越えて正しく機能することを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| PERSIST-01 | read | [UID ごとに remote data を分離して reload 後も表示できる](#persist-01) |
+| PERSIST-02 | batch | [offline cache の変更を再接続後に remote へ同期できる](#persist-02) |
+
+<a id="persist-01"></a>
+
+### PERSIST-01 UID ごとに remote data を分離して reload 後も表示できる
+
+カテゴリ: `read`
+
+Given:
+
+- 異なる UID の認証済みユーザーが、それぞれ固有の remote Deck と Card を所有している。
+- 各ユーザーで認証した独立した browser context がある。
+- 各 browser context で Sample Deck の自動生成が無効であり、local-only Deck と Card は存在しない。
+
+When:
+
+- 各 browser context で Deck 一覧を開いて reload し、そのユーザーが所有する Deck を開く。
+
+Then:
+
+- 各 browser context には現在の UID が所有する remote Deck と Card だけが表示される。
+- 別の UID が所有する remote Deck と Card は reload の前後で表示されない。
+- 未処理の browser error が発生しない。
+
+<a id="persist-02"></a>
+
+### PERSIST-02 offline cache の変更を再接続後に remote へ同期できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 認証済みユーザーが remote の Deck と Card を所有している。
+- primary browser は対象の Deck と Card を永続 cache に読み込み、offline で reload した後も対象 Card を表示している。
+- 同じ UID で認証した online の verification browser context がある。
+
+When:
+
+- primary browser で対象 Card を編集して保存し、network を再接続して同期の完了を待った後、verification browser context で対象 Card を reload する。
+
+Then:
+
+- 編集内容が primary browser の画面に維持される。
+- verification browser context に編集内容が remote data として表示される。
+- queued write による重複した Deck や Card は作成されない。
+- 未処理の browser error が発生しない。

--- a/docs/e2e/settings.md
+++ b/docs/e2e/settings.md
@@ -1,0 +1,53 @@
+# Settings E2E テスト仕様書
+
+## 目的
+
+Settings の自動保存が reload を越えて維持され、保存した学習設定が次の学習 session に反映されることを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| SETTINGS-01 | write | [Dark mode を自動保存して reload 後も反映できる](#settings-01) |
+| SETTINGS-02 | write | [Maximum cards 設定を次の学習 session に反映できる](#settings-02) |
+
+<a id="settings-01"></a>
+
+### SETTINGS-01 Dark mode を自動保存して reload 後も反映できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが Settings 画面を開き、変更前の Dark mode 設定が画面に反映されている。
+
+When:
+
+- Dark mode を現在と異なる状態に変更し、自動保存後にページを reload する。
+
+Then:
+
+- Dark mode が reload 後も変更後の状態を維持する。
+- アプリケーションの配色に Dark mode の変更が反映される。
+- browser error が発生しない。
+
+<a id="settings-02"></a>
+
+### SETTINGS-02 Maximum cards 設定を次の学習 session に反映できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、変更後の上限より多くの学習対象 Card が存在する。
+- 対象 Deck に進行中の学習 session が存在しない。
+
+When:
+
+- Settings 画面で `Maximum cards` を現在と異なる上限に変更し、自動保存後にページを reload して対象 Deck の学習開始画面を開く。
+
+Then:
+
+- 学習開始画面に表示される session の Card 数が変更後の上限と一致する。
+- start action に変更後の上限と同じ Card 数が表示される。
+- browser error が発生しない。

--- a/docs/e2e/swipe.md
+++ b/docs/e2e/swipe.md
@@ -2,55 +2,350 @@
 
 ## 目的
 
-Deck の学習画面で swipe 操作が、表面・裏面表示、学習結果の保存、次 card への遷移まで破綻しないことを確認する。
+Deck の学習画面で、Card の表示、学習結果の保存、session の移動・再開・完了、各入力操作が破綻しないことを確認する。
 
 ## テストケース
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| SWIPE-01 | read | [Deck 学習画面で card の表面と裏面を表示できる](#swipe-01) |
-| SWIPE-02 | write | [Deck 学習画面で mastered swipe を実行できる](#swipe-02) |
+| SWIPE-01 | read | [学習中の Card を表面から裏面へ切り替えられる](#swipe-01) |
+| SWIPE-02 | write | [mastered action で学習結果を保存して次の Card へ進める](#swipe-02) |
+| SWIPE-03 | write | [non-mastered action で学習結果を保存して次の Card へ進める](#swipe-03) |
+| SWIPE-04 | write | [next-card action で次の Card へ進める](#swipe-04) |
+| SWIPE-05 | write | [previous-card action で前の Card へ戻れる](#swipe-05) |
+| SWIPE-06 | write | [filter と学習上限を反映して session を開始できる](#swipe-06) |
+| SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](#swipe-07) |
+| SWIPE-08 | write | [Exit 後に同じ位置から Continue できる](#swipe-08) |
+| SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](#swipe-09) |
+| SWIPE-10 | write | [最後の Card を完了して session を終了できる](#swipe-10) |
+| SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
+| SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](#swipe-12) |
+| SWIPE-13 | write | [primary mouse の上方向 drag で次の Card へ進める](#swipe-13) |
+| SWIPE-14 | read | [non-primary mouse の drag を無視できる](#swipe-14) |
+| SWIPE-15 | read | [裏面 text を選択しても Card の状態を維持できる](#swipe-15) |
 
 <a id="swipe-01"></a>
 
-### SWIPE-01 Deck 学習画面で card の表面と裏面を表示できる
+### SWIPE-01 学習中の Card を表面から裏面へ切り替えられる
 
 カテゴリ: `read`
 
 Given:
 
-- 認証済みユーザーが所有する Deck が存在する。
-- 対象 Deck の学習セッションがあり、現在の Card に front text と back text が設定されている。
+- 認証済みユーザーが所有する Deck に進行中の学習 session が存在する。
+- 現在の Card に front text と back text が設定されている。
 
 When:
 
-- 対象 deck の学習画面を開き、裏面表示を切り替える。
+- 学習画面に表示された現在の Card の front text を選択して裏面へ切り替える。
 
 Then:
 
-- 現在の card の front text を確認できる。
-- 現在の card の back text を確認できる。
+- 現在の Card の back text が表示される。
+- Card の学習結果と session の位置が変更されない。
 - browser error が発生しない。
 
 <a id="swipe-02"></a>
 
-### SWIPE-02 Deck 学習画面で mastered swipe を実行できる
+### SWIPE-02 mastered action で学習結果を保存して次の Card へ進める
 
 カテゴリ: `write`
 
 Given:
 
-- 認証済みユーザーが所有する Deck が存在する。
-- 対象 Deck の学習セッションに複数の Card が学習順に含まれている。
-- 現在の Card が未学習状態である。
+- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 現在の Card の次に別の Card がある。
 
 When:
 
-- 対象 deck の学習画面で mastered に対応する swipe 操作を実行する。
+- 現在の Card に mastered action を実行する。
 
 Then:
 
-- swipe した card の score が増える。
-- swipe した card の学習回数が増える。
-- 次の card の front text が表示される。
+- 現在だった Card の score が mastered rule に従って増加し、学習回数が 1 増えて保存される。
+- session の位置が次の Card へ進む。
+- 次の Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-03"></a>
+
+### SWIPE-03 non-mastered action で学習結果を保存して次の Card へ進める
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 現在の Card の次に別の Card がある。
+
+When:
+
+- 現在の Card に non-mastered action を実行する。
+
+Then:
+
+- 現在だった Card の score が non-mastered rule に従って減少し、学習回数が 1 増えて保存される。
+- session の位置が次の Card へ進む。
+- 次の Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-04"></a>
+
+### SWIPE-04 next-card action で次の Card へ進める
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 現在の Card の次に別の Card がある。
+
+When:
+
+- 現在の Card に next-card action を実行する。
+
+Then:
+
+- 現在だった Card の score は変わらず、学習回数が 1 増えて保存される。
+- session の位置が次の Card へ進む。
+- 次の Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-05"></a>
+
+### SWIPE-05 previous-card action で前の Card へ戻れる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 現在の Card の前に別の Card がある。
+
+When:
+
+- 現在の Card に previous-card action を実行する。
+
+Then:
+
+- 現在だった Card の score は変わらず、学習回数が 1 増えて保存される。
+- session の位置が前の Card へ戻る。
+- 前の Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-06"></a>
+
+### SWIPE-06 filter と学習上限を反映して session を開始できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、score と tags の組み合わせが異なる複数の Card が存在する。
+- 対象 Deck に score と tag の filter が保存されている。
+- 設定済みの学習上限より多くの Card が保存済み filter に一致する。
+
+When:
+
+- 対象 Deck の学習開始画面から session を開始する。
+
+Then:
+
+- session には保存済み filter に一致する Card だけが含まれる。
+- session の Card 数が設定済みの学習上限を超えない。
+- session の先頭 Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-07"></a>
+
+### SWIPE-07 filter に一致する Card がない場合は session を開始できない
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に Card が存在する。
+- 学習開始画面の score と tag の filter に一致する Card が存在しない。
+
+When:
+
+- 対象 Deck の学習開始画面を開く。
+
+Then:
+
+- filter に一致する Card がないことが表示される。
+- session の start action が無効になる。
+- 対象 Deck の学習 session が作成されない。
+- browser error が発生しない。
+
+<a id="swipe-08"></a>
+
+### SWIPE-08 Exit 後に同じ位置から Continue できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、先頭より後の Card まで進んだ学習 session が存在する。
+
+When:
+
+- 学習画面で Exit を実行し、Deck 一覧から同じ Deck の Continue を実行する。
+
+Then:
+
+- Exit 前と同じ学習 session が維持される。
+- Exit 前に表示されていた Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-09"></a>
+
+### SWIPE-09 Restart で新しい session を先頭から開始できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、先頭より後の Card まで進んだ学習 session が存在する。
+
+When:
+
+- Deck 一覧から対象 Deck の Restart を選択し、学習開始画面で session を開始する。
+
+Then:
+
+- 以前とは異なる新しい学習 session が保存される。
+- 新しい session の位置が先頭になる。
+- 新しい session の先頭 Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-10"></a>
+
+### SWIPE-10 最後の Card を完了して session を終了できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck の学習 session で、最後の Card が表示されている。
+
+When:
+
+- 最後の Card に学習結果を保存する action を実行する。
+
+Then:
+
+- 最後の Card の学習結果が保存される。
+- 対象 Deck の学習 session が削除される。
+- Deck 一覧へ戻り、対象 Deck に Continue action が表示されない。
+- browser error が発生しない。
+
+<a id="swipe-11"></a>
+
+### SWIPE-11 複数 Deck の学習 session を独立して維持できる
+
+カテゴリ: `batch`
+
+Given:
+
+- 認証済みユーザーが所有する複数の Deck に、それぞれ異なる位置の学習 session が存在する。
+
+When:
+
+- 一方の Deck で学習 action を実行して Exit し、もう一方の Deck を Continue する。
+
+Then:
+
+- 最初の Deck の学習結果と session の位置が保存される。
+- もう一方の Deck は操作前の session と位置から再開する。
+- 各 Deck の Card と session が混在しない。
+- browser error が発生しない。
+
+<a id="swipe-12"></a>
+
+### SWIPE-12 学習結果の保存失敗後に同じ Card から再試行できる
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 前回の学習結果の保存要求が失敗し、同じ Card と session の位置が維持されている。
+- 次の学習結果の保存要求は成功できる。
+
+When:
+
+- 現在の Card に同じ学習 action を再度実行する。
+
+Then:
+
+- 再試行した学習結果が一度だけ保存される。
+- session の位置が次の Card へ一度だけ進む。
+- 次の Card の front text が表示される。
+- 最初の保存失敗に伴う未処理の browser error が発生しない。
+
+<a id="swipe-13"></a>
+
+### SWIPE-13 primary mouse の上方向 drag で次の Card へ進める
+
+カテゴリ: `write`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 現在の Card の表面が表示されている。
+- 上方向の drag は mastered action に設定されている。
+
+When:
+
+- primary mouse button で現在の Card を上方向へ drag する。
+
+Then:
+
+- 現在だった Card の mastered 学習結果が保存される。
+- 次の Card の front text が表示され、back text は表示されない。
+- drag 後の click によって次の Card が裏面へ切り替わらない。
+- browser error が発生しない。
+
+<a id="swipe-14"></a>
+
+### SWIPE-14 non-primary mouse の drag を無視できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に進行中の学習 session が存在する。
+- 現在の Card の表面が表示されている。
+
+When:
+
+- non-primary mouse button で現在の Card を swipe action に対応する方向へ drag する。
+
+Then:
+
+- 現在の Card の front text が引き続き表示される。
+- Card の学習結果と session の位置が変更されない。
+- browser error が発生しない。
+
+<a id="swipe-15"></a>
+
+### SWIPE-15 裏面 text を選択しても Card の状態を維持できる
+
+カテゴリ: `read`
+
+Given:
+
+- 認証済みユーザーが所有する Deck に進行中の学習 session が存在する。
+- 現在の Card の selectable な back text が表示されている。
+
+When:
+
+- primary mouse button の drag で back text を選択する。
+
+Then:
+
+- 選択範囲に対象 Card の back text が含まれる。
+- 対象 Card の back text が引き続き表示される。
+- Card の学習結果と session の位置が変更されない。
 - browser error が発生しない。


### PR DESCRIPTION
## Related issue

None

## Summary

- expand the E2E acceptance specification to 51 cases across eight domains
- define read, write, batch, and browser error conventions in the index
- cover major workflows, persistence behavior, and representative failure recovery without changing Playwright tests or application code

## Testing

- npm run lint:markdown
- git diff --check
- validated case IDs, links, anchors, categories, and Given/When/Then structure