### PR TITLE
[No issue] refactor(deck-list): remove sections key wrapper from useDeckListState

### DIFF
--- a/src/pages/deck-list/model/useDeckListState.spec.tsx
+++ b/src/pages/deck-list/model/useDeckListState.spec.tsx
@@ -56,7 +56,7 @@ describe("useDeckListState", () => {
 
   it("puts active Decks in recent order and inactive Decks in name order", () => {
     const { result } = renderHook(() => useDeckListState());
-    const { sections } = result.current;
+    const sections = result.current;
 
     expect(sections.studying.map((item) => item.deck.id)).toEqual(["active-new", "active-old"]);
     expect(sections.studying[0]?.studySession).toMatchObject({

--- a/src/pages/deck-list/model/useDeckListState.ts
+++ b/src/pages/deck-list/model/useDeckListState.ts
@@ -41,7 +41,5 @@ export const useDeckListState = () => {
   const decks = useDecks();
   const sessionsByDeckId = useStudySessions();
 
-  return {
-    sections: buildDeckListSections(decks, cards, sessionsByDeckId),
-  };
+  return buildDeckListSections(decks, cards, sessionsByDeckId);
 };

--- a/src/pages/deck-list/ui/DeckListPage.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.tsx
@@ -15,7 +15,7 @@ import { DeckList } from "./DeckList";
 
 export const DeckListPage: React.FC = () => {
   const navigate = useNavigate();
-  const deckList = useDeckListState();
+  const sections = useDeckListState();
   const deletion = useDeckDeletion();
   const exportDeck = useDeckExport();
 
@@ -36,7 +36,7 @@ export const DeckListPage: React.FC = () => {
         <DeckDeletionDialog target={deletion.target} onCancel={deletion.cancel} onConfirm={deletion.confirm} />
       )}
       <DeckList
-        sections={deckList.sections}
+        sections={sections}
         onCreateDeck={() => void navigate(routes.deckCreate.to())}
         deckCard={{
           onClickEdit: (id) => void navigate(routes.deckForm.to(id)),


### PR DESCRIPTION
## Summary
Refactored `useDeckListState` to directly return `{ studying, other }` sections instead of wrapping them inside a `sections` key.

## Changes Made
- Updated `useDeckListState` in `src/pages/deck-list/model/useDeckListState.ts` to return `buildDeckListSections(...)` directly.
- Updated `DeckListPage.tsx` to pass the hook result directly to `<DeckList sections={sections} />`.
- Updated unit test in `src/pages/deck-list/model/useDeckListState.spec.tsx` to inspect `result.current` directly.

## Verification
- `mise run check` passed successfully (lint, typecheck, tests).
- Code review completed by `reviewer` subagent with 0 P0/P1 findings.