### PR TITLE
docs: Account E2E の検証境界を明確化

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -5,6 +5,7 @@
 - `mise run e2e` で Playwright を実行する。
 - Deck / Card は Firestore emulator または localStorage、Config / Study session は localStorage に保存し、
   Firebase Auth API は mock する。
+- Google など外部 identity provider の画面操作は対象外とし、Account E2E ではアプリ内の認証状態とデータ境界を確認する。
 - E2E は代表的な利用者導線を対象とし、各 validation rule や設定・入力手段の組み合わせは
   unit / component test で確認する。
 
@@ -35,7 +36,7 @@
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
 | ACCOUNT-01 | batch | [匿名アカウントを Google アカウントに連携してデータを維持できる](./account.md#account-01) |
-| ACCOUNT-02 | write | [Google sign-in 失敗後に再試行できる](./account.md#account-02) |
+| ACCOUNT-02 | write | [Google sign-in のエラー表示から再試行できる](./account.md#account-02) |
 | ACCOUNT-03 | batch | [sign-out 後に新しい匿名アカウントへ切り替えられる](./account.md#account-03) |
 
 ### Settings

--- a/docs/e2e/account.md
+++ b/docs/e2e/account.md
@@ -2,14 +2,14 @@
 
 ## 目的
 
-匿名アカウントと Google アカウントの切り替えが、認証情報、ユーザーデータ、cache、学習 session の境界を保つことを確認する。
+匿名アカウントと Google アカウントの切り替えで、アカウント状態、UID、ユーザーデータ、学習 session の境界が保たれることを確認する。
 
 ## テストケース
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
 | ACCOUNT-01 | batch | [匿名アカウントを Google アカウントに連携してデータを維持できる](#account-01) |
-| ACCOUNT-02 | write | [Google sign-in 失敗後に再試行できる](#account-02) |
+| ACCOUNT-02 | write | [Google sign-in のエラー表示から再試行できる](#account-02) |
 | ACCOUNT-03 | batch | [sign-out 後に新しい匿名アカウントへ切り替えられる](#account-03) |
 
 <a id="account-01"></a>
@@ -22,7 +22,7 @@ Given:
 
 - 匿名アカウントに Deck と Card が存在する。
 - 対象 Deck に進行中の学習 session が存在する。
-- 連携する Google アカウントは別の Firebase Auth ユーザーに紐づいていない。
+- Google アカウントへ連携できる。
 
 When:
 
@@ -31,13 +31,13 @@ When:
 Then:
 
 - Account 画面に Google アカウントとの連携状態が表示される。
-- 匿名アカウントと同じ UID が維持される。
+- 匿名アカウントと同じ UID が表示される。
 - 連携前の Deck、Card、学習 session を引き続き利用できる。
 - browser error が発生しない。
 
 <a id="account-02"></a>
 
-### ACCOUNT-02 Google sign-in 失敗後に再試行できる
+### ACCOUNT-02 Google sign-in のエラー表示から再試行できる
 
 カテゴリ: `write`
 
@@ -55,7 +55,7 @@ Then:
 
 - 再試行後にエラー表示が残らない。
 - Account 画面に Google アカウントとの連携状態が表示される。
-- 未処理の browser error が発生しない。
+- browser error が発生しない。
 
 <a id="account-03"></a>
 
@@ -65,7 +65,7 @@ Then:
 
 Given:
 
-- Google アカウントに連携したユーザーの remote Deck と Card が query cache に存在する。
+- Google アカウントに連携したユーザーに Deck と Card が存在する。
 - 対象ユーザーに進行中の学習 session が存在する。
 
 When:
@@ -74,7 +74,8 @@ When:
 
 Then:
 
-- Account 画面に新しい匿名アカウントと連携前とは異なる UID が表示される。
-- 前の UID に属する remote Deck と Card が query cache や画面に残らない。
-- 前の UID で開始した学習 session を利用できない。
+- Account 画面に匿名アカウントが表示される。
+- sign-out 前とは異なる UID が表示される。
+- sign-out 前のアカウントに属する Deck と Card が表示されない。
+- sign-out 前のアカウントで開始した学習 session を利用できない。
 - browser error が発生しない。


### PR DESCRIPTION
## Summary

- Account E2E の目的から cache などの実装詳細を外し、アカウント状態・UID・データ境界に整理
- ACCOUNT-02 を「エラー表示からの再試行」という1つの振る舞いとして明確化
- sign-out 後の期待結果を query cache ではなく画面・利用可能データで定義
- Google など外部 identity provider の画面操作は E2E 対象外であることを README に明記

## Test

- Documentation only; not run