### PR TITLE
chore: manage gcloud with mise (#234)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ monorepo_root = true
 config_roots = ["sample"]
 
 [tools]
+gcloud = "581.0.0"
 hadolint = "2.15.0"
 node = "24.15.0"
 npm = "12.0.1"

--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,9 @@ ps = "docker compose ps"
 [tasks.git-cleanup]
 file = "scripts/cleanup-branches.sh"
 
+[tasks.gcloud-auth-login]
+run = "gcloud auth login"
+
 [tasks.setup-github-oidc]
 file = "scripts/setup-github-oidc.sh"
 


### PR DESCRIPTION
## Summary

- manage Google Cloud CLI with mise
- pin `gcloud` to `581.0.0`, matching the repository's existing exact-version tool policy
- add `mise run gcloud-auth-login` for the required interactive `gcloud auth login` step
- make `mise run setup-github-oidc` use the repository-managed `gcloud` installation

## Context

Follow-up to #234. The OIDC setup task already runs `scripts/setup-github-oidc.sh`, so no script changes are needed. The script requires an active gcloud account, so the login step is exposed as a separate mise task instead of making setup depend on an interactive login every time.

## Usage

```bash
mise install
mise run gcloud-auth-login
mise run setup-github-oidc
```

## Verification

- confirmed the branch changes only `mise.toml`
- local `mise run check` could not be run because mise is not installed in the execution environment
