### PR TITLE
[No issue] Keep study card answers readable beneath swipe overlays

### DIFF
--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -65,6 +65,20 @@ export const LongAnswer: Story = {
     showBackText: true,
     backTextSlot: <CardView text={fixture.card.long.backText.repeat(4)} variant="bare" />,
   },
+  play: async ({ canvasElement }) => {
+    const answer = canvasElement.querySelector<HTMLElement>("pre");
+    const swipeOverlays = canvasElement.querySelectorAll<HTMLElement>("[aria-label^='Swipe ']");
+    const swipeOverlayStyles = Array.from(swipeOverlays, (overlay) => {
+      const style = getComputedStyle(overlay);
+      return { backgroundColor: style.backgroundColor, boxShadow: style.boxShadow };
+    });
+
+    await expect(answer).toBeVisible();
+    await expect(swipeOverlays).toHaveLength(4);
+    await expect(swipeOverlayStyles).toEqual(
+      Array.from({ length: 4 }, () => ({ backgroundColor: "rgba(0, 0, 0, 0)", boxShadow: "none" }))
+    );
+  },
 };
 
 export const CodeAnswer: Story = {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -73,35 +73,19 @@ const SwipeFeedback: React.FC<{
 
 const BackTextOverlays: React.FC<{ swipeOverlay: SwipeButtonListProps | undefined }> = ({ swipeOverlay }) => {
   // Gesture hit zones must remain visually neutral so the full-width answer stays readable beneath them.
-  const overlayClassName = "bg-transparent shadow-none";
   return (
     <>
       {swipeOverlay?.onClickLeft !== undefined ? (
-        <Overlay
-          position="left"
-          ariaLabel="Swipe left"
-          className={overlayClassName}
-          onClick={swipeOverlay.onClickLeft}
-        />
+        <Overlay position="left" variant="transparent" ariaLabel="Swipe left" onClick={swipeOverlay.onClickLeft} />
       ) : null}
       {swipeOverlay?.onClickRight !== undefined ? (
-        <Overlay
-          position="right"
-          ariaLabel="Swipe right"
-          className={overlayClassName}
-          onClick={swipeOverlay.onClickRight}
-        />
+        <Overlay position="right" variant="transparent" ariaLabel="Swipe right" onClick={swipeOverlay.onClickRight} />
       ) : null}
       {swipeOverlay?.onClickUp !== undefined ? (
-        <Overlay position="top" ariaLabel="Swipe up" className={overlayClassName} onClick={swipeOverlay.onClickUp} />
+        <Overlay position="top" variant="transparent" ariaLabel="Swipe up" onClick={swipeOverlay.onClickUp} />
       ) : null}
       {swipeOverlay?.onClickDown !== undefined ? (
-        <Overlay
-          position="bottom"
-          ariaLabel="Swipe down"
-          className={overlayClassName}
-          onClick={swipeOverlay.onClickDown}
-        />
+        <Overlay position="bottom" variant="transparent" ariaLabel="Swipe down" onClick={swipeOverlay.onClickDown} />
       ) : null}
     </>
   );

--- a/src/shared/ui/feedback/Overlay.stories.tsx
+++ b/src/shared/ui/feedback/Overlay.stories.tsx
@@ -45,6 +45,14 @@ export const Bottom: Story = {
   },
 };
 
+export const Transparent: Story = {
+  args: {
+    position: "center",
+    variant: "transparent",
+    children: "Content remains visible beneath this overlay",
+  },
+};
+
 export const LongMobile: Story = {
   args: {
     position: "center",

--- a/src/shared/ui/feedback/Overlay.tsx
+++ b/src/shared/ui/feedback/Overlay.tsx
@@ -17,6 +17,7 @@ import { useButtonInteraction } from "../button-interaction";
 export const Overlay: React.FC<{
   className?: string;
   position: "left" | "right" | "top" | "bottom" | "center";
+  variant?: "surface" | "transparent";
   onClick?: () => void;
   ariaLabel?: string;
   children?: React.ReactNode;
@@ -27,8 +28,10 @@ export const Overlay: React.FC<{
       {...clickInteraction}
       {...(props.onClick !== undefined && props.ariaLabel !== undefined ? { "aria-label": props.ariaLabel } : {})}
       className={cx(
-        "absolute z-30 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control bg-surface-elevated text-ink shadow-elevated",
-        props.position === "center" &&
+        "absolute z-30 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control text-ink",
+        props.variant !== "transparent" && "bg-surface-elevated shadow-elevated",
+        props.variant !== "transparent" &&
+          props.position === "center" &&
           "before:pointer-events-none before:fixed before:inset-0 before:-z-10 before:bg-canvas/70",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2",
         ["left", "right"].includes(props.position) && "w-20",


### PR DESCRIPTION
## Related issue

None

## Summary

- add an explicit transparent variant to the shared Overlay component
- use the transparent variant for all study-session back-text swipe hit zones
- cover transparent backgrounds and shadows with Storybook browser assertions

## Testing

- `mise run check`
- `npm run test:storybook -- src/pages/study-session/ui/StudySession.stories.tsx src/shared/ui/feedback/Overlay.stories.tsx`
- manual Storybook browser verification of all four swipe overlays
- mandatory reviewer subagent: no P0, P1, or P2 findings