### PR TITLE
No issue: Refactor deck form state handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ For every task that changes repository files:
 - Do not retain a Feature or Entity slice solely because the code is conceptually a user action or domain concept when it has only one Page consumer; prefer colocating insignificant slices with that Page.
 - Move reusable cross-Page workflows to Features, reusable domain concepts and rules to Entities, and broadly reusable technical or UI primitives to Shared.
 - UI components must define their own props instead of reusing model return types.
+- Keep locale-dependent presentation formatting, such as dates and numbers, in UI components rather than model hooks.
 
 ## Coding Style
 

--- a/src/pages/deck-form/model/useDeckFormState.ts
+++ b/src/pages/deck-form/model/useDeckFormState.ts
@@ -27,12 +27,6 @@ const getDeckEditInput = (deck: Deck, values: DeckFormValues): Parameters<typeof
   url: values.url ?? null,
 });
 
-const getDeckInfo = (deck: Deck) => ({
-  id: deck.id,
-  createdAt: new Date(deck.createdAt).toLocaleDateString(),
-  updatedAt: new Date(deck.updatedAt).toLocaleDateString(),
-});
-
 interface UseDeckFormStateOptions {
   deckId: string;
   onCancel: () => void;
@@ -66,7 +60,11 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
   };
 
   const form = {
-    deckInfo: getDeckInfo(deck),
+    deckInfo: {
+      id: deck.id,
+      createdAt: deck.createdAt,
+      updatedAt: deck.updatedAt,
+    },
     fields: {
       name: register("name"),
       convertToBr: register("convertToBr"),

--- a/src/pages/deck-form/model/useDeckFormState.ts
+++ b/src/pages/deck-form/model/useDeckFormState.ts
@@ -40,11 +40,6 @@ const getDeckInfo = (deck: Deck) => {
   };
 };
 
-const getLocalModeHelp = (deck: Deck): string =>
-  deck.localMode
-    ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
-    : "This deck and its cards are saved to Firestore.";
-
 interface UseDeckFormStateOptions {
   deckId: string;
   onCancel: () => void;
@@ -91,7 +86,7 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
         options: categoryOptions,
       },
     },
-    localModeHelp: getLocalModeHelp(deck),
+    isLocalOnly: deck.localMode,
     errors: {
       name: formState.errors.name?.message,
       url: formState.errors.url?.message,

--- a/src/pages/deck-form/model/useDeckFormState.ts
+++ b/src/pages/deck-form/model/useDeckFormState.ts
@@ -27,18 +27,11 @@ const getDeckEditInput = (deck: Deck, values: DeckFormValues): Parameters<typeof
   url: values.url ?? null,
 });
 
-const getFormattedDate = (timestamp: number): string | undefined =>
-  timestamp ? new Date(timestamp).toLocaleDateString() : undefined;
-
-const getDeckInfo = (deck: Deck) => {
-  const createdAt = getFormattedDate(deck.createdAt);
-  const updatedAt = getFormattedDate(deck.updatedAt);
-  return {
-    id: deck.id,
-    ...(createdAt ? { createdAt } : {}),
-    ...(updatedAt ? { updatedAt } : {}),
-  };
-};
+const getDeckInfo = (deck: Deck) => ({
+  id: deck.id,
+  createdAt: new Date(deck.createdAt).toLocaleDateString(),
+  updatedAt: new Date(deck.updatedAt).toLocaleDateString(),
+});
 
 interface UseDeckFormStateOptions {
   deckId: string;

--- a/src/pages/deck-form/model/useDeckFormState.ts
+++ b/src/pages/deck-form/model/useDeckFormState.ts
@@ -5,9 +5,45 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
 import { useAuthUid } from "@/entities/auth";
-import { CATEGORY, deckFormSchema, editDeck, useDeck } from "@/entities/deck";
+import { CATEGORY, type Deck, deckFormSchema, editDeck, useDeck } from "@/entities/deck";
+import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 
 type DeckFormValues = z.infer<typeof deckFormSchema>;
+
+const categoryOptions = CATEGORY.map((category) => ({ label: category, value: category }));
+
+const getDeckFormValues = (deck: Deck): DeckFormValues => ({
+  name: deck.name,
+  category: deck.category,
+  url: deck.url || undefined,
+  convertToBr: deck.convertToBr,
+  localMode: deck.localMode,
+});
+
+const getDeckEditInput = (deck: Deck, values: DeckFormValues): Parameters<typeof editDeck>[1] => ({
+  id: deck.id,
+  ...values,
+  localMode: values.localMode ?? deck.localMode,
+  url: values.url ?? null,
+});
+
+const getFormattedDate = (timestamp: number): string | undefined =>
+  timestamp ? new Date(timestamp).toLocaleDateString() : undefined;
+
+const getDeckInfo = (deck: Deck) => {
+  const createdAt = getFormattedDate(deck.createdAt);
+  const updatedAt = getFormattedDate(deck.updatedAt);
+  return {
+    id: deck.id,
+    ...(createdAt ? { createdAt } : {}),
+    ...(updatedAt ? { updatedAt } : {}),
+  };
+};
+
+const getLocalModeHelp = (deck: Deck): string =>
+  deck.localMode
+    ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
+    : "This deck and its cards are saved to Firestore.";
 
 interface UseDeckFormStateOptions {
   deckId: string;
@@ -18,17 +54,10 @@ interface UseDeckFormStateOptions {
 export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormStateOptions) => {
   const uid = useAuthUid();
   const deck = useDeck(deckId);
+  const isMounted = useMountedGuard();
   const [saveError, setSaveError] = React.useState<unknown>(null);
   const { formState, handleSubmit, register } = useForm<DeckFormValues>({
-    ...(deck && {
-      values: {
-        name: deck.name,
-        category: deck.category,
-        url: deck.url || undefined,
-        convertToBr: deck.convertToBr,
-        localMode: deck.localMode,
-      },
-    }),
+    ...(deck && { values: getDeckFormValues(deck) }),
     resolver: zodResolver(deckFormSchema),
   });
 
@@ -37,15 +66,11 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
   const submit = handleSubmit(async (values) => {
     setSaveError(null);
     try {
-      await editDeck(uid, {
-        id: deck.id,
-        ...values,
-        localMode: values.localMode ?? deck.localMode,
-        url: values.url ?? null,
-      });
-      onSaved();
+      await editDeck(uid, getDeckEditInput(deck, values));
+      // A Deck write may finish after the user leaves this Page; prevent that stale completion from navigating them.
+      if (isMounted()) onSaved();
     } catch (error) {
-      setSaveError(error);
+      if (isMounted()) setSaveError(error);
     }
   });
   const onFormSubmit = (event?: Parameters<typeof submit>[0]) => {
@@ -53,11 +78,7 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
   };
 
   const form = {
-    deckInfo: {
-      id: deck.id,
-      ...(deck.createdAt ? { createdAt: new Date(deck.createdAt).toLocaleDateString() } : {}),
-      ...(deck.updatedAt ? { updatedAt: new Date(deck.updatedAt).toLocaleDateString() } : {}),
-    },
+    deckInfo: getDeckInfo(deck),
     fields: {
       name: register("name"),
       convertToBr: register("convertToBr"),
@@ -67,12 +88,10 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
       url: register("url", { setValueAs: (value: unknown) => (value === "" ? undefined : value) }),
       category: {
         ...register("category"),
-        options: CATEGORY.map((category) => ({ label: category, value: category })),
+        options: categoryOptions,
       },
     },
-    localModeHelp: deck.localMode
-      ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
-      : "This deck and its cards are saved to Firestore.",
+    localModeHelp: getLocalModeHelp(deck),
     errors: {
       name: formState.errors.name?.message,
       url: formState.errors.url?.message,

--- a/src/pages/deck-form/ui/DeckEditor.spec.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.spec.tsx
@@ -133,6 +133,28 @@ describe("DeckEditor", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
   });
 
+  it("does not navigate when saving finishes after leaving the editor", async () => {
+    let finishSave: () => void = () => undefined;
+    writeControls.beforeWrite = () =>
+      new Promise<void>((resolve) => {
+        finishSave = resolve;
+      });
+    const onSaved = vi.fn();
+    const view = renderForm(onSaved);
+    const name = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(name);
+    await userEvent.type(name, "Saved after leaving");
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+    view.unmount();
+    finishSave();
+    renderForm();
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Saved after leaving" })).toBeVisible());
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
   it("removes a cleared optional URL from the stored Deck", async () => {
     await createDeck("", createLocalDeck({ id: deckId, name: "Deck name", url: "https://example.com/deck.csv" }));
     const onSaved = vi.fn();

--- a/src/pages/deck-form/ui/DeckEditor.stories.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.stories.tsx
@@ -27,9 +27,7 @@ const createForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
     url: { defaultValue: deck.url },
     category: { defaultValue: deck.category, options: [{ label: deck.category, value: deck.category }] },
   },
-  localModeHelp: deck.localMode
-    ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
-    : "This deck and its cards are saved to Firestore.",
+  isLocalOnly: deck.localMode,
   errors: { name: undefined, url: undefined },
   isSubmitting: false,
   onCancel: fn(),

--- a/src/pages/deck-form/ui/DeckEditor.stories.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.stories.tsx
@@ -17,8 +17,8 @@ const longDeck = {
 const createForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
   deckInfo: {
     id: deck.id,
-    createdAt: new Date(deck.createdAt).toLocaleDateString(),
-    updatedAt: new Date(deck.updatedAt).toLocaleDateString(),
+    createdAt: deck.createdAt,
+    updatedAt: deck.updatedAt,
   },
   fields: {
     name: { defaultValue: deck.name },

--- a/src/pages/deck-form/ui/DeckForm.stories.tsx
+++ b/src/pages/deck-form/ui/DeckForm.stories.tsx
@@ -27,9 +27,7 @@ const createDeckForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
     url: { defaultValue: deck.url },
     convertToBr: { checked: deck.convertToBr, onChange: fn() },
   },
-  localModeHelp: deck.localMode
-    ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
-    : "This deck and its cards are saved to Firestore.",
+  isLocalOnly: deck.localMode,
   errors: { name: undefined, url: undefined },
   isSubmitting: false,
   onCancel: fn(),
@@ -83,7 +81,7 @@ export const LocalDeck: Story = {
       ...defaultForm.fields,
       localMode: { checked: true, onChange: fn() },
     },
-    localModeHelp: "Turn off to save this deck and its cards to Firestore. This change cannot be undone.",
+    isLocalOnly: true,
   },
 };
 

--- a/src/pages/deck-form/ui/DeckForm.stories.tsx
+++ b/src/pages/deck-form/ui/DeckForm.stories.tsx
@@ -10,8 +10,8 @@ import { DeckForm, type DeckFormProps } from "./DeckForm";
 const createDeckForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
   deckInfo: {
     id: deck.id,
-    createdAt: "July 1, 2026",
-    updatedAt: "July 14, 2026",
+    createdAt: deck.createdAt,
+    updatedAt: deck.updatedAt,
   },
   fields: {
     name: { defaultValue: deck.name },

--- a/src/pages/deck-form/ui/DeckForm.tsx
+++ b/src/pages/deck-form/ui/DeckForm.tsx
@@ -13,11 +13,13 @@ interface DeckFormFields {
   category: React.ComponentProps<typeof Select>;
 }
 
+const formatDate = (timestamp: number): string => new Date(timestamp).toLocaleDateString();
+
 export interface DeckFormProps {
   deckInfo: {
     id: DeckId;
-    createdAt: string;
-    updatedAt: string;
+    createdAt: number;
+    updatedAt: number;
   };
   fields: DeckFormFields;
   isLocalOnly: boolean;
@@ -126,11 +128,11 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </div>
           <div>
             <dt className="font-medium text-ink-muted">Created</dt>
-            <dd className="text-ink">{props.deckInfo.createdAt}</dd>
+            <dd className="text-ink">{formatDate(props.deckInfo.createdAt)}</dd>
           </div>
           <div>
             <dt className="font-medium text-ink-muted">Updated</dt>
-            <dd className="text-ink">{props.deckInfo.updatedAt}</dd>
+            <dd className="text-ink">{formatDate(props.deckInfo.updatedAt)}</dd>
           </div>
         </dl>
       </details>

--- a/src/pages/deck-form/ui/DeckForm.tsx
+++ b/src/pages/deck-form/ui/DeckForm.tsx
@@ -20,7 +20,7 @@ export interface DeckFormProps {
     updatedAt?: string;
   };
   fields: DeckFormFields;
-  localModeHelp: string;
+  isLocalOnly: boolean;
   errors: {
     name: string | undefined;
     url: string | undefined;
@@ -39,6 +39,9 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
   const nameErrorId = `${nameInputId}-error`;
   const urlInputId = `${sectionHeadingIdPrefix}-deck-url`;
   const urlErrorId = `${urlInputId}-error`;
+  const localModeHelp = props.isLocalOnly
+    ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
+    : "This deck and its cards are saved to Firestore.";
 
   return (
     <Form onSubmit={props.onSubmit}>
@@ -52,7 +55,7 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
           </h2>
           <p className="mt-1 text-caption text-ink-muted">Choose whether this deck stays on this device.</p>
         </div>
-        <FormItem label="Local only" help={props.localModeHelp}>
+        <FormItem label="Local only" help={localModeHelp}>
           <Switch {...props.fields.localMode} aria-label="Local only" />
         </FormItem>
       </section>

--- a/src/pages/deck-form/ui/DeckForm.tsx
+++ b/src/pages/deck-form/ui/DeckForm.tsx
@@ -16,8 +16,8 @@ interface DeckFormFields {
 export interface DeckFormProps {
   deckInfo: {
     id: DeckId;
-    createdAt?: string;
-    updatedAt?: string;
+    createdAt: string;
+    updatedAt: string;
   };
   fields: DeckFormFields;
   isLocalOnly: boolean;
@@ -124,18 +124,14 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
             <dt className="font-medium text-ink-muted">ID</dt>
             <dd className="break-all text-ink">{props.deckInfo.id}</dd>
           </div>
-          {props.deckInfo.createdAt !== undefined && (
-            <div>
-              <dt className="font-medium text-ink-muted">Created</dt>
-              <dd className="text-ink">{props.deckInfo.createdAt}</dd>
-            </div>
-          )}
-          {props.deckInfo.updatedAt !== undefined && (
-            <div>
-              <dt className="font-medium text-ink-muted">Updated</dt>
-              <dd className="text-ink">{props.deckInfo.updatedAt}</dd>
-            </div>
-          )}
+          <div>
+            <dt className="font-medium text-ink-muted">Created</dt>
+            <dd className="text-ink">{props.deckInfo.createdAt}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-ink-muted">Updated</dt>
+            <dd className="text-ink">{props.deckInfo.updatedAt}</dd>
+          </div>
         </dl>
       </details>
       <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">


### PR DESCRIPTION
## Summary

- Extract Deck-to-form, edit-input, date, and help-text transformations into focused helpers.
- Ignore save completions and failures after the editor has unmounted.
- Cover delayed save completion after leaving the editor.

## Testing

- mise run check