### PR TITLE
ci(#1245): Migrate Firebase deploy to OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
   deploy:
     needs: [test]
     name: Deploy To Firebase
+    permissions:
+      contents: read
+      id-token: write
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -29,4 +33,10 @@ jobs:
 
       - run: mise run build
 
-      - run: npx firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}" --only hosting,firestore:rules
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: tango-ts
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - run: npx firebase deploy --project tango-ts --only hosting,firestore:rules

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules
 
 # firebase
 .firebase/
+gha-creds-*.json
 
 storybook-static/
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,3 @@ npm run e2e:ui
 ```
 
 The initial E2E suite seeds local browser storage and does not require a real Firebase project or emulator.
-
-## Get Firebase Token
-
-get a new token if old one expired
-
-```bash
-npx firebase login:ci
-```
-
-paste the new token here
-https://github.com/her0e1c1/tango/settings/secrets/actions


### PR DESCRIPTION
## Related issue

Related to #1245

The issue remains open until the post-merge production deployment and legacy credential cleanup are complete.

## Summary

- grant `id-token: write` only to the production deploy job and authenticate with the SHA-pinned Google auth action
- deploy Hosting and Firestore Rules to `tango-ts` through ADC without `FIREBASE_TOKEN`
- generate the short-lived ADC credential only after the build and ignore `gha-creds-*.json`
- remove the legacy `firebase login:ci` and token registration instructions

## External configuration

- created the GitHub `production` environment with a custom deployment branch policy limited to `main`
- registered `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SERVICE_ACCOUNT` as environment variables
- verified the GCP provider trust condition, deploy service account roles, and absence of user-managed service account keys
- retained the repository `FIREBASE_TOKEN` secret until a representative OIDC deployment succeeds

## Testing

- `mise run check`
- mandatory reviewer gate completed with no remaining P0/P1/P2 findings

## Post-merge

- verify the main Deploy workflow authenticates through OIDC and deploys Hosting and Firestore Rules
- confirm the generated ADC credential is not uploaded as an artifact or cached
- delete the repository `FIREBASE_TOKEN` secret and revoke the legacy Firebase CLI token only after the deployment succeeds
- record the workflow run and credential retirement before closing #1245