### PR TITLE
feat(#1035): Keep anonymous sessions fully local

### DIFF
--- a/.storybook/support/PageDecorator.tsx
+++ b/.storybook/support/PageDecorator.tsx
@@ -47,8 +47,8 @@ export const preparePageStory = (parameters: PageStoryParameters): void => {
   replaceAuthSession({
     status: "authenticated",
     uid: PAGE_STORY_UID,
-    isAnonymous: true,
-    displayName: null,
+    isAnonymous: false,
+    googleAccount: { displayName: "Storybook User" },
   });
 
   const decks = (parameters.decks ?? []).map(cloneDeck);

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -100,6 +100,7 @@
 | DECK-08 | read | [Deck の Card を CSV で export できる](./deck.md#deck-08) |
 | DECK-09 | write | [空の remote Deck を作成して reload 後も確認できる](./deck.md#deck-09) |
 | DECK-10 | write | [remote Deck の作成失敗後に重複なく再試行できる](./deck.md#deck-10) |
+| DECK-11 | write | [匿名時の Deck を local-only に作成して reload 後も確認できる](./deck.md#deck-11) |
 
 ### Card
 

--- a/docs/e2e/account.md
+++ b/docs/e2e/account.md
@@ -21,7 +21,7 @@
 Given:
 
 - Fixture: [`study-session-middle`](./fixture/batch/study-session-middle.yaml)
-- 匿名アカウントに Deck と Card が存在する。
+- 匿名アカウントの browser storage に local-only Deck と Card が存在する。
 - 対象 Deck に進行中の学習 session が存在する。
 - Google アカウントへ連携できる。
 
@@ -33,7 +33,7 @@ Then:
 
 - Account 画面に Google アカウントとの連携状態が表示される。
 - 匿名アカウントと同じ UID が表示される。
-- 連携前の Deck、Card、学習 session を引き続き利用できる。
+- 連携前の local-only Deck、Card、学習 session を引き続き利用できる。
 - browser error が発生しない。
 
 <a id="account-02"></a>

--- a/docs/e2e/deck.md
+++ b/docs/e2e/deck.md
@@ -18,6 +18,7 @@ Deck 管理の主要導線が、ブラウザ上で表示・作成・編集・削
 | DECK-08 | read | [Deck の Card を CSV で export できる](#deck-08) |
 | DECK-09 | write | [空の remote Deck を作成して reload 後も確認できる](#deck-09) |
 | DECK-10 | write | [remote Deck の作成失敗後に重複なく再試行できる](#deck-10) |
+| DECK-11 | write | [匿名時の Deck を local-only に作成して reload 後も確認できる](#deck-11) |
 
 <a id="deck-01"></a>
 
@@ -69,7 +70,7 @@ Then:
 
 Given:
 
-- Fixture: [`study-session-middle`](./fixture/batch/study-session-middle.yaml)
+- Fixture: [`google-study-session-middle`](./fixture/batch/google-study-session-middle.yaml)
 - 認証済みユーザーが所有する削除対象の Deck が存在する。
 - 対象 Deck に複数の Card と再開可能な学習 session が存在する。
 
@@ -116,7 +117,7 @@ Then:
 
 Given:
 
-- Fixture: [`study-session-middle`](./fixture/batch/study-session-middle.yaml)
+- Fixture: [`google-study-session-middle`](./fixture/batch/google-study-session-middle.yaml)
 - 認証済みユーザーが所有する削除対象の Deck が存在する。
 - 対象 Deck に Card と再開可能な学習 session が存在する。
 - 削除要求の失敗が dialog 内で処理され、同じ削除対象が維持されている。
@@ -244,3 +245,26 @@ Then:
 - 作成した Deck の name、category、remote の保存先が最初の作成要求から維持されている。
 - browser storage に同じ Deck の local-only duplicate が存在しない。
 - 最初の作成失敗に伴う未処理の browser error が発生しない。
+
+<a id="deck-11"></a>
+
+### DECK-11 匿名時の Deck を local-only に作成して reload 後も確認できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`empty`](./fixture/write/empty.yaml)
+- Google アカウントに連携していない匿名ユーザーである。
+- 作成対象の Deck は browser storage と remote data のどちらにも存在しない。
+
+When:
+
+- Deck の作成画面で name と category を入力して保存し、Deck 一覧を reload する。
+
+Then:
+
+- Local only は選択されたまま無効化され、remote の保存先を選択できない。
+- 作成した Deck は local-only data として reload 後も Deck 一覧に表示される。
+- 対応する Deck は Firestore に作成されない。
+- browser error が発生しない。

--- a/docs/e2e/fixture/batch/empty.yaml
+++ b/docs/e2e/fixture/batch/empty.yaml
@@ -2,6 +2,8 @@ auth:
   users:
     - uid: user-1
       provider: anonymous
+    - uid: google-user
+      provider: google
 browser:
   preferences:
     loadSample: false

--- a/docs/e2e/fixture/batch/local-deck-with-cards.yaml
+++ b/docs/e2e/fixture/batch/local-deck-with-cards.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 browser:
   preferences:
     loadSample: false

--- a/docs/e2e/fixture/batch/multi-study-sessions.yaml
+++ b/docs/e2e/fixture/batch/multi-study-sessions.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-a

--- a/docs/e2e/fixture/batch/remote-deck-with-card.yaml
+++ b/docs/e2e/fixture/batch/remote-deck-with-card.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/batch/study-session-middle.yaml
+++ b/docs/e2e/fixture/batch/study-session-middle.yaml
@@ -2,22 +2,22 @@ auth:
   users:
     - uid: user-1
       provider: anonymous
-remote:
-  decks:
+browser:
+  preferences:
+    loadSample: false
+  localDecks:
     - id: deck-1
-      uid: user-1
+      localMode: true
       name: Study Deck
       category: English
-  cards:
+  localCards:
     - id: card-1
       deckId: deck-1
-      uid: user-1
       frontText: first
       backText: first answer
       uniqueKey: first
     - id: card-2
       deckId: deck-1
-      uid: user-1
       frontText: second
       backText: second answer
       uniqueKey: second
@@ -25,15 +25,11 @@ remote:
       numberOfSeen: 1
     - id: card-3
       deckId: deck-1
-      uid: user-1
       frontText: third
       backText: third answer
       uniqueKey: third
       score: -1
       numberOfSeen: 2
-browser:
-  preferences:
-    loadSample: false
   studySessions:
     deck-1:
       sessionId: session-1

--- a/docs/e2e/fixture/read/remote-deck-with-card.yaml
+++ b/docs/e2e/fixture/read/remote-deck-with-card.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/read/remote-deck-with-cards.yaml
+++ b/docs/e2e/fixture/read/remote-deck-with-cards.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/read/remote-deck.yaml
+++ b/docs/e2e/fixture/read/remote-deck.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/read/study-filter-no-matches.yaml
+++ b/docs/e2e/fixture/read/study-filter-no-matches.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/read/study-session-middle.yaml
+++ b/docs/e2e/fixture/read/study-session-middle.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/read/study-session-start.yaml
+++ b/docs/e2e/fixture/read/study-session-start.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/read/two-users.yaml
+++ b/docs/e2e/fixture/read/two-users.yaml
@@ -1,9 +1,9 @@
 auth:
   users:
     - uid: user-a
-      provider: anonymous
+      provider: google
     - uid: user-b
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-a

--- a/docs/e2e/fixture/write/empty.yaml
+++ b/docs/e2e/fixture/write/empty.yaml
@@ -2,6 +2,8 @@ auth:
   users:
     - uid: user-1
       provider: anonymous
+    - uid: google-user
+      provider: google
 browser:
   preferences:
     loadSample: false

--- a/docs/e2e/fixture/write/remote-deck-with-card.yaml
+++ b/docs/e2e/fixture/write/remote-deck-with-card.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/remote-deck-with-cards.yaml
+++ b/docs/e2e/fixture/write/remote-deck-with-cards.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/remote-deck.yaml
+++ b/docs/e2e/fixture/write/remote-deck.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/study-filter.yaml
+++ b/docs/e2e/fixture/write/study-filter.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/study-session-last.yaml
+++ b/docs/e2e/fixture/write/study-session-last.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/study-session-middle.yaml
+++ b/docs/e2e/fixture/write/study-session-middle.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/study-session-start-drag.yaml
+++ b/docs/e2e/fixture/write/study-session-start-drag.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/fixture/write/study-session-start.yaml
+++ b/docs/e2e/fixture/write/study-session-start.yaml
@@ -1,7 +1,7 @@
 auth:
   users:
     - uid: user-1
-      provider: anonymous
+      provider: google
 remote:
   decks:
     - id: deck-1

--- a/docs/e2e/import.md
+++ b/docs/e2e/import.md
@@ -99,12 +99,14 @@ Given:
 When:
 
 - Import 画面で local-only の保存先を選択し、CSV の preview を確認して import した後、reload して import した Deck の学習を開始する。
+- 最初の Card に mastered action を実行し、画面を reload する。
 
 Then:
 
 - import した Deck とすべての Card が local storage に維持される。
 - 対応する Deck と Card は remote data に作成されない。
-- 学習画面に import した Card が表示される。
+- 学習画面に import した Card が表示され、mastered progress が専用の local storage に保存される。
+- reload 後も保存した score と学習回数が復元される。
 - 未処理の browser error が発生しない。
 
 <a id="import-05"></a>

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,4 +1,9 @@
 service cloud.firestore {
+  // The current sign-in provider may differ, so remote access depends on the account's linked identities.
+  function hasGoogleIdentity() {
+    return request.auth != null &&
+           request.auth.token.get(["firebase", "identities", "google.com"], []).size() > 0;
+  }
   function isOwner() {
     return request.auth.uid == resource.data.uid;
   }
@@ -14,10 +19,10 @@ service cloud.firestore {
       function isPublic() {
         return resource.data.isPublic == true;
       }
-      allow read: if isOwner() || isPublic();
-      allow create: if isValid();
-      allow update: if isValidOwner();
-      allow delete: if isOwner();
+      allow read: if hasGoogleIdentity() && (isOwner() || isPublic());
+      allow create: if hasGoogleIdentity() && isValid();
+      allow update: if hasGoogleIdentity() && isValidOwner();
+      allow delete: if hasGoogleIdentity() && isOwner();
     }
     match /card/{cardId} {
       function getDeck(deckId) {
@@ -29,10 +34,10 @@ service cloud.firestore {
       function belongsToDeck() {
         return getDeck(request.resource.data.deckId).data.uid == request.auth.uid
       }
-      allow read: if isOwner() || isPublic();
-      allow create: if isValid() && belongsToDeck();
-      allow update: if isValidOwner() && belongsToDeck();
-      allow delete: if isOwner();
+      allow read: if hasGoogleIdentity() && (isOwner() || isPublic());
+      allow create: if hasGoogleIdentity() && isValid() && belongsToDeck();
+      allow update: if hasGoogleIdentity() && isValidOwner() && belongsToDeck();
+      allow delete: if hasGoogleIdentity() && isOwner();
     }
   }
 }

--- a/src/app/auth/index.spec.tsx
+++ b/src/app/auth/index.spec.tsx
@@ -17,6 +17,7 @@ const firebaseAuth = vi.hoisted(() => ({
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
 vi.mock("firebase/auth", () => ({
+  GoogleAuthProvider: { PROVIDER_ID: "google.com" },
   onIdTokenChanged: (_auth: unknown, observer: (user: User | null) => void) => {
     firebaseAuth.observer = observer;
     firebaseAuth.observing = true;

--- a/src/app/auth/lifecycle.spec.ts
+++ b/src/app/auth/lifecycle.spec.ts
@@ -9,18 +9,26 @@ const singletonMocks = vi.hoisted(() => ({
 
 vi.mock("@/shared/firebase", () => ({ auth: singletonMocks.auth }));
 vi.mock("firebase/auth", () => ({
+  GoogleAuthProvider: { PROVIDER_ID: "google.com" },
   onIdTokenChanged: singletonMocks.onIdTokenChanged,
   signInAnonymously: singletonMocks.signInAnonymously,
 }));
 
 const createUser = (
   uid: string,
-  { isAnonymous = true, displayName = null }: { isAnonymous?: boolean; displayName?: string | null } = {}
+  {
+    isAnonymous = true,
+    googleDisplayName,
+    otherDisplayName,
+  }: { isAnonymous?: boolean; googleDisplayName?: string | null; otherDisplayName?: string | null } = {}
 ) =>
   ({
     uid,
     isAnonymous,
-    providerData: displayName == null ? [] : [{ displayName }],
+    providerData: [
+      ...(otherDisplayName === undefined ? [] : [{ providerId: "password", displayName: otherDisplayName }]),
+      ...(googleDisplayName === undefined ? [] : [{ providerId: "google.com", displayName: googleDisplayName }]),
+    ],
   }) as User;
 
 const createHarness = async (signInAnonymously = vi.fn(() => new Promise<UserCredential>(() => undefined))) => {
@@ -65,13 +73,13 @@ describe("lifecycle", () => {
   it("maps Firebase users to a Firebase-independent session snapshot", async () => {
     const { getAuthSession, publishUser } = await createHarness();
 
-    publishUser(createUser("uid-a", { isAnonymous: false, displayName: "Ada" }));
+    publishUser(createUser("uid-a", { isAnonymous: false, googleDisplayName: "Ada" }));
 
     expect(getAuthSession()).toEqual({
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: false,
-      displayName: "Ada",
+      googleAccount: { displayName: "Ada" },
     });
   });
 
@@ -79,13 +87,26 @@ describe("lifecycle", () => {
     const { getAuthSession, publishUser } = await createHarness();
     publishUser(createUser("uid-a"));
 
-    publishUser(createUser("uid-a", { isAnonymous: false, displayName: "Ada" }));
+    publishUser(createUser("uid-a", { isAnonymous: false, googleDisplayName: "Ada" }));
 
     expect(getAuthSession()).toEqual({
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: false,
-      displayName: "Ada",
+      googleAccount: { displayName: "Ada" },
+    });
+  });
+
+  it("does not grant Google access from another linked provider", async () => {
+    const { getAuthSession, publishUser } = await createHarness();
+
+    publishUser(createUser("uid-a", { isAnonymous: false, otherDisplayName: "Password User" }));
+
+    expect(getAuthSession()).toEqual({
+      status: "authenticated",
+      uid: "uid-a",
+      isAnonymous: false,
+      googleAccount: null,
     });
   });
 

--- a/src/app/auth/lifecycle.ts
+++ b/src/app/auth/lifecycle.ts
@@ -1,15 +1,19 @@
-import { onIdTokenChanged, signInAnonymously, type User } from "firebase/auth";
+import { GoogleAuthProvider, onIdTokenChanged, signInAnonymously, type User } from "firebase/auth";
 
 import { getAuthSession, replaceAuthSession } from "@/entities/auth";
 import { clearStudySessions } from "@/entities/study-session";
 import { auth } from "@/shared/firebase";
 
-const authSessionFromUser = (user: User) => ({
-  status: "authenticated" as const,
-  uid: user.uid,
-  isAnonymous: user.isAnonymous,
-  displayName: user.providerData[0]?.displayName ?? null,
-});
+const authSessionFromUser = (user: User) => {
+  const googleProvider = user.providerData.find((provider) => provider.providerId === GoogleAuthProvider.PROVIDER_ID);
+
+  return {
+    status: "authenticated" as const,
+    uid: user.uid,
+    isAnonymous: user.isAnonymous,
+    googleAccount: googleProvider == null ? null : { displayName: googleProvider.displayName },
+  };
+};
 
 const startAnonymousBootstrap = () => {
   if (getAuthSession().status !== "unauthenticated") return;

--- a/src/app/firestore-subscriptions/index.spec.tsx
+++ b/src/app/firestore-subscriptions/index.spec.tsx
@@ -7,6 +7,8 @@ interface FirestoreSnapshot {
   docs: { id: string; data: () => Record<string, unknown> }[];
 }
 
+const firestoreMocks = vi.hoisted(() => ({ queries: [] as FirestoreQuery[] }));
+
 import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -31,6 +33,7 @@ vi.mock("firebase/firestore", async (importOriginal) => {
       publishSnapshot: (snapshot: FirestoreSnapshot) => void,
       _onError: (error: Error) => void
     ) => {
+      firestoreMocks.queries.push(request);
       const deckId = `deck-${request.uid}`;
       const document =
         request.collectionName === "deck"
@@ -75,11 +78,18 @@ vi.mock("firebase/firestore", async (importOriginal) => {
 
 import { FirestoreSubscriptionsProvider } from ".";
 
-const authenticatedSession = (uid: string) => ({
+const googleSession = (uid: string) => ({
+  status: "authenticated" as const,
+  uid,
+  isAnonymous: false,
+  googleAccount: { displayName: null },
+});
+
+const anonymousSession = (uid: string) => ({
   status: "authenticated" as const,
   uid,
   isAnonymous: true,
-  displayName: null,
+  googleAccount: null,
 });
 
 const RepositoryView = () => {
@@ -105,6 +115,7 @@ describe("FirestoreSubscriptionsProvider", () => {
   beforeEach(() => {
     clearRemoteCards();
     clearRemoteDecks();
+    firestoreMocks.queries = [];
     replaceAuthSession({ status: "initializing" });
   });
 
@@ -116,8 +127,18 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(screen.getByText("No remote Cards")).toBeVisible();
   });
 
-  it("shows remote data for the authenticated identity", () => {
-    act(() => replaceAuthSession(authenticatedSession("user-a")));
+  it("does not subscribe for an anonymous Firebase identity", () => {
+    act(() => replaceAuthSession(anonymousSession("anonymous-user")));
+
+    renderProvider();
+
+    expect(firestoreMocks.queries).toEqual([]);
+    expect(screen.getByText("No remote Decks")).toBeVisible();
+    expect(screen.getByText("No remote Cards")).toBeVisible();
+  });
+
+  it("shows remote data for the linked Google identity", () => {
+    act(() => replaceAuthSession(googleSession("user-a")));
 
     renderProvider();
 
@@ -125,12 +146,23 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(screen.getByText("Front for user-a")).toBeVisible();
   });
 
+  it("starts remote subscriptions after the same Firebase identity links Google", () => {
+    act(() => replaceAuthSession(anonymousSession("user-a")));
+    renderProvider();
+    expect(screen.getByText("No remote Decks")).toBeVisible();
+
+    act(() => replaceAuthSession(googleSession("user-a")));
+
+    expect(screen.getByText("Deck for user-a")).toBeVisible();
+    expect(screen.getByText("Front for user-a")).toBeVisible();
+  });
+
   it("replaces visible remote data when the authenticated identity changes", () => {
-    act(() => replaceAuthSession(authenticatedSession("user-a")));
+    act(() => replaceAuthSession(googleSession("user-a")));
     renderProvider();
     expect(screen.getByText("Deck for user-a")).toBeVisible();
 
-    act(() => replaceAuthSession(authenticatedSession("user-b")));
+    act(() => replaceAuthSession(googleSession("user-b")));
 
     expect(screen.getByText("Deck for user-b")).toBeVisible();
     expect(screen.getByText("Front for user-b")).toBeVisible();
@@ -138,8 +170,20 @@ describe("FirestoreSubscriptionsProvider", () => {
     expect(screen.queryByText("Front for user-a")).not.toBeInTheDocument();
   });
 
+  it("clears visible remote data when Google is unlinked from the same Firebase user", () => {
+    act(() => replaceAuthSession(googleSession("user-a")));
+    renderProvider();
+    expect(screen.getByText("Deck for user-a")).toBeVisible();
+
+    act(() => replaceAuthSession(anonymousSession("user-a")));
+
+    expect(screen.getByText("Application content")).toBeVisible();
+    expect(screen.getByText("No remote Decks")).toBeVisible();
+    expect(screen.getByText("No remote Cards")).toBeVisible();
+  });
+
   it("clears visible remote data on logout while preserving application content", () => {
-    act(() => replaceAuthSession(authenticatedSession("user-a")));
+    act(() => replaceAuthSession(googleSession("user-a")));
     renderProvider();
     expect(screen.getByText("Deck for user-a")).toBeVisible();
 
@@ -151,7 +195,7 @@ describe("FirestoreSubscriptionsProvider", () => {
   });
 
   it("clears remote data when the provider unmounts", () => {
-    act(() => replaceAuthSession(authenticatedSession("user-a")));
+    act(() => replaceAuthSession(googleSession("user-a")));
     const view = renderProvider();
     expect(screen.getByText("Deck for user-a")).toBeVisible();
 

--- a/src/app/firestore-subscriptions/index.tsx
+++ b/src/app/firestore-subscriptions/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { clearRemoteCards, subscribeCards } from "@/entities/card";
 import { clearRemoteDecks, subscribeDecks } from "@/entities/deck";
 
@@ -10,10 +10,12 @@ const reportSubscriptionError = (error: Error): void => {
 };
 
 export const FirestoreSubscriptionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
 
   React.useEffect(() => {
     if (uid === "") {
+      clearRemoteCards();
+      clearRemoteDecks();
       return;
     }
 

--- a/src/entities/auth/index.ts
+++ b/src/entities/auth/index.ts
@@ -1,2 +1,2 @@
-export { useAuthAccount, useAuthSession, useAuthUid } from "./model/hooks";
+export { useAuthSession, useFirebaseUid, useGoogleAccount, useGoogleAccountUid } from "./model/hooks";
 export { getAuthSession, replaceAuthSession } from "./model/store";

--- a/src/entities/auth/model/hooks.spec.ts
+++ b/src/entities/auth/model/hooks.spec.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { useAuthAccount, useAuthSession, useAuthUid } from "./hooks";
+import { useAuthSession, useFirebaseUid, useGoogleAccount, useGoogleAccountUid } from "./hooks";
 import { replaceAuthSession } from "./store";
 
 describe("useAuthSession", () => {
@@ -15,7 +15,7 @@ describe("useAuthSession", () => {
         status: "authenticated",
         uid: "uid-a",
         isAnonymous: true,
-        displayName: null,
+        googleAccount: null,
       })
     );
 
@@ -23,12 +23,12 @@ describe("useAuthSession", () => {
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: true,
-      displayName: null,
+      googleAccount: null,
     });
   });
 });
 
-describe("useAuthUid", () => {
+describe("useFirebaseUid", () => {
   beforeEach(() => replaceAuthSession({ status: "initializing" }));
 
   it("returns the authenticated user UID", () => {
@@ -36,10 +36,10 @@ describe("useAuthUid", () => {
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: true,
-      displayName: null,
+      googleAccount: null,
     });
 
-    const { result } = renderHook(useAuthUid);
+    const { result } = renderHook(useFirebaseUid);
 
     expect(result.current).toBe("uid-a");
   });
@@ -52,13 +52,13 @@ describe("useAuthUid", () => {
   ])("returns an empty string when the session is $status", (session) => {
     replaceAuthSession(session);
 
-    const { result } = renderHook(useAuthUid);
+    const { result } = renderHook(useFirebaseUid);
 
     expect(result.current).toBe("");
   });
 });
 
-describe("useAuthAccount", () => {
+describe("useGoogleAccount", () => {
   beforeEach(() => replaceAuthSession({ status: "initializing" }));
 
   it("returns a linked account", () => {
@@ -66,30 +66,60 @@ describe("useAuthAccount", () => {
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: false,
-      displayName: "Test User",
+      googleAccount: { displayName: "Test User" },
     });
 
-    const { result } = renderHook(useAuthAccount);
+    const { result } = renderHook(useGoogleAccount);
 
     expect(result.current).toEqual({ uid: "uid-a", displayName: "Test User" });
   });
 
-  it("does not return an anonymous user as an account", () => {
+  it("does not infer Google access from a non-anonymous Firebase user", () => {
     replaceAuthSession({
       status: "authenticated",
-      uid: "anonymous-uid",
-      isAnonymous: true,
-      displayName: null,
+      uid: "password-user",
+      isAnonymous: false,
+      googleAccount: null,
     });
 
-    const { result } = renderHook(useAuthAccount);
+    const { result } = renderHook(useGoogleAccount);
 
     expect(result.current).toBeUndefined();
   });
 
   it("returns no account before authentication", () => {
-    const { result } = renderHook(useAuthAccount);
+    const { result } = renderHook(useGoogleAccount);
 
     expect(result.current).toBeUndefined();
+  });
+});
+
+describe("useGoogleAccountUid", () => {
+  beforeEach(() => replaceAuthSession({ status: "initializing" }));
+
+  it("returns the Firebase uid only when Google is linked", () => {
+    replaceAuthSession({
+      status: "authenticated",
+      uid: "uid-a",
+      isAnonymous: false,
+      googleAccount: { displayName: null },
+    });
+
+    const { result } = renderHook(useGoogleAccountUid);
+
+    expect(result.current).toBe("uid-a");
+  });
+
+  it("returns an empty string for a Firebase user without Google", () => {
+    replaceAuthSession({
+      status: "authenticated",
+      uid: "uid-a",
+      isAnonymous: true,
+      googleAccount: null,
+    });
+
+    const { result } = renderHook(useGoogleAccountUid);
+
+    expect(result.current).toBe("");
   });
 });

--- a/src/entities/auth/model/hooks.ts
+++ b/src/entities/auth/model/hooks.ts
@@ -1,20 +1,23 @@
 import { useStore } from "zustand";
 
 import { authSessionStore } from "./store";
-import type { AuthAccount, AuthSessionState } from "./types";
+import type { AuthSessionState, GoogleAccount } from "./types";
 
 // Reads the complete authentication lifecycle state.
 export const useAuthSession = (): AuthSessionState => useStore(authSessionStore);
 
-// Pre-authentication renders use a stable sentinel that remote command schemas reject as an unauthenticated uid.
-export const useAuthUid = (): string =>
+// This raw Firebase identity is for display and authentication diagnostics, never remote authorization.
+export const useFirebaseUid = (): string =>
   useStore(authSessionStore, (auth) => (auth.status === "authenticated" ? auth.uid : ""));
 
-// Reads the linked account identity while excluding anonymous sessions.
-export const useAuthAccount = (): AuthAccount | undefined => {
+// Reads the linked Google identity that grants remote persistence access.
+export const useGoogleAccount = (): GoogleAccount | undefined => {
   const auth = useAuthSession();
 
-  return auth.status === "authenticated" && !auth.isAnonymous
-    ? { uid: auth.uid, displayName: auth.displayName }
+  return auth.status === "authenticated" && auth.googleAccount != null
+    ? { uid: auth.uid, displayName: auth.googleAccount.displayName }
     : undefined;
 };
+
+// Pre-authentication and non-Google sessions use a sentinel that remote command schemas reject.
+export const useGoogleAccountUid = (): string => useGoogleAccount()?.uid ?? "";

--- a/src/entities/auth/model/store.spec.ts
+++ b/src/entities/auth/model/store.spec.ts
@@ -15,14 +15,14 @@ describe("authSessionStore", () => {
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: true,
-      displayName: null,
+      googleAccount: null,
     });
 
     expect(getAuthSession()).toEqual({
       status: "authenticated",
       uid: "uid-a",
       isAnonymous: true,
-      displayName: null,
+      googleAccount: null,
     });
   });
 

--- a/src/entities/auth/model/types.ts
+++ b/src/entities/auth/model/types.ts
@@ -1,12 +1,14 @@
-/** Linked Firebase account details exposed to authenticated consumers. */
-export interface AuthAccount {
+/** Linked Google account details exposed to remote-capable consumers. */
+export interface GoogleAccount {
   uid: string;
   displayName: string | null;
 }
 
 /** Authenticated Firebase session details shared by anonymous and linked users. */
-interface AuthenticatedSession extends AuthAccount {
+interface AuthenticatedSession {
+  uid: string;
   isAnonymous: boolean;
+  googleAccount: Omit<GoogleAccount, "uid"> | null;
 }
 
 /**
@@ -15,8 +17,8 @@ interface AuthenticatedSession extends AuthAccount {
  * A typical anonymous startup follows:
  * `initializing` -> `unauthenticated` -> `authenticating` -> `authenticated`.
  *
- * `authenticated` represents any Firebase user. Use `isAnonymous` to distinguish
- * an anonymous user from a linked account.
+ * `authenticated` represents any Firebase user. Remote access depends on
+ * `googleAccount`, not on the provider used for the latest sign-in.
  */
 export type AuthSessionState =
   /** Waiting for Firebase to publish the initial authentication snapshot. */
@@ -39,8 +41,8 @@ export type AuthSessionState =
   /**
    * Firebase has an active user.
    *
-   * Both anonymous and linked users use this state. `isAnonymous` indicates
-   * which kind of authenticated user is active.
+   * Both anonymous and linked users use this state. `googleAccount` is present
+   * only when Google is among the identities linked to the Firebase user.
    */
   | ({ status: "authenticated" } & AuthenticatedSession)
   /**

--- a/src/entities/card/@x/deck.ts
+++ b/src/entities/card/@x/deck.ts
@@ -1,2 +1,1 @@
-export { moveLocalCardsToRemote } from "../api/mutations";
-export { deleteLocalCardsByDeckId } from "../model/store";
+export { deleteLocalCardsByDeckId, moveLocalCardsToRemote } from "../api/mutations";

--- a/src/entities/card/@x/study-progress.ts
+++ b/src/entities/card/@x/study-progress.ts
@@ -1,1 +1,2 @@
+export { editLocalCardStudyProgress, findCardById } from "../model/store";
 export type { CardId } from "../model/types";

--- a/src/entities/card/api/mutations.spec.ts
+++ b/src/entities/card/api/mutations.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createLocalStudyProgress, deleteLocalStudyProgresses } from "@/entities/study-progress/@x/card";
 import { createCard as createCardFixture, createLocalCard } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -18,9 +19,18 @@ vi.mock("./firestore", () => ({
 import { cardStore } from "../model/store";
 import { deleteCard, editCard, moveLocalCardsToRemote } from "./mutations";
 
+// Reads persisted progress IDs so lifecycle assertions do not depend on another Entity's internal store.
+const persistedProgressIds = (): string[] => {
+  const persisted = JSON.parse(localStorage.getItem("tango-local-study-progresses") ?? "null") as {
+    state?: { localProgresses?: { cardId: string }[] };
+  } | null;
+  return persisted?.state?.localProgresses?.map(({ cardId }) => cardId) ?? [];
+};
+
 describe("Card mutations", () => {
   beforeEach(() => {
     cardStore.setState({ remoteCards: [], localCards: [] });
+    deleteLocalStudyProgresses(["first", "second", "other"]);
     localStorage.clear();
     vi.clearAllMocks();
   });
@@ -51,6 +61,9 @@ describe("Card mutations", () => {
       createLocalCard({ id: "other", deckId: "other-deck" }),
     ];
     cardStore.setState({ localCards: cards });
+    cards.forEach(({ id }) => {
+      createLocalStudyProgress({ cardId: id, score: 0, numberOfSeen: 0 });
+    });
 
     await moveLocalCardsToRemote("uid", "deck");
 
@@ -62,5 +75,20 @@ describe("Card mutations", () => {
     expect(mocks.createRemoteCard.mock.calls[0]?.[1]).not.toHaveProperty("createdAt");
     expect(mocks.createRemoteCard.mock.calls[0]?.[1]).not.toHaveProperty("updatedAt");
     expect(cardStore.getState().localCards).toEqual([cards[2]]);
+    expect(persistedProgressIds()).toEqual(["other"]);
+  });
+
+  it("keeps local Cards and progress when remote migration fails", async () => {
+    const cards = [createLocalCard({ id: "first", deckId: "deck" }), createLocalCard({ id: "second", deckId: "deck" })];
+    cardStore.setState({ localCards: cards });
+    cards.forEach(({ id }) => {
+      createLocalStudyProgress({ cardId: id, score: 0, numberOfSeen: 0 });
+    });
+    mocks.createRemoteCard.mockRejectedValueOnce(new Error("write failed"));
+
+    await expect(moveLocalCardsToRemote("uid", "deck")).rejects.toThrow("write failed");
+
+    expect(cardStore.getState().localCards).toEqual(cards);
+    expect(persistedProgressIds()).toEqual(["first", "second"]);
   });
 });

--- a/src/entities/card/api/mutations.ts
+++ b/src/entities/card/api/mutations.ts
@@ -8,12 +8,18 @@ import type {
 } from "../model/types";
 
 import { findDeckById } from "@/entities/deck/@x/card";
+import {
+  createLocalStudyProgress,
+  createStudyProgressFromCard,
+  deleteLocalStudyProgress,
+  deleteLocalStudyProgresses,
+} from "@/entities/study-progress/@x/card";
 import { cardCreateSchema } from "../model/schema";
 import {
   cardStore,
   createLocalCard,
   deleteLocalCard,
-  deleteLocalCardsByDeckId,
+  deleteLocalCardsByDeckId as deleteLocalCardRecordsByDeckId,
   editLocalCard,
   findCardById,
 } from "../model/store";
@@ -47,7 +53,8 @@ const requireRemoteCardCreate = (card: CardMutationCreateInput): CardCreateInput
 // Routes a Card create through the owning Deck's persistence mode.
 const createCard = async (uid: string, card: CardMutationCreateInput): Promise<void> => {
   if (isLocalDeck(card.deckId)) {
-    createLocalCard(card);
+    const createdCard = createLocalCard(card);
+    createLocalStudyProgress(createStudyProgressFromCard(createdCard));
     return;
   }
   await createRemoteCard(uid, requireRemoteCardCreate(card));
@@ -61,6 +68,7 @@ export const moveLocalCardsToRemote = async (uid: string, deckId: string): Promi
       createRemoteCard(uid, { ...card, uid })
     )
   );
+  // Local Card and progress remain retryable until every remote Card has been persisted.
   deleteLocalCardsByDeckId(deckId);
 };
 
@@ -98,7 +106,14 @@ export const deleteCard = async (uid: string, card: { id: CardId }): Promise<voi
   const currentCard = requireCard(card.id);
   if (requireLocalMode(currentCard.deckId)) {
     deleteLocalCard(card.id);
+    deleteLocalStudyProgress(card.id);
     return;
   }
   await deleteRemoteCard(uid, { id: card.id, uid: requireRemoteCard(currentCard).uid });
+};
+
+// Deletes local Cards and their progress together so Deck removal cannot leave orphaned learning state.
+export const deleteLocalCardsByDeckId = (deckId: string): void => {
+  const deletedCardIds = deleteLocalCardRecordsByDeckId(deckId);
+  deleteLocalStudyProgresses(deletedCardIds);
 };

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -4,17 +4,18 @@ import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
 import { cardStore } from "./store";
 import type { Card, CardId } from "./types";
 
-// Reads remote and local Cards as one ordered collection.
+// Hides remote duplicates left by a partial migration while their retryable local Cards still exist.
 export const useCards = (): Card[] => {
   const state = useStore(cardStore);
-  return [...state.remoteCards, ...state.localCards];
+  const localIds = new Set(state.localCards.map((card) => card.id));
+  return [...state.remoteCards.filter((card) => !localIds.has(card.id)), ...state.localCards];
 };
 
-// Reads one Card by identifier across both persistence modes.
+// Reads one Card with the retryable local record taking precedence over a partial remote copy.
 export const useCard = (id: CardId | undefined): Card | undefined =>
   useStore(
     cardStore,
-    (state) => state.remoteCards.find((card) => card.id === id) ?? state.localCards.find((card) => card.id === id)
+    (state) => state.localCards.find((card) => card.id === id) ?? state.remoteCards.find((card) => card.id === id)
   );
 
 // Reads the Cards and available tags owned by one Deck.

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -11,6 +11,8 @@ import {
   deleteLocalCard,
   deleteLocalCardsByDeckId,
   editLocalCard,
+  editLocalCardStudyProgress,
+  findCardById,
   replaceRemoteCards,
 } from "./store";
 
@@ -69,6 +71,38 @@ describe("Card store", () => {
     expect(renderHook(() => useCard("remote")).result.current).toEqual(remoteCard);
     expect(renderHook(() => useCard("local")).result.current).toEqual(localCard);
     expect(renderHook(() => useCard("missing")).result.current).toBeUndefined();
+  });
+
+  it("keeps a local Card authoritative over a matching remote snapshot", () => {
+    const remoteCard = createCard({ id: "shared", deckId: "deck", frontText: "Remote" });
+    const localCard = createLocalCardFixture({ id: "shared", deckId: "deck", frontText: "Local" });
+    cardStore.setState({ remoteCards: [remoteCard], localCards: [localCard] });
+
+    expect(renderHook(useCards).result.current).toEqual([localCard]);
+    expect(renderHook(() => useCard("shared")).result.current).toEqual(localCard);
+    expect(renderHook(() => useCardsByDeckId("deck")).result.current.cards).toEqual([localCard]);
+    expect(findCardById("shared")).toEqual(localCard);
+  });
+
+  it("restores an authoritative local Card over a matching remote snapshot during hydration", async () => {
+    const remoteCard = createCard({ id: "shared", deckId: "deck", frontText: "Remote" });
+    const localCard = createLocalCardFixture({ id: "shared", deckId: "deck", frontText: "Local" });
+    cardStore.setState({ remoteCards: [remoteCard], localCards: [] });
+    useMemoryStorage({
+      "tango-local-cards": JSON.stringify({ state: { localCards: [localCard] }, version: 1 }),
+    });
+
+    await cardStore.persist.rehydrate();
+
+    expect(renderHook(useCards).result.current).toEqual([localCard]);
+    expect(findCardById("shared")).toEqual(localCard);
+
+    const editedLocalCard = editLocalCard({ id: localCard.id, frontText: "Retryable" });
+    expect(renderHook(() => useCard("shared")).result.current).toEqual(editedLocalCard);
+
+    deleteLocalCard(localCard.id);
+    expect(renderHook(useCards).result.current).toEqual([remoteCard]);
+    expect(findCardById("shared")).toBe(remoteCard);
   });
 
   it("selects cards and tags for a deck", () => {
@@ -142,6 +176,10 @@ describe("Card store", () => {
     const updatedCard = editLocalCard({ id: "local", frontText: "updated" });
     expect(updatedCard).toEqual(expect.objectContaining({ frontText: "updated", createdAt: 10, updatedAt: 20 }));
 
+    vi.mocked(Date.now).mockReturnValueOnce(30);
+    const updatedProgress = editLocalCardStudyProgress({ id: "local", score: 2, numberOfSeen: 3 });
+    expect(updatedProgress).toEqual(expect.objectContaining({ score: 2, numberOfSeen: 3, updatedAt: 30 }));
+
     deleteLocalCard("local");
     expect(cardStore.getState().localCards).toEqual([]);
   });
@@ -150,7 +188,7 @@ describe("Card store", () => {
     createLocalCard(cardInput("first", "deck-a"));
     createLocalCard(cardInput("second", "deck-b"));
 
-    deleteLocalCardsByDeckId("deck-a");
+    expect(deleteLocalCardsByDeckId("deck-a")).toEqual(["first"]);
 
     expect(cardStore.getState().localCards.map(({ id }) => id)).toEqual(["second"]);
   });

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -25,6 +25,10 @@ interface CardState {
   localCards: LocalCard[];
 }
 
+/** Progress-only edit retained until Card consumers move to the separated StudyProgress store. */
+type LocalCardStudyProgressEdit = Pick<LocalCard, "id"> &
+  Partial<Pick<LocalCard, "score" | "numberOfSeen" | "lastSeenAt" | "nextSeeingAt" | "interval">>;
+
 /** Injectable persistence controls used to create an isolated Card store. */
 interface CreateCardStoreOptions {
   storage?: StateStorage;
@@ -72,7 +76,8 @@ export const clearRemoteCards = (): void => {
 export const findCardById = (id: CardId): Card | undefined => {
   const cardId = cardIdSchema.parse(id);
   const state = cardStore.getState();
-  return state.remoteCards.find((card) => card.id === cardId) ?? state.localCards.find((card) => card.id === cardId);
+  // A failed migration can leave a remote duplicate; local remains authoritative until a retry succeeds.
+  return state.localCards.find((card) => card.id === cardId) ?? state.remoteCards.find((card) => card.id === cardId);
 };
 
 // Creates and persists a local Card with Entity-owned timestamps.
@@ -98,14 +103,31 @@ export const editLocalCard = (input: LocalCardEdit): LocalCard => {
   return updatedCard;
 };
 
+// Mirrors local progress into the compatibility Card view until #604 removes these fields.
+export const editLocalCardStudyProgress = (input: LocalCardStudyProgressEdit): LocalCard => {
+  const cardId = cardIdSchema.parse(input.id);
+  const { localCards } = cardStore.getState();
+  const currentCard = localCards.find(({ id }) => id === cardId);
+  if (currentCard === undefined) throw new Error(`Local Card "${cardId}" was not found`);
+
+  const updatedCard = localCardSchema.parse({ ...currentCard, ...input, updatedAt: Date.now() });
+  cardStore.setState({ localCards: localCards.map((card) => (card.id === cardId ? updatedCard : card)) });
+  return updatedCard;
+};
+
 // Removes one local Card after validating its identifier.
 export const deleteLocalCard = (input: CardId): void => {
   const cardId = cardIdSchema.parse(input);
   cardStore.setState({ localCards: cardStore.getState().localCards.filter(({ id }) => id !== cardId) });
 };
 
-// Removes every local Card owned by a deleted Deck.
-export const deleteLocalCardsByDeckId = (deckId: string): void => {
+// Removes every local Card owned by a deleted Deck and returns their identifiers for dependent cleanup.
+export const deleteLocalCardsByDeckId = (deckId: string): CardId[] => {
   const parsedDeckId = cardDeckIdSchema.parse(deckId);
+  const deletedCardIds = cardStore
+    .getState()
+    .localCards.filter((card) => card.deckId === parsedDeckId)
+    .map((card) => card.id);
   cardStore.setState({ localCards: cardStore.getState().localCards.filter((card) => card.deckId !== parsedDeckId) });
+  return deletedCardIds;
 };

--- a/src/entities/deck/model/hooks.ts
+++ b/src/entities/deck/model/hooks.ts
@@ -3,15 +3,16 @@ import { useStore } from "zustand";
 import { deckStore } from "./store";
 import type { Deck, DeckId } from "./types";
 
-// Reads the remote and local Deck collections without remapping their values.
+// Hides remote duplicates left by a partial migration while their retryable local Deck still exists.
 export const useDecks = (): Deck[] => {
   const state = useStore(deckStore);
-  return [...state.remoteDecks, ...state.localDecks];
+  const localIds = new Set(state.localDecks.map((deck) => deck.id));
+  return [...state.remoteDecks.filter((deck) => !localIds.has(deck.id)), ...state.localDecks];
 };
 
-// Reads one Deck by identifier without remapping its value.
+// Reads one Deck with the retryable local record taking precedence over a partial remote copy.
 export const useDeck = (id: DeckId | undefined): Deck | undefined =>
   useStore(
     deckStore,
-    (state) => state.remoteDecks.find((deck) => deck.id === id) ?? state.localDecks.find((deck) => deck.id === id)
+    (state) => state.localDecks.find((deck) => deck.id === id) ?? state.remoteDecks.find((deck) => deck.id === id)
   );

--- a/src/entities/deck/model/store.spec.tsx
+++ b/src/entities/deck/model/store.spec.tsx
@@ -10,6 +10,7 @@ import {
   deckStore,
   deleteLocalDeck,
   editLocalDeck,
+  findDeckById,
   replaceRemoteDecks,
 } from "./store";
 
@@ -58,6 +59,37 @@ describe("Deck store", () => {
     expect(renderHook(() => useDeck("remote")).result.current).toBe(remoteDeck);
     expect(renderHook(() => useDeck("local")).result.current).toBe(localDeck);
     expect(renderHook(() => useDeck("missing")).result.current).toBeUndefined();
+  });
+
+  it("keeps a local Deck authoritative over a matching remote snapshot", () => {
+    const remoteDeck = createDeck({ id: "shared", name: "Remote" });
+    const localDeck = createLocalDeckFixture({ id: "shared", name: "Local" });
+    deckStore.setState({ remoteDecks: [remoteDeck], localDecks: [localDeck] });
+
+    expect(renderHook(useDecks).result.current).toEqual([localDeck]);
+    expect(renderHook(() => useDeck("shared")).result.current).toBe(localDeck);
+    expect(findDeckById("shared")).toEqual(localDeck);
+  });
+
+  it("restores an authoritative local Deck over a matching remote snapshot during hydration", async () => {
+    const remoteDeck = createDeck({ id: "shared", name: "Remote" });
+    const localDeck = createLocalDeckFixture({ id: "shared", name: "Local" });
+    deckStore.setState({ remoteDecks: [remoteDeck], localDecks: [] });
+    useMemoryStorage({
+      "tango-local-decks": JSON.stringify({ state: { localDecks: [localDeck] }, version: 1 }),
+    });
+
+    await deckStore.persist.rehydrate();
+
+    expect(renderHook(useDecks).result.current).toEqual([localDeck]);
+    expect(findDeckById("shared")).toEqual(localDeck);
+
+    const editedLocalDeck = editLocalDeck({ id: localDeck.id, name: "Retryable" });
+    expect(renderHook(() => useDeck("shared")).result.current).toBe(editedLocalDeck);
+
+    deleteLocalDeck(localDeck.id);
+    expect(renderHook(useDecks).result.current).toEqual([remoteDeck]);
+    expect(findDeckById("shared")).toBe(remoteDeck);
   });
 
   it("persists only local Decks and restores them after hydration", async () => {

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -65,7 +65,8 @@ export const clearRemoteDecks = (): void => {
 export const findDeckById = (id: DeckId): Deck | undefined => {
   const deckId = deckIdSchema.parse(id);
   const state = deckStore.getState();
-  return state.remoteDecks.find((deck) => deck.id === deckId) ?? state.localDecks.find((deck) => deck.id === deckId);
+  // A failed migration can leave a remote duplicate; local remains authoritative until a retry succeeds.
+  return state.localDecks.find((deck) => deck.id === deckId) ?? state.remoteDecks.find((deck) => deck.id === deckId);
 };
 
 // Creates and persists a local Deck with Entity-owned timestamps.

--- a/src/entities/study-progress/@x/card.ts
+++ b/src/entities/study-progress/@x/card.ts
@@ -1,2 +1,8 @@
 export { mapStudyProgressDocument } from "../model/dto";
 export type { StudyProgress } from "../model/types";
+export {
+  createLocalStudyProgress,
+  deleteLocalStudyProgress,
+  deleteLocalStudyProgresses,
+} from "../model/store";
+export { createStudyProgressFromCard } from "../model/rules";

--- a/src/entities/study-progress/api/firestore.spec.ts
+++ b/src/entities/study-progress/api/firestore.spec.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 
-import { editStudyProgress } from "./firestore";
+import { editRemoteStudyProgress } from "./firestore";
 
 describe("StudyProgress Firestore persistence", () => {
   it("rejects edit requests without a confirmed user identity", async () => {
-    await expect(editStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
+    await expect(editRemoteStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
   });
 
   it("rejects edit requests without a card ID", async () => {
-    await expect(editStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
+    await expect(editRemoteStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
   });
 });

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -8,7 +8,10 @@ import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { editStudyProgressSchema } from "../model/schema";
 
 // Validates and writes StudyProgress-owned fields into the shared Card document.
-export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
+export const editRemoteStudyProgress = async (
+  uid: string,
+  progress: EditStudyProgressInput["progress"]
+): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });
   const { cardId, ...fields } = input.progress;
   // StudyProgress is embedded in its Card document; patch only progress fields so Card content remains untouched.

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  editLocalCardStudyProgress: vi.fn(),
+  editLocalStudyProgress: vi.fn(),
+  editRemoteStudyProgress: vi.fn(),
+  findCardById: vi.fn(),
+}));
+
+vi.mock("@/entities/card/@x/study-progress", () => ({
+  editLocalCardStudyProgress: mocks.editLocalCardStudyProgress,
+  findCardById: mocks.findCardById,
+}));
+vi.mock("../model/store", () => ({ editLocalStudyProgress: mocks.editLocalStudyProgress }));
+vi.mock("./firestore", () => ({ editRemoteStudyProgress: mocks.editRemoteStudyProgress }));
+
+import { editStudyProgress } from "./mutations";
+
+describe("StudyProgress mutations", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("updates local state without requiring a UID or writing to Firestore", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck" });
+    mocks.editLocalStudyProgress.mockReturnValue({ cardId: "local", score: 2, numberOfSeen: 3 });
+
+    await editStudyProgress("", { cardId: "local", score: 2, numberOfSeen: 3 });
+
+    expect(mocks.editLocalStudyProgress).toHaveBeenCalledExactlyOnceWith({
+      cardId: "local",
+      score: 2,
+      numberOfSeen: 3,
+    });
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({
+      id: "local",
+      score: 2,
+      numberOfSeen: 3,
+    });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("preserves the remote Firestore write path", async () => {
+    mocks.findCardById.mockReturnValue({ id: "remote", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "remote", score: 2 });
+
+    expect(mocks.editRemoteStudyProgress).toHaveBeenCalledExactlyOnceWith("user", {
+      cardId: "remote",
+      score: 2,
+    });
+    expect(mocks.editLocalStudyProgress).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects progress for an unknown Card", async () => {
+    await expect(editStudyProgress("user", { cardId: "missing", score: 2 })).rejects.toThrow(
+      'Card "missing" was not found'
+    );
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+    expect(mocks.editLocalStudyProgress).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,0 +1,20 @@
+import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
+import { editLocalStudyProgress } from "../model/store";
+import type { StudyProgressEdit } from "../model/types";
+import { editRemoteStudyProgress } from "./firestore";
+
+// Routes a progress edit to the persistence mode owned by its Card.
+export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
+  const card = findCardById(progress.cardId);
+  if (card === undefined) throw new Error(`Card "${progress.cardId}" was not found`);
+
+  if ("uid" in card) {
+    await editRemoteStudyProgress(uid, progress);
+    return;
+  }
+
+  const updatedProgress = editLocalStudyProgress(progress);
+  const { cardId: id, ...fields } = updatedProgress;
+  // Card consumers still read the combined model; keep this mirror until #604 completes the separation.
+  editLocalCardStudyProgress({ id, ...fields });
+};

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,1 +1,1 @@
-export { editStudyProgress } from "./api/firestore";
+export { editStudyProgress } from "./api/mutations";

--- a/src/entities/study-progress/model/schema.ts
+++ b/src/entities/study-progress/model/schema.ts
@@ -2,13 +2,28 @@ import { z } from "zod";
 
 const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote StudyProgress writes");
 
-const studyProgressEditSchema = z.object({
+export const studyProgressEditSchema = z.object({
   cardId: z.string().min(1, "Card id is required"),
   score: z.number().optional(),
   numberOfSeen: z.number().optional(),
   lastSeenAt: z.number().optional(),
   nextSeeingAt: z.date().optional(),
   interval: z.number().optional(),
+});
+
+export const studyProgressSchema = studyProgressEditSchema.extend({
+  score: z.number(),
+  numberOfSeen: z.number(),
+});
+
+// Zustand JSON storage serializes Dates as strings, so persisted progress restores them explicitly.
+const persistedDateSchema = z.preprocess(
+  (value) => (typeof value === "string" ? new Date(value) : value),
+  z.date().refine((value) => !Number.isNaN(value.getTime()), "Invalid date")
+);
+
+export const persistedStudyProgressSchema = studyProgressSchema.extend({
+  nextSeeingAt: persistedDateSchema.optional(),
 });
 
 export const editStudyProgressSchema = z.object({

--- a/src/entities/study-progress/model/store.spec.ts
+++ b/src/entities/study-progress/model/store.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStudyProgress } from "./defaults";
+
+// Reloads the module so each scenario exercises initialization and migration from fresh storage.
+const loadStore = () => {
+  vi.resetModules();
+  return import("./store");
+};
+
+describe("StudyProgress store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists local progress and restores scheduled dates", async () => {
+    const { createLocalStudyProgress } = await loadStore();
+    const local = { ...createStudyProgress("local"), nextSeeingAt: new Date(1000) };
+    createLocalStudyProgress(local);
+
+    expect(JSON.parse(localStorage.getItem("tango-local-study-progresses") ?? "null")).toEqual({
+      state: { localProgresses: [{ ...local, nextSeeingAt: new Date(1000).toISOString() }] },
+      version: 1,
+    });
+
+    const { editLocalStudyProgress } = await loadStore();
+    expect(editLocalStudyProgress({ cardId: local.cardId, score: 2 })).toEqual({ ...local, score: 2 });
+  });
+
+  it("hydrates valid progress while discarding a malformed neighboring record", async () => {
+    const valid = { ...createStudyProgress("valid"), nextSeeingAt: new Date(1000) };
+    localStorage.setItem(
+      "tango-local-study-progresses",
+      JSON.stringify({
+        state: {
+          localProgresses: [
+            { ...valid, nextSeeingAt: valid.nextSeeingAt.toISOString() },
+            { ...createStudyProgress("malformed"), numberOfSeen: "invalid" },
+          ],
+        },
+        version: 1,
+      })
+    );
+
+    const { editLocalStudyProgress } = await loadStore();
+
+    expect(editLocalStudyProgress({ cardId: valid.cardId })).toEqual(valid);
+    expect(() => editLocalStudyProgress({ cardId: "malformed" })).toThrow(
+      'Local StudyProgress "malformed" was not found'
+    );
+  });
+
+  it("migrates valid legacy Card progress once and defaults missing counters", async () => {
+    const nextSeeingAt = new Date(1000);
+    const legacyCards = [
+      {
+        id: "legacy-card",
+        frontText: "Legacy",
+        score: 3,
+        numberOfSeen: 4,
+        lastSeenAt: 500,
+        nextSeeingAt: nextSeeingAt.toISOString(),
+        interval: 2,
+      },
+      { id: "legacy-defaults", frontText: "Defaults" },
+      { id: "malformed", score: "invalid", numberOfSeen: 1 },
+    ];
+    localStorage.setItem("tango-local-cards", JSON.stringify({ state: { localCards: legacyCards }, version: 1 }));
+
+    const { editLocalStudyProgress } = await loadStore();
+
+    const migrated = {
+      cardId: "legacy-card",
+      score: 3,
+      numberOfSeen: 4,
+      lastSeenAt: 500,
+      nextSeeingAt,
+      interval: 2,
+    };
+    expect(editLocalStudyProgress({ cardId: "legacy-card" })).toEqual(migrated);
+    expect(editLocalStudyProgress({ cardId: "legacy-defaults" })).toEqual(createStudyProgress("legacy-defaults"));
+    expect(() => editLocalStudyProgress({ cardId: "malformed" })).toThrow(
+      'Local StudyProgress "malformed" was not found'
+    );
+    expect(JSON.parse(localStorage.getItem("tango-local-study-progresses") ?? "null")).toEqual({
+      state: {
+        localProgresses: [
+          { ...migrated, nextSeeingAt: nextSeeingAt.toISOString() },
+          createStudyProgress("legacy-defaults"),
+        ],
+      },
+      version: 1,
+    });
+  });
+
+  it("prefers an existing dedicated key over legacy Card progress", async () => {
+    localStorage.setItem(
+      "tango-local-study-progresses",
+      JSON.stringify({ state: { localProgresses: [createStudyProgress("dedicated")] }, version: 1 })
+    );
+    localStorage.setItem(
+      "tango-local-cards",
+      JSON.stringify({ state: { localCards: [{ id: "legacy", score: 5, numberOfSeen: 6 }] }, version: 1 })
+    );
+
+    const { editLocalStudyProgress } = await loadStore();
+
+    expect(editLocalStudyProgress({ cardId: "dedicated" })).toEqual(createStudyProgress("dedicated"));
+    expect(() => editLocalStudyProgress({ cardId: "legacy" })).toThrow('Local StudyProgress "legacy" was not found');
+  });
+
+  it("creates, edits, and deletes local progress synchronously", async () => {
+    const { createLocalStudyProgress, deleteLocalStudyProgress, deleteLocalStudyProgresses, editLocalStudyProgress } =
+      await loadStore();
+    expect(createLocalStudyProgress(createStudyProgress("first"))).toEqual(createStudyProgress("first"));
+    createLocalStudyProgress(createStudyProgress("second"));
+
+    expect(editLocalStudyProgress({ cardId: "first", score: 3 })).toEqual({
+      ...createStudyProgress("first"),
+      score: 3,
+    });
+
+    deleteLocalStudyProgress("first");
+    deleteLocalStudyProgresses(["second"]);
+    expect(() => editLocalStudyProgress({ cardId: "first" })).toThrow('Local StudyProgress "first" was not found');
+    expect(() => editLocalStudyProgress({ cardId: "second" })).toThrow('Local StudyProgress "second" was not found');
+  });
+
+  it("fails when local progress is missing", async () => {
+    const { editLocalStudyProgress } = await loadStore();
+    expect(() => editLocalStudyProgress({ cardId: "missing", score: 1 })).toThrow(
+      'Local StudyProgress "missing" was not found'
+    );
+  });
+});

--- a/src/entities/study-progress/model/store.ts
+++ b/src/entities/study-progress/model/store.ts
@@ -1,0 +1,146 @@
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import { createStore } from "zustand/vanilla";
+import { z } from "zod";
+
+import { mapStudyProgressDocument } from "./dto";
+import { persistedStudyProgressSchema, studyProgressEditSchema, studyProgressSchema } from "./schema";
+import type { StudyProgress, StudyProgressEdit } from "./types";
+
+/** Local StudyProgress state stored independently from the compatibility Card model. */
+interface StudyProgressState {
+  localProgresses: StudyProgress[];
+}
+
+/** Browser-persisted subset of StudyProgress state. */
+interface PersistedStudyProgressState {
+  localProgresses: StudyProgress[];
+}
+
+/** Injectable persistence controls used to create an isolated StudyProgress store. */
+interface CreateStudyProgressStoreOptions {
+  storage?: StateStorage;
+  skipHydration?: boolean;
+}
+
+const LOCAL_STUDY_PROGRESS_STORAGE_KEY = "tango-local-study-progresses";
+const LEGACY_LOCAL_CARD_STORAGE_KEY = "tango-local-cards";
+
+const persistedStudyProgressStateSchema = z.object({
+  localProgresses: z.array(z.unknown()),
+});
+
+const legacyLocalCardProgressSchema = persistedStudyProgressSchema.omit({ cardId: true }).extend({
+  id: studyProgressSchema.shape.cardId,
+  score: studyProgressSchema.shape.score.default(0),
+  numberOfSeen: studyProgressSchema.shape.numberOfSeen.default(0),
+});
+const legacyLocalCardStorageSchema = z.object({
+  state: z.object({ localCards: z.array(z.unknown()) }),
+  version: z.literal(1),
+});
+
+// Removes explicit undefined optionals so hydrated data satisfies the domain's exact optional contract.
+const normalizeStudyProgress = (input: z.output<typeof studyProgressSchema>): StudyProgress => {
+  const { cardId, ...document } = input;
+  return mapStudyProgressDocument(cardId, document);
+};
+
+// Keeps every recoverable record so one damaged entry cannot hide otherwise valid local progress.
+const parsePersistedStudyProgressState = (value: unknown): PersistedStudyProgressState => {
+  const result = persistedStudyProgressStateSchema.safeParse(value);
+  if (!result.success) return { localProgresses: [] };
+  return {
+    localProgresses: result.data.localProgresses.flatMap((progress) => {
+      const parsedProgress = persistedStudyProgressSchema.safeParse(progress);
+      return parsedProgress.success ? [normalizeStudyProgress(parsedProgress.data)] : [];
+    }),
+  };
+};
+
+// Extracts individually valid progress records from the released combined local Card payload.
+const parseLegacyLocalCardProgresses = (value: string | null): StudyProgress[] | null => {
+  if (value === null) return null;
+  try {
+    const legacyStore = legacyLocalCardStorageSchema.safeParse(JSON.parse(value));
+    if (!legacyStore.success) return null;
+    return legacyStore.data.state.localCards.flatMap((card) => {
+      const result = legacyLocalCardProgressSchema.safeParse(card);
+      if (!result.success) return [];
+      const { id: cardId, ...document } = result.data;
+      return [mapStudyProgressDocument(cardId, document)];
+    });
+  } catch {
+    return null;
+  }
+};
+
+// Copies legacy progress once; the dedicated key is the marker and always wins when already present.
+const migrateLegacyLocalCardProgresses = (storage: Storage): void => {
+  if (storage.getItem(LOCAL_STUDY_PROGRESS_STORAGE_KEY) !== null) return;
+  const localProgresses = parseLegacyLocalCardProgresses(storage.getItem(LEGACY_LOCAL_CARD_STORAGE_KEY));
+  if (localProgresses === null) return;
+  storage.setItem(LOCAL_STUDY_PROGRESS_STORAGE_KEY, JSON.stringify({ state: { localProgresses }, version: 1 }));
+};
+
+// Creates a StudyProgress store whose durable state contains only local progress.
+const createStudyProgressStore = ({ storage, skipHydration }: CreateStudyProgressStoreOptions = {}) => {
+  if (storage === undefined) migrateLegacyLocalCardProgresses(localStorage);
+  const persistStorage = createJSONStorage<PersistedStudyProgressState>(() => storage ?? localStorage);
+  return createStore<StudyProgressState>()(
+    persist<StudyProgressState, [], [], PersistedStudyProgressState>(() => ({ localProgresses: [] }), {
+      name: LOCAL_STUDY_PROGRESS_STORAGE_KEY,
+      version: 1,
+      ...(persistStorage !== undefined ? { storage: persistStorage } : {}),
+      ...(skipHydration !== undefined ? { skipHydration } : {}),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...parsePersistedStudyProgressState(persistedState),
+      }),
+      partialize: ({ localProgresses }) => ({ localProgresses }),
+    })
+  );
+};
+
+const studyProgressStore = createStudyProgressStore();
+
+// Creates or replaces one local progress record after validating the complete model.
+export const createLocalStudyProgress = (input: StudyProgress): StudyProgress => {
+  const progress = normalizeStudyProgress(studyProgressSchema.parse(input));
+  const localProgresses = studyProgressStore
+    .getState()
+    .localProgresses.filter((item) => item.cardId !== progress.cardId);
+  studyProgressStore.setState({ localProgresses: [...localProgresses, progress] });
+  return progress;
+};
+
+// Applies a validated partial update to an existing local progress record.
+export const editLocalStudyProgress = (input: StudyProgressEdit): StudyProgress => {
+  const edit = studyProgressEditSchema.parse(input);
+  const { localProgresses } = studyProgressStore.getState();
+  const currentProgress = localProgresses.find(({ cardId }) => cardId === edit.cardId);
+  if (currentProgress === undefined) throw new Error(`Local StudyProgress "${edit.cardId}" was not found`);
+
+  const updatedProgress = normalizeStudyProgress(studyProgressSchema.parse({ ...currentProgress, ...edit }));
+  studyProgressStore.setState({
+    localProgresses: localProgresses.map((progress) =>
+      progress.cardId === updatedProgress.cardId ? updatedProgress : progress
+    ),
+  });
+  return updatedProgress;
+};
+
+// Deletes one local progress record after validating its Card identifier.
+export const deleteLocalStudyProgress = (cardId: string): void => {
+  const id = studyProgressEditSchema.shape.cardId.parse(cardId);
+  studyProgressStore.setState({
+    localProgresses: studyProgressStore.getState().localProgresses.filter((progress) => progress.cardId !== id),
+  });
+};
+
+// Deletes every local progress record owned by the supplied Card identifiers.
+export const deleteLocalStudyProgresses = (cardIds: string[]): void => {
+  const ids = new Set(cardIds.map((cardId) => studyProgressEditSchema.shape.cardId.parse(cardId)));
+  studyProgressStore.setState({
+    localProgresses: studyProgressStore.getState().localProgresses.filter((progress) => !ids.has(progress.cardId)),
+  });
+};

--- a/src/features/deck-deletion/model/useDeckDeletion.ts
+++ b/src/features/deck-deletion/model/useDeckDeletion.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { filterCardsByDeckId, useCards } from "@/entities/card";
 import { deleteDeck, mustFindDeckById, type Deck, useDecks } from "@/entities/deck";
 
@@ -20,7 +20,7 @@ interface UseDeckDeletionOptions {
 }
 
 export const useDeckDeletion = ({ onDeleted }: UseDeckDeletionOptions = {}) => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const cards = useCards();
   const decks = useDecks();
   const [target, setTarget] = React.useState<DeckDeletionTarget>();

--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -22,7 +22,7 @@ const writeControls = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthUid: () => "user-id",
+  useGoogleAccountUid: () => "user-id",
 }));
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 vi.mock("@/entities/deck", async (importOriginal) => {

--- a/src/features/deck-filter/model/useDeckFilterState.ts
+++ b/src/features/deck-filter/model/useDeckFilterState.ts
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { type Deck, editDeck } from "@/entities/deck";
 
 export interface DeckFilterState {
@@ -84,7 +84,7 @@ const reconcileStoredFilter = (
 };
 
 export const useDeckFilterState = (deck: Deck): DeckFilterState => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const storedFilter = toFilterValues(deck);
   const [filterState, setFilterState] = useState<FilterModelState>(() => ({
     deckId: deck.id,

--- a/src/features/sample-deck/model/useAddSampleDeck.spec.ts
+++ b/src/features/sample-deck/model/useAddSampleDeck.spec.ts
@@ -15,7 +15,7 @@ const repository = vi.hoisted(() => ({
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => repository.uid }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => repository.uid }));
 vi.mock("@/entities/card", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/card")>();
   return {

--- a/src/features/sample-deck/model/useAddSampleDeck.ts
+++ b/src/features/sample-deck/model/useAddSampleDeck.ts
@@ -3,7 +3,7 @@ import type { DeckId, LocalDeckCreateInput } from "@/entities/deck";
 
 import { useEffect } from "react";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { mutateCards } from "@/entities/card";
 import { createDeck, useDecks } from "@/entities/deck";
 import { updatePreferences, usePreferences } from "@/entities/preference";
@@ -44,7 +44,7 @@ export const addSampleDeck = async (uid: string) => {
 };
 
 export const useAddSampleDeck = () => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const decks = useDecks();
   const { loadSample } = usePreferences();
 

--- a/src/pages/account/ui/AccountPage.spec.tsx
+++ b/src/pages/account/ui/AccountPage.spec.tsx
@@ -37,7 +37,7 @@ describe("AccountPage", () => {
     vi.mocked(signOut).mockReset();
     vi.mocked(signOut).mockResolvedValue(undefined);
     replaceAuthSession({
-      displayName: null,
+      googleAccount: null,
       isAnonymous: true,
       status: "authenticated",
       uid: "anonymous-user",
@@ -57,7 +57,7 @@ describe("AccountPage", () => {
 
   it("shows the linked identity and offers sign-out", () => {
     replaceAuthSession({
-      displayName: "Test User",
+      googleAccount: { displayName: "Test User" },
       isAnonymous: false,
       status: "authenticated",
       uid: "linked-user",
@@ -94,7 +94,7 @@ describe("AccountPage", () => {
 
   it("lets the user retry a failed sign-out", async () => {
     replaceAuthSession({
-      displayName: "Test User",
+      googleAccount: { displayName: "Test User" },
       isAnonymous: false,
       status: "authenticated",
       uid: "linked-user",

--- a/src/pages/account/ui/AccountPage.tsx
+++ b/src/pages/account/ui/AccountPage.tsx
@@ -3,7 +3,7 @@ import { AiOutlineUser } from "react-icons/ai";
 import { useNavigate } from "react-router-dom";
 import { useKey } from "react-use";
 
-import { useAuthAccount, useAuthUid } from "@/entities/auth";
+import { useFirebaseUid, useGoogleAccount } from "@/entities/auth";
 import { routes } from "@/shared/router";
 import { Button } from "@/shared/ui/button";
 import { RemoteMutationNotice } from "@/shared/ui/remote-mutation-notice";
@@ -14,8 +14,8 @@ import { useSignOut } from "../model/useSignOut";
 
 export const AccountPage: React.FC = () => {
   const navigate = useNavigate();
-  const account = useAuthAccount();
-  const uid = useAuthUid();
+  const account = useGoogleAccount();
+  const uid = useFirebaseUid();
   const signIn = useSignIn();
   const signOut = useSignOut();
   const isLoggedIn = account != null;

--- a/src/pages/card-form/model/useCardFormState.ts
+++ b/src/pages/card-form/model/useCardFormState.ts
@@ -4,7 +4,7 @@ import type * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { cardContentSchema, editCard, useCard } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
 
@@ -18,7 +18,7 @@ interface UseCardFormStateOptions {
 }
 
 export const useCardFormState = ({ cardId, onCancel, onSaved }: UseCardFormStateOptions) => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const card = useCard(cardId);
   const [saveError, setSaveError] = React.useState<unknown>(null);
   const { formState, handleSubmit, register } = useForm<CardFormValues>({

--- a/src/pages/card-form/ui/CardEditor.spec.tsx
+++ b/src/pages/card-form/ui/CardEditor.spec.tsx
@@ -17,7 +17,7 @@ const writeControls = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthUid: () => "user-id",
+  useGoogleAccountUid: () => "user-id",
 }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/card", async (importOriginal) => {

--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-id" }));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,

--- a/src/pages/card-list/model/useCardListState.ts
+++ b/src/pages/card-list/model/useCardListState.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { deleteCard, mustFindCardById, type Card, type CardId, useCardsByDeckId } from "@/entities/card";
 import { type Deck, getCategory, isHighlightLanguage } from "@/entities/deck";
 import { usePreferences } from "@/entities/preference";
@@ -47,7 +47,7 @@ const buildCardListItem = (card: Card): CardListItem => ({
 });
 
 export const useCardListState = (deck: Deck): CardListState => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const preferences = usePreferences();
   const { cards: deckCards, tags } = useCardsByDeckId(deck.id);
   const [shownCard, setShownCard] = React.useState<Card>();

--- a/src/pages/card-list/ui/CardListContainer.spec.tsx
+++ b/src/pages/card-list/ui/CardListContainer.spec.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/auth", () => ({
-  useAuthUid: () => "user-id",
+  useGoogleAccountUid: () => "user-id",
 }));
 vi.mock("@/entities/card", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/card")>()),

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-id" }));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,

--- a/src/pages/deck-create/model/useDeckCreateState.ts
+++ b/src/pages/deck-create/model/useDeckCreateState.ts
@@ -2,9 +2,9 @@ import * as React from "react";
 import type * as z from "zod";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm, useWatch } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { CATEGORY, createDeck, deckFormSchema, generateDeckId, type DeckId } from "@/entities/deck";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 
@@ -16,16 +16,20 @@ interface UseDeckCreateStateOptions {
 }
 
 export const useDeckCreateState = ({ onCancel, onCreated }: UseDeckCreateStateOptions) => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
+  const remoteStorageAvailable = uid !== "";
   // A failed response may hide a successful write, so retries must reuse this Deck identity.
   const [deckId] = React.useState(generateDeckId);
   const isMounted = useMountedGuard();
   const [saveError, setSaveError] = React.useState<unknown>(null);
-  const { control, formState, handleSubmit, register } = useForm<DeckCreateFormValues>({
-    defaultValues: { name: "", category: "", convertToBr: false, localMode: false },
+  const { formState, handleSubmit, register, setValue } = useForm<DeckCreateFormValues>({
+    defaultValues: { name: "", category: "", convertToBr: false, localMode: !remoteStorageAvailable },
     resolver: zodResolver(deckFormSchema),
   });
-  const localMode = useWatch({ control, name: "localMode" }) ?? false;
+
+  React.useEffect(() => {
+    if (!remoteStorageAvailable) setValue("localMode", true);
+  }, [remoteStorageAvailable, setValue]);
 
   const submit = handleSubmit(async (values) => {
     setSaveError(null);
@@ -36,6 +40,7 @@ export const useDeckCreateState = ({ onCancel, onCreated }: UseDeckCreateStateOp
         category: values.category,
         convertToBr: values.convertToBr,
       };
+      const localMode = !remoteStorageAvailable || values.localMode === true;
       await createDeck(uid, localMode ? { ...deck, localMode: true } : { ...deck, uid, localMode: false });
       // A Deck write may finish after the user leaves this Page; prevent that stale completion from navigating them.
       if (isMounted()) onCreated(deckId);
@@ -55,10 +60,14 @@ export const useDeckCreateState = ({ onCancel, onCreated }: UseDeckCreateStateOp
         options: CATEGORY.map((category) => ({ label: category, value: category })),
       },
       // A retry must keep using react-hook-form's original persistence mode after a failed write.
-      localMode: { ...register("localMode"), disabled: formState.isSubmitting || saveError !== null },
+      localMode: {
+        ...register("localMode"),
+        disabled: !remoteStorageAvailable || formState.isSubmitting || saveError !== null,
+      },
     },
     errors: { name: formState.errors.name?.message },
     isSubmitting: formState.isSubmitting,
+    remoteStorageAvailable,
     onCancel,
     onSubmit: onFormSubmit,
   };

--- a/src/pages/deck-create/ui/DeckCreatePage.spec.tsx
+++ b/src/pages/deck-create/ui/DeckCreatePage.spec.tsx
@@ -15,9 +15,10 @@ const mocks = vi.hoisted(() => ({
   generateDeckId: vi.fn(),
   preferences: null as unknown as Preferences,
   setDarkMode: vi.fn(),
+  uid: "user-id",
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => mocks.uid }));
 vi.mock("@/entities/deck", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/entities/deck")>();
   return { ...original, createDeck: mocks.createDeck, generateDeckId: mocks.generateDeckId };
@@ -56,6 +57,7 @@ describe("DeckCreatePage", () => {
   beforeEach(() => {
     mocks.createDeck.mockReset().mockResolvedValue(undefined);
     mocks.generateDeckId.mockReset().mockReturnValue("new-deck");
+    mocks.uid = "user-id";
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
     mocks.setDarkMode.mockReset();
   });
@@ -91,6 +93,37 @@ describe("DeckCreatePage", () => {
       category: "",
       convertToBr: false,
     });
+  });
+
+  it("forces anonymous creation into local storage", async () => {
+    mocks.uid = "";
+    renderPage();
+
+    const localMode = screen.getByRole("checkbox", { name: "Local only" });
+    expect(localMode).toBeChecked();
+    expect(localMode).toBeDisabled();
+    expect(screen.getByText(/Sign in with Google to sync decks/)).toBeVisible();
+    await userEvent.type(screen.getByRole("textbox", { name: "Name" }), "Anonymous deck");
+    await userEvent.click(screen.getByRole("button", { name: "Create deck" }));
+
+    expect(mocks.createDeck).toHaveBeenCalledExactlyOnceWith("", {
+      id: "new-deck",
+      localMode: true,
+      name: "Anonymous deck",
+      category: "",
+      convertToBr: false,
+    });
+  });
+
+  it("forces an unsubmitted remote choice back to local when Google disconnects", () => {
+    const view = renderPage();
+    expect(screen.getByRole("checkbox", { name: "Local only" })).not.toBeChecked();
+
+    mocks.uid = "";
+    view.rerender(page());
+
+    expect(screen.getByRole("checkbox", { name: "Local only" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Local only" })).toBeDisabled();
   });
 
   it("keeps entered values, Deck ID, and persistence mode across retries", async () => {

--- a/src/pages/deck-create/ui/DeckCreateView.stories.tsx
+++ b/src/pages/deck-create/ui/DeckCreateView.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+
+import { withPageLayout } from "@/storybook/PageLayoutDecorator";
+
+import { DeckCreateView, type DeckCreateViewProps } from "./DeckCreateView";
+
+const createForm = (remoteStorageAvailable: boolean): DeckCreateViewProps["form"] => ({
+  fields: {
+    name: { defaultValue: "Japanese vocabulary" },
+    category: { options: [{ label: "Language", value: "language" }] },
+    localMode: {
+      checked: !remoteStorageAvailable,
+      disabled: !remoteStorageAvailable,
+      onChange: fn(),
+    },
+  },
+  errors: { name: undefined },
+  isSubmitting: false,
+  remoteStorageAvailable,
+  onCancel: fn(),
+  onSubmit: fn(),
+});
+
+const meta = {
+  title: "Pages/Deck Create/DeckCreateView",
+  component: DeckCreateView,
+  tags: ["autodocs"],
+  decorators: [withPageLayout],
+  parameters: { layout: "fullscreen" },
+  args: { form: createForm(true) },
+} satisfies Meta<typeof DeckCreateView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const GoogleAccount: Story = {};
+
+export const AnonymousLocalOnly: Story = {
+  args: { form: createForm(false) },
+};
+
+export const SaveError: Story = {
+  args: { saveError: new Error("Deck write failed") },
+};

--- a/src/pages/deck-create/ui/DeckCreateView.tsx
+++ b/src/pages/deck-create/ui/DeckCreateView.tsx
@@ -16,6 +16,7 @@ interface DeckCreateFormProps {
   fields: DeckCreateFields;
   errors: { name: string | undefined };
   isSubmitting: boolean;
+  remoteStorageAvailable: boolean;
   onCancel: () => void;
   onSubmit: NonNullable<React.ComponentProps<typeof Form>["onSubmit"]>;
 }
@@ -67,7 +68,14 @@ export const DeckCreateView: React.FC<DeckCreateViewProps> = ({ form, saveError 
           <FormItem col label="Category">
             <Select empty {...form.fields.category} />
           </FormItem>
-          <FormItem label="Local only" help="Keep this deck and its cards on this device.">
+          <FormItem
+            label="Local only"
+            help={
+              form.remoteStorageAvailable
+                ? "Keep this deck and its cards on this device."
+                : "Sign in with Google to sync decks across devices. This deck will stay on this device."
+            }
+          >
             <Switch {...form.fields.localMode} aria-label="Local only" />
           </FormItem>
         </section>

--- a/src/pages/deck-form/model/useDeckFormState.ts
+++ b/src/pages/deck-form/model/useDeckFormState.ts
@@ -4,7 +4,7 @@ import type * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { CATEGORY, type Deck, deckFormSchema, editDeck, useDeck } from "@/entities/deck";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 
@@ -20,10 +20,14 @@ const getDeckFormValues = (deck: Deck): DeckFormValues => ({
   localMode: deck.localMode,
 });
 
-const getDeckEditInput = (deck: Deck, values: DeckFormValues): Parameters<typeof editDeck>[1] => ({
+const getDeckEditInput = (
+  deck: Deck,
+  values: DeckFormValues,
+  remoteStorageAvailable: boolean
+): Parameters<typeof editDeck>[1] => ({
   id: deck.id,
   ...values,
-  localMode: values.localMode ?? deck.localMode,
+  localMode: deck.localMode && !remoteStorageAvailable ? true : (values.localMode ?? deck.localMode),
   url: values.url ?? null,
 });
 
@@ -34,21 +38,26 @@ interface UseDeckFormStateOptions {
 }
 
 export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormStateOptions) => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
+  const remoteStorageAvailable = uid !== "";
   const deck = useDeck(deckId);
   const isMounted = useMountedGuard();
   const [saveError, setSaveError] = React.useState<unknown>(null);
-  const { formState, handleSubmit, register } = useForm<DeckFormValues>({
+  const { formState, handleSubmit, register, setValue } = useForm<DeckFormValues>({
     ...(deck && { values: getDeckFormValues(deck) }),
     resolver: zodResolver(deckFormSchema),
   });
+
+  React.useLayoutEffect(() => {
+    if (deck?.localMode === true && !remoteStorageAvailable) setValue("localMode", true);
+  }, [deck?.localMode, remoteStorageAvailable, setValue]);
 
   if (deck == null) return;
 
   const submit = handleSubmit(async (values) => {
     setSaveError(null);
     try {
-      await editDeck(uid, getDeckEditInput(deck, values));
+      await editDeck(uid, getDeckEditInput(deck, values, remoteStorageAvailable));
       // A Deck write may finish after the user leaves this Page; prevent that stale completion from navigating them.
       if (isMounted()) onSaved();
     } catch (error) {
@@ -69,7 +78,7 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
       name: register("name"),
       convertToBr: register("convertToBr"),
       // Moving Firestore data back into browser-only storage needs a separate copy-and-delete workflow.
-      localMode: { ...register("localMode"), disabled: !deck.localMode },
+      localMode: { ...register("localMode"), disabled: !(deck.localMode && remoteStorageAvailable) },
       // Keep optional Deck URLs absent even though an empty HTML input reports an empty string.
       url: register("url", { setValueAs: (value: unknown) => (value === "" ? undefined : value) }),
       category: {
@@ -78,6 +87,7 @@ export const useDeckFormState = ({ deckId, onCancel, onSaved }: UseDeckFormState
       },
     },
     isLocalOnly: deck.localMode,
+    remoteStorageAvailable,
     errors: {
       name: formState.errors.name?.message,
       url: formState.errors.url?.message,

--- a/src/pages/deck-form/ui/DeckEditor.spec.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.spec.tsx
@@ -14,10 +14,11 @@ const writeControls = vi.hoisted(() => ({
   beforeWrite: undefined as (() => Promise<void>) | undefined,
   nextError: undefined as unknown,
   writes: [] as { uid: string; deck: Record<string, unknown> }[],
+  uid: "user-id",
 }));
 
 vi.mock("@/entities/auth", () => ({
-  useAuthUid: () => "user-id",
+  useGoogleAccountUid: () => writeControls.uid,
 }));
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 vi.mock("@/entities/deck", async (importOriginal) => {
@@ -68,6 +69,7 @@ describe("DeckEditor", () => {
     writeControls.beforeWrite = undefined;
     writeControls.nextError = undefined;
     writeControls.writes = [];
+    writeControls.uid = "user-id";
     await createDeck(
       "",
       createLocalDeck({
@@ -116,6 +118,38 @@ describe("DeckEditor", () => {
       uid: "user-id",
       deck: expect.objectContaining({ id: deckId, localMode: false }),
     });
+  });
+
+  it("keeps a local Deck local when Google is not linked", async () => {
+    writeControls.uid = "";
+    const onSaved = vi.fn();
+    renderForm(onSaved);
+    const localOnly = screen.getByRole("checkbox", { name: "Local only" });
+
+    expect(localOnly).toBeChecked();
+    expect(localOnly).toBeDisabled();
+    expect(screen.getByText(/Sign in with Google to sync this deck/)).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    expect(writeControls.writes.at(-1)).toEqual({
+      uid: "",
+      deck: expect.objectContaining({ id: deckId, localMode: true }),
+    });
+  });
+
+  it("restores the local-only switch when Google disconnects before saving", async () => {
+    const view = renderForm();
+    const localOnly = screen.getByRole("checkbox", { name: "Local only" });
+    await userEvent.click(localOnly);
+    expect(localOnly).not.toBeChecked();
+
+    writeControls.uid = "";
+    view.rerender(<StoredDeckEditorHarness deckId={deckId} onCancel={() => undefined} onSaved={() => undefined} />);
+
+    expect(screen.getByRole("checkbox", { name: "Local only" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Local only" })).toBeDisabled();
+    expect(screen.getByText(/Sign in with Google to sync this deck/)).toBeVisible();
   });
 
   it("uses the form submit state while saving", async () => {

--- a/src/pages/deck-form/ui/DeckEditor.stories.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.stories.tsx
@@ -28,6 +28,7 @@ const createForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
     category: { defaultValue: deck.category, options: [{ label: deck.category, value: deck.category }] },
   },
   isLocalOnly: deck.localMode,
+  remoteStorageAvailable: true,
   errors: { name: undefined, url: undefined },
   isSubmitting: false,
   onCancel: fn(),
@@ -85,6 +86,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const AnonymousLocalOnly: Story = {
+  args: {
+    form: {
+      ...createForm(fixture.deck.default),
+      fields: {
+        ...createForm(fixture.deck.default).fields,
+        localMode: { checked: true, disabled: true, onChange: fn() },
+      },
+      isLocalOnly: true,
+      remoteStorageAvailable: false,
+    },
+  },
+};
 export const Interaction: Story = {
   play: async ({ args, canvas, userEvent }) => {
     const checkbox = canvas.getByRole<HTMLInputElement>("checkbox", { name: "Convert line breaks" });

--- a/src/pages/deck-form/ui/DeckForm.stories.tsx
+++ b/src/pages/deck-form/ui/DeckForm.stories.tsx
@@ -28,6 +28,7 @@ const createDeckForm = (deck: typeof fixture.deck.default): DeckFormProps => ({
     convertToBr: { checked: deck.convertToBr, onChange: fn() },
   },
   isLocalOnly: deck.localMode,
+  remoteStorageAvailable: true,
   errors: { name: undefined, url: undefined },
   isSubmitting: false,
   onCancel: fn(),
@@ -82,6 +83,17 @@ export const LocalDeck: Story = {
       localMode: { checked: true, onChange: fn() },
     },
     isLocalOnly: true,
+  },
+};
+
+export const AnonymousLocalDeck: Story = {
+  args: {
+    fields: {
+      ...defaultForm.fields,
+      localMode: { checked: true, disabled: true, onChange: fn() },
+    },
+    isLocalOnly: true,
+    remoteStorageAvailable: false,
   },
 };
 

--- a/src/pages/deck-form/ui/DeckForm.tsx
+++ b/src/pages/deck-form/ui/DeckForm.tsx
@@ -23,6 +23,7 @@ export interface DeckFormProps {
   };
   fields: DeckFormFields;
   isLocalOnly: boolean;
+  remoteStorageAvailable: boolean;
   errors: {
     name: string | undefined;
     url: string | undefined;
@@ -42,7 +43,9 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
   const urlInputId = `${sectionHeadingIdPrefix}-deck-url`;
   const urlErrorId = `${urlInputId}-error`;
   const localModeHelp = props.isLocalOnly
-    ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
+    ? props.remoteStorageAvailable
+      ? "Turn off to save this deck and its cards to Firestore. This change cannot be undone."
+      : "Sign in with Google to sync this deck across devices. It will stay on this device until then."
     : "This deck and its cards are saved to Firestore.";
 
   return (

--- a/src/pages/deck-form/ui/DeckFormPage.spec.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.spec.tsx
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-id" }));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,

--- a/src/pages/deck-import/model/useDeckImport.spec.tsx
+++ b/src/pages/deck-import/model/useDeckImport.spec.tsx
@@ -13,7 +13,7 @@ const controls = vi.hoisted(() => ({
   nextMutationError: undefined as unknown,
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => controls.uid }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => controls.uid }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/card", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/card")>();
@@ -81,6 +81,15 @@ describe("useDeckImport", () => {
     expect(result.current.deckImport.result).toMatchObject({ created: 1 });
   });
 
+  it("defaults anonymous imports to local and rejects a remote selection", () => {
+    const { result } = renderDeckImport();
+
+    expect(result.current.deckImport.storageMode).toBe("local");
+    expect(result.current.deckImport.remoteStorageAvailable).toBe(false);
+    act(() => result.current.deckImport.setStorageMode("remote"));
+    expect(result.current.deckImport.storageMode).toBe("local");
+  });
+
   it("creates a new local Deck without changing a same-name Deck or its Cards", async () => {
     const name = "behavior-reimport.csv";
     const { result } = renderDeckImport();
@@ -138,6 +147,7 @@ describe("useDeckImport", () => {
   });
 
   it("clears a prepared preview when the destination changes", async () => {
+    controls.uid = "user-id";
     const { result } = renderDeckImport();
     act(() => result.current.deckImport.setStorageMode("local"));
     await actAsync(async () => result.current.deckImport.selectFile(csvFile("behavior-mode.csv")));
@@ -147,6 +157,46 @@ describe("useDeckImport", () => {
     expect(result.current.deckImport.storageMode).toBe("remote");
     expect(result.current.deckImport.preview).toBeUndefined();
     await expect(result.current.deckImport.importPreview()).resolves.toBeUndefined();
+  });
+
+  it("resets a prepared remote import when Google access is removed", async () => {
+    controls.uid = "user-id";
+    const view = renderDeckImport();
+    await actAsync(async () => view.result.current.deckImport.selectFile(csvFile("remote-preview.csv")));
+    expect(view.result.current.deckImport.storageMode).toBe("remote");
+    expect(view.result.current.deckImport.preview).toBeDefined();
+
+    controls.uid = "";
+    view.rerender();
+
+    expect(view.result.current.deckImport.storageMode).toBe("local");
+    expect(view.result.current.deckImport.preview).toBeUndefined();
+  });
+
+  it("discards a remote preview that finishes parsing after Google access is removed", async () => {
+    controls.uid = "user-id";
+    const view = renderDeckImport();
+    const file = csvFile("delayed-remote.csv");
+    let resolveText: (text: string) => void = () => undefined;
+    const text = new Promise<string>((resolve) => {
+      resolveText = resolve;
+    });
+    vi.spyOn(file, "text").mockReturnValue(text);
+    let selection: Promise<void> = Promise.resolve();
+    act(() => {
+      selection = view.result.current.deckImport.selectFile(file);
+    });
+
+    controls.uid = "";
+    view.rerender();
+    await actAsync(async () => {
+      resolveText('"front","back","tag","key"');
+      await selection;
+    });
+
+    expect(view.result.current.deckImport.storageMode).toBe("local");
+    expect(view.result.current.deckImport.preview).toBeUndefined();
+    expect(view.result.current.deckImport.previewError).toBeNull();
   });
 
   it("retries a failed save with the same new Deck", async () => {

--- a/src/pages/deck-import/model/useDeckImport.ts
+++ b/src/pages/deck-import/model/useDeckImport.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import { usePreferences } from "@/entities/preference";
 import { addSampleDeck } from "@/features/sample-deck";
 import type { DeckImportResult, DeckImportStorageMode } from "./useDeckImportExecution";
@@ -10,7 +10,7 @@ import { useDeckImportPreview } from "./useDeckImportPreview";
 type DeckImportStatus = "idle" | "validating" | "importing";
 
 export const useDeckImport = () => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const preferences = usePreferences();
   const execution = useDeckImportExecution(uid);
   const preview = useDeckImportPreview(uid);
@@ -55,6 +55,7 @@ export const useDeckImport = () => {
     setStorageMode,
     importPreview,
     addSample,
+    remoteStorageAvailable: uid !== "",
     storageMode: preview.storageMode,
     preview: preview.preview,
     validating: status === "validating",

--- a/src/pages/deck-import/model/useDeckImportPreview.ts
+++ b/src/pages/deck-import/model/useDeckImportPreview.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { generateCardId } from "@/entities/card";
 import { generateDeckId } from "@/entities/deck";
@@ -19,26 +19,41 @@ interface PreparedDeckImportState {
   preparedImport: PreparedDeckImport | undefined;
 }
 
-const initialState = (): DeckImportPreviewState => ({
-  storageMode: "remote",
+const initialState = (uid: string): DeckImportPreviewState => ({
+  storageMode: uid === "" ? "local" : "remote",
   error: null,
 });
 const createPreparedImportState = (): PreparedDeckImportState => ({ preparedImport: undefined });
 
 export const useDeckImportPreview = (uid: string) => {
   const preparedImportRef = useRef<PreparedDeckImportState>(createPreparedImportState());
-  const [state, setState] = useState<DeckImportPreviewState>(initialState);
+  const operationRevisionRef = useRef(0);
+  const previousUidRef = useRef(uid);
+  const [state, setState] = useState<DeckImportPreviewState>(() => initialState(uid));
   const updateState = (update: Partial<DeckImportPreviewState>) => {
     setState((current) => ({ ...current, ...update }));
   };
 
+  useLayoutEffect(() => {
+    if (previousUidRef.current === uid) return;
+
+    // A prepared remote import must never execute after account access changes.
+    previousUidRef.current = uid;
+    operationRevisionRef.current += 1;
+    preparedImportRef.current.preparedImport = undefined;
+    setState(initialState(uid));
+  }, [uid]);
+
   const selectFile = async (file: File) => {
+    operationRevisionRef.current += 1;
+    const operationRevision = operationRevisionRef.current;
     const { storageMode } = state;
     preparedImportRef.current.preparedImport = undefined;
     setState({ storageMode, error: null });
 
     try {
       const analysis = await parseCsv(await file.text());
+      if (operationRevisionRef.current !== operationRevision) return;
       const preparedImport = prepareDeckImport(
         { name: file.name, rows: analysis.rows, storageMode },
         { uid, generateDeckId, generateCardId }
@@ -47,13 +62,16 @@ export const useDeckImportPreview = (uid: string) => {
       preparedImportRef.current.preparedImport = preparedImport;
       updateState({ preview });
     } catch (caughtError) {
+      if (operationRevisionRef.current !== operationRevision) return;
       updateState({ error: caughtError });
     }
   };
 
   const setStorageMode = (storageMode: DeckImportStorageMode) => {
+    if (storageMode === "remote" && uid === "") return false;
     if (state.storageMode === storageMode) return false;
 
+    operationRevisionRef.current += 1;
     preparedImportRef.current.preparedImport = undefined;
     setState({ storageMode, error: null });
     return true;

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -12,7 +12,7 @@ const controls = vi.hoisted(() => ({
   setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "" }));
 vi.mock("@/entities/card", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/card")>();
   return {

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -18,6 +18,7 @@ export const DeckImportPage: React.FC = () => {
     <AppLayout showHeader>
       <DeckImportView
         storageMode={deckImport.storageMode}
+        remoteStorageAvailable={deckImport.remoteStorageAvailable}
         onStorageModeChange={deckImport.setStorageMode}
         onChange={(file) => {
           void deckImport.selectFile(file);

--- a/src/pages/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.spec.tsx
@@ -78,6 +78,14 @@ describe("DeckImportView", () => {
     expect(screen.getByRole("radio", { name: /Sync with account/ })).toBeDisabled();
   });
 
+  it("keeps the remote option visible but unavailable without Google", () => {
+    render(<DeckImportView sampleText="front,back,,key" storageMode="local" remoteStorageAvailable={false} />);
+
+    expect(screen.getByRole("radio", { name: /Local only/ })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /Sync with account/ })).toBeDisabled();
+    expect(screen.getByText("Sign in with Google to sync across devices.")).toBeVisible();
+  });
+
   it("documents uniqueKey and exposes sample add, download, and code controls", async () => {
     const onAddSample = vi.fn();
     const onDownloadSample = vi.fn();

--- a/src/pages/deck-import/ui/DeckImportView.stories.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.stories.tsx
@@ -35,6 +35,7 @@ const meta = {
   },
   args: {
     sampleText: SAMPLE_CSV_TEXT,
+    remoteStorageAvailable: true,
   },
 } satisfies Meta<typeof DeckImportView>;
 
@@ -42,6 +43,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const AnonymousLocalOnly: Story = {
+  args: { storageMode: "local", remoteStorageAvailable: false },
+};
 
 export const Preview: Story = {
   args: { preview },

--- a/src/pages/deck-import/ui/DeckImportView.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.tsx
@@ -53,6 +53,7 @@ export interface DeckImportViewProps {
   error?: unknown;
   previewError?: unknown;
   storageMode?: DeckImportStorageMode;
+  remoteStorageAvailable?: boolean;
 }
 
 const resultCounts = (result: DeckImportResult) => (
@@ -213,6 +214,7 @@ const ImportPreview = (props: ImportPreviewProps) => {
 export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
   const busy = Boolean(props.pending || props.validating);
   const storageMode = props.storageMode ?? "remote";
+  const remoteStorageAvailable = props.remoteStorageAvailable ?? true;
 
   return (
     <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
@@ -252,11 +254,16 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
                 name="deck-import-storage-mode"
                 value="remote"
                 checked={storageMode === "remote"}
+                disabled={busy || !remoteStorageAvailable}
                 onChange={() => props.onStorageModeChange?.("remote")}
               />
               <span>
                 <span className="block font-semibold">Sync with account</span>
-                <span className="block text-caption text-ink-muted">Save to your account and sync across devices.</span>
+                <span className="block text-caption text-ink-muted">
+                  {remoteStorageAvailable
+                    ? "Save to your account and sync across devices."
+                    : "Sign in with Google to sync across devices."}
+                </span>
               </span>
             </label>
           </fieldset>

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   setDarkMode: vi.fn(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-id" }));
 vi.mock("@/entities/deck", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/entities/deck")>();
   mocks.deleteDeck.mockImplementation(original.deleteDeck);

--- a/src/pages/study-session-start/model/useStudySessionStartState.spec.ts
+++ b/src/pages/study-session-start/model/useStudySessionStartState.spec.ts
@@ -53,7 +53,7 @@ const futureCard = createLocalCard({
 describe("useStudySessionStartState", () => {
   beforeEach(async () => {
     replaceAuthSession({
-      displayName: null,
+      googleAccount: null,
       isAnonymous: true,
       status: "authenticated",
       uid: "local-user",

--- a/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/entities/card", () => ({
   useCardsByDeckId: () => ({ cards: mocks.cards, tags: [] }),
 }));
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-id" }));
 vi.mock("@/entities/deck", () => ({
   editDeck: vi.fn(),
   isDeckTagSelectionMatching: () => true,

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-1" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-1" }));
 vi.mock("@/entities/preference", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/preference")>()),
   usePreferences: () => {

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -1,4 +1,4 @@
-import { useAuthUid } from "@/entities/auth";
+import { useGoogleAccountUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
@@ -18,7 +18,7 @@ export interface SwipeState {
 }
 
 export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: () => void): SwipeState => {
-  const uid = useAuthUid();
+  const uid = useGoogleAccountUid();
   const preferences = usePreferences();
   const feedback = useSwipeFeedback(preferences.appearance.showSwipeFeedback);
   const swipeState = React.useRef<{ inProgress: boolean }>({ inProgress: false });

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   toggleShowSwipeButtonList: vi.fn(),
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({ useGoogleAccountUid: () => "user-id" }));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,

--- a/test/e2e/account.spec.ts
+++ b/test/e2e/account.spec.ts
@@ -59,11 +59,9 @@ test("ACCOUNT-01 Google linking preserves the anonymous identity and its data", 
   await page.goto("/account");
   await expect(page.getByText("Anonymous account")).toBeVisible();
   const anonymousUid = await accountUid(page);
-  const runtimeFixture = fixture.remapUsers({ "user-1": anonymousUid });
-  const deck = runtimeFixture.deck();
-  const card = runtimeFixture.card("card-2");
-  await runtimeFixture.seedRemote();
-  await runtimeFixture.seedPage(page, { auth: false, preferences: false, localData: false });
+  const deck = fixture.deck();
+  const card = fixture.card("card-2");
+  await fixture.seedPage(page, { auth: false, preferences: false, localData: false });
   await page.goto("/account");
 
   await completeGooglePopup(page, namespace.uid);

--- a/test/e2e/deck.spec.ts
+++ b/test/e2e/deck.spec.ts
@@ -177,8 +177,8 @@ test("DECK-08 downloads every Card field as one CSV row", async ({ fixture, page
 test("DECK-09 creates one empty remote Deck without a local duplicate", async ({ fixture, page, namespace }) => {
   const name = `${namespace.caseId} created`;
   const category = "typescript";
-  const { uid } = fixture.user();
-  await fixture.apply(page);
+  const { uid } = fixture.user("google-user");
+  await fixture.apply(page, { user: "google-user" });
 
   await page.goto("/");
   await page.getByRole("button", { name: "Create deck" }).click();
@@ -219,8 +219,8 @@ test("DECK-10 retries a failed remote create with the same ID and no duplicate",
 }) => {
   const name = `${namespace.caseId} retry deck`;
   const category = "typescript";
-  const { uid } = fixture.user();
-  await fixture.apply(page);
+  const { uid } = fixture.user("google-user");
+  await fixture.apply(page, { user: "google-user" });
   await page.goto("/");
   await page.getByRole("button", { name: "Create deck" }).click();
   let attemptedDeckId: string | undefined;
@@ -234,8 +234,9 @@ test("DECK-10 retries a failed remote create with the same ID and no duplicate",
   await page.getByRole("textbox", { name: "Name" }).fill(name);
   await page.getByRole("combobox").selectOption(category);
   await page.getByRole("button", { name: "Create deck" }).click();
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
   await expect(page.getByRole("status")).toContainText("Unable to create this deck");
-  expect(fault.wasTriggered()).toBe(true);
   await fault.dispose();
   expect(attemptedDeckId).toBeDefined();
 
@@ -262,4 +263,35 @@ test("DECK-10 retries a failed remote create with the same ID and no duplicate",
   const local = await readLocalData(page);
   expect(local.decks).toEqual([]);
   expect(local.cards).toEqual([]);
+});
+
+test("DECK-11 creates anonymous Decks locally and preserves them across reload", async ({
+  fixture,
+  page,
+  namespace,
+}) => {
+  const name = `${namespace.caseId} local`;
+  const category = "typescript";
+  await fixture.apply(page);
+  await page.goto("/");
+  await page.getByRole("button", { name: "Create deck" }).click();
+
+  const localOnly = page.getByRole("checkbox", { name: "Local only" });
+  await expect(localOnly).toBeChecked();
+  await expect(localOnly).toBeDisabled();
+  await page.getByRole("textbox", { name: "Name" }).fill(name);
+  await page.getByRole("combobox").selectOption(category);
+  await page.getByRole("button", { name: "Create deck" }).click();
+  await expect(page).toHaveURL(/\/deck\/(?!new$)[^/]+$/);
+
+  await page.reload();
+  await page.getByRole("button", { name: "tango" }).click();
+  await expect(page.getByRole("button", { name: `View ${name}` })).toBeVisible();
+
+  const stored = await readLocalData(page);
+  const localDecks = stored.decks.filter(({ name: candidate }: { name?: string }) => candidate === name);
+  expect(localDecks).toHaveLength(1);
+  expect(localDecks[0]).toMatchObject({ category, localMode: true });
+  const remoteDecks = (await listDocuments("deck")).filter(({ fields }) => fields.name?.stringValue === name);
+  expect(remoteDecks).toEqual([]);
 });

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -142,14 +142,16 @@ export const expect = playwrightExpect;
 
 const encodeTokenPart = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
 
-const emulatorToken = (uid: string) => {
+const emulatorToken = (uid: string, hasGoogleIdentity: boolean) => {
   const now = Math.floor(Date.now() / 1000);
   const header = encodeTokenPart({ alg: "none", typ: "JWT" });
   const payload = encodeTokenPart({
     aud: projectId,
     auth_time: now,
     exp: now + 3600,
-    firebase: { identities: {}, sign_in_provider: "anonymous" },
+    firebase: hasGoogleIdentity
+      ? { identities: { "google.com": [uid] }, sign_in_provider: "google.com" }
+      : { identities: {}, sign_in_provider: "anonymous" },
     iat: now,
     iss: `https://securetoken.google.com/${projectId}`,
     sub: uid,
@@ -164,9 +166,13 @@ export interface AnonymousAuthOptions {
   failSignUpOnce?: boolean;
 }
 
+const isInitialGoogleIdentity = (signInCount: number, linked: boolean | undefined) =>
+  signInCount === 0 && linked === true;
+
 export const routeAnonymousAuth = async (page: Page, uid: string, options: AnonymousAuthOptions | string = {}) => {
   const normalizedOptions = typeof options === "string" ? { nextUid: options } : options;
   let activeUid = uid;
+  let hasGoogleIdentity = normalizedOptions.linked ?? false;
   let signInCount = 0;
   let shouldFailSignUp = normalizedOptions.failSignUpOnce ?? false;
   await page.route("**/identitytoolkit.googleapis.com/**", async (route) => {
@@ -180,7 +186,7 @@ export const routeAnonymousAuth = async (page: Page, uid: string, options: Anony
           users: [
             {
               localId: activeUid,
-              ...(normalizedOptions.linked && activeUid === uid
+              ...(hasGoogleIdentity
                 ? {
                     providerUserInfo: [{ providerId: "google.com", rawId: activeUid, displayName: "E2E User" }],
                   }
@@ -204,14 +210,16 @@ export const routeAnonymousAuth = async (page: Page, uid: string, options: Anony
       return;
     }
     if (url.includes("accounts:signUp")) {
-      activeUid = signInCount === 0 ? uid : (normalizedOptions.nextUid ?? uid);
+      const isInitialIdentity = signInCount === 0;
+      activeUid = isInitialIdentity ? uid : (normalizedOptions.nextUid ?? uid);
+      hasGoogleIdentity = isInitialGoogleIdentity(signInCount, normalizedOptions.linked);
       signInCount += 1;
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
           kind: "identitytoolkit#SignupNewUserResponse",
-          idToken: emulatorToken(activeUid),
+          idToken: emulatorToken(activeUid, hasGoogleIdentity),
           refreshToken: "e2e-refresh-token",
           expiresIn: "3600",
           localId: activeUid,
@@ -336,6 +344,11 @@ export const readLocalData = async (page: Page) =>
     cards: JSON.parse(window.localStorage.getItem("tango-local-cards") ?? "{}").state?.localCards ?? [],
     sessionsByDeckId: JSON.parse(window.localStorage.getItem("tango-study") ?? "{}").state?.sessionsByDeckId ?? {},
   }));
+
+export const readLocalStudyProgresses = async (page: Page) =>
+  page.evaluate(
+    () => JSON.parse(window.localStorage.getItem("tango-local-study-progresses") ?? "{}").state?.localProgresses ?? []
+  );
 
 export interface FixtureAuthSeedOptions extends AnonymousAuthOptions {
   /** Logical UID of the anonymous user created after a linked user signs out. */

--- a/test/e2e/import.spec.ts
+++ b/test/e2e/import.spec.ts
@@ -5,6 +5,7 @@ import {
   failNextFirestoreWrite,
   listDocuments,
   readLocalData,
+  readLocalStudyProgresses,
   test,
 } from "./fixtures";
 
@@ -63,8 +64,8 @@ test("IMPORT-02 Invalid CSV rows block persistence", async ({ fixture, page, nam
 });
 
 test("IMPORT-03 A remote CSV import survives reload", async ({ fixture, page, namespace }) => {
-  const { uid } = fixture.user();
-  await fixture.apply(page);
+  const { uid } = fixture.user("google-user");
+  await fixture.apply(page, { user: "google-user" });
   await page.goto("/import");
   const csvNamespace = namespace.id("remote");
   const file = validCsv(csvNamespace);
@@ -110,13 +111,36 @@ test("IMPORT-04 A local-only CSV import survives reload and can be studied", asy
   expect(decks).toHaveLength(1);
   const localDeck = decks[0] as { id: string; localMode: boolean };
   expect(localDeck.localMode).toBe(true);
-  expect(stored.cards.filter(({ deckId }: { deckId?: string }) => deckId === localDeck.id)).toHaveLength(2);
+  const localCards = stored.cards.filter(({ deckId }: { deckId?: string }) => deckId === localDeck.id) as {
+    id: string;
+    frontText: string;
+  }[];
+  expect(localCards).toHaveLength(2);
   expect(await documentsForUid("deck", uid)).toEqual([]);
   expect(await documentsForUid("card", uid)).toEqual([]);
 
   await page.getByRole("button", { name: `Study ${file.name}` }).click();
   await page.getByRole("button", { name: "Start 2 cards" }).click();
-  await expect(page.getByText(new RegExp(`^front ${csvNamespace} (one|two)$`))).toBeVisible();
+  const visibleFront = page.getByRole("button", { name: new RegExp(`^front ${csvNamespace} (one|two)$`) });
+  await expect(visibleFront).toBeVisible();
+  const frontText = await visibleFront.textContent();
+  const firstCard = localCards.find(({ frontText: candidate }) => candidate === frontText);
+  if (firstCard === undefined) throw new Error("The displayed imported local Card was not found");
+  await page.getByRole("button", { name: "Swipe up" }).click();
+  await expect
+    .poll(async () =>
+      (await readLocalStudyProgresses(page)).find(({ cardId }: { cardId?: string }) => cardId === firstCard.id)
+    )
+    .toMatchObject({ cardId: firstCard.id, score: 1, numberOfSeen: 1 });
+
+  await page.reload();
+  await expect
+    .poll(async () =>
+      (await readLocalStudyProgresses(page)).find(({ cardId }: { cardId?: string }) => cardId === firstCard.id)
+    )
+    .toMatchObject({ cardId: firstCard.id, score: 1, numberOfSeen: 1 });
+  expect(await documentsForUid("deck", uid)).toEqual([]);
+  expect(await documentsForUid("card", uid)).toEqual([]);
 });
 
 test("IMPORT-05 A partial remote import retries without duplicates", async ({
@@ -126,8 +150,8 @@ test("IMPORT-05 A partial remote import retries without duplicates", async ({
   page,
 }) => {
   browserErrors.allow(expectedFirestoreWriteBrowserError);
-  const { uid } = fixture.user();
-  await fixture.apply(page);
+  const { uid } = fixture.user("google-user");
+  await fixture.apply(page, { user: "google-user" });
   await page.goto("/import");
   const file = csvFile(`${namespace.id("retry")}.csv`, [
     `"retry front ${namespace.caseId}","retry back ${namespace.caseId}","","${namespace.id("retry-key")}"`,

--- a/test/initializeTestFirestore.ts
+++ b/test/initializeTestFirestore.ts
@@ -9,5 +9,11 @@ initializeApp({
 
 export const testDb = getFirestore();
 connectFirestoreEmulator(testDb, import.meta.env.VITE_DB_HOST, Number.parseInt(import.meta.env.VITE_DB_PORT, 10), {
-  mockUserToken: { user_id: "uid" },
+  mockUserToken: {
+    user_id: "uid",
+    firebase: {
+      identities: { "google.com": ["uid"] },
+      sign_in_provider: "google.com",
+    },
+  },
 });

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -14,7 +14,7 @@ import { createCard as createCardCommand, deleteCard, editCard } from "@/entitie
 import { createDeck as createDeckCommand } from "@/entities/deck/api/firestore";
 import { replaceRemoteCards } from "@/entities/card/model/store";
 import { replaceRemoteDecks } from "@/entities/deck/model/store";
-import { editStudyProgress } from "@/entities/study-progress";
+import { editRemoteStudyProgress } from "@/entities/study-progress/api/firestore";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as Uuid from "uuid";
 import { createCard, createDeck } from "@/test/factories";
@@ -98,9 +98,9 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
       deckId: "other-deck",
       uid: "other-user",
       deletedAt: 1,
-    } as unknown as Parameters<typeof editStudyProgress>[1];
+    } as unknown as Parameters<typeof editRemoteStudyProgress>[1];
 
-    await editStudyProgress("uid", untrustedProgress);
+    await editRemoteStudyProgress("uid", untrustedProgress);
 
     expect((await getDoc(doc(db, "card", card.id))).data()).toEqual({ ...card, score: 2, numberOfSeen: 3 });
   });

--- a/test/integration/firestore/rules.spec.ts
+++ b/test/integration/firestore/rules.spec.ts
@@ -1,29 +1,38 @@
-/**
- * @file Verifies the Firestore security-rule contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "should read a deck",
- * "should create a deck", "should update a deck".
- */
+/** Verifies the Firestore security-rule contract for Google-linked accounts. */
 
-import { it, describe, beforeEach, beforeAll, afterAll } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, it } from "vitest";
 import * as fs from "node:fs";
 import {
   assertFails,
   assertSucceeds,
   initializeTestEnvironment,
   type RulesTestEnvironment,
+  type TokenOptions,
 } from "@firebase/rules-unit-testing";
-import { setDoc, doc, getDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { deleteDoc, doc, getDoc, setDoc, updateDoc } from "firebase/firestore";
 import * as Uuid from "uuid";
 
 const uuid = Uuid.v4;
+const googleAuth = (signInProvider: NonNullable<TokenOptions["firebase"]>["sign_in_provider"] = "google.com") =>
+  ({
+    firebase: {
+      identities: { "google.com": ["google-subject"] },
+      sign_in_provider: signInProvider,
+    },
+  }) satisfies TokenOptions;
+const anonymousAuth = {
+  firebase: { identities: {}, sign_in_provider: "anonymous" },
+} satisfies TokenOptions;
+const googleProviderWithoutIdentity = {
+  firebase: { identities: {}, sign_in_provider: "google.com" },
+} satisfies TokenOptions;
 
 describe("firestore/rule", () => {
   let testEnv: RulesTestEnvironment;
 
   const createData = async (path: string, id: string, data: object) => {
     await testEnv.withSecurityRulesDisabled(async (context) => {
-      const db = context.firestore();
-      await setDoc(doc(db, path, id), data);
+      await setDoc(doc(context.firestore(), path, id), data);
     });
   };
 
@@ -46,32 +55,31 @@ describe("firestore/rule", () => {
     await testEnv.cleanup();
   });
 
-  describe("authenticated context", () => {
+  describe("Google-linked owner", () => {
     let db: firebase.default.firestore.Firestore;
 
     beforeEach(() => {
-      db = testEnv.authenticatedContext("uid").firestore();
+      db = testEnv.authenticatedContext("uid", googleAuth()).firestore();
     });
 
     describe("deck", () => {
-      it("should read a deck", async () => {
+      it("reads an owned Deck", async () => {
         const id = uuid();
         await createData("deck", id, { uid: "uid", isPublic: false });
         await assertSucceeds(getDoc(doc(db, "deck", id)));
       });
 
-      it("should create a deck", async () => {
-        const id = uuid();
-        await assertSucceeds(setDoc(doc(db, "deck", id), { uid: "uid" }));
+      it("creates an owned Deck", async () => {
+        await assertSucceeds(setDoc(doc(db, "deck", uuid()), { uid: "uid" }));
       });
 
-      it("should update a deck", async () => {
+      it("updates an owned Deck", async () => {
         const id = uuid();
         await createData("deck", id, { uid: "uid" });
         await assertSucceeds(updateDoc(doc(db, "deck", id), { uid: "uid", name: "update" }));
       });
 
-      it("should delete a deck", async () => {
+      it("deletes an owned Deck", async () => {
         const id = uuid();
         await createData("deck", id, { uid: "uid" });
         await assertSucceeds(deleteDoc(doc(db, "deck", id)));
@@ -79,26 +87,26 @@ describe("firestore/rule", () => {
     });
 
     describe("card", () => {
-      it("should read a card", async () => {
+      it("reads an owned Card", async () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertSucceeds(getDoc(doc(db, "card", id)));
       });
 
-      it("should create a card", async () => {
+      it("creates an owned Card in an owned Deck", async () => {
         const [deckId, id] = [uuid(), uuid()];
         await createData("deck", deckId, { uid: "uid" });
         await assertSucceeds(setDoc(doc(db, "card", id), { uid: "uid", deckId }));
       });
 
-      it("should update a card", async () => {
+      it("updates an owned Card in an owned Deck", async () => {
         const [deckId, id] = [uuid(), uuid()];
         await createData("deck", deckId, { uid: "uid" });
-        await createData("card", id, { uid: "uid" });
-        await assertSucceeds(updateDoc(doc(db, "card", id), { uid: "uid", deckId }));
+        await createData("card", id, { uid: "uid", deckId });
+        await assertSucceeds(updateDoc(doc(db, "card", id), { uid: "uid", deckId, name: "update" }));
       });
 
-      it("should delete a card", async () => {
+      it("deletes an owned Card", async () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertSucceeds(deleteDoc(doc(db, "card", id)));
@@ -106,145 +114,115 @@ describe("firestore/rule", () => {
     });
   });
 
-  describe("invalid authenticated context", () => {
+  describe("Google-linked non-owner", () => {
     let db: firebase.default.firestore.Firestore;
 
     beforeEach(() => {
-      db = testEnv.authenticatedContext("invalid").firestore();
+      db = testEnv.authenticatedContext("other", googleAuth()).firestore();
     });
 
-    describe("deck", () => {
-      it("should not read a deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid" });
-        await assertFails(getDoc(doc(db, "deck", id)));
-      });
+    it("reads a public Deck and its Cards", async () => {
+      const [deckId, cardId] = [uuid(), uuid()];
+      await createData("deck", deckId, { uid: "uid", isPublic: true });
+      await createData("card", cardId, { uid: "uid", deckId });
 
-      it("should read a publick deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid", isPublic: true });
-        await assertSucceeds(getDoc(doc(db, "deck", id)));
-      });
-
-      it("should not create a deck", async () => {
-        const id = uuid();
-        await assertFails(setDoc(doc(db, "deck", id), { uid: "uid" }));
-      });
-
-      it("should not update a deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid" });
-        await assertFails(updateDoc(doc(db, "deck", id), { uid: "uid", name: "update" }));
-      });
-
-      it("should not delete a deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid" });
-        await assertFails(deleteDoc(doc(db, "deck", id)));
-      });
+      await assertSucceeds(getDoc(doc(db, "deck", deckId)));
+      await assertSucceeds(getDoc(doc(db, "card", cardId)));
     });
 
-    describe("card", () => {
-      it("should not read a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(getDoc(doc(db, "card", id)));
-      });
+    it("cannot read private data or mutate another account's data", async () => {
+      const [deckId, cardId] = [uuid(), uuid()];
+      await createData("deck", deckId, { uid: "uid", isPublic: false });
+      await createData("card", cardId, { uid: "uid", deckId });
 
-      it("should read a public card", async () => {
-        const [deckId, id] = [uuid(), uuid()];
-        await createData("deck", deckId, { uid: "uid", isPublic: true });
-        await createData("card", id, { uid: "uid", deckId });
-        await assertSucceeds(getDoc(doc(db, "card", id)));
-      });
-
-      it("should not create a card", async () => {
-        const id = uuid();
-        await assertFails(setDoc(doc(db, "card", id), { uid: "uid" }));
-      });
-
-      it("should not update a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(updateDoc(doc(db, "card", id), { uid: "uid", name: "update" }));
-      });
-
-      it("should not delete a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(deleteDoc(doc(db, "card", id)));
-      });
+      await assertFails(getDoc(doc(db, "deck", deckId)));
+      await assertFails(getDoc(doc(db, "card", cardId)));
+      await assertFails(setDoc(doc(db, "deck", uuid()), { uid: "uid" }));
+      await assertFails(updateDoc(doc(db, "deck", deckId), { uid: "uid", name: "update" }));
+      await assertFails(deleteDoc(doc(db, "deck", deckId)));
+      await assertFails(setDoc(doc(db, "card", uuid()), { uid: "uid", deckId }));
+      await assertFails(updateDoc(doc(db, "card", cardId), { uid: "uid", deckId, name: "update" }));
+      await assertFails(deleteDoc(doc(db, "card", cardId)));
     });
   });
 
-  describe("unauthenticated context", () => {
+  describe("anonymous user with the owner's UID", () => {
+    let db: firebase.default.firestore.Firestore;
+
+    beforeEach(() => {
+      db = testEnv.authenticatedContext("uid", anonymousAuth).firestore();
+    });
+
+    it("cannot read or mutate Decks", async () => {
+      const [privateId, publicId] = [uuid(), uuid()];
+      await createData("deck", privateId, { uid: "uid", isPublic: false });
+      await createData("deck", publicId, { uid: "uid", isPublic: true });
+
+      await assertFails(getDoc(doc(db, "deck", privateId)));
+      await assertFails(getDoc(doc(db, "deck", publicId)));
+      await assertFails(setDoc(doc(db, "deck", uuid()), { uid: "uid" }));
+      await assertFails(updateDoc(doc(db, "deck", privateId), { uid: "uid", name: "update" }));
+      await assertFails(deleteDoc(doc(db, "deck", privateId)));
+    });
+
+    it("cannot read or mutate Cards", async () => {
+      const [deckId, cardId] = [uuid(), uuid()];
+      await createData("deck", deckId, { uid: "uid", isPublic: true });
+      await createData("card", cardId, { uid: "uid", deckId });
+
+      await assertFails(getDoc(doc(db, "card", cardId)));
+      await assertFails(setDoc(doc(db, "card", uuid()), { uid: "uid", deckId }));
+      await assertFails(updateDoc(doc(db, "card", cardId), { uid: "uid", deckId, name: "update" }));
+      await assertFails(deleteDoc(doc(db, "card", cardId)));
+    });
+  });
+
+  describe("unauthenticated user", () => {
     let db: firebase.default.firestore.Firestore;
 
     beforeEach(() => {
       db = testEnv.unauthenticatedContext().firestore();
     });
 
-    describe("deck", () => {
-      it("should not read a deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid" });
-        await assertFails(getDoc(doc(db, "deck", id)));
-      });
+    it("cannot read public Decks or Cards", async () => {
+      const [deckId, cardId] = [uuid(), uuid()];
+      await createData("deck", deckId, { uid: "uid", isPublic: true });
+      await createData("card", cardId, { uid: "uid", deckId });
 
-      it("should read a publick deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid", isPublic: true });
-        await assertSucceeds(getDoc(doc(db, "deck", id)));
-      });
-
-      it("should not create a deck", async () => {
-        const id = uuid();
-        await assertFails(setDoc(doc(db, "deck", id), { uid: "uid" }));
-      });
-
-      it("should not update a deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid" });
-        await assertFails(updateDoc(doc(db, "deck", id), { uid: "uid", name: "update" }));
-      });
-
-      it("should not delete a deck", async () => {
-        const id = uuid();
-        await createData("deck", id, { uid: "uid" });
-        await assertFails(deleteDoc(doc(db, "deck", id)));
-      });
+      await assertFails(getDoc(doc(db, "deck", deckId)));
+      await assertFails(getDoc(doc(db, "card", cardId)));
     });
 
-    describe("card", () => {
-      it("should not read a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(getDoc(doc(db, "card", id)));
-      });
+    it("cannot mutate Decks or Cards", async () => {
+      const [deckId, cardId] = [uuid(), uuid()];
+      await createData("deck", deckId, { uid: "uid" });
+      await createData("card", cardId, { uid: "uid", deckId });
 
-      it("should read a public card", async () => {
-        const [deckId, id] = [uuid(), uuid()];
-        await createData("deck", deckId, { uid: "uid", isPublic: true });
-        await createData("card", id, { uid: "uid", deckId });
-        await assertSucceeds(getDoc(doc(db, "card", id)));
-      });
-
-      it("should not create a card", async () => {
-        const id = uuid();
-        await assertFails(setDoc(doc(db, "card", id), { uid: "uid" }));
-      });
-
-      it("should not update a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(updateDoc(doc(db, "card", id), { uid: "uid", name: "update" }));
-      });
-
-      it("should not delete a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(deleteDoc(doc(db, "card", id)));
-      });
+      await assertFails(setDoc(doc(db, "deck", uuid()), { uid: "uid" }));
+      await assertFails(updateDoc(doc(db, "deck", deckId), { uid: "uid", name: "update" }));
+      await assertFails(deleteDoc(doc(db, "deck", deckId)));
+      await assertFails(setDoc(doc(db, "card", uuid()), { uid: "uid", deckId }));
+      await assertFails(updateDoc(doc(db, "card", cardId), { uid: "uid", deckId, name: "update" }));
+      await assertFails(deleteDoc(doc(db, "card", cardId)));
     });
+  });
+
+  it("allows a linked Google identity when the current sign-in provider is different", async () => {
+    const db = testEnv.authenticatedContext("uid", googleAuth("password")).firestore();
+    const id = uuid();
+
+    await assertSucceeds(setDoc(doc(db, "deck", id), { uid: "uid" }));
+    await assertSucceeds(getDoc(doc(db, "deck", id)));
+  });
+
+  it("denies a Google sign-in provider without a linked Google identity", async () => {
+    const db = testEnv.authenticatedContext("uid", googleProviderWithoutIdentity).firestore();
+    const [privateId, publicId] = [uuid(), uuid()];
+    await createData("deck", privateId, { uid: "uid", isPublic: false });
+    await createData("deck", publicId, { uid: "uid", isPublic: true });
+
+    await assertFails(getDoc(doc(db, "deck", privateId)));
+    await assertFails(getDoc(doc(db, "deck", publicId)));
+    await assertFails(setDoc(doc(db, "deck", uuid()), { uid: "uid" }));
   });
 });

--- a/test/integration/local-mutations.spec.ts
+++ b/test/integration/local-mutations.spec.ts
@@ -1,18 +1,62 @@
 import { renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { deleteCard, editCard, mutateCards, useCards } from "@/entities/card";
-import { createDeck, deleteDeck, editDeck, useDecks } from "@/entities/deck";
+import { deleteCard, editCard, mutateCards, useCard, useCards } from "@/entities/card";
+import { cardStore, findCardById, replaceRemoteCards } from "@/entities/card/model/store";
+import { createDeck, deleteDeck, editDeck, useDeck, useDecks } from "@/entities/deck";
+import { deckStore, findDeckById, replaceRemoteDecks } from "@/entities/deck/model/store";
+import { editStudyProgress } from "@/entities/study-progress";
+import { deleteLocalStudyProgresses, editLocalStudyProgress } from "@/entities/study-progress/model/store";
 import { clearStudySessions, getStudySession, startStudy } from "@/entities/study-session";
-import { createLocalCard, createLocalDeck } from "@/test/factories";
+import {
+  createCard as createRemoteCardFixture,
+  createDeck as createRemoteDeckFixture,
+  createLocalCard,
+  createLocalDeck,
+} from "@/test/factories";
+
+const remoteMocks = vi.hoisted(() => ({
+  createRemoteCard: vi.fn(),
+  createRemoteDeck: vi.fn(),
+  deleteRemoteCard: vi.fn(),
+  deleteRemoteDeck: vi.fn(),
+  editRemoteCard: vi.fn(),
+  editRemoteDeck: vi.fn(),
+}));
 
 vi.mock("@/shared/firebase", () => ({ db: {} }));
+vi.mock("@/entities/card/api/firestore", () => ({
+  createCard: remoteMocks.createRemoteCard,
+  deleteCard: remoteMocks.deleteRemoteCard,
+  editCard: remoteMocks.editRemoteCard,
+  fetchCardReads: vi.fn().mockResolvedValue([]),
+  subscribeCardReads: vi.fn(() => vi.fn()),
+  subscribeCards: vi.fn(() => vi.fn()),
+}));
+vi.mock("@/entities/deck/api/firestore", () => ({
+  createDeck: remoteMocks.createRemoteDeck,
+  deleteDeck: remoteMocks.deleteRemoteDeck,
+  editDeck: remoteMocks.editRemoteDeck,
+  subscribeDecks: vi.fn(() => vi.fn()),
+}));
 
 const studyOptions = { shuffled: false, maxNumberOfCardsToLearn: 0 };
 
 describe("local Entity mutations", () => {
+  beforeEach(() => {
+    remoteMocks.createRemoteCard.mockReset().mockResolvedValue(undefined);
+    remoteMocks.createRemoteDeck.mockReset().mockResolvedValue(undefined);
+    remoteMocks.deleteRemoteCard.mockReset().mockResolvedValue(undefined);
+    remoteMocks.deleteRemoteDeck.mockReset().mockResolvedValue(undefined);
+    remoteMocks.editRemoteCard.mockReset().mockResolvedValue(undefined);
+    remoteMocks.editRemoteDeck.mockReset().mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     clearStudySessions();
+    deleteLocalStudyProgresses(["edited-card", "deleted-card", "kept-card", "retry-first", "retry-second"]);
+    cardStore.setState({ remoteCards: [], localCards: [] });
+    deckStore.setState({ remoteDecks: [], localDecks: [] });
     localStorage.clear();
   });
 
@@ -22,16 +66,34 @@ describe("local Entity mutations", () => {
     await createDeck("", deck);
     await mutateCards("", [{ kind: "create", card }]);
 
+    expect(editLocalStudyProgress({ cardId: card.id })).toEqual({ cardId: card.id, score: 0, numberOfSeen: 0 });
+
     await editCard("", { id: card.id, frontText: "Updated" });
+    await editStudyProgress("", { cardId: card.id, score: 2, numberOfSeen: 3, nextSeeingAt: new Date(1000) });
 
     const editedCards = renderHook(() => useCards());
-    expect(editedCards.result.current).toContainEqual(expect.objectContaining({ id: card.id, frontText: "Updated" }));
+    expect(editedCards.result.current).toContainEqual(
+      expect.objectContaining({
+        id: card.id,
+        frontText: "Updated",
+        score: 2,
+        numberOfSeen: 3,
+        nextSeeingAt: new Date(1000),
+      })
+    );
+    expect(editLocalStudyProgress({ cardId: card.id })).toEqual({
+      cardId: card.id,
+      score: 2,
+      numberOfSeen: 3,
+      nextSeeingAt: new Date(1000),
+    });
     editedCards.unmount();
 
     await deleteCard("", card);
 
     const remainingCards = renderHook(() => useCards());
     expect(remainingCards.result.current.find(({ id }) => id === card.id)).toBeUndefined();
+    expect(() => editLocalStudyProgress({ cardId: card.id })).toThrow(`Local StudyProgress "${card.id}" was not found`);
     remainingCards.unmount();
     await deleteDeck("", deck.id);
   });
@@ -57,12 +119,125 @@ describe("local Entity mutations", () => {
     const cards = renderHook(() => useCards());
     expect(decks.result.current.find(({ id }) => id === deck.id)).toBeUndefined();
     expect(cards.result.current.find(({ id }) => id === card.id)).toBeUndefined();
+    expect(() => editLocalStudyProgress({ cardId: card.id })).toThrow(`Local StudyProgress "${card.id}" was not found`);
     expect(getStudySession(deck.id)).toBeUndefined();
     expect(decks.result.current).toContainEqual(expect.objectContaining({ id: otherDeck.id }));
     expect(cards.result.current).toContainEqual(expect.objectContaining({ id: otherCard.id }));
+    expect(editLocalStudyProgress({ cardId: otherCard.id })).toEqual({
+      cardId: otherCard.id,
+      score: 0,
+      numberOfSeen: 0,
+    });
     expect(getStudySession(otherDeck.id)).toBeDefined();
     decks.unmount();
     cards.unmount();
     await deleteDeck("", otherDeck.id);
+  });
+
+  it("keeps a partially migrated local graph authoritative through reload and a successful retry", async () => {
+    const uid = "google-user";
+    const deck = createLocalDeck({ id: "retry-deck", name: "Local source" });
+    const firstCard = createLocalCard({ id: "retry-first", deckId: deck.id, frontText: "Local first" });
+    const secondCard = createLocalCard({ id: "retry-second", deckId: deck.id, frontText: "Local second" });
+    await createDeck("", deck);
+    await mutateCards("", [
+      { kind: "create", card: firstCard },
+      { kind: "create", card: secondCard },
+    ]);
+    remoteMocks.createRemoteCard
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("partial remote write"));
+
+    await expect(editDeck(uid, { id: deck.id, name: "First sync", localMode: false })).rejects.toThrow(
+      "partial remote write"
+    );
+
+    const partialRemoteDeck = createRemoteDeckFixture({ id: deck.id, uid, name: "Partial remote" });
+    const partialRemoteCard = createRemoteCardFixture({
+      id: firstCard.id,
+      deckId: deck.id,
+      uid,
+      frontText: "Partial remote",
+    });
+    replaceRemoteDecks([partialRemoteDeck]);
+    replaceRemoteCards([partialRemoteCard]);
+
+    expect(renderHook(useDecks).result.current).toEqual([
+      expect.objectContaining({ id: deck.id, localMode: true, name: "First sync" }),
+    ]);
+    expect(renderHook(useCards).result.current).toEqual([
+      expect.objectContaining({ id: firstCard.id, frontText: "Local first" }),
+      expect.objectContaining({ id: secondCard.id, frontText: "Local second" }),
+    ]);
+    expect(renderHook(() => useDeck(deck.id)).result.current).toEqual(
+      expect.objectContaining({ localMode: true, name: "First sync" })
+    );
+    expect(renderHook(() => useCard(firstCard.id)).result.current).toEqual(
+      expect.objectContaining({ frontText: "Local first" })
+    );
+    expect(findDeckById(deck.id)).toEqual(expect.objectContaining({ localMode: true }));
+    expect(findCardById(firstCard.id)).toEqual(expect.objectContaining({ frontText: "Local first" }));
+
+    const persistedDecks = localStorage.getItem("tango-local-decks");
+    const persistedCards = localStorage.getItem("tango-local-cards");
+    if (persistedDecks === null || persistedCards === null)
+      throw new Error("Expected retryable local graph to persist");
+    deckStore.setState({ localDecks: [] });
+    cardStore.setState({ localCards: [] });
+    localStorage.setItem("tango-local-decks", persistedDecks);
+    localStorage.setItem("tango-local-cards", persistedCards);
+
+    await Promise.all([deckStore.persist.rehydrate(), cardStore.persist.rehydrate()]);
+
+    expect(renderHook(useDecks).result.current).toEqual([
+      expect.objectContaining({ id: deck.id, localMode: true, name: "First sync" }),
+    ]);
+    expect(renderHook(useCards).result.current).toHaveLength(2);
+
+    await editCard("", { id: firstCard.id, frontText: "Edited after failure" });
+    await editStudyProgress("", { cardId: firstCard.id, score: 4 });
+    const retryableFirstCard = findCardById(firstCard.id);
+    expect(retryableFirstCard).toEqual(
+      expect.objectContaining({ frontText: "Edited after failure", score: 4, numberOfSeen: 0 })
+    );
+
+    remoteMocks.createRemoteCard.mockClear();
+    remoteMocks.createRemoteDeck.mockClear();
+    await editDeck(uid, { id: deck.id, name: "Retry succeeded", localMode: false });
+
+    expect(remoteMocks.createRemoteDeck).toHaveBeenCalledExactlyOnceWith(
+      uid,
+      expect.objectContaining({ id: deck.id, name: "Retry succeeded", localMode: false, uid })
+    );
+    expect(remoteMocks.createRemoteCard).toHaveBeenCalledWith(
+      uid,
+      expect.objectContaining({ id: firstCard.id, frontText: "Edited after failure", score: 4, uid })
+    );
+
+    replaceRemoteDecks([createRemoteDeckFixture({ id: deck.id, uid, name: "Retry succeeded" })]);
+    replaceRemoteCards([
+      createRemoteCardFixture({
+        id: firstCard.id,
+        deckId: deck.id,
+        uid,
+        frontText: "Edited after failure",
+        score: 4,
+      }),
+      createRemoteCardFixture({ id: secondCard.id, deckId: deck.id, uid, frontText: secondCard.frontText }),
+    ]);
+
+    expect(renderHook(useDecks).result.current).toEqual([
+      expect.objectContaining({ id: deck.id, localMode: false, name: "Retry succeeded" }),
+    ]);
+    expect(renderHook(useCards).result.current).toEqual([
+      expect.objectContaining({ id: firstCard.id, uid, frontText: "Edited after failure", score: 4 }),
+      expect.objectContaining({ id: secondCard.id, uid }),
+    ]);
+    expect(() => editLocalStudyProgress({ cardId: firstCard.id })).toThrow(
+      `Local StudyProgress "${firstCard.id}" was not found`
+    );
+    expect(() => editLocalStudyProgress({ cardId: secondCard.id })).toThrow(
+      `Local StudyProgress "${secondCard.id}" was not found`
+    );
   });
 });


### PR DESCRIPTION
## Related issue
Fixes #1035

## Summary

- Restrict remote auth, subscriptions, and controls to linked Google identities while retaining anonymous Firebase auth for account linking.
- Enforce Google identity claims in Firestore Rules and keep anonymous Deck creation, import, editing, and study data local-only.
- Persist local StudyProgress with legacy migration, Card compatibility mirroring, lifecycle cleanup, and retry-safe local-to-remote migration.
- Update unit, integration, Storybook, Rules, and E2E coverage for anonymous local-only behavior.

## Testing

- `mise run check`
- `mise run test-integration`
- `mise run e2e`