### PR TITLE
fix(No issue): advance local study sessions after swipes

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -118,25 +118,27 @@
 | CARD-11 | read | [Card view を直接開ける](./card.md#card-11) |
 | CARD-12 | read | [存在しない Card から復帰できる](./card.md#card-12) |
 
-### Swipe
+### Study
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
-| SWIPE-01 | read | [学習中の Card を表面から裏面へ切り替えられる](./swipe.md#swipe-01) |
-| SWIPE-02 | write | [mastered action で学習結果を保存して次の Card へ進める](./swipe.md#swipe-02) |
-| SWIPE-03 | write | [non-mastered action で学習結果を保存して次の Card へ進める](./swipe.md#swipe-03) |
-| SWIPE-04 | write | [next-card action で次の Card へ進める](./swipe.md#swipe-04) |
-| SWIPE-05 | write | [previous-card action で前の Card へ戻れる](./swipe.md#swipe-05) |
-| SWIPE-06 | write | [filter と学習上限を反映して session を開始できる](./swipe.md#swipe-06) |
-| SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](./swipe.md#swipe-07) |
-| SWIPE-08 | write | [Exit 後に同じ位置から Continue できる](./swipe.md#swipe-08) |
-| SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](./swipe.md#swipe-09) |
-| SWIPE-10 | write | [最後の Card を完了して session を終了できる](./swipe.md#swipe-10) |
-| SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](./swipe.md#swipe-11) |
-| SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](./swipe.md#swipe-12) |
-| SWIPE-13 | write | [primary mouse の上方向 drag で次の Card へ進める](./swipe.md#swipe-13) |
-| SWIPE-14 | read | [non-primary mouse の drag を無視できる](./swipe.md#swipe-14) |
-| SWIPE-15 | read | [裏面 text を選択しても Card の状態を維持できる](./swipe.md#swipe-15) |
+| SWIPE-01 | read | [学習中の Card を表面から裏面へ切り替えられる](./study.md#swipe-01) |
+| SWIPE-02 | write | [mastered action で学習結果を保存して次の Card へ進める](./study.md#swipe-02) |
+| SWIPE-03 | write | [non-mastered action で学習結果を保存して次の Card へ進める](./study.md#swipe-03) |
+| SWIPE-04 | write | [next-card action で次の Card へ進める](./study.md#swipe-04) |
+| SWIPE-05 | write | [previous-card action で前の Card へ戻れる](./study.md#swipe-05) |
+| SWIPE-06 | write | [filter と学習上限を反映して session を開始できる](./study.md#swipe-06) |
+| SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](./study.md#swipe-07) |
+| SWIPE-08 | write | [Exit 後に同じ位置から Continue できる](./study.md#swipe-08) |
+| SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](./study.md#swipe-09) |
+| SWIPE-10 | write | [最後の Card を完了して session を終了できる](./study.md#swipe-10) |
+| SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](./study.md#swipe-11) |
+| SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](./study.md#swipe-12) |
+| SWIPE-13 | write | [remote Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-13) |
+| SWIPE-14 | read | [non-primary mouse の drag を無視できる](./study.md#swipe-14) |
+| SWIPE-15 | read | [裏面 text を選択しても Card の状態を維持できる](./study.md#swipe-15) |
+| SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-16) |
+| SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](./study.md#swipe-17) |
 
 ### Persistence
 

--- a/docs/e2e/fixture/write/study-session-start-local.yaml
+++ b/docs/e2e/fixture/write/study-session-start-local.yaml
@@ -1,0 +1,33 @@
+auth:
+  users:
+    - uid: user-1
+      provider: anonymous
+browser:
+  preferences:
+    loadSample: false
+  localDecks:
+    - id: deck-1
+      localMode: true
+      name: Local Study Deck
+      category: English
+  localCards:
+    - id: card-1
+      deckId: deck-1
+      frontText: local first
+      backText: local first answer
+      uniqueKey: local-first
+    - id: card-2
+      deckId: deck-1
+      frontText: local second
+      backText: local second answer
+      uniqueKey: local-second
+      score: 1
+      numberOfSeen: 1
+  studySessions:
+    deck-1:
+      sessionId: session-1
+      deckId: deck-1
+      cardOrderIds:
+        - card-1
+        - card-2
+      currentIndex: 0

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -1,4 +1,4 @@
-# Swipe E2E テスト仕様書
+# Study E2E テスト仕様書
 
 ## 目的
 
@@ -20,9 +20,11 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-10 | write | [最後の Card を完了して session を終了できる](#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
 | SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](#swipe-12) |
-| SWIPE-13 | write | [primary mouse の上方向 drag で次の Card へ進める](#swipe-13) |
+| SWIPE-13 | write | [remote Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-13) |
 | SWIPE-14 | read | [non-primary mouse の drag を無視できる](#swipe-14) |
 | SWIPE-15 | read | [裏面 text を選択しても Card の状態を維持できる](#swipe-15) |
+| SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-16) |
+| SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
 
 <a id="swipe-01"></a>
 
@@ -298,14 +300,14 @@ Then:
 
 <a id="swipe-13"></a>
 
-### SWIPE-13 primary mouse の上方向 drag で次の Card へ進める
+### SWIPE-13 remote Deck で primary mouse の上方向 drag により次の Card へ進める
 
 カテゴリ: `write`
 
 Given:
 
 - Fixture: [`study-session-start-drag`](./fixture/write/study-session-start-drag.yaml)
-- 認証済みユーザーが所有する Deck に、複数の Card を含む進行中の学習 session が存在する。
+- 認証済みユーザーが所有する remote Deck に、複数の Card を含む進行中の学習 session が存在する。
 - 現在の Card の表面が表示されている。
 - 上方向の drag は mastered action に設定されている。
 
@@ -363,4 +365,52 @@ Then:
 - 選択範囲に対象 Card の back text が含まれる。
 - 対象 Card の back text が引き続き表示される。
 - Card の学習結果と session の位置が変更されない。
+- browser error が発生しない。
+
+<a id="swipe-16"></a>
+
+### SWIPE-16 local-only Deck で primary mouse の上方向 drag により次の Card へ進める
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`study-session-start-local`](./fixture/write/study-session-start-local.yaml)
+- browser storage に、複数の Card を含む local-only Deck と進行中の学習 session が存在する。
+- 現在の Card の表面が表示されている。
+- 上方向の drag は mastered action に設定されている。
+
+When:
+
+- primary mouse button で現在の Card を上方向へ drag する。
+
+Then:
+
+- 現在だった Card の mastered 学習結果が browser storage に保存される。
+- session の位置が次の Card へ進む。
+- 次の Card の front text が表示され、back text は表示されない。
+- browser error が発生しない。
+
+<a id="swipe-17"></a>
+
+### SWIPE-17 local-only Deck の学習結果と session を reload 後も維持できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`study-session-start-local`](./fixture/write/study-session-start-local.yaml)
+- browser storage に、複数の Card を含む local-only Deck と進行中の学習 session が存在する。
+- 現在の Card の表面が表示されている。
+- 上方向の drag は mastered action に設定されている。
+
+When:
+
+- primary mouse button で現在の Card を上方向へ drag し、次の Card への遷移完了後にページを reload する。
+
+Then:
+
+- 現在だった Card の mastered 学習結果が browser storage に維持されている。
+- session の位置が次の Card に維持されている。
+- 次の Card の front text が表示され、back text は表示されない。
 - browser error が発生しない。

--- a/src/entities/card/@x/study-progress.ts
+++ b/src/entities/card/@x/study-progress.ts
@@ -1,1 +1,2 @@
+export { editLocalCardStudyProgress, findCardById } from "../model/store";
 export type { CardId } from "../model/types";

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -152,6 +152,43 @@ describe("Card store", () => {
     expect(cardStore.getState().localCards).toEqual([]);
   });
 
+  it("restores local progress after a failed storage write before retrying", async () => {
+    const storage = useMemoryStorage();
+    createLocalCard(cardInput("local"));
+    const failingStorage: StateStorage = {
+      ...storage,
+      setItem: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error("storage write failed");
+        })
+        .mockImplementation((name, value) => storage.setItem(name, value)),
+    };
+    cardStore.persist.setOptions({ storage: createJSONStorage(() => failingStorage) });
+
+    const recordInteraction = () => {
+      const card = cardStore.getState().localCards.find(({ id }) => id === "local");
+      if (card === undefined) throw new Error("Missing local Card");
+      return editLocalCardStudyProgress({
+        id: card.id,
+        score: card.score + 1,
+        numberOfSeen: card.numberOfSeen + 1,
+      });
+    };
+    const readPersistedCard = async () => {
+      const value = (await storage.getItem("tango-local-cards")) ?? "{}";
+      return JSON.parse(value).state.localCards[0];
+    };
+
+    expect(recordInteraction).toThrow("storage write failed");
+    expect(cardStore.getState().localCards[0]).toEqual(expect.objectContaining({ score: 0, numberOfSeen: 0 }));
+    await expect(readPersistedCard()).resolves.toEqual(expect.objectContaining({ score: 0, numberOfSeen: 0 }));
+
+    expect(recordInteraction()).toEqual(expect.objectContaining({ score: 1, numberOfSeen: 1 }));
+    expect(cardStore.getState().localCards[0]).toEqual(expect.objectContaining({ score: 1, numberOfSeen: 1 }));
+    await expect(readPersistedCard()).resolves.toEqual(expect.objectContaining({ score: 1, numberOfSeen: 1 }));
+  });
+
   it("deletes local Cards by Deck", () => {
     createLocalCard(cardInput("first", "deck-a"));
     createLocalCard(cardInput("second", "deck-b"));

--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -11,6 +11,7 @@ import {
   deleteLocalCard,
   deleteLocalCardsByDeckId,
   editLocalCard,
+  editLocalCardStudyProgress,
   replaceRemoteCards,
 } from "./store";
 
@@ -132,7 +133,7 @@ describe("Card store", () => {
   });
 
   it("creates, edits, and deletes a local Card synchronously", () => {
-    vi.spyOn(Date, "now").mockReturnValueOnce(10).mockReturnValueOnce(20);
+    vi.spyOn(Date, "now").mockReturnValueOnce(10).mockReturnValueOnce(20).mockReturnValueOnce(30);
     const createdCard = createLocalCard(cardInput("local"));
 
     expect(createdCard).toEqual(expect.objectContaining({ id: "local", createdAt: 10, updatedAt: 10 }));
@@ -141,6 +142,11 @@ describe("Card store", () => {
 
     const updatedCard = editLocalCard({ id: "local", frontText: "updated" });
     expect(updatedCard).toEqual(expect.objectContaining({ frontText: "updated", createdAt: 10, updatedAt: 20 }));
+
+    const updatedProgress = editLocalCardStudyProgress({ id: "local", score: 2, numberOfSeen: 3 });
+    expect(updatedProgress).toEqual(
+      expect.objectContaining({ frontText: "updated", score: 2, numberOfSeen: 3, createdAt: 10, updatedAt: 30 })
+    );
 
     deleteLocalCard("local");
     expect(cardStore.getState().localCards).toEqual([]);

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -25,6 +25,10 @@ interface CardState {
   localCards: LocalCard[];
 }
 
+/** Learning fields embedded in a browser-persisted Card until local StudyProgress has its own store. */
+type LocalCardStudyProgressEdit = Pick<LocalCard, "id"> &
+  Partial<Pick<LocalCard, "score" | "numberOfSeen" | "lastSeenAt" | "nextSeeingAt" | "interval">>;
+
 /** Injectable persistence controls used to create an isolated Card store. */
 interface CreateCardStoreOptions {
   storage?: StateStorage;
@@ -95,6 +99,18 @@ export const editLocalCard = (input: LocalCardEdit): LocalCard => {
 
   const updatedCard = localCardSchema.parse({ ...currentCard, ...edit, updatedAt: Date.now() });
   cardStore.setState({ localCards: localCards.map((card) => (card.id === updatedCard.id ? updatedCard : card)) });
+  return updatedCard;
+};
+
+// Persists local learning progress with the Card while keeping content edits behind their narrower schema.
+export const editLocalCardStudyProgress = (input: LocalCardStudyProgressEdit): LocalCard => {
+  const cardId = cardIdSchema.parse(input.id);
+  const { localCards } = cardStore.getState();
+  const currentCard = localCards.find(({ id }) => id === cardId);
+  if (currentCard === undefined) throw new Error(`Local Card "${cardId}" was not found`);
+
+  const updatedCard = localCardSchema.parse({ ...currentCard, ...input, updatedAt: Date.now() });
+  cardStore.setState({ localCards: localCards.map((card) => (card.id === cardId ? updatedCard : card)) });
   return updatedCard;
 };
 

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -110,7 +110,23 @@ export const editLocalCardStudyProgress = (input: LocalCardStudyProgressEdit): L
   if (currentCard === undefined) throw new Error(`Local Card "${cardId}" was not found`);
 
   const updatedCard = localCardSchema.parse({ ...currentCard, ...input, updatedAt: Date.now() });
-  cardStore.setState({ localCards: localCards.map((card) => (card.id === cardId ? updatedCard : card)) });
+  const updatedLocalCards = localCards.map((card) => (card.id === cardId ? updatedCard : card));
+  try {
+    cardStore.setState({ localCards: updatedLocalCards });
+  } catch (error) {
+    // Zustand publishes before persisting; roll back only our still-live replacement so retries cannot compound it.
+    const liveLocalCards = cardStore.getState().localCards;
+    if (liveLocalCards.some((card) => card === updatedCard)) {
+      try {
+        cardStore.setState({
+          localCards: liveLocalCards.map((card) => (card === updatedCard ? currentCard : card)),
+        });
+      } catch {
+        // The rollback reaches memory before its persistence attempt, even while browser storage remains unavailable.
+      }
+    }
+    throw error;
+  }
   return updatedCard;
 };
 

--- a/src/entities/study-progress/api/firestore.spec.ts
+++ b/src/entities/study-progress/api/firestore.spec.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 
-import { editStudyProgress } from "./firestore";
+import { editRemoteStudyProgress } from "./firestore";
 
 describe("StudyProgress Firestore persistence", () => {
   it("rejects edit requests without a confirmed user identity", async () => {
-    await expect(editStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
+    await expect(editRemoteStudyProgress("", { cardId: "card-a", score: 1 })).rejects.toThrow("confirmed user");
   });
 
   it("rejects edit requests without a card ID", async () => {
-    await expect(editStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
+    await expect(editRemoteStudyProgress("uid-a", { cardId: "", score: 1 })).rejects.toThrow("Card id");
   });
 });

--- a/src/entities/study-progress/api/firestore.ts
+++ b/src/entities/study-progress/api/firestore.ts
@@ -8,7 +8,10 @@ import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { editStudyProgressSchema } from "../model/schema";
 
 // Validates and writes StudyProgress-owned fields into the shared Card document.
-export const editStudyProgress = async (uid: string, progress: EditStudyProgressInput["progress"]): Promise<void> => {
+export const editRemoteStudyProgress = async (
+  uid: string,
+  progress: EditStudyProgressInput["progress"]
+): Promise<void> => {
   const input = editStudyProgressSchema.parse({ uid, progress });
   const { cardId, ...fields } = input.progress;
   // StudyProgress is embedded in its Card document; patch only progress fields so Card content remains untouched.

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -19,9 +19,20 @@ describe("StudyProgress mutations", () => {
 
   it("updates local Card progress without writing to Firestore", async () => {
     mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck" });
+    const untrustedProgress = {
+      cardId: "local",
+      score: 2,
+      numberOfSeen: 3,
+      id: "other-local",
+      frontText: "unexpected",
+      deckId: "other-deck",
+      uid: "other-user",
+      deletedAt: 1,
+    } as unknown as Parameters<typeof editStudyProgress>[1];
 
-    await editStudyProgress("", { cardId: "local", score: 2, numberOfSeen: 3 });
+    await editStudyProgress("", untrustedProgress);
 
+    expect(mocks.findCardById).toHaveBeenCalledExactlyOnceWith("local");
     expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({
       id: "local",
       score: 2,

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  editLocalCardStudyProgress: vi.fn(),
+  editRemoteStudyProgress: vi.fn(),
+  findCardById: vi.fn(),
+}));
+
+vi.mock("@/entities/card/@x/study-progress", () => ({
+  editLocalCardStudyProgress: mocks.editLocalCardStudyProgress,
+  findCardById: mocks.findCardById,
+}));
+vi.mock("./firestore", () => ({ editRemoteStudyProgress: mocks.editRemoteStudyProgress }));
+
+import { editStudyProgress } from "./mutations";
+
+describe("StudyProgress mutations", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("updates local Card progress without writing to Firestore", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck" });
+
+    await editStudyProgress("", { cardId: "local", score: 2, numberOfSeen: 3 });
+
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({
+      id: "local",
+      score: 2,
+      numberOfSeen: 3,
+    });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("preserves remote Firestore progress writes", async () => {
+    mocks.findCardById.mockReturnValue({ id: "remote", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "remote", score: 2 });
+
+    expect(mocks.editRemoteStudyProgress).toHaveBeenCalledExactlyOnceWith("user", {
+      cardId: "remote",
+      score: 2,
+    });
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects progress for an unknown Card", async () => {
+    await expect(editStudyProgress("user", { cardId: "missing", score: 2 })).rejects.toThrow(
+      'Card "missing" was not found'
+    );
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,0 +1,17 @@
+import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
+import type { StudyProgressEdit } from "../model/types";
+import { editRemoteStudyProgress } from "./firestore";
+
+// Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
+export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
+  const card = findCardById(progress.cardId);
+  if (card === undefined) throw new Error(`Card "${progress.cardId}" was not found`);
+
+  if ("uid" in card) {
+    await editRemoteStudyProgress(uid, progress);
+    return;
+  }
+
+  const { cardId: id, ...fields } = progress;
+  editLocalCardStudyProgress({ id, ...fields });
+};

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,17 +1,20 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
+import { omitUndefined } from "@/shared/lib/omitUndefined";
+import { studyProgressEditSchema } from "../model/schema";
 import type { StudyProgressEdit } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
 export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
-  const card = findCardById(progress.cardId);
-  if (card === undefined) throw new Error(`Card "${progress.cardId}" was not found`);
+  const edit = studyProgressEditSchema.parse(progress);
+  const card = findCardById(edit.cardId);
+  if (card === undefined) throw new Error(`Card "${edit.cardId}" was not found`);
 
   if ("uid" in card) {
-    await editRemoteStudyProgress(uid, progress);
+    await editRemoteStudyProgress(uid, edit);
     return;
   }
 
-  const { cardId: id, ...fields } = progress;
-  editLocalCardStudyProgress({ id, ...fields });
+  const { cardId: id, ...fields } = edit;
+  editLocalCardStudyProgress(omitUndefined({ id, ...fields }));
 };

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,1 +1,1 @@
-export { editStudyProgress } from "./api/firestore";
+export { editStudyProgress } from "./api/mutations";

--- a/src/entities/study-progress/model/schema.ts
+++ b/src/entities/study-progress/model/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote StudyProgress writes");
 
-const studyProgressEditSchema = z.object({
+export const studyProgressEditSchema = z.object({
   cardId: z.string().min(1, "Card id is required"),
   score: z.number().optional(),
   numberOfSeen: z.number().optional(),

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -29,6 +29,16 @@ const readProgress = async (cardId: string) => {
   };
 };
 
+const readLocalProgress = async (page: Page, cardId: string) => {
+  const { cards } = await readLocalData(page);
+  const card = cards.find((candidate: Record<string, unknown>) => candidate.id === cardId);
+  if (card === undefined) throw new Error(`Missing local Card ${cardId}`);
+  return {
+    score: Number(card.score),
+    numberOfSeen: Number(card.numberOfSeen),
+  };
+};
+
 const readSession = async (page: Page, deckId: string) => {
   const { sessionsByDeckId } = await readLocalData(page);
   return sessionsByDeckId[deckId] as StudySessionFixture | undefined;
@@ -297,7 +307,10 @@ test("SWIPE-12 retries a failed progress write from the same Card once", async (
   await fault.dispose();
 });
 
-test("SWIPE-13 advances on a primary upward mouse drag without flipping", async ({ fixture, page }) => {
+test("SWIPE-13 advances a remote session on a primary upward mouse drag without flipping", async ({
+  fixture,
+  page,
+}) => {
   const deck = fixture.deck();
   const currentCard = fixture.card("card-1");
   const nextCard = fixture.card("card-2");
@@ -347,4 +360,49 @@ test("SWIPE-15 selects answer text without changing the Card state", async ({ fi
     .toContain(currentCard.backText);
   await expect.poll(() => readProgress(currentCard.id)).toEqual(progressOf(currentCard));
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+});
+
+test("SWIPE-16 saves local-only progress and advances on a primary upward mouse drag", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  const currentCard = fixture.card("card-1");
+  const nextCard = fixture.card("card-2");
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+  await swipeFrontUp(page, currentCard.frontText);
+
+  await expect(page.getByText(nextCard.frontText, { exact: true })).toBeVisible();
+  await expect(page.getByText(nextCard.backText, { exact: true })).toBeHidden();
+  await expect
+    .poll(() => readLocalProgress(page, currentCard.id))
+    .toEqual({
+      score: currentCard.score + 1,
+      numberOfSeen: currentCard.numberOfSeen + 1,
+    });
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex + 1);
+});
+
+test("SWIPE-17 preserves local-only progress and session position across reload", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  const currentCard = fixture.card("card-1");
+  const nextCard = fixture.card("card-2");
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+  await swipeFrontUp(page, currentCard.frontText);
+  await page.getByText(nextCard.frontText, { exact: true }).waitFor();
+
+  await page.reload();
+
+  await expect(page.getByText(nextCard.frontText, { exact: true })).toBeVisible();
+  await expect(page.getByText(nextCard.backText, { exact: true })).toBeHidden();
+  await expect
+    .poll(() => readLocalProgress(page, currentCard.id))
+    .toEqual({
+      score: currentCard.score + 1,
+      numberOfSeen: currentCard.numberOfSeen + 1,
+    });
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex + 1);
 });

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -14,7 +14,7 @@ import { createCard as createCardCommand, deleteCard, editCard } from "@/entitie
 import { createDeck as createDeckCommand } from "@/entities/deck/api/firestore";
 import { replaceRemoteCards } from "@/entities/card/model/store";
 import { replaceRemoteDecks } from "@/entities/deck/model/store";
-import { editStudyProgress } from "@/entities/study-progress";
+import { editRemoteStudyProgress } from "@/entities/study-progress/api/firestore";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as Uuid from "uuid";
 import { createCard, createDeck } from "@/test/factories";
@@ -98,9 +98,9 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
       deckId: "other-deck",
       uid: "other-user",
       deletedAt: 1,
-    } as unknown as Parameters<typeof editStudyProgress>[1];
+    } as unknown as Parameters<typeof editRemoteStudyProgress>[1];
 
-    await editStudyProgress("uid", untrustedProgress);
+    await editRemoteStudyProgress("uid", untrustedProgress);
 
     expect((await getDoc(doc(db, "card", card.id))).data()).toEqual({ ...card, score: 2, numberOfSeen: 3 });
   });


### PR DESCRIPTION
## Summary

- route StudyProgress writes to browser storage for local-only Cards while preserving Firestore writes for remote Cards
- keep session movement behind successful persistence so local swipes advance to the next Card
- rename docs/e2e/swipe.md to docs/e2e/study.md and document explicit remote and local coverage
- add real-drag local E2E cases for immediate advancement and reload persistence
- keep the Firestore integration contract focused on the remote persistence adapter

## Testing

- `mise run check`
- `mise run test-integration`: 46 passed
- scoped Docker E2E for SWIPE-13, SWIPE-16, and SWIPE-17: 3 passed
- GitHub Actions Test and Audit workflows: all checks passed

## Review

- mandatory reviewer: no P0, P1, or P2 findings