### PR TITLE
[No issue] Refresh study session controls

### DIFF
--- a/.storybook/support/fixture.ts
+++ b/.storybook/support/fixture.ts
@@ -113,7 +113,6 @@ export const cards = {
 
 export const preferences = {
   default: createPreferences({
-    showHeader: true,
     maxNumberOfCardsToLearn: 10,
   }),
 } as const satisfies Record<string, Preferences>;

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -129,7 +129,7 @@
 | SWIPE-05 | write | [previous-card action で前の Card へ戻れる](./swipe.md#swipe-05) |
 | SWIPE-06 | write | [filter と学習上限を反映して session を開始できる](./swipe.md#swipe-06) |
 | SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](./swipe.md#swipe-07) |
-| SWIPE-08 | write | [Exit 後に同じ位置から Continue できる](./swipe.md#swipe-08) |
+| SWIPE-08 | write | [学習画面から戻った後に同じ位置から Continue できる](./swipe.md#swipe-08) |
 | SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](./swipe.md#swipe-09) |
 | SWIPE-10 | write | [最後の Card を完了して session を終了できる](./swipe.md#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](./swipe.md#swipe-11) |

--- a/docs/e2e/swipe.md
+++ b/docs/e2e/swipe.md
@@ -15,7 +15,7 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-05 | write | [previous-card action で前の Card へ戻れる](#swipe-05) |
 | SWIPE-06 | write | [filter と学習上限を反映して session を開始できる](#swipe-06) |
 | SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](#swipe-07) |
-| SWIPE-08 | write | [Exit 後に同じ位置から Continue できる](#swipe-08) |
+| SWIPE-08 | write | [学習画面から戻った後に同じ位置から Continue できる](#swipe-08) |
 | SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](#swipe-09) |
 | SWIPE-10 | write | [最後の Card を完了して session を終了できる](#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
@@ -187,7 +187,7 @@ Then:
 
 <a id="swipe-08"></a>
 
-### SWIPE-08 Exit 後に同じ位置から Continue できる
+### SWIPE-08 学習画面から戻った後に同じ位置から Continue できる
 
 カテゴリ: `write`
 
@@ -198,12 +198,12 @@ Given:
 
 When:
 
-- 学習画面で Exit を実行し、Deck 一覧から同じ Deck の Continue を実行する。
+- 学習画面から Card 一覧へ戻り、Deck 一覧から同じ Deck の Continue を実行する。
 
 Then:
 
-- Exit 前と同じ学習 session が維持される。
-- Exit 前に表示されていた Card の front text が表示される。
+- Card 一覧へ戻る前と同じ学習 session が維持される。
+- Card 一覧へ戻る前に表示されていた Card の front text が表示される。
 - browser error が発生しない。
 
 <a id="swipe-09"></a>
@@ -263,7 +263,7 @@ Given:
 
 When:
 
-- 一方の Deck で学習 action を実行して Exit し、もう一方の Deck を Continue する。
+- 一方の Deck で学習 action を実行して Card 一覧へ戻り、もう一方の Deck を Continue する。
 
 Then:
 

--- a/src/entities/preference/index.ts
+++ b/src/entities/preference/index.ts
@@ -4,4 +4,4 @@ export type {
   Preferences,
   SwipeDirection,
 } from "./model/types";
-export { setDarkMode, toggleShowHeader, toggleShowSwipeButtonList, updatePreferences } from "./model/store";
+export { setDarkMode, toggleShowPlaybackControls, toggleShowSwipeButtonList, updatePreferences } from "./model/store";

--- a/src/entities/preference/model/schema.ts
+++ b/src/entities/preference/model/schema.ts
@@ -2,7 +2,7 @@ import * as z from "zod";
 
 import { studyPreferencesLimits } from "./rules";
 
-// Preferences outlive releases in localStorage; field-level fallbacks preserve valid settings around obsolete values.
+// Current-version runtime input recovers malformed fields; breaking persisted shapes are rejected by store versioning.
 const DEFAULT_APPEARANCE = {
   darkMode: false,
   fullscreen: false,

--- a/src/entities/preference/model/schema.ts
+++ b/src/entities/preference/model/schema.ts
@@ -5,7 +5,6 @@ import { studyPreferencesLimits } from "./rules";
 // Preferences outlive releases in localStorage; field-level fallbacks preserve valid settings around obsolete values.
 const DEFAULT_APPEARANCE = {
   darkMode: false,
-  showHeader: true,
   fullscreen: false,
   sizeBackText: 0,
   hideBodyWhenCardChanged: true,
@@ -24,6 +23,7 @@ const DEFAULT_STUDY = {
 
 const DEFAULT_CONTROLS = {
   showSwipeButtonList: true,
+  showPlaybackControls: true,
   showScoreSlider: false,
   cardSwipeUp: "GoToNextCardMastered" as const,
   cardSwipeDown: "GoToNextCardNotMastered" as const,
@@ -46,7 +46,6 @@ export const swipeActionSchema = z.enum([
 const appearancePreferencesSchema = z
   .object({
     darkMode: z.boolean().catch(DEFAULT_APPEARANCE.darkMode),
-    showHeader: z.boolean().catch(DEFAULT_APPEARANCE.showHeader),
     fullscreen: z.boolean().catch(DEFAULT_APPEARANCE.fullscreen),
     sizeBackText: z.number().min(0).catch(DEFAULT_APPEARANCE.sizeBackText),
     hideBodyWhenCardChanged: z.boolean().catch(DEFAULT_APPEARANCE.hideBodyWhenCardChanged),
@@ -78,6 +77,7 @@ const studyPreferencesSchema = z
 export const controlPreferencesSchema = z
   .object({
     showSwipeButtonList: z.boolean().catch(DEFAULT_CONTROLS.showSwipeButtonList),
+    showPlaybackControls: z.boolean().catch(DEFAULT_CONTROLS.showPlaybackControls),
     showScoreSlider: z.boolean().catch(DEFAULT_CONTROLS.showScoreSlider),
     cardSwipeUp: swipeActionSchema.catch(DEFAULT_CONTROLS.cardSwipeUp),
     cardSwipeDown: swipeActionSchema.catch(DEFAULT_CONTROLS.cardSwipeDown),

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
 import { defaultPreferences } from "./defaults";
@@ -107,7 +107,7 @@ describe("preferences store", () => {
           appearance: { ...defaultPreferences.appearance, darkMode: true },
         },
       },
-      version: 0,
+      version: 1,
     });
   });
 
@@ -119,7 +119,7 @@ describe("preferences store", () => {
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
     };
     useMemoryStorage({
-      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 0 }),
+      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 1 }),
     });
 
     await preferencesStore.persist.rehydrate();
@@ -127,33 +127,38 @@ describe("preferences store", () => {
     expect(preferencesStore.getState().preferences).toEqual(persistedPreferences);
   });
 
-  it("ignores the retired header preference and defaults playback controls when hydrating older preferences", async () => {
+  it("discards version 0 preferences after the persisted shape changes", async () => {
     const { showPlaybackControls: _showPlaybackControls, ...legacyControls } = defaultPreferences.controls;
     useMemoryStorage({
       "tango-config": JSON.stringify({
         state: {
           preferences: {
             ...defaultPreferences,
-            appearance: { ...defaultPreferences.appearance, showHeader: false },
-            controls: legacyControls,
+            loadSample: false,
+            appearance: { ...defaultPreferences.appearance, darkMode: true, showHeader: false },
+            study: { ...defaultPreferences.study, cardInterval: 15, selectedTags: ["legacy"] },
+            controls: { ...legacyControls, showSwipeButtonList: false },
           },
         },
         version: 0,
       }),
     });
 
-    await preferencesStore.persist.rehydrate();
+    // A rejected version is expected to be reported by Zustand; keep intentional invalidation quiet in test output.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      await preferencesStore.persist.rehydrate();
+    } finally {
+      consoleError.mockRestore();
+    }
 
-    const hydratedPreferences = preferencesStore.getState().preferences;
-    expect(hydratedPreferences).toEqual(defaultPreferences);
-    expect(hydratedPreferences.appearance).not.toHaveProperty("showHeader");
-    expect(hydratedPreferences.controls.showPlaybackControls).toBe(true);
+    expect(preferencesStore.getState().preferences).toEqual(defaultPreferences);
   });
 
   it.each([
     ["malformed JSON", "not-json"],
-    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 0 })],
-    ["legacy envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 0 })],
+    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 1 })],
+    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 1 })],
   ])("uses current defaults for %s", async (_case, persistedValue) => {
     useMemoryStorage({ "tango-config": persistedValue });
 

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
 import { defaultPreferences } from "./defaults";
-import { preferencesStore, setDarkMode, toggleShowHeader, toggleShowSwipeButtonList, updatePreferences } from "./store";
+import {
+  preferencesStore,
+  setDarkMode,
+  toggleShowPlaybackControls,
+  toggleShowSwipeButtonList,
+  updatePreferences,
+} from "./store";
 
 /** Synchronous storage contract used by preferences persistence scenarios. */
 type MemoryStorage = Omit<StateStorage, "getItem"> & {
@@ -41,16 +47,20 @@ describe("preferences store", () => {
       study: { cardInterval: 15 },
       controls: { showScoreSlider: true },
     });
-    store.getState().updatePreferences({ appearance: { showHeader: false } });
-    store.getState().updatePreferences({ appearance: { showHeader: true } });
     store.getState().updatePreferences({ controls: { showSwipeButtonList: false } });
+    store.getState().updatePreferences({ controls: { showPlaybackControls: false } });
 
     expect(store.getState().preferences).toEqual({
       ...defaultPreferences,
       loadSample: false,
       study: { ...defaultPreferences.study, cardInterval: 15 },
-      appearance: { ...defaultPreferences.appearance, darkMode: true, showHeader: true },
-      controls: { ...defaultPreferences.controls, showScoreSlider: true, showSwipeButtonList: false },
+      appearance: { ...defaultPreferences.appearance, darkMode: true },
+      controls: {
+        ...defaultPreferences.controls,
+        showScoreSlider: true,
+        showSwipeButtonList: false,
+        showPlaybackControls: false,
+      },
     });
   });
 
@@ -72,15 +82,15 @@ describe("preferences store", () => {
   it("updates preferences through the public helpers", () => {
     setDarkMode(true);
     updatePreferences({ loadSample: false, study: { cardInterval: 15 } });
-    toggleShowHeader();
     toggleShowSwipeButtonList();
+    toggleShowPlaybackControls();
 
     expect(preferencesStore.getState().preferences).toEqual({
       ...defaultPreferences,
       loadSample: false,
-      appearance: { ...defaultPreferences.appearance, darkMode: true, showHeader: false },
+      appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, cardInterval: 15 },
-      controls: { ...defaultPreferences.controls, showSwipeButtonList: false },
+      controls: { ...defaultPreferences.controls, showSwipeButtonList: false, showPlaybackControls: false },
     });
   });
 
@@ -117,10 +127,33 @@ describe("preferences store", () => {
     expect(preferencesStore.getState().preferences).toEqual(persistedPreferences);
   });
 
+  it("ignores the retired header preference and defaults playback controls when hydrating older preferences", async () => {
+    const { showPlaybackControls: _showPlaybackControls, ...legacyControls } = defaultPreferences.controls;
+    useMemoryStorage({
+      "tango-config": JSON.stringify({
+        state: {
+          preferences: {
+            ...defaultPreferences,
+            appearance: { ...defaultPreferences.appearance, showHeader: false },
+            controls: legacyControls,
+          },
+        },
+        version: 0,
+      }),
+    });
+
+    await preferencesStore.persist.rehydrate();
+
+    const hydratedPreferences = preferencesStore.getState().preferences;
+    expect(hydratedPreferences).toEqual(defaultPreferences);
+    expect(hydratedPreferences.appearance).not.toHaveProperty("showHeader");
+    expect(hydratedPreferences.controls.showPlaybackControls).toBe(true);
+  });
+
   it.each([
     ["malformed JSON", "not-json"],
     ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 0 })],
-    ["legacy envelope", JSON.stringify({ state: { config: { darkMode: true, showHeader: false } }, version: 0 })],
+    ["legacy envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 0 })],
   ])("uses current defaults for %s", async (_case, persistedValue) => {
     useMemoryStorage({ "tango-config": persistedValue });
 

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -6,6 +6,10 @@ import { defaultPreferences } from "./defaults";
 import { preferencesSchema } from "./schema";
 import type { Preferences } from "./types";
 
+const PREFERENCES_STORAGE_KEY = "tango-config";
+// No migration is registered: changing this version deliberately invalidates older state shapes.
+const PREFERENCES_STORAGE_VERSION = 1;
+
 /** @internal Partial updates for each top-level preference field. */
 export type PartialPreferences = {
   loadSample?: Preferences["loadSample"];
@@ -46,9 +50,10 @@ const createPreferencesStore = () =>
           }),
       })),
       {
-        name: "tango-config",
+        name: PREFERENCES_STORAGE_KEY,
+        version: PREFERENCES_STORAGE_VERSION,
         merge: (persistedState, currentState) => {
-          // Revalidate untrusted storage; the schema recovers fields independently and current defaults remain the fallback.
+          // Version-mismatched state is rejected before merge; validate only current-version state before replacing defaults.
           const result = preferencesSchema.safeParse(
             (persistedState as Partial<PersistedPreferencesState> | undefined)?.preferences
           );

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -82,14 +82,14 @@ export const replacePreferences = (input: PartialPreferences): void => {
 // Sets the appearance color mode preference explicitly.
 export const setDarkMode = (darkMode: boolean): void => updatePreferences({ appearance: { darkMode } });
 
-// Toggles whether the application header is shown.
-export const toggleShowHeader = (): void => {
-  const { showHeader } = preferencesStore.getState().preferences.appearance;
-  updatePreferences({ appearance: { showHeader: !showHeader } });
-};
-
 // Toggles whether study swipe controls are shown.
 export const toggleShowSwipeButtonList = (): void => {
   const { showSwipeButtonList } = preferencesStore.getState().preferences.controls;
   updatePreferences({ controls: { showSwipeButtonList: !showSwipeButtonList } });
+};
+
+// Toggles whether study playback controls are shown.
+export const toggleShowPlaybackControls = (): void => {
+  const { showPlaybackControls } = preferencesStore.getState().preferences.controls;
+  updatePreferences({ controls: { showPlaybackControls: !showPlaybackControls } });
 };

--- a/src/pages/settings/model/usePreferencesFormState.spec.tsx
+++ b/src/pages/settings/model/usePreferencesFormState.spec.tsx
@@ -11,8 +11,8 @@ import { createPreferences } from "@/test/factories";
 import { usePreferencesFormState } from "./usePreferencesFormState";
 
 const preferences = createPreferences({
-  showHeader: false,
   showSwipeButtonList: false,
+  showPlaybackControls: false,
   showSwipeFeedback: false,
   fullscreen: false,
   darkMode: false,
@@ -29,11 +29,13 @@ const PreferencesFormHarness: React.FC = () => {
 
   return (
     <>
-      <input aria-label="Show header" type="checkbox" {...formState.fields.showHeader} />
+      <input aria-label="Show playback controls" type="checkbox" {...formState.fields.showPlaybackControls} />
       <input aria-label="Dark mode" type="checkbox" {...formState.fields.darkMode} />
       <input aria-label="Maximum cards" type="range" {...formState.fields.maxNumberOfCardsToLearn} />
       <input aria-label="Autoplay interval" type="range" {...formState.fields.cardInterval} />
-      <output aria-label="Saved header preference">{String(savedPreferences.appearance.showHeader)}</output>
+      <output aria-label="Saved playback controls preference">
+        {String(savedPreferences.controls.showPlaybackControls)}
+      </output>
       <output aria-label="Saved maximum cards">{savedPreferences.study.maxNumberOfCardsToLearn}</output>
       <output aria-label="Saved autoplay interval">{savedPreferences.study.cardInterval}</output>
     </>
@@ -48,7 +50,7 @@ describe("usePreferencesFormState", () => {
   it("saves boolean and numeric changes as the user edits them", async () => {
     render(<PreferencesFormHarness />);
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Show header" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Show playback controls" }));
     fireEvent.change(screen.getByRole("slider", { name: "Maximum cards" }), {
       target: { value: 10 },
     });
@@ -57,7 +59,7 @@ describe("usePreferencesFormState", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Saved header preference")).toHaveTextContent("true");
+      expect(screen.getByLabelText("Saved playback controls preference")).toHaveTextContent("true");
       expect(screen.getByLabelText("Saved maximum cards")).toHaveTextContent("10");
       expect(screen.getByLabelText("Saved autoplay interval")).toHaveTextContent("10");
     });

--- a/src/pages/settings/model/usePreferencesFormState.ts
+++ b/src/pages/settings/model/usePreferencesFormState.ts
@@ -25,8 +25,8 @@ export const usePreferencesFormState = () => {
   }, [preferences.appearance.darkMode, setValue]);
 
   const fields = {
-    showHeader: register("appearance.showHeader"),
     showSwipeButtonList: register("controls.showSwipeButtonList"),
+    showPlaybackControls: register("controls.showPlaybackControls"),
     showSwipeFeedback: register("appearance.showSwipeFeedback"),
     darkMode: register("appearance.darkMode"),
     shuffled: register("study.shuffled"),

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -11,8 +11,8 @@ type SettingsFields = React.ComponentProps<typeof SettingsForm>["fields"];
 
 function createFields(): SettingsFields {
   return {
-    showHeader: { name: "showHeader", checked: true, onChange: vi.fn() },
     showSwipeButtonList: { name: "showSwipeButtonList", checked: false, onChange: vi.fn() },
+    showPlaybackControls: { name: "showPlaybackControls", checked: true, onChange: vi.fn() },
     showSwipeFeedback: { name: "showSwipeFeedback", checked: true, onChange: vi.fn() },
     darkMode: { name: "darkMode", checked: false, onChange: vi.fn() },
     shuffled: { name: "shuffled", checked: false, onChange: vi.fn() },
@@ -48,15 +48,16 @@ describe("SettingsForm", () => {
     expect(screen.queryByRole("heading", { level: 2, name: "Layout" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 2, name: "Autoplay" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 2, name: "Metadata" })).not.toBeInTheDocument();
-    expect(screen.getByText("Show header")).toBeInTheDocument();
-    expect(screen.queryByText("Show Heaer")).not.toBeInTheDocument();
+    expect(screen.getByText("Show swipe controls")).toBeInTheDocument();
+    expect(screen.getByText("Show playback controls")).toBeInTheDocument();
+    expect(screen.queryByText("Show header")).not.toBeInTheDocument();
   });
 
   it("preserves all switch, slider, and settings metadata values", () => {
     render(<SettingsForm {...createProps()} />);
 
     expect(screen.getAllByRole("checkbox")).toHaveLength(7);
-    expect(screen.getByRole("checkbox", { name: "Show header" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Show playback controls" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Respect review schedule" })).toBeChecked();
     expect(screen.getByRole("slider", { name: "Maximum cards" })).toHaveValue("24");
     expect(screen.getByRole("slider", { name: "Autoplay interval" })).toHaveValue("7");
@@ -83,24 +84,24 @@ describe("SettingsForm", () => {
   it("forwards switch and slider changes to their field callbacks", async () => {
     let switchArguments: { name: string; checked: boolean } | undefined;
     let sliderArguments: { name: string; value: string } | undefined;
-    const showHeader = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+    const showPlaybackControls = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
       switchArguments = { name: event.target.name, checked: event.target.checked };
     });
     const maxNumberOfCardsToLearn = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
       sliderArguments = { name: event.target.name, value: event.target.value };
     });
     const fields = createFields();
-    fields.showHeader.onChange = showHeader;
+    fields.showPlaybackControls.onChange = showPlaybackControls;
     fields.maxNumberOfCardsToLearn.onChange = maxNumberOfCardsToLearn;
     render(<SettingsForm {...createProps({ fields })} />);
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Show header" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Show playback controls" }));
     fireEvent.change(screen.getByRole("slider", { name: "Maximum cards" }), {
       target: { value: "31" },
     });
 
-    expect(showHeader).toHaveBeenCalledOnce();
-    expect(switchArguments).toEqual({ name: "showHeader", checked: false });
+    expect(showPlaybackControls).toHaveBeenCalledOnce();
+    expect(switchArguments).toEqual({ name: "showPlaybackControls", checked: false });
     expect(maxNumberOfCardsToLearn).toHaveBeenCalledOnce();
     expect(sliderArguments).toEqual({ name: "maxNumberOfCardsToLearn", value: "31" });
   });

--- a/src/pages/settings/ui/SettingsForm.stories.tsx
+++ b/src/pages/settings/ui/SettingsForm.stories.tsx
@@ -10,8 +10,8 @@ import { SettingsForm } from "./SettingsForm";
 type SettingsFields = React.ComponentProps<typeof SettingsForm>["fields"];
 
 const fields: SettingsFields = {
-  showHeader: { checked: fixture.preferences.default.appearance.showHeader, onChange: fn() },
   showSwipeButtonList: { checked: fixture.preferences.default.controls.showSwipeButtonList, onChange: fn() },
+  showPlaybackControls: { checked: fixture.preferences.default.controls.showPlaybackControls, onChange: fn() },
   showSwipeFeedback: { checked: fixture.preferences.default.appearance.showSwipeFeedback, onChange: fn() },
   darkMode: { checked: fixture.preferences.default.appearance.darkMode, onChange: fn() },
   shuffled: { checked: fixture.preferences.default.study.shuffled, onChange: fn() },
@@ -39,8 +39,8 @@ const settingsFormProps = {
 };
 
 type SwitchFieldName =
-  | "showHeader"
   | "showSwipeButtonList"
+  | "showPlaybackControls"
   | "showSwipeFeedback"
   | "darkMode"
   | "shuffled"
@@ -50,8 +50,8 @@ type SliderFieldName = "maxNumberOfCardsToLearn" | "cardInterval";
 
 const InteractiveSettingsForm: React.FC<React.ComponentProps<typeof SettingsForm>> = (props) => {
   const [values, setValues] = React.useState({
-    showHeader: Boolean(props.fields.showHeader.checked),
     showSwipeButtonList: Boolean(props.fields.showSwipeButtonList.checked),
+    showPlaybackControls: Boolean(props.fields.showPlaybackControls.checked),
     showSwipeFeedback: Boolean(props.fields.showSwipeFeedback.checked),
     darkMode: Boolean(props.fields.darkMode.checked),
     shuffled: Boolean(props.fields.shuffled.checked),
@@ -83,8 +83,8 @@ const InteractiveSettingsForm: React.FC<React.ComponentProps<typeof SettingsForm
       maxNumberOfCardsToLearn={values.maxNumberOfCardsToLearn}
       cardInterval={values.cardInterval}
       fields={{
-        showHeader: switchField("showHeader"),
         showSwipeButtonList: switchField("showSwipeButtonList"),
+        showPlaybackControls: switchField("showPlaybackControls"),
         showSwipeFeedback: switchField("showSwipeFeedback"),
         darkMode: switchField("darkMode"),
         shuffled: switchField("shuffled"),
@@ -114,13 +114,13 @@ export const Default: Story = {};
 
 export const Interaction: Story = {
   play: async ({ args, canvas, userEvent }) => {
-    const showHeader = canvas.getByRole<HTMLInputElement>("checkbox", { name: "Show header" });
-    const initialValue = Boolean(args.fields.showHeader.checked);
+    const showPlaybackControls = canvas.getByRole<HTMLInputElement>("checkbox", { name: "Show playback controls" });
+    const initialValue = Boolean(args.fields.showPlaybackControls.checked);
 
-    await userEvent.click(showHeader);
+    await userEvent.click(showPlaybackControls);
 
-    await expect(args.fields.showHeader.onChange).toHaveBeenCalledOnce();
-    await expect(showHeader.checked).toBe(!initialValue);
+    await expect(args.fields.showPlaybackControls.onChange).toHaveBeenCalledOnce();
+    await expect(showPlaybackControls.checked).toBe(!initialValue);
   },
 };
 export const LongContent: Story = {

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -6,8 +6,8 @@ import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Slider, Switch } from "@/shared/ui/forms";
 
 interface SettingsFields {
-  showHeader: React.ComponentProps<typeof Switch>;
   showSwipeButtonList: React.ComponentProps<typeof Switch>;
+  showPlaybackControls: React.ComponentProps<typeof Switch>;
   showSwipeFeedback: React.ComponentProps<typeof Switch>;
   darkMode: React.ComponentProps<typeof Switch>;
   shuffled: React.ComponentProps<typeof Switch>;
@@ -27,8 +27,8 @@ export interface SettingsFormProps {
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
   const idPrefix = useId();
   const inputIds = {
-    showHeader: `${idPrefix}-show-header`,
-    showSwipeButtonList: `${idPrefix}-show-study-buttons`,
+    showSwipeButtonList: `${idPrefix}-show-swipe-controls`,
+    showPlaybackControls: `${idPrefix}-show-playback-controls`,
     showSwipeFeedback: `${idPrefix}-show-swipe-feedback`,
     darkMode: `${idPrefix}-dark-mode`,
     shuffled: `${idPrefix}-shuffle-cards`,
@@ -52,23 +52,27 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
         <p className="text-caption text-ink-muted">Changes are saved automatically</p>
       </div>
       <div className="space-y-4">
-        <SettingsSection title="Appearance" description="Navigation and visual feedback" icon={<AiOutlineEye />}>
-          <SettingsRow inputId={inputIds.showHeader} label="Show header" description="Keep app navigation visible">
-            <Switch
-              {...props.fields.showHeader}
-              id={inputIds.showHeader}
-              aria-describedby={descriptionId(inputIds.showHeader)}
-            />
-          </SettingsRow>
+        <SettingsSection title="Appearance" description="Study controls and visual feedback" icon={<AiOutlineEye />}>
           <SettingsRow
             inputId={inputIds.showSwipeButtonList}
-            label="Show study buttons"
-            description="Display study action controls"
+            label="Show swipe controls"
+            description="Display study swipe action controls"
           >
             <Switch
               {...props.fields.showSwipeButtonList}
               id={inputIds.showSwipeButtonList}
               aria-describedby={descriptionId(inputIds.showSwipeButtonList)}
+            />
+          </SettingsRow>
+          <SettingsRow
+            inputId={inputIds.showPlaybackControls}
+            label="Show playback controls"
+            description="Display autoplay and progress controls"
+          >
+            <Switch
+              {...props.fields.showPlaybackControls}
+              id={inputIds.showPlaybackControls}
+              aria-describedby={descriptionId(inputIds.showPlaybackControls)}
             />
           </SettingsRow>
           <SettingsRow

--- a/src/pages/settings/ui/SettingsSection.spec.tsx
+++ b/src/pages/settings/ui/SettingsSection.spec.tsx
@@ -7,13 +7,13 @@ import { SettingsRow, SettingsSection } from "./SettingsSection";
 describe("settings presentation", () => {
   it("relates a settings section to its unique heading", () => {
     render(
-      <SettingsSection title="Appearance" description="Navigation and visual feedback" icon="icon">
+      <SettingsSection title="Appearance" description="Study controls and visual feedback" icon="icon">
         <div>content</div>
       </SettingsSection>
     );
 
     expect(screen.getByRole("region", { name: "Appearance" })).toBeInTheDocument();
-    expect(screen.getByText("Navigation and visual feedback")).toBeInTheDocument();
+    expect(screen.getByText("Study controls and visual feedback")).toBeInTheDocument();
     expect(screen.getByText("icon", { selector: "[aria-hidden='true']" })).toHaveAttribute("aria-hidden", "true");
   });
 

--- a/src/pages/settings/ui/SettingsSection.stories.tsx
+++ b/src/pages/settings/ui/SettingsSection.stories.tsx
@@ -8,22 +8,22 @@ import { Switch } from "@/shared/ui/forms";
 
 import { SettingsRow, SettingsSection, type SettingsSectionProps } from "./SettingsSection";
 
-const inputId = "storybook-show-header";
-const onShowHeaderChange = fn();
+const inputId = "storybook-show-swipe-controls";
+const onShowSwipeControlsChange = fn();
 
 const SettingsSectionStory = (args: SettingsSectionProps) => {
-  const [showHeader, setShowHeader] = useState(true);
+  const [showSwipeControls, setShowSwipeControls] = useState(true);
 
   return (
     <SettingsSection {...args}>
-      <SettingsRow inputId={inputId} label="Show header" description="Keep app navigation visible">
+      <SettingsRow inputId={inputId} label="Show swipe controls" description="Display study swipe action controls">
         <Switch
           id={inputId}
-          checked={showHeader}
+          checked={showSwipeControls}
           aria-describedby={`${inputId}-description`}
           onChange={(event) => {
-            onShowHeaderChange(event);
-            setShowHeader(event.target.checked);
+            onShowSwipeControlsChange(event);
+            setShowSwipeControls(event.target.checked);
           }}
         />
       </SettingsRow>
@@ -46,10 +46,10 @@ const meta = {
   decorators: [withPageLayout],
   args: {
     title: "Appearance",
-    description: "Navigation and visual feedback",
+    description: "Study controls and visual feedback",
     icon: <AiOutlineEye />,
     children: (
-      <SettingsRow inputId={inputId} label="Show header" description="Keep app navigation visible">
+      <SettingsRow inputId={inputId} label="Show swipe controls" description="Display study swipe action controls">
         <Switch id={inputId} checked onChange={fn()} />
       </SettingsRow>
     ),
@@ -76,10 +76,10 @@ export const Row: Story = {
 export const Interaction: Story = {
   render: (args) => <SettingsSectionStory {...args} />,
   play: async ({ canvas, userEvent }) => {
-    const control = canvas.getByRole("checkbox", { name: "Show header" });
+    const control = canvas.getByRole("checkbox", { name: "Show swipe controls" });
     await userEvent.click(control);
     await expect(control).not.toBeChecked();
-    await expect(onShowHeaderChange).toHaveBeenCalledOnce();
+    await expect(onShowSwipeControlsChange).toHaveBeenCalledOnce();
   },
 };
 

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -91,7 +91,6 @@ describe("useStudy", () => {
     mocks.preferences = createPreferences({
       cardInterval: 1,
       defaultAutoPlay: false,
-      showHeader: true,
       showSwipeFeedback: true,
       cardSwipeRight: "GoToNextCardMastered",
     });
@@ -110,6 +109,8 @@ describe("useStudy", () => {
       session: { currentIndex: 0, cardCount: 2 },
       card: { frontText: "card-1" },
       showBackText: false,
+      showPlaybackControls: true,
+      playbackControlsAvailable: true,
     });
     expect(result.current).not.toHaveProperty("index");
     expect(result.current).not.toHaveProperty("numberOfCards");
@@ -128,6 +129,21 @@ describe("useStudy", () => {
     mocks.cards = [];
     const { result } = renderHook(() => useStudy(deckId));
     expect(result.current.status).toBe("preparing");
+  });
+
+  it("reports persisted control visibility and playback availability", () => {
+    mocks.preferences = createPreferences({
+      cardInterval: 0,
+      controls: { showSwipeButtonList: false, showPlaybackControls: false },
+    });
+
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current).toMatchObject({
+      showSwipeButtonList: false,
+      showPlaybackControls: false,
+      playbackControlsAvailable: false,
+    });
   });
 
   it("reports invalid when the session has no current card", async () => {

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { useCards } from "@/entities/card";
 import { getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
-import { toggleShowHeader, toggleShowSwipeButtonList, usePreferences } from "@/entities/preference";
+import { toggleShowPlaybackControls, toggleShowSwipeButtonList, usePreferences } from "@/entities/preference";
 import { setStudySessionIndex } from "@/entities/study-session";
 
 import { useAutoPlay } from "./useAutoPlay";
@@ -31,11 +31,11 @@ export const useStudy = (deckId: string) => {
     ...swipe,
     toggleBackText: () => setShowBackText((visible) => !visible),
     toggleAutoPlay,
-    toggleHeader: toggleShowHeader,
+    toggleShowPlaybackControls,
     toggleSwipeButtonList: toggleShowSwipeButtonList,
-    showHeader: preferences.appearance.showHeader && !showBackText,
     showBackText,
-    showController: preferences.study.cardInterval > 0,
+    playbackControlsAvailable: preferences.study.cardInterval > 0,
+    showPlaybackControls: preferences.controls.showPlaybackControls,
     showSwipeButtonList: preferences.controls.showSwipeButtonList,
     autoPlay,
     updateIndex,

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -6,6 +6,8 @@ vi.mock("@/shared/firebase", () => ({ auth: {} }));
 
 import { StudySession } from "./StudySession";
 
+const playbackUnavailableDescription = "Playback controls unavailable because the card interval is set to 0";
+
 const toolbarProps = () => ({
   showSwipeControls: true,
   showPlaybackControls: true,
@@ -83,12 +85,14 @@ describe("StudySession", () => {
     );
 
     const back = screen.getByRole("button", { name: "Back to cards" });
-    const swipeToggle = screen.getByRole("button", { name: "Hide swipe controls" });
-    const playbackToggle = screen.getByRole("button", { name: "Hide playback controls" });
-    const actions = screen.getByRole("toolbar", { name: "Study actions" });
+    const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
+    const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
+    const actions = screen.getByRole("group", { name: "Study actions" });
     expect(back).toBeVisible();
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
     expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
+    expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
+    expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(actions).toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
@@ -114,16 +118,14 @@ describe("StudySession", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: "Show swipe controls" })).toHaveAttribute("aria-pressed", "false");
-    const playbackToggle = screen.getByRole("button", {
-      name: "Playback controls unavailable because the card interval is set to 0",
-    });
+    const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
+    expect(swipeToggle).toHaveAttribute("aria-pressed", "false");
+    expect(swipeToggle).toHaveAttribute("title", "Show swipe controls");
+    const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     expect(playbackToggle).toHaveAttribute("aria-disabled", "true");
     expect(playbackToggle).not.toBeDisabled();
-    expect(playbackToggle).toHaveAttribute(
-      "title",
-      "Playback controls unavailable because the card interval is set to 0"
-    );
+    expect(playbackToggle).toHaveAttribute("title", playbackUnavailableDescription);
+    expect(playbackToggle).toHaveAccessibleDescription(playbackUnavailableDescription);
 
     playbackToggle.focus();
     expect(playbackToggle).toHaveFocus();
@@ -171,7 +173,7 @@ describe("StudySession", () => {
       />
     );
 
-    expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
+    expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -6,6 +6,15 @@ vi.mock("@/shared/firebase", () => ({ auth: {} }));
 
 import { StudySession } from "./StudySession";
 
+const toolbarProps = () => ({
+  showSwipeControls: true,
+  showPlaybackControls: true,
+  playbackControlsAvailable: true,
+  onBack: vi.fn(),
+  onToggleSwipeControls: vi.fn(),
+  onTogglePlaybackControls: vi.fn(),
+});
+
 const swipeLeft = (target: HTMLElement) => {
   const start = { identifier: 1, target, clientX: 200, clientY: 24 };
   const end = { identifier: 1, target, clientX: 20, clientY: 24 };
@@ -39,7 +48,7 @@ describe("StudySession", () => {
   it("gives swipe overlays accessible names", () => {
     render(
       <StudySession
-        onExit={vi.fn()}
+        {...toolbarProps()}
         showBackText
         backTextSlot={<div>Back</div>}
         swipeOverlay={{
@@ -58,26 +67,119 @@ describe("StudySession", () => {
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
   });
 
-  it("reports the explicit Exit action through a plain callback", () => {
-    const onExit = vi.fn();
+  it("reports toolbar actions through accessible controls", () => {
+    const onBack = vi.fn();
+    const onToggleSwipeControls = vi.fn();
+    const onTogglePlaybackControls = vi.fn();
     render(
-      <StudySession onExit={onExit} cardOverlaySlot={<div>Card metadata</div>} frontTextSlot={<div>Front</div>} />
+      <StudySession
+        {...toolbarProps()}
+        onBack={onBack}
+        onToggleSwipeControls={onToggleSwipeControls}
+        onTogglePlaybackControls={onTogglePlaybackControls}
+        cardOverlaySlot={<div>Card metadata</div>}
+        frontTextSlot={<div>Front</div>}
+      />
     );
 
-    const exit = screen.getByRole("button", { name: "Exit" });
+    const back = screen.getByRole("button", { name: "Back to cards" });
+    const swipeToggle = screen.getByRole("button", { name: "Hide swipe controls" });
+    const playbackToggle = screen.getByRole("button", { name: "Hide playback controls" });
     const actions = screen.getByRole("toolbar", { name: "Study actions" });
-    expect(exit).toBeVisible();
-    expect(actions).toContainElement(exit);
+    expect(back).toBeVisible();
+    expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
+    expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
+    expect(actions).toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
-    fireEvent.click(exit);
+    fireEvent.click(back);
+    fireEvent.click(swipeToggle);
+    fireEvent.click(playbackToggle);
 
-    expect(onExit).toHaveBeenCalledOnce();
+    expect(onBack).toHaveBeenCalledOnce();
+    expect(onToggleSwipeControls).toHaveBeenCalledOnce();
+    expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
+  });
+
+  it("describes hidden controls and keeps the unavailable playback toggle disabled", () => {
+    const onTogglePlaybackControls = vi.fn();
+    render(
+      <StudySession
+        {...toolbarProps()}
+        showSwipeControls={false}
+        showPlaybackControls={false}
+        playbackControlsAvailable={false}
+        onTogglePlaybackControls={onTogglePlaybackControls}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Show swipe controls" })).toHaveAttribute("aria-pressed", "false");
+    const playbackToggle = screen.getByRole("button", {
+      name: "Playback controls unavailable because the card interval is set to 0",
+    });
+    expect(playbackToggle).toHaveAttribute("aria-disabled", "true");
+    expect(playbackToggle).not.toBeDisabled();
+    expect(playbackToggle).toHaveAttribute(
+      "title",
+      "Playback controls unavailable because the card interval is set to 0"
+    );
+
+    playbackToggle.focus();
+    expect(playbackToggle).toHaveFocus();
+
+    fireEvent.click(playbackToggle);
+    expect(onTogglePlaybackControls).not.toHaveBeenCalled();
+  });
+
+  it("shows only the selected bottom control groups", () => {
+    const { rerender } = render(
+      <StudySession
+        {...toolbarProps()}
+        showSwipeControls={false}
+        controller={{ autoPlay: false, index: 0, numberOfCards: 2 }}
+        swipeButtonList={{ onClickLeft: vi.fn() }}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play" })).toBeVisible();
+
+    rerender(
+      <StudySession
+        {...toolbarProps()}
+        showPlaybackControls={false}
+        controller={{ autoPlay: false, index: 0, numberOfCards: 2 }}
+        swipeButtonList={{ onClickLeft: vi.fn() }}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Swipe left" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
+  });
+
+  it("hides the bottom dock for the answer while keeping the toolbar", () => {
+    render(
+      <StudySession
+        {...toolbarProps()}
+        showBackText
+        backTextSlot={<div>Back</div>}
+        controller={{ autoPlay: false, index: 0, numberOfCards: 2 }}
+        swipeButtonList={{ onClickLeft: vi.fn() }}
+      />
+    );
+
+    expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
   });
 
   it("reports a swipe performed on the back text", () => {
     const onSwipeLeft = vi.fn();
-    render(<StudySession onExit={vi.fn()} showBackText backTextSlot={<div>Back</div>} onSwipeLeft={onSwipeLeft} />);
+    render(<StudySession {...toolbarProps()} showBackText backTextSlot={<div>Back</div>} onSwipeLeft={onSwipeLeft} />);
 
     swipeLeft(screen.getByText("Back"));
 
@@ -86,7 +188,7 @@ describe("StudySession", () => {
 
   it("reserves vertical drags on the back text for scrolling", () => {
     const onSwipeUp = vi.fn();
-    render(<StudySession onExit={vi.fn()} showBackText backTextSlot={<div>Long back</div>} onSwipeUp={onSwipeUp} />);
+    render(<StudySession {...toolbarProps()} showBackText backTextSlot={<div>Long back</div>} onSwipeUp={onSwipeUp} />);
 
     swipeUp(screen.getByText("Long back"));
 
@@ -95,7 +197,14 @@ describe("StudySession", () => {
 
   it("reports a vertical swipe performed on the front text", () => {
     const onSwipeUp = vi.fn();
-    render(<StudySession onExit={vi.fn()} frontTextSlot={<div>Front</div>} onSwipeUp={onSwipeUp} />);
+    render(
+      <StudySession
+        {...toolbarProps()}
+        showSwipeControls={false}
+        frontTextSlot={<div>Front</div>}
+        onSwipeUp={onSwipeUp}
+      />
+    );
 
     swipeUp(screen.getByText("Front"));
 
@@ -107,7 +216,7 @@ describe("StudySession", () => {
     const onFrontClick = vi.fn();
     render(
       <StudySession
-        onExit={vi.fn()}
+        {...toolbarProps()}
         frontTextSlot={
           <button type="button" onClick={onFrontClick}>
             Front
@@ -127,7 +236,7 @@ describe("StudySession", () => {
 
   it("ignores non-primary mouse drags on the front text", () => {
     const onSwipeUp = vi.fn();
-    render(<StudySession onExit={vi.fn()} frontTextSlot={<div>Front</div>} onSwipeUp={onSwipeUp} />);
+    render(<StudySession {...toolbarProps()} frontTextSlot={<div>Front</div>} onSwipeUp={onSwipeUp} />);
     const front = screen.getByText("Front");
 
     swipeWithMouse(front, { clientX: 24, clientY: 200 }, { clientX: 24, clientY: 20 }, 1);
@@ -141,7 +250,7 @@ describe("StudySession", () => {
     const onBackClick = vi.fn();
     render(
       <StudySession
-        onExit={vi.fn()}
+        {...toolbarProps()}
         showBackText
         backTextSlot={
           <button type="button" onClick={onBackClick}>

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -82,7 +82,9 @@ export const LongAnswer: Story = {
   },
   play: async ({ canvasElement }) => {
     const answer = canvasElement.querySelector<HTMLElement>("pre");
-    const swipeOverlays = canvasElement.querySelectorAll<HTMLElement>("[aria-label^='Swipe ']");
+    const swipeOverlays = canvasElement.querySelectorAll<HTMLElement>(
+      "[aria-label='Swipe left'], [aria-label='Swipe right'], [aria-label='Swipe up'], [aria-label='Swipe down']"
+    );
     const swipeOverlayStyles = Array.from(swipeOverlays, (overlay) => {
       const style = getComputedStyle(overlay);
       return { backgroundColor: style.backgroundColor, boxShadow: style.boxShadow };

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -22,9 +22,12 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
-    onExit: fn(),
-    showSwipeButtonList: true,
-    showController: true,
+    onBack: fn(),
+    onToggleSwipeControls: fn(),
+    onTogglePlaybackControls: fn(),
+    showSwipeControls: true,
+    showPlaybackControls: true,
+    playbackControlsAvailable: true,
     frontTextSlot: <FrontText text={fixture.card.default.frontText} />,
     cardOverlaySlot: (
       <CardOverlay
@@ -53,11 +56,23 @@ export const SwipeFeedback: Story = {
   args: { swipeFeedback: "cardSwipeRight" },
 };
 
+export const SwipeControlsHidden: Story = {
+  args: { showSwipeControls: false },
+};
+
+export const PlaybackControlsHidden: Story = {
+  args: { showPlaybackControls: false },
+};
+
 export const ControlsHidden: Story = {
   args: {
-    showSwipeButtonList: false,
-    showController: false,
+    showSwipeControls: false,
+    showPlaybackControls: false,
   },
+};
+
+export const PlaybackUnavailable: Story = {
+  args: { playbackControlsAvailable: false },
 };
 
 export const LongAnswer: Story = {
@@ -126,6 +141,10 @@ export const UnavailableSwipeActions: Story = {
 };
 
 export const Dark: Story = {
+  globals: { theme: "dark" },
+};
+
+export const DarkCodeAnswer: Story = {
   ...CodeAnswer,
   args: {
     ...CodeAnswer.args,

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -16,6 +16,8 @@ const SWIPE_FEEDBACK_LABEL: Record<SwipeDirection, string> = {
   cardSwipeRight: "Swiped right",
 };
 
+const PLAYBACK_UNAVAILABLE_DESCRIPTION = "Playback controls unavailable because the card interval is set to 0";
+
 type StudyLayoutStyles = React.CSSProperties & {
   "--study-toolbar-top": string;
   "--study-card-top": string;
@@ -62,18 +64,18 @@ const StudyToolbar: React.FC<{
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
 }> = (props) => {
-  const swipeLabel = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
-  const playbackLabel = props.playbackControlsAvailable
+  const playbackDescriptionId = React.useId();
+  const swipeTitle = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
+  const playbackTitle = props.playbackControlsAvailable
     ? props.showPlaybackControls
       ? "Hide playback controls"
       : "Show playback controls"
-    : "Playback controls unavailable because the card interval is set to 0";
+    : PLAYBACK_UNAVAILABLE_DESCRIPTION;
 
   return (
-    <div
-      role="toolbar"
+    <fieldset
       aria-label="Study actions"
-      className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 flex items-center justify-between pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]"
+      className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 m-0 flex min-w-0 items-center justify-between border-0 p-0 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]"
     >
       <button
         type="button"
@@ -89,8 +91,9 @@ const StudyToolbar: React.FC<{
       <div className="pointer-events-auto flex items-center rounded-pill border border-border bg-surface-elevated/90 p-0.5 shadow-elevated backdrop-blur-md">
         <button
           type="button"
-          aria-label={swipeLabel}
+          aria-label="Swipe controls"
           aria-pressed={props.showSwipeControls}
+          title={swipeTitle}
           className={cx(toolbarButtonClass, props.showSwipeControls && "bg-surface-muted text-accent-primary")}
           onClick={props.onToggleSwipeControls}
         >
@@ -99,10 +102,11 @@ const StudyToolbar: React.FC<{
         <span aria-hidden="true" className="h-6 w-px bg-border" />
         <button
           type="button"
-          aria-label={playbackLabel}
+          aria-label="Playback controls"
           aria-pressed={props.showPlaybackControls}
           aria-disabled={!props.playbackControlsAvailable}
-          title={!props.playbackControlsAvailable ? playbackLabel : undefined}
+          aria-describedby={!props.playbackControlsAvailable ? playbackDescriptionId : undefined}
+          title={playbackTitle}
           className={cx(
             toolbarButtonClass,
             props.showPlaybackControls && "bg-surface-muted text-accent-primary",
@@ -112,8 +116,13 @@ const StudyToolbar: React.FC<{
         >
           <AiOutlinePlayCircle aria-hidden="true" className="text-xl" />
         </button>
+        {!props.playbackControlsAvailable ? (
+          <span id={playbackDescriptionId} className="sr-only">
+            {PLAYBACK_UNAVAILABLE_DESCRIPTION}
+          </span>
+        ) : null}
       </div>
-    </div>
+    </fieldset>
   );
 };
 

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -1,8 +1,9 @@
 import cx from "classnames";
 import * as React from "react";
+import { AiOutlineLeft, AiOutlinePlayCircle } from "react-icons/ai";
+import { MdSwipe } from "react-icons/md";
 import { type SwipeEventData, useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
-import { Button } from "@/shared/ui/button";
 import { Overlay } from "@/shared/ui/feedback";
 
 import { Controller, type ControllerProps } from "./Controller";
@@ -15,11 +16,24 @@ const SWIPE_FEEDBACK_LABEL: Record<SwipeDirection, string> = {
   cardSwipeRight: "Swiped right",
 };
 
+type StudyLayoutStyles = React.CSSProperties & {
+  "--study-toolbar-top": string;
+  "--study-card-top": string;
+  "--study-feedback-top": string;
+};
+
+const studyLayoutStyles: StudyLayoutStyles = {
+  "--study-toolbar-top": "calc(0.75rem + env(safe-area-inset-top))",
+  "--study-card-top": "calc(var(--study-toolbar-top) + var(--spacing-touch) + 0.75rem)",
+  // Card metadata is fixed at h-10; feedback starts immediately after it so neither surface overlaps.
+  "--study-feedback-top": "calc(var(--study-card-top) + 2.5rem)",
+};
+
 export interface StudySessionProps {
-  showHeader?: boolean;
   showBackText?: boolean;
-  showSwipeButtonList?: boolean;
-  showController?: boolean;
+  showSwipeControls: boolean;
+  showPlaybackControls: boolean;
+  playbackControlsAvailable: boolean;
   swipeFeedback?: SwipeDirection;
   backTextSlot?: React.ReactNode;
   cardOverlaySlot?: React.ReactNode;
@@ -32,39 +46,83 @@ export interface StudySessionProps {
   onSwipeUp?: () => void;
   onSwipeRight?: () => void;
   onSwipeDown?: () => void;
-  onExit: () => void;
+  onBack: () => void;
+  onToggleSwipeControls: () => void;
+  onTogglePlaybackControls: () => void;
 }
 
-const ExitAction: React.FC<{ showHeader: boolean | undefined; onExit: () => void }> = ({ showHeader, onExit }) => (
-  // The action stays in flow so card content starts below it; Header owns the top safe area when visible.
-  <div
-    role="toolbar"
-    aria-label="Study actions"
-    className={cx(
-      "relative z-40 flex shrink-0 border-b border-border bg-surface-elevated pb-2 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]",
-      showHeader ? "pt-2" : "pt-[calc(0.5rem+env(safe-area-inset-top))]"
-    )}
-  >
-    <Button size="sm" variant="quiet" onClick={onExit}>
-      Exit
-    </Button>
-  </div>
-);
+const toolbarButtonClass =
+  "pointer-events-auto inline-flex size-touch shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
-const SwipeFeedback: React.FC<{
-  showHeader: boolean | undefined;
-  swipeFeedback: SwipeDirection | undefined;
-}> = ({ showHeader, swipeFeedback }) => {
+const StudyToolbar: React.FC<{
+  showSwipeControls: boolean;
+  showPlaybackControls: boolean;
+  playbackControlsAvailable: boolean;
+  onBack: () => void;
+  onToggleSwipeControls: () => void;
+  onTogglePlaybackControls: () => void;
+}> = (props) => {
+  const swipeLabel = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
+  const playbackLabel = props.playbackControlsAvailable
+    ? props.showPlaybackControls
+      ? "Hide playback controls"
+      : "Show playback controls"
+    : "Playback controls unavailable because the card interval is set to 0";
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Study actions"
+      className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 flex items-center justify-between pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]"
+    >
+      <button
+        type="button"
+        aria-label="Back to cards"
+        className={cx(
+          toolbarButtonClass,
+          "border border-border bg-surface-elevated/90 shadow-elevated backdrop-blur-md"
+        )}
+        onClick={props.onBack}
+      >
+        <AiOutlineLeft aria-hidden="true" className="text-xl" />
+      </button>
+      <div className="pointer-events-auto flex items-center rounded-pill border border-border bg-surface-elevated/90 p-0.5 shadow-elevated backdrop-blur-md">
+        <button
+          type="button"
+          aria-label={swipeLabel}
+          aria-pressed={props.showSwipeControls}
+          className={cx(toolbarButtonClass, props.showSwipeControls && "bg-surface-muted text-accent-primary")}
+          onClick={props.onToggleSwipeControls}
+        >
+          <MdSwipe aria-hidden="true" className="text-xl" />
+        </button>
+        <span aria-hidden="true" className="h-6 w-px bg-border" />
+        <button
+          type="button"
+          aria-label={playbackLabel}
+          aria-pressed={props.showPlaybackControls}
+          aria-disabled={!props.playbackControlsAvailable}
+          title={!props.playbackControlsAvailable ? playbackLabel : undefined}
+          className={cx(
+            toolbarButtonClass,
+            props.showPlaybackControls && "bg-surface-muted text-accent-primary",
+            !props.playbackControlsAvailable && "cursor-not-allowed opacity-50"
+          )}
+          onClick={props.playbackControlsAvailable ? props.onTogglePlaybackControls : undefined}
+        >
+          <AiOutlinePlayCircle aria-hidden="true" className="text-xl" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const SwipeFeedback: React.FC<{ swipeFeedback: SwipeDirection | undefined }> = ({ swipeFeedback }) => {
   if (swipeFeedback === undefined) return null;
   return (
     <div
       role="status"
-      className={cx(
-        "pointer-events-none absolute left-1/2 z-50 -translate-x-1/2 rounded-control border border-border bg-surface-elevated px-4 py-2 text-body font-bold text-ink shadow-elevated",
-        showHeader
-          ? "top-[calc(var(--spacing-touch)+1rem)]"
-          : "top-[calc(var(--spacing-touch)+1rem+env(safe-area-inset-top))]"
-      )}
+      className="pointer-events-none absolute left-1/2 top-[var(--study-feedback-top)] z-50 -translate-x-1/2 rounded-pill border border-border bg-surface-elevated/90 px-4 py-2 text-body font-bold text-ink shadow-elevated backdrop-blur-md"
     >
       {SWIPE_FEEDBACK_LABEL[swipeFeedback]}
     </div>
@@ -119,16 +177,27 @@ const CardContent: React.FC<{
 
 const Controls: React.FC<{
   showBackText: boolean | undefined;
-  showSwipeButtonList: boolean | undefined;
-  showController: boolean | undefined;
+  showSwipeControls: boolean;
+  showPlaybackControls: boolean;
+  playbackControlsAvailable: boolean;
   swipeButtonList: SwipeButtonListProps | undefined;
   controller: ControllerProps | undefined;
-}> = ({ showBackText, showSwipeButtonList, showController, swipeButtonList, controller }) => {
-  if (showBackText || !(showSwipeButtonList || showController)) return null;
+}> = ({
+  showBackText,
+  showSwipeControls,
+  showPlaybackControls,
+  playbackControlsAvailable,
+  swipeButtonList,
+  controller,
+}) => {
+  const showController = showPlaybackControls && playbackControlsAvailable;
+  if (showBackText || !(showSwipeControls || showController)) return null;
   return (
-    <div className="relative z-40 shrink-0 space-y-2 border-t border-border bg-surface-elevated pb-[calc(0.5rem+env(safe-area-inset-bottom))] pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))] pt-2">
-      {showSwipeButtonList ? <SwipeButtonList {...swipeButtonList} /> : null}
-      {showController ? <Controller {...controller} /> : null}
+    <div className="relative z-40 shrink-0 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))] pt-2">
+      <div className="mx-auto w-full max-w-content space-y-2 rounded-surface border border-border bg-surface-elevated/90 p-2 shadow-elevated backdrop-blur-md">
+        {showSwipeControls ? <SwipeButtonList {...swipeButtonList} /> : null}
+        {showController ? <Controller {...controller} /> : null}
+      </div>
     </div>
   );
 };
@@ -195,12 +264,22 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
   };
 
   return (
-    <div className="relative flex h-full min-h-0 flex-1 flex-col bg-canvas text-ink">
+    <div className="relative flex h-full min-h-0 flex-1 flex-col bg-canvas text-ink" style={studyLayoutStyles}>
       {props.feedbackSlot}
-      <ExitAction showHeader={props.showHeader} onExit={props.onExit} />
-      <SwipeFeedback showHeader={props.showHeader} swipeFeedback={props.swipeFeedback} />
+      <StudyToolbar
+        showSwipeControls={props.showSwipeControls}
+        showPlaybackControls={props.showPlaybackControls}
+        playbackControlsAvailable={props.playbackControlsAvailable}
+        onBack={props.onBack}
+        onToggleSwipeControls={props.onToggleSwipeControls}
+        onTogglePlaybackControls={props.onTogglePlaybackControls}
+      />
+      <SwipeFeedback swipeFeedback={props.swipeFeedback} />
       <div
-        className={cx("relative min-h-0 flex-1", props.showBackText ? "overflow-y-auto" : "overflow-hidden")}
+        className={cx(
+          "relative min-h-0 flex-1 pt-[var(--study-card-top)]",
+          props.showBackText ? "overflow-y-auto" : "overflow-hidden"
+        )}
         {...cardGestureHandlers}
       >
         <CardContent
@@ -213,8 +292,9 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       </div>
       <Controls
         showBackText={props.showBackText}
-        showSwipeButtonList={props.showSwipeButtonList}
-        showController={props.showController}
+        showSwipeControls={props.showSwipeControls}
+        showPlaybackControls={props.showPlaybackControls}
+        playbackControlsAvailable={props.playbackControlsAvailable}
         swipeButtonList={props.swipeButtonList}
         controller={props.controller}
       />

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -20,11 +20,22 @@ type StudyShortcutAction =
   | "toggleSwipeButtonList"
   | "toggleAutoPlay";
 
-const studyShortcutInteractiveTarget =
-  "a[href], button, input, select, textarea, summary, [contenteditable]:not([contenteditable='false']), [role='button'], [role='link'], [role='slider'], [role='switch'], [role='checkbox'], [role='radio'], [role='tab'], [tabindex]:not([tabindex='-1'])";
+const studyShortcutTextEntryTarget =
+  "input:not([type]), input[type='text'], input[type='search'], input[type='email'], input[type='url'], input[type='tel'], input[type='password'], input[type='number'], input[type='date'], input[type='datetime-local'], input[type='month'], input[type='time'], input[type='week'], textarea, select";
+const studyShortcutButtonTarget =
+  "a[href], button, summary, input[type='button'], input[type='submit'], input[type='reset'], input[type='checkbox'], input[type='radio'], [role='button'], [role='link'], [role='switch'], [role='checkbox'], [role='radio'], [role='tab']";
+const studyShortcutSliderTarget = "input[type='range'], [role='slider']";
 
-const isInteractiveTarget = (target: EventTarget | null): boolean =>
-  target instanceof Element && target.closest(studyShortcutInteractiveTarget) !== null;
+const shouldIgnoreStudyShortcut = (event: KeyboardEvent): boolean => {
+  if (!(event.target instanceof Element)) return false;
+  if (event.target.closest(studyShortcutTextEntryTarget) !== null) return true;
+  const editableTarget = event.target.closest("[contenteditable]");
+  if (editableTarget !== null && editableTarget.getAttribute("contenteditable") !== "false") return true;
+  if ((event.key === "Enter" || event.key === " ") && event.target.closest(studyShortcutButtonTarget) !== null) {
+    return true;
+  }
+  return event.key.startsWith("Arrow") && event.target.closest(studyShortcutSliderTarget) !== null;
+};
 
 const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) => {
   if (state == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
@@ -91,8 +102,9 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
   const latestStudy = useLatest(study);
   const goBack = () => void navigate(routes.cardList.to(deckId));
   const runWhileStudying = (action: StudyShortcutAction) => (event: KeyboardEvent) => {
-    // Study shortcuts must not compete with native keyboard behavior on toolbar and controller controls.
-    if (isInteractiveTarget(event.target)) return;
+    // Native editing and activation keys take precedence, while unrelated Study shortcuts remain
+    // available after a user moves focus into the card or floating controls.
+    if (shouldIgnoreStudyShortcut(event)) return;
     const currentStudy = latestStudy.current;
     if (currentStudy?.status === "studying") void currentStudy[action]();
   };

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -17,11 +17,16 @@ type StudyShortcutAction =
   | "swipeLeft"
   | "swipeRight"
   | "toggleBackText"
-  | "toggleHeader"
   | "toggleSwipeButtonList"
   | "toggleAutoPlay";
 
-const renderStudyScreen = (state: StudyState | undefined, onExit: () => void) => {
+const studyShortcutInteractiveTarget =
+  "a[href], button, input, select, textarea, summary, [contenteditable]:not([contenteditable='false']), [role='button'], [role='link'], [role='slider'], [role='switch'], [role='checkbox'], [role='radio'], [role='tab'], [tabindex]:not([tabindex='-1'])";
+
+const isInteractiveTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element && target.closest(studyShortcutInteractiveTarget) !== null;
+
+const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) => {
   if (state == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
 
   if (state.status !== "studying") {
@@ -41,13 +46,15 @@ const renderStudyScreen = (state: StudyState | undefined, onExit: () => void) =>
   };
 
   return (
-    <AppLayout fullscreen showHeader={state.showHeader}>
+    <AppLayout fullscreen showHeader={false}>
       <StudySession
-        onExit={onExit}
-        showHeader={state.showHeader}
-        showController={state.showController}
+        onBack={onBack}
+        onToggleSwipeControls={state.toggleSwipeButtonList}
+        onTogglePlaybackControls={state.toggleShowPlaybackControls}
         showBackText={state.showBackText}
-        showSwipeButtonList={state.showSwipeButtonList}
+        showSwipeControls={state.showSwipeButtonList}
+        showPlaybackControls={state.showPlaybackControls}
+        playbackControlsAvailable={state.playbackControlsAvailable}
         onSwipeUp={swipeActions.onClickUp}
         onSwipeDown={swipeActions.onClickDown}
         onSwipeLeft={swipeActions.onClickLeft}
@@ -82,8 +89,10 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
   const navigate = useNavigate();
   const study = useStudy(deckId);
   const latestStudy = useLatest(study);
-  const exit = () => void navigate(routes.cardList.to(deckId));
-  const runWhileStudying = (action: StudyShortcutAction) => () => {
+  const goBack = () => void navigate(routes.cardList.to(deckId));
+  const runWhileStudying = (action: StudyShortcutAction) => (event: KeyboardEvent) => {
+    // Study shortcuts must not compete with native keyboard behavior on toolbar and controller controls.
+    if (isInteractiveTarget(event.target)) return;
     const currentStudy = latestStudy.current;
     if (currentStudy?.status === "studying") void currentStudy[action]();
   };
@@ -94,7 +103,6 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
   useKey("ArrowLeft", runWhileStudying("swipeLeft"));
   useKey("ArrowRight", runWhileStudying("swipeRight"));
   useKey("Enter", runWhileStudying("toggleBackText"));
-  useKey("h", runWhileStudying("toggleHeader"));
   useKey("b", runWhileStudying("toggleSwipeButtonList"));
   useKey(" ", runWhileStudying("toggleAutoPlay"));
 
@@ -103,7 +111,7 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
     void navigate(routes.deckList.to(), { replace: true });
   }, [navigate, study?.status]);
 
-  return renderStudyScreen(study, exit);
+  return renderStudyScreen(study, goBack);
 };
 
 export const StudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) => {

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -106,7 +106,7 @@ describe("StudySessionPage", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-    expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
+    expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
     expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
@@ -120,12 +120,16 @@ describe("StudySessionPage", () => {
     expect(screen.getByText("Back one")).toBeVisible();
   });
 
-  it("shows the next stored card after the ArrowRight shortcut", async () => {
+  it("keeps the ArrowRight shortcut active while the front card is focused", async () => {
+    const user = userEvent.setup();
     renderPage();
 
-    fireEvent.keyDown(window, { key: "ArrowRight" });
+    const front = screen.getByRole("button", { name: "Front one" });
+    front.focus();
+    await user.keyboard("{ArrowRight}");
 
     await waitFor(() => expect(screen.getByText("Front two")).toBeVisible());
+    expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
     expect(screen.queryByText("Front one")).not.toBeInTheDocument();
   });
 
@@ -146,7 +150,7 @@ describe("StudySessionPage", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-    expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
+    expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
     expect(screen.getByLabelText("Score 2, positive")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
@@ -155,18 +159,18 @@ describe("StudySessionPage", () => {
   it("delegates visibility toggles to persisted preference actions", () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole("button", { name: "Hide swipe controls" }));
-    fireEvent.click(screen.getByRole("button", { name: "Hide playback controls" }));
+    fireEvent.click(screen.getByRole("button", { name: "Swipe controls" }));
+    fireEvent.click(screen.getByRole("button", { name: "Playback controls" }));
 
     expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
     expect(mocks.toggleShowPlaybackControls).toHaveBeenCalledOnce();
   });
 
   it.each([
-    ["swipe", "Hide swipe controls", "{Enter}"],
-    ["swipe", "Hide swipe controls", " "],
-    ["playback", "Hide playback controls", "{Enter}"],
-    ["playback", "Hide playback controls", " "],
+    ["swipe", "Swipe controls", "{Enter}"],
+    ["swipe", "Swipe controls", " "],
+    ["playback", "Playback controls", "{Enter}"],
+    ["playback", "Playback controls", " "],
   ] as const)("uses %s visibility with %s without running a Study shortcut", async (control, label, key) => {
     const user = userEvent.setup();
     renderPage();
@@ -180,6 +184,40 @@ describe("StudySessionPage", () => {
     expect(screen.getByRole("button", { name: "Play" })).toBeVisible();
   });
 
+  it("keeps the swipe visibility shortcut active while a toolbar button is focused", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
+    swipeToggle.focus();
+    await user.keyboard("b");
+
+    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
+    expect(mocks.editStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it.each(["{ArrowUp}", "{ArrowDown}", "{ArrowLeft}", "{ArrowRight}"])(
+    "keeps %s native to the focused progress slider",
+    async (key) => {
+      mocks.preferences = createPreferences({
+        controls: {
+          cardSwipeUp: "GoToNextCard",
+          cardSwipeDown: "GoToNextCard",
+          cardSwipeLeft: "GoToNextCard",
+          cardSwipeRight: "GoToNextCard",
+        },
+      });
+      const user = userEvent.setup();
+      renderPage();
+
+      const progress = screen.getByRole("slider", { name: "Study progress" });
+      progress.focus();
+      await user.keyboard(key);
+
+      expect(mocks.editStudyProgress).not.toHaveBeenCalled();
+    }
+  );
+
   it("renders the selected visibility combination", () => {
     mocks.preferences = createPreferences({
       controls: { showSwipeButtonList: false, showPlaybackControls: false },
@@ -187,8 +225,8 @@ describe("StudySessionPage", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: "Show swipe controls" })).not.toBePressed();
-    expect(screen.getByRole("button", { name: "Show playback controls" })).not.toBePressed();
+    expect(screen.getByRole("button", { name: "Swipe controls" })).not.toBePressed();
+    expect(screen.getByRole("button", { name: "Playback controls" })).not.toBePressed();
     expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
@@ -198,11 +236,12 @@ describe("StudySessionPage", () => {
 
     renderPage();
 
-    const playbackToggle = screen.getByRole("button", {
-      name: "Playback controls unavailable because the card interval is set to 0",
-    });
+    const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     expect(playbackToggle).toHaveAttribute("aria-disabled", "true");
     expect(playbackToggle).not.toBeDisabled();
+    expect(playbackToggle).toHaveAccessibleDescription(
+      "Playback controls unavailable because the card interval is set to 0"
+    );
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -1,6 +1,7 @@
 import type { Preferences } from "@/entities/preference";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -16,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   removeStudySession: vi.fn(),
   setDarkMode: vi.fn(),
   touchStudySession: vi.fn(),
-  toggleShowHeader: vi.fn(),
+  toggleShowPlaybackControls: vi.fn(),
   toggleShowSwipeButtonList: vi.fn(),
 }));
 
@@ -24,7 +25,7 @@ vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
-  toggleShowHeader: mocks.toggleShowHeader,
+  toggleShowPlaybackControls: mocks.toggleShowPlaybackControls,
   toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
 }));
 vi.mock("@/entities/study-session", async (importOriginal) => {
@@ -91,7 +92,7 @@ describe("StudySessionPage", () => {
     mocks.removeStudySession.mockReset();
     mocks.setDarkMode.mockReset();
     mocks.touchStudySession.mockReset();
-    mocks.toggleShowHeader.mockReset();
+    mocks.toggleShowPlaybackControls.mockReset();
     mocks.toggleShowSwipeButtonList.mockReset();
     await createDeck("", deck);
     await mutateCards("", [
@@ -104,8 +105,9 @@ describe("StudySessionPage", () => {
   it("renders the active session from stored Entity state", () => {
     renderPage();
 
-    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
     expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });
@@ -127,27 +129,81 @@ describe("StudySessionPage", () => {
     expect(screen.queryByText("Front one")).not.toBeInTheDocument();
   });
 
-  it("exits a deep-linked Study to the same Deck without changing the resumable session", () => {
+  it("returns from a deep-linked Study to the same Deck without changing the resumable session", () => {
     renderPage();
     const sessionBeforeExit = getStudySession(deckId);
 
-    fireEvent.click(screen.getByRole("button", { name: "Exit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to cards" }));
 
     expect(screen.getByRole("heading", { level: 1, name: `Cards for ${deckId}` })).toBeVisible();
     expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
     expect(mocks.removeStudySession).not.toHaveBeenCalled();
   });
 
-  it("keeps Exit available when the Header is hidden", () => {
-    mocks.preferences = createPreferences({ appearance: { darkMode: false, showHeader: false } });
+  it("keeps study actions available while the Header stays hidden", () => {
+    mocks.preferences = createPreferences({ appearance: { darkMode: false } });
 
     renderPage();
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     expect(screen.getByRole("toolbar", { name: "Study actions" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Exit" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
     expect(screen.getByLabelText("Score 2, positive")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
+  });
+
+  it("delegates visibility toggles to persisted preference actions", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide swipe controls" }));
+    fireEvent.click(screen.getByRole("button", { name: "Hide playback controls" }));
+
+    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
+    expect(mocks.toggleShowPlaybackControls).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["swipe", "Hide swipe controls", "{Enter}"],
+    ["swipe", "Hide swipe controls", " "],
+    ["playback", "Hide playback controls", "{Enter}"],
+    ["playback", "Hide playback controls", " "],
+  ] as const)("uses %s visibility with %s without running a Study shortcut", async (control, label, key) => {
+    const user = userEvent.setup();
+    renderPage();
+
+    screen.getByRole("button", { name: label }).focus();
+    await user.keyboard(key);
+
+    expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledTimes(control === "swipe" ? 1 : 0);
+    expect(mocks.toggleShowPlaybackControls).toHaveBeenCalledTimes(control === "playback" ? 1 : 0);
+    expect(screen.queryByText("Back one")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play" })).toBeVisible();
+  });
+
+  it("renders the selected visibility combination", () => {
+    mocks.preferences = createPreferences({
+      controls: { showSwipeButtonList: false, showPlaybackControls: false },
+    });
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "Show swipe controls" })).not.toBePressed();
+    expect(screen.getByRole("button", { name: "Show playback controls" })).not.toBePressed();
+    expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
+  });
+
+  it("disables playback visibility when the card interval is zero", () => {
+    mocks.preferences = createPreferences({ cardInterval: 0 });
+
+    renderPage();
+
+    const playbackToggle = screen.getByRole("button", {
+      name: "Playback controls unavailable because the card interval is set to 0",
+    });
+    expect(playbackToggle).toHaveAttribute("aria-disabled", "true");
+    expect(playbackToggle).not.toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
   it("shows loading feedback while active session cards are unavailable", async () => {

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -273,7 +273,7 @@ export const seedConfig = async (page: Page, overrides: E2EConfigOverrides = {})
     // Seed only the first app document so reload assertions observe mutations made by the application.
     if (!window.location.origin.startsWith("http")) return;
     if (window.sessionStorage.getItem("tango-e2e-config-seeded") !== null) return;
-    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 0 }));
+    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 1 }));
     window.sessionStorage.setItem("tango-e2e-config-seeded", "true");
   }, config);
 };

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -227,7 +227,6 @@ export const e2eConfig = {
   loadSample: false,
   appearance: {
     darkMode: false,
-    showHeader: true,
     fullscreen: false,
     sizeBackText: 0,
     hideBodyWhenCardChanged: true,
@@ -244,6 +243,7 @@ export const e2eConfig = {
   },
   controls: {
     showSwipeButtonList: true,
+    showPlaybackControls: true,
     showScoreSlider: false,
     cardSwipeUp: "GoToNextCardMastered",
     cardSwipeDown: "GoToNextCardNotMastered",

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -185,7 +185,7 @@ test("SWIPE-07 prevents an empty filtered session from starting", async ({ fixtu
   expect(await readSession(page, deck.id)).toBeUndefined();
 });
 
-test("SWIPE-08 exits and continues from the same Card", async ({ fixture, page }) => {
+test("SWIPE-08 returns and continues from the same Card", async ({ fixture, page }) => {
   const deck = fixture.deck();
   const session = fixture.session();
   const currentCard = fixture.card("card-2");
@@ -193,7 +193,7 @@ test("SWIPE-08 exits and continues from the same Card", async ({ fixture, page }
 
   await page.goto(`/deck/${deck.id}/study`);
   await expect(page.getByText(currentCard.frontText, { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "Exit" }).click();
+  await page.getByRole("button", { name: "Back to cards" }).click();
   await page.getByRole("button", { name: "tango" }).click();
   await page.getByRole("button", { name: `Continue ${deck.name}` }).click();
 
@@ -251,7 +251,7 @@ test("SWIPE-11 keeps multiple Deck sessions independent", async ({ fixture, page
 
   await page.goto(`/deck/${deckA.id}/study`);
   await page.getByRole("button", { name: "Swipe up" }).click();
-  await page.getByRole("button", { name: "Exit" }).click();
+  await page.getByRole("button", { name: "Back to cards" }).click();
   await page.getByRole("button", { name: "tango" }).click();
   await page.getByRole("button", { name: `Continue ${deckB.name}` }).click();
 

--- a/test/e2e/yaml-fixture.ts
+++ b/test/e2e/yaml-fixture.ts
@@ -68,7 +68,6 @@ export interface FixturePreferences {
   loadSample: boolean;
   appearance: {
     darkMode: boolean;
-    showHeader: boolean;
     fullscreen: boolean;
     sizeBackText: number;
     hideBodyWhenCardChanged: boolean;
@@ -85,6 +84,7 @@ export interface FixturePreferences {
   };
   controls: {
     showSwipeButtonList: boolean;
+    showPlaybackControls: boolean;
     showScoreSlider: boolean;
     cardSwipeUp: SwipeAction;
     cardSwipeDown: SwipeAction;
@@ -250,7 +250,6 @@ const preferencesSchema = z.strictObject({
   appearance: z
     .strictObject({
       darkMode: z.boolean().optional(),
-      showHeader: z.boolean().optional(),
       fullscreen: z.boolean().optional(),
       sizeBackText: z.number().min(0).optional(),
       hideBodyWhenCardChanged: z.boolean().optional(),
@@ -271,6 +270,7 @@ const preferencesSchema = z.strictObject({
   controls: z
     .strictObject({
       showSwipeButtonList: z.boolean().optional(),
+      showPlaybackControls: z.boolean().optional(),
       showScoreSlider: z.boolean().optional(),
       cardSwipeUp: swipeActionSchema.optional(),
       cardSwipeDown: swipeActionSchema.optional(),
@@ -470,7 +470,6 @@ const applicationPreferences: FixturePreferences = {
   loadSample: true,
   appearance: {
     darkMode: false,
-    showHeader: true,
     fullscreen: false,
     sizeBackText: 0,
     hideBodyWhenCardChanged: true,
@@ -487,6 +486,7 @@ const applicationPreferences: FixturePreferences = {
   },
   controls: {
     showSwipeButtonList: true,
+    showPlaybackControls: true,
     showScoreSlider: false,
     cardSwipeUp: "GoToNextCardMastered",
     cardSwipeDown: "GoToNextCardNotMastered",

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -95,7 +95,6 @@ export type PreferencesOverrides = {
   study?: Partial<StudyPreferences>;
   controls?: Partial<ControlPreferences>;
   darkMode?: boolean;
-  showHeader?: boolean;
   fullscreen?: boolean;
   sizeBackText?: number;
   hideBodyWhenCardChanged?: boolean;
@@ -108,6 +107,7 @@ export type PreferencesOverrides = {
   defaultAutoPlay?: boolean;
   selectedTags?: string[];
   showSwipeButtonList?: boolean;
+  showPlaybackControls?: boolean;
   showScoreSlider?: boolean;
   cardSwipeUp?: SwipeAction;
   cardSwipeDown?: SwipeAction;
@@ -120,7 +120,6 @@ const createAppearance = (
   flat?: Partial<PreferencesOverrides>
 ): AppearancePreferences => ({
   darkMode: appearance?.darkMode ?? flat?.darkMode ?? false,
-  showHeader: appearance?.showHeader ?? flat?.showHeader ?? true,
   fullscreen: appearance?.fullscreen ?? flat?.fullscreen ?? false,
   sizeBackText: appearance?.sizeBackText ?? flat?.sizeBackText ?? 0,
   hideBodyWhenCardChanged: appearance?.hideBodyWhenCardChanged ?? flat?.hideBodyWhenCardChanged ?? true,
@@ -142,6 +141,7 @@ const createControls = (
   flat?: Partial<PreferencesOverrides>
 ): ControlPreferences => ({
   showSwipeButtonList: controls?.showSwipeButtonList ?? flat?.showSwipeButtonList ?? true,
+  showPlaybackControls: controls?.showPlaybackControls ?? flat?.showPlaybackControls ?? true,
   showScoreSlider: controls?.showScoreSlider ?? flat?.showScoreSlider ?? false,
   cardSwipeUp: controls?.cardSwipeUp ?? flat?.cardSwipeUp ?? "GoToNextCardMastered",
   cardSwipeDown: controls?.cardSwipeDown ?? flat?.cardSwipeDown ?? "GoToNextCardNotMastered",


### PR DESCRIPTION
## Related issue

None

## Summary

- replace the Study Session header and Exit bar with floating back, swipe, and playback controls
- persist playback control visibility and remove the obsolete header preference from Settings
- add safe-area-aware Calm Focus styling, accessibility states, stories, and behavior-focused tests
- keep swipe gestures, autoplay, keyboard shortcuts, and resumable sessions working when controls are hidden

## Testing

- mise run check
- npm run test:storybook
- manual Storybook checks for desktop, iPhone X, dark mode, long answers, hidden controls, and interval 0 focus states
- full Playwright E2E was not completed because unrelated ACCOUNT and APP scenarios timed out and Docker startup became unstable

## Known gap

- the legacy preference regression fixture is default-valued, so it does not independently prove that non-default legacy values survive hydration; current-format non-default hydration is covered separately