### PR TITLE
[No issue] Stabilize Firestore retry handling

### DIFF
--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -96,7 +96,10 @@ const deleteDeckDocuments = async (uid: string, deckId: string): Promise<void> =
   const snapshot = await getDocs(
     query(collection(db, CARD_COLLECTION), where("uid", "==", uid), where("deckId", "==", deckId))
   );
-  await Promise.all(snapshot.docs.map((document) => deleteDoc(document.ref)));
+  // A retry must not overlap Card deletions still running from the previous attempt.
+  const cardDeletions = await Promise.allSettled(snapshot.docs.map((document) => deleteDoc(document.ref)));
+  const failure = cardDeletions.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (failure !== undefined) throw failure.reason;
   await deleteDoc(doc(db, DECK_COLLECTION, deckId));
 };
 

--- a/test/e2e/card.spec.ts
+++ b/test/e2e/card.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import {
+  allowExpectedFirestoreWriteFailure,
   expect,
-  expectedFirestoreWriteBrowserError,
   failNextFirestoreWrite,
   getDocument,
   requireDocument,
@@ -198,12 +198,13 @@ test("CARD-09 retries the same Card edit after a handled failure", async ({
   await page.getByRole("menuitem", { name: "Edit" }).click();
   await expect(page).toHaveURL(new RegExp(`/card/${card.id}/edit$`));
   const fault = await failNextFirestoreWrite(page, { collection: "card", id: card.id });
-  browserErrors.allow(expectedFirestoreWriteBrowserError);
+  allowExpectedFirestoreWriteFailure(browserErrors);
   await page.getByRole("textbox", { name: "Front text" }).fill(changedFront);
   await page.getByRole("textbox", { name: "Back text" }).fill(changedBack);
   await page.getByRole("button", { name: "Save changes" }).click();
   await expect(page.getByRole("status")).toContainText("Unable to save changes");
-  expect(fault.wasTriggered()).toBe(true);
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
   await fault.dispose();
   await expect(page.getByRole("textbox", { name: "Front text" })).toHaveValue(changedFront);
   await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue(changedBack);

--- a/test/e2e/deck.spec.ts
+++ b/test/e2e/deck.spec.ts
@@ -1,9 +1,9 @@
 import { readFile } from "node:fs/promises";
 import type { Page } from "@playwright/test";
 import {
+  allowExpectedFirestoreWriteFailure,
   documentId,
   expect,
-  expectedFirestoreWriteBrowserError,
   failNextFirestoreWrite,
   getDocument,
   listDocuments,
@@ -102,12 +102,13 @@ test("DECK-05 retries the same Deck deletion after a handled failure", async ({ 
   await fixture.apply(page);
   await page.goto("/");
   const fault = await failNextFirestoreWrite(page, { collection: "card", id: card.id });
-  browserErrors.allow(expectedFirestoreWriteBrowserError);
+  allowExpectedFirestoreWriteFailure(browserErrors);
 
   const dialog = await openDeckDeleteDialog(page, deck.name);
   await dialog.getByRole("button", { name: "Delete deck" }).click();
   await expect(dialog.getByRole("alert")).toBeVisible();
-  expect(fault.wasTriggered()).toBe(true);
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
   await fault.dispose();
   await dialog.getByRole("button", { name: "Delete deck" }).click();
 
@@ -230,12 +231,13 @@ test("DECK-10 retries a failed remote create with the same ID and no duplicate",
     attemptedDeckId ??= /\/documents\/deck\/([a-zA-Z0-9-]+)/.exec(body)?.[1];
   });
   const fault = await failNextFirestoreWrite(page, { collection: "deck" });
-  browserErrors.allow(expectedFirestoreWriteBrowserError);
+  allowExpectedFirestoreWriteFailure(browserErrors);
   await page.getByRole("textbox", { name: "Name" }).fill(name);
   await page.getByRole("combobox").selectOption(category);
   await page.getByRole("button", { name: "Create deck" }).click();
   await expect(page.getByRole("status")).toContainText("Unable to create this deck");
-  expect(fault.wasTriggered()).toBe(true);
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
   await fault.dispose();
   expect(attemptedDeckId).toBeDefined();
 

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -49,8 +49,17 @@ export interface BrowserErrorCollector {
   errors: () => readonly string[];
 }
 
-export const expectedFirestoreWriteBrowserError =
+const expectedFirestoreWritePermissionBrowserError =
   /^console error: Failed to load resource: the server responded with a status of 403(?: \([^\]]*\))? \[http:\/\/(?:db|127\.0\.0\.1|localhost):[0-9]+\/google\.firestore\.v1\.Firestore\/Write\/channel(?:\?[^\]]*)?:[0-9]+:[0-9]+\]$/iu;
+
+const expectedFirestoreWriteTerminationBrowserError =
+  /^console error: Failed to load resource: the server responded with a status of 400(?: \([^\]]*\))? \[http:\/\/(?:db|127\.0\.0\.1|localhost):[0-9]+\/google\.firestore\.v1\.Firestore\/Write\/channel\?(?=[^\]]*SID=)(?![^\]]*AID=)(?=[^\]]*TYPE=terminate(?:&|:))[^\]]*:[0-9]+:[0-9]+\]$/iu;
+
+export const allowExpectedFirestoreWriteFailure = (collector: BrowserErrorCollector) => {
+  collector.allow(expectedFirestoreWritePermissionBrowserError);
+  // The injected 403 can invalidate the stream ID before the SDK's best-effort terminate request reaches the emulator.
+  collector.allow(expectedFirestoreWriteTerminationBrowserError);
+};
 
 interface E2EFixtures {
   namespace: TestNamespace;

--- a/test/e2e/import.spec.ts
+++ b/test/e2e/import.spec.ts
@@ -1,7 +1,7 @@
 import {
+  allowExpectedFirestoreWriteFailure,
   documentId,
   expect,
-  expectedFirestoreWriteBrowserError,
   failNextFirestoreWrite,
   listDocuments,
   readLocalData,
@@ -125,7 +125,7 @@ test("IMPORT-05 A partial remote import retries without duplicates", async ({
   namespace,
   page,
 }) => {
-  browserErrors.allow(expectedFirestoreWriteBrowserError);
+  allowExpectedFirestoreWriteFailure(browserErrors);
   const { uid } = fixture.user();
   await fixture.apply(page);
   await page.goto("/import");
@@ -142,7 +142,8 @@ test("IMPORT-05 A partial remote import retries without duplicates", async ({
   await expect(page.getByText(file.name, { exact: true }).first()).toBeVisible();
   await expect(page.getByRole("radio", { name: /Sync with account/ })).toBeChecked();
   await expect.poll(async () => (await documentsForUid("deck", uid)).length).toBe(1);
-  expect(fault.wasTriggered()).toBe(true);
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
   await fault.dispose();
   expect(await documentsForUid("card", uid)).toEqual([]);
   const [partialDeck] = await documentsForUid("deck", uid);

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -1,8 +1,8 @@
 import type { Page } from "@playwright/test";
 
 import {
+  allowExpectedFirestoreWriteFailure,
   expect,
-  expectedFirestoreWriteBrowserError,
   failNextFirestoreWrite,
   readLocalData,
   requireDocument,
@@ -275,7 +275,7 @@ test("SWIPE-12 retries a failed progress write from the same Card once", async (
   await fixture.apply(page);
 
   await page.goto(`/deck/${deck.id}/study`);
-  browserErrors.allow(expectedFirestoreWriteBrowserError);
+  allowExpectedFirestoreWriteFailure(browserErrors);
   const fault = await failNextFirestoreWrite(page, { collection: "card", id: currentCard.id });
   await page.getByRole("button", { name: "Swipe up" }).click();
   await expect.poll(fault.wasTriggered).toBe(true);


### PR DESCRIPTION
## Related issue

None

## Summary

- wait for every started child Card deletion before surfacing a Deck deletion failure, preventing retries from overlapping prior Firestore writes
- synchronize E2E fault teardown with Firestore SDK error processing across retry scenarios
- allow only the expected WebChannel terminate 400 after an injected permission error

## Testing

- mise run check
- mise run e2e (53 passed)
- Playwright DECK-05 repeat run with 4 workers, 50 repetitions, and no retries (50 passed)