### PR TITLE
fix: [No issue] show only back text during study

### DIFF
--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -119,6 +119,15 @@ describe("useStudy", () => {
     act(() => result.current.toggleBackText());
     expect(result.current).toMatchObject({ status: "studying", showBackText: true });
     await actAsync(() => result.current.swipeRight());
+    expect(result.current).toMatchObject({
+      status: "studying",
+      card: { frontText: "card-1" },
+      showBackText: true,
+    });
+    expect(mocks.editStudyProgress).not.toHaveBeenCalled();
+
+    act(() => result.current.toggleBackText());
+    await actAsync(() => result.current.swipeRight());
 
     await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-2" } }));
     expect(result.current).toMatchObject({ showBackText: false, swipeFeedback: "cardSwipeRight" });

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -21,7 +21,8 @@ export const useStudy = (deckId: string) => {
     cardInterval: preferences.study.cardInterval,
     onAdvance: hideBackText,
   });
-  const swipe = useSwipe(deckId, cards, hideBackText);
+  // The answer is a reading surface; directional study actions resume after returning to the front.
+  const swipe = useSwipe(deckId, cards, hideBackText, !showBackText);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -17,13 +17,19 @@ export interface SwipeState {
   swipeFeedback?: SwipeDirection;
 }
 
-export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: () => void): SwipeState => {
+export const useSwipe = (
+  deckId: DeckId,
+  cards: readonly Card[],
+  onCardChanged: () => void,
+  enabled: boolean
+): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
   const feedback = useSwipeFeedback(preferences.appearance.showSwipeFeedback);
   const swipeState = React.useRef<{ inProgress: boolean }>({ inProgress: false });
 
   const swipe = async (direction: SwipeDirection): Promise<void> => {
+    if (!enabled) return;
     // biome-ignore lint/suspicious/noUnnecessaryConditions: The awaited write lets another event enter this closure.
     if (swipeState.current.inProgress) return;
 

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -47,26 +47,32 @@ const swipeWithMouse = (
 };
 
 describe("StudySession", () => {
-  it("gives swipe overlays accessible names", () => {
+  it("shows only the answer on the back", () => {
     render(
       <StudySession
         {...toolbarProps()}
         showBackText
         backTextSlot={<div>Back</div>}
-        swipeOverlay={{
-          onClickLeft: vi.fn(),
-          onClickRight: vi.fn(),
-          onClickUp: vi.fn(),
-          onClickDown: vi.fn(),
-        }}
+        cardOverlaySlot={<div>Card metadata</div>}
+        frontTextSlot={<div>Front</div>}
+        feedbackSlot={<div>Save failed</div>}
+        swipeFeedback="cardSwipeRight"
+        controller={{ autoPlay: false, index: 0, numberOfCards: 2 }}
+        swipeButtonList={{ onClickLeft: vi.fn() }}
       />
     );
 
-    expect(screen.getByRole("button", { name: "Swipe left" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Swipe right" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Swipe up" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Swipe down" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeVisible();
+    expect(screen.queryByText("Front")).not.toBeInTheDocument();
+    expect(screen.queryByText("Card metadata")).not.toBeInTheDocument();
+    expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to cards" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Swipe controls" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Playback controls" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
   it("reports toolbar actions through accessible controls", () => {
@@ -162,38 +168,24 @@ describe("StudySession", () => {
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
-  it("hides the bottom dock for the answer while keeping the toolbar", () => {
+  it("ignores horizontal and vertical swipes on the back text", () => {
+    const onSwipeLeft = vi.fn();
+    const onSwipeUp = vi.fn();
     render(
       <StudySession
         {...toolbarProps()}
         showBackText
         backTextSlot={<div>Back</div>}
-        controller={{ autoPlay: false, index: 0, numberOfCards: 2 }}
-        swipeButtonList={{ onClickLeft: vi.fn() }}
+        onSwipeLeft={onSwipeLeft}
+        onSwipeUp={onSwipeUp}
       />
     );
+    const back = screen.getByText("Back");
 
-    expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
-    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
-  });
+    swipeLeft(back);
+    swipeUp(back);
 
-  it("reports a swipe performed on the back text", () => {
-    const onSwipeLeft = vi.fn();
-    render(<StudySession {...toolbarProps()} showBackText backTextSlot={<div>Back</div>} onSwipeLeft={onSwipeLeft} />);
-
-    swipeLeft(screen.getByText("Back"));
-
-    expect(onSwipeLeft).toHaveBeenCalledOnce();
-  });
-
-  it("reserves vertical drags on the back text for scrolling", () => {
-    const onSwipeUp = vi.fn();
-    render(<StudySession {...toolbarProps()} showBackText backTextSlot={<div>Long back</div>} onSwipeUp={onSwipeUp} />);
-
-    swipeUp(screen.getByText("Long back"));
-
+    expect(onSwipeLeft).not.toHaveBeenCalled();
     expect(onSwipeUp).not.toHaveBeenCalled();
   });
 

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -38,12 +38,6 @@ const meta = {
     ),
     controller: { autoPlay: false, index: 3, numberOfCards: 24 },
     swipeButtonList: {},
-    swipeOverlay: {
-      onClickLeft: fn(),
-      onClickRight: fn(),
-      onClickUp: fn(),
-      onClickDown: fn(),
-    },
   },
 } satisfies Meta<typeof StudySession>;
 
@@ -85,16 +79,11 @@ export const LongAnswer: Story = {
     const swipeOverlays = canvasElement.querySelectorAll<HTMLElement>(
       "[aria-label='Swipe left'], [aria-label='Swipe right'], [aria-label='Swipe up'], [aria-label='Swipe down']"
     );
-    const swipeOverlayStyles = Array.from(swipeOverlays, (overlay) => {
-      const style = getComputedStyle(overlay);
-      return { backgroundColor: style.backgroundColor, boxShadow: style.boxShadow };
-    });
+    const studyActions = canvasElement.querySelector<HTMLElement>("[aria-label='Study actions']");
 
     await expect(answer).toBeVisible();
-    await expect(swipeOverlays).toHaveLength(4);
-    await expect(swipeOverlayStyles).toEqual(
-      Array.from({ length: 4 }, () => ({ backgroundColor: "rgba(0, 0, 0, 0)", boxShadow: "none" }))
-    );
+    await expect(swipeOverlays).toHaveLength(0);
+    await expect(studyActions).toBeNull();
   },
 };
 
@@ -123,23 +112,6 @@ export const Mobile: Story = {
 export const MobileLongAnswer: Story = {
   ...LongAnswer,
   globals: { viewport: { value: "iphonex", isRotated: false } },
-};
-
-export const UnavailableSwipeActions: Story = {
-  args: {
-    showBackText: true,
-    backTextSlot: <div className="h-full w-full">Back without swipe actions</div>,
-    swipeOverlay: {},
-  },
-  play: async ({ canvasElement }) => {
-    const answer = canvasElement.querySelector<HTMLElement>(".h-full.w-full");
-    await expect(answer).not.toBeNull();
-    if (answer === null) return;
-
-    const bounds = answer.getBoundingClientRect();
-    const leftEdgeTarget = document.elementFromPoint(bounds.left + 8, bounds.top + bounds.height / 2);
-    await expect(leftEdgeTarget).toBe(answer);
-  },
 };
 
 export const Dark: Story = {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -2,9 +2,8 @@ import cx from "classnames";
 import * as React from "react";
 import { AiOutlineLeft, AiOutlinePlayCircle } from "react-icons/ai";
 import { MdSwipe } from "react-icons/md";
-import { type SwipeEventData, useSwipeable } from "react-swipeable";
+import { useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
-import { Overlay } from "@/shared/ui/feedback";
 
 import { Controller, type ControllerProps } from "./Controller";
 import { SwipeButtonList, type SwipeButtonListProps } from "./SwipeButtonList";
@@ -40,7 +39,6 @@ export interface StudySessionProps {
   backTextSlot?: React.ReactNode;
   cardOverlaySlot?: React.ReactNode;
   frontTextSlot?: React.ReactNode;
-  swipeOverlay?: SwipeButtonListProps;
   controller?: ControllerProps;
   swipeButtonList?: SwipeButtonListProps;
   feedbackSlot?: React.ReactNode;
@@ -138,40 +136,14 @@ const SwipeFeedback: React.FC<{ swipeFeedback: SwipeDirection | undefined }> = (
   );
 };
 
-const BackTextOverlays: React.FC<{ swipeOverlay: SwipeButtonListProps | undefined }> = ({ swipeOverlay }) => {
-  // Gesture hit zones must remain visually neutral so the full-width answer stays readable beneath them.
-  return (
-    <>
-      {swipeOverlay?.onClickLeft !== undefined ? (
-        <Overlay position="left" variant="transparent" ariaLabel="Swipe left" onClick={swipeOverlay.onClickLeft} />
-      ) : null}
-      {swipeOverlay?.onClickRight !== undefined ? (
-        <Overlay position="right" variant="transparent" ariaLabel="Swipe right" onClick={swipeOverlay.onClickRight} />
-      ) : null}
-      {swipeOverlay?.onClickUp !== undefined ? (
-        <Overlay position="top" variant="transparent" ariaLabel="Swipe up" onClick={swipeOverlay.onClickUp} />
-      ) : null}
-      {swipeOverlay?.onClickDown !== undefined ? (
-        <Overlay position="bottom" variant="transparent" ariaLabel="Swipe down" onClick={swipeOverlay.onClickDown} />
-      ) : null}
-    </>
-  );
-};
-
 const CardContent: React.FC<{
   showBackText: boolean | undefined;
   backTextSlot: React.ReactNode | undefined;
   frontTextSlot: React.ReactNode | undefined;
   cardOverlaySlot: React.ReactNode | undefined;
-  swipeOverlay: SwipeButtonListProps | undefined;
-}> = ({ showBackText, backTextSlot, frontTextSlot, cardOverlaySlot, swipeOverlay }) => {
+}> = ({ showBackText, backTextSlot, frontTextSlot, cardOverlaySlot }) => {
   if (showBackText && backTextSlot != null) {
-    return (
-      <>
-        <BackTextOverlays swipeOverlay={swipeOverlay} />
-        <div className="flex min-h-full w-full">{backTextSlot}</div>
-      </>
-    );
+    return <div className="flex min-h-full w-full">{backTextSlot}</div>;
   }
   if (frontTextSlot != null) {
     return (
@@ -232,21 +204,12 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
     }, 0);
   };
 
-  const runSwipeAction =
-    (action: () => void) =>
-    ({ event }: SwipeEventData) => {
-      // Back mouse drags are tracked only to suppress their trailing click; touch swipes still change progress.
-      if (!(props.showBackText && "button" in event)) action();
-    };
-
   const swipeHandlers = useSwipeable({
     onSwiped: suppressTrailingCardClick,
-    ...(props.onSwipeLeft !== undefined ? { onSwipedLeft: runSwipeAction(props.onSwipeLeft) } : {}),
-    ...(!props.showBackText && props.onSwipeUp !== undefined ? { onSwipedUp: runSwipeAction(props.onSwipeUp) } : {}),
-    ...(props.onSwipeRight !== undefined ? { onSwipedRight: runSwipeAction(props.onSwipeRight) } : {}),
-    ...(!props.showBackText && props.onSwipeDown !== undefined
-      ? { onSwipedDown: runSwipeAction(props.onSwipeDown) }
-      : {}),
+    ...(!props.showBackText && props.onSwipeLeft !== undefined ? { onSwipedLeft: props.onSwipeLeft } : {}),
+    ...(!props.showBackText && props.onSwipeUp !== undefined ? { onSwipedUp: props.onSwipeUp } : {}),
+    ...(!props.showBackText && props.onSwipeRight !== undefined ? { onSwipedRight: props.onSwipeRight } : {}),
+    ...(!props.showBackText && props.onSwipeDown !== undefined ? { onSwipedDown: props.onSwipeDown } : {}),
     trackMouse: true,
   });
 
@@ -271,23 +234,29 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
     onClickCapture: stopTrailingCardClick,
     onMouseDown: startPrimaryMouseSwipe,
   };
+  // The answer owns the reading surface, so session chrome stays unmounted until the front returns.
+  const showStudyChrome = !props.showBackText;
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 flex-col bg-canvas text-ink" style={studyLayoutStyles}>
-      {props.feedbackSlot}
-      <StudyToolbar
-        showSwipeControls={props.showSwipeControls}
-        showPlaybackControls={props.showPlaybackControls}
-        playbackControlsAvailable={props.playbackControlsAvailable}
-        onBack={props.onBack}
-        onToggleSwipeControls={props.onToggleSwipeControls}
-        onTogglePlaybackControls={props.onTogglePlaybackControls}
-      />
-      <SwipeFeedback swipeFeedback={props.swipeFeedback} />
+      {showStudyChrome ? props.feedbackSlot : null}
+      {showStudyChrome ? (
+        <StudyToolbar
+          showSwipeControls={props.showSwipeControls}
+          showPlaybackControls={props.showPlaybackControls}
+          playbackControlsAvailable={props.playbackControlsAvailable}
+          onBack={props.onBack}
+          onToggleSwipeControls={props.onToggleSwipeControls}
+          onTogglePlaybackControls={props.onTogglePlaybackControls}
+        />
+      ) : null}
+      {showStudyChrome ? <SwipeFeedback swipeFeedback={props.swipeFeedback} /> : null}
       <div
         className={cx(
-          "relative min-h-0 flex-1 pt-[var(--study-card-top)]",
-          props.showBackText ? "overflow-y-auto" : "overflow-hidden"
+          "relative min-h-0 flex-1",
+          props.showBackText
+            ? "overflow-y-auto pt-[env(safe-area-inset-top)]"
+            : "overflow-hidden pt-[var(--study-card-top)]"
         )}
         {...cardGestureHandlers}
       >
@@ -296,7 +265,6 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
           backTextSlot={props.backTextSlot}
           frontTextSlot={props.frontTextSlot}
           cardOverlaySlot={props.cardOverlaySlot}
-          swipeOverlay={props.swipeOverlay}
         />
       </div>
       <Controls

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -90,7 +90,6 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
           onToggleAutoPlay: state.toggleAutoPlay,
         }}
         swipeButtonList={swipeActions}
-        swipeOverlay={swipeActions}
       />
     </AppLayout>
   );

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -118,6 +118,35 @@ describe("StudySessionPage", () => {
     fireEvent.keyDown(window, { key: "Enter" });
 
     expect(screen.getByText("Back one")).toBeVisible();
+    expect(screen.queryByText("Front one")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Score 2, positive")).not.toBeInTheDocument();
+    expect(screen.queryByText(/3 times/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to cards" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Swipe controls" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Playback controls" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
+  });
+
+  it("ignores directional shortcuts while showing the answer", async () => {
+    mocks.preferences = createPreferences({
+      controls: {
+        cardSwipeUp: "GoToNextCard",
+        cardSwipeDown: "GoToNextCard",
+        cardSwipeLeft: "GoToNextCard",
+        cardSwipeRight: "GoToNextCard",
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.keyboard("{Enter}");
+
+    await user.keyboard("{ArrowUp}{ArrowDown}{ArrowLeft}{ArrowRight}");
+
+    expect(screen.getByText("Back one")).toBeVisible();
+    expect(mocks.editStudyProgress).not.toHaveBeenCalled();
+    expect(getStudySession(deckId)?.currentIndex).toBe(0);
   });
 
   it("keeps the ArrowRight shortcut active while the front card is focused", async () => {


### PR DESCRIPTION
## Related issue

None

## Summary

- Render only the answer content while the study card back is visible.
- Remove back-side study chrome and swipe overlays, and ignore directional actions until the front returns.
- Preserve answer scrolling, text selection, and tap-to-return behavior.

## Testing

- mise run check
- npm run test:storybook -- src/pages/study-session/ui/StudySession.stories.tsx