### PR TITLE
No issue: Decouple deck deletion dialog props

### DIFF
--- a/src/features/deck-deletion/model/useDeckDeletion.ts
+++ b/src/features/deck-deletion/model/useDeckDeletion.ts
@@ -9,12 +9,6 @@ interface DeckDeletionTarget {
   cardCount: number;
 }
 
-export interface DeckDeletionTargetView {
-  deckName: string;
-  cardCount: number;
-  hasError: boolean;
-}
-
 interface UseDeckDeletionOptions {
   onDeleted?: () => void;
 }

--- a/src/features/deck-deletion/ui/DeckDeletionDialog.tsx
+++ b/src/features/deck-deletion/ui/DeckDeletionDialog.tsx
@@ -2,10 +2,12 @@ import type * as React from "react";
 
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
 
-import type { DeckDeletionTargetView } from "../model/useDeckDeletion";
-
 interface DeckDeletionDialogProps {
-  target: DeckDeletionTargetView;
+  target: {
+    deckName: string;
+    cardCount: number;
+    hasError: boolean;
+  };
   onCancel: () => void;
   onConfirm: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary

- define the Deck deletion dialog target prop contract in the UI component
- remove the model-owned view type that coupled presentation to hook internals

## Testing

- mise run check