### PR TITLE
No issue: Consolidate account action state

### DIFF
--- a/src/pages/account/model/useAccountAction.ts
+++ b/src/pages/account/model/useAccountAction.ts
@@ -1,0 +1,21 @@
+import { useState } from "react";
+
+export const useAccountAction = (action: () => Promise<unknown>) => {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const run = async (): Promise<void> => {
+    setPending(true);
+    setError(null);
+    try {
+      await action();
+    } catch (nextError) {
+      setError(nextError);
+      throw nextError;
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return { pending, error, run };
+};

--- a/src/pages/account/model/useSignIn.ts
+++ b/src/pages/account/model/useSignIn.ts
@@ -1,23 +1,8 @@
-import { useState } from "react";
-
 import { loginGoogle } from "./signIn";
+import { useAccountAction } from "./useAccountAction";
 
 export const useSignIn = () => {
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<unknown>(null);
+  const action = useAccountAction(loginGoogle);
 
-  const run = async () => {
-    setPending(true);
-    setError(null);
-    try {
-      await loginGoogle();
-    } catch (nextError) {
-      setError(nextError);
-      throw nextError;
-    } finally {
-      setPending(false);
-    }
-  };
-
-  return { pending, error, signIn: run };
+  return { pending: action.pending, error: action.error, signIn: action.run };
 };

--- a/src/pages/account/model/useSignOut.ts
+++ b/src/pages/account/model/useSignOut.ts
@@ -1,23 +1,8 @@
-import { useState } from "react";
-
 import { signOutCurrentUser } from "./signOut";
+import { useAccountAction } from "./useAccountAction";
 
 export const useSignOut = () => {
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<unknown>(null);
+  const action = useAccountAction(signOutCurrentUser);
 
-  const run = async () => {
-    setPending(true);
-    setError(null);
-    try {
-      await signOutCurrentUser();
-    } catch (nextError) {
-      setError(nextError);
-      throw nextError;
-    } finally {
-      setPending(false);
-    }
-  };
-
-  return { pending, error, signOut: run };
+  return { pending: action.pending, error: action.error, signOut: action.run };
 };

--- a/src/pages/account/ui/AccountPage.tsx
+++ b/src/pages/account/ui/AccountPage.tsx
@@ -16,6 +16,7 @@ export const AccountPage: React.FC = () => {
   const navigate = useNavigate();
   const account = useAuthAccount();
   const uid = useAuthUid();
+  // Keep operation state separate so an auth transition cannot expose feedback from the action that just finished.
   const signIn = useSignIn();
   const signOut = useSignOut();
   const isLoggedIn = account != null;


### PR DESCRIPTION
## Summary

- extract the shared pending, error, and retry state machine into a Page-local account action hook
- keep sign-in and sign-out state independent across authentication transitions

## Testing

- mise run check