### PR TITLE
[No issue] Return study sessions to deck list

### DIFF
--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -200,12 +200,12 @@ Given:
 
 When:
 
-- 学習画面から Card 一覧へ戻り、Deck 一覧から同じ Deck の Continue を実行する。
+- 学習画面から Deck 一覧へ戻り、同じ Deck の Continue を実行する。
 
 Then:
 
-- Card 一覧へ戻る前と同じ学習 session が維持される。
-- Card 一覧へ戻る前に表示されていた Card の front text が表示される。
+- Deck 一覧へ戻る前と同じ学習 session が維持される。
+- Deck 一覧へ戻る前に表示されていた Card の front text が表示される。
 - browser error が発生しない。
 
 <a id="swipe-09"></a>
@@ -265,7 +265,7 @@ Given:
 
 When:
 
-- 一方の Deck で学習 action を実行して Card 一覧へ戻り、もう一方の Deck を Continue する。
+- 一方の Deck で学習 action を実行して Deck 一覧へ戻り、もう一方の Deck を Continue する。
 
 Then:
 

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -68,7 +68,7 @@ describe("StudySession", () => {
     expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Back to cards" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Swipe controls" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Playback controls" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
@@ -90,7 +90,7 @@ describe("StudySession", () => {
       />
     );
 
-    const back = screen.getByRole("button", { name: "Back to cards" });
+    const back = screen.getByRole("button", { name: "Back to deck list" });
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const actions = screen.getByRole("group", { name: "Study actions" });

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -77,7 +77,7 @@ const StudyToolbar: React.FC<{
     >
       <button
         type="button"
-        aria-label="Back to cards"
+        aria-label="Back to deck list"
         className={cx(
           toolbarButtonClass,
           "border border-border bg-surface-elevated/90 shadow-elevated backdrop-blur-md"

--- a/src/pages/study-session/ui/StudySessionContainer.tsx
+++ b/src/pages/study-session/ui/StudySessionContainer.tsx
@@ -99,7 +99,7 @@ const ActiveStudySessionContainer: React.FC<{ deckId: string }> = ({ deckId }) =
   const navigate = useNavigate();
   const study = useStudy(deckId);
   const latestStudy = useLatest(study);
-  const goBack = () => void navigate(routes.cardList.to(deckId));
+  const goBack = () => void navigate(routes.deckList.to());
   const runWhileStudying = (action: StudyShortcutAction) => (event: KeyboardEvent) => {
     // Native editing and activation keys take precedence, while unrelated Study shortcuts remain
     // available after a user moves focus into the card or floating controls.

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Preferences } from "@/entities/preference";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -48,11 +48,6 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { StudySessionPage } from "./StudySessionPage";
 
-const CardListDestination = () => {
-  const { id } = useParams();
-  return <h1>Cards for {id}</h1>;
-};
-
 describe("StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
@@ -79,7 +74,6 @@ describe("StudySessionPage", () => {
       <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/" element={<h1>Deck list destination</h1>} />
-          <Route path="/deck/:id" element={<CardListDestination />} />
           <Route path="/deck/:id/study" element={<StudySessionPage />} />
         </Routes>
       </MemoryRouter>
@@ -107,7 +101,7 @@ describe("StudySessionPage", () => {
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
     expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });
@@ -122,7 +116,7 @@ describe("StudySessionPage", () => {
     expect(screen.queryByLabelText("Score 2, positive")).not.toBeInTheDocument();
     expect(screen.queryByText(/3 times/)).not.toBeInTheDocument();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Back to cards" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Swipe controls" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Playback controls" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
@@ -162,13 +156,13 @@ describe("StudySessionPage", () => {
     expect(screen.queryByText("Front one")).not.toBeInTheDocument();
   });
 
-  it("returns from a deep-linked Study to the same Deck without changing the resumable session", () => {
+  it("returns from a deep-linked Study to the Deck list without changing the resumable session", () => {
     renderPage();
     const sessionBeforeExit = getStudySession(deckId);
 
-    fireEvent.click(screen.getByRole("button", { name: "Back to cards" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
 
-    expect(screen.getByRole("heading", { level: 1, name: `Cards for ${deckId}` })).toBeVisible();
+    expect(screen.getByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
     expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
     expect(mocks.removeStudySession).not.toHaveBeenCalled();
   });
@@ -180,7 +174,7 @@ describe("StudySessionPage", () => {
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Back to cards" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
     expect(screen.getByLabelText("Score 2, positive")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -203,8 +203,8 @@ test("SWIPE-08 returns and continues from the same Card", async ({ fixture, page
 
   await page.goto(`/deck/${deck.id}/study`);
   await expect(page.getByText(currentCard.frontText, { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "Back to cards" }).click();
-  await page.getByRole("button", { name: "tango" }).click();
+  await page.getByRole("button", { name: "Back to deck list" }).click();
+  await expect(page).toHaveURL(/\/$/);
   await page.getByRole("button", { name: `Continue ${deck.name}` }).click();
 
   await expect(page.getByText(currentCard.frontText, { exact: true })).toBeVisible();
@@ -261,8 +261,8 @@ test("SWIPE-11 keeps multiple Deck sessions independent", async ({ fixture, page
 
   await page.goto(`/deck/${deckA.id}/study`);
   await page.getByRole("button", { name: "Swipe up" }).click();
-  await page.getByRole("button", { name: "Back to cards" }).click();
-  await page.getByRole("button", { name: "tango" }).click();
+  await page.getByRole("button", { name: "Back to deck list" }).click();
+  await expect(page).toHaveURL(/\/$/);
   await page.getByRole("button", { name: `Continue ${deckB.name}` }).click();
 
   await expect(page.getByText(currentCardB.frontText, { exact: true })).toBeVisible();


### PR DESCRIPTION
## Related issue

None

## Summary

- Navigate the Study Session back button directly to the Deck list.
- Update the accessible label, unit coverage, E2E scenarios, and E2E specification.

## Testing

- `npm run test:unit -- src/pages/study-session/ui/StudySession.spec.tsx src/pages/study-session/ui/StudySessionPage.spec.tsx`
- `mise run check`