### PR TITLE
No issue: Show commit hash in Advanced settings

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -15,7 +15,7 @@
     "lineWidth": 120
   },
   "javascript": {
-    "globals": ["__APP_VERSION__"],
+    "globals": ["__APP_VERSION__", "__COMMIT_HASH__"],
     "formatter": {
       "trailingCommas": "es5"
     }

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -29,6 +29,7 @@ function createProps(overrides: Partial<SettingsFormProps> = {}): SettingsFormPr
     maxNumberOfCardsToLearn: 24,
     cardInterval: 7,
     version: "1.2.3",
+    commitHash: "0123456789abcdef0123456789abcdef01234567",
     ...overrides,
   };
 }
@@ -69,6 +70,7 @@ describe("SettingsForm", () => {
     expect(details).not.toHaveAttribute("open");
     expect(details).not.toHaveTextContent("Github Access Token");
     expect(details).toHaveTextContent("1.2.3");
+    expect(details).toHaveTextContent("0123456789abcdef0123456789abcdef01234567");
     expect(details).not.toHaveTextContent("User ID");
   });
 

--- a/src/pages/settings/ui/SettingsForm.stories.tsx
+++ b/src/pages/settings/ui/SettingsForm.stories.tsx
@@ -36,6 +36,7 @@ const settingsFormProps = {
   maxNumberOfCardsToLearn: fixture.preferences.default.study.maxNumberOfCardsToLearn,
   cardInterval: fixture.preferences.default.study.cardInterval,
   version: "1.2.3",
+  commitHash: "0123456789abcdef0123456789abcdef01234567",
 };
 
 type SwitchFieldName =

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -22,6 +22,7 @@ export interface SettingsFormProps {
   maxNumberOfCardsToLearn: number;
   cardInterval: number;
   version?: string;
+  commitHash?: string;
 }
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
@@ -176,7 +177,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
               <h2 id={advancedHeadingId} className="text-body font-bold text-ink">
                 Advanced
               </h2>
-              <span className="block text-caption text-ink-muted">Application version</span>
+              <span className="block text-caption text-ink-muted">Application version and commit</span>
             </span>
             <AiOutlineDown
               aria-hidden="true"
@@ -187,6 +188,10 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
               <span className="text-body font-medium text-ink">Version</span>
               <span className="min-w-0 break-all text-right text-caption text-ink-muted">{props.version}</span>
+            </div>
+            <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
+              <span className="text-body font-medium text-ink">Commit hash</span>
+              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{props.commitHash}</span>
             </div>
           </div>
         </details>

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -15,7 +15,7 @@ export const SettingsPage: React.FC = () => {
 
   return (
     <AppLayout showHeader>
-      <SettingsForm {...formState} version={__APP_VERSION__} />
+      <SettingsForm {...formState} version={__APP_VERSION__} commitHash={__COMMIT_HASH__} />
     </AppLayout>
   );
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __COMMIT_HASH__: string;
 
 interface ImportMetaEnv {
   readonly VITE_PROJECT_ID: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,18 @@
 import babel from "@rolldown/plugin-babel";
+import { execFileSync } from "node:child_process";
 import { defineConfig } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { pwaOptions } from "./pwa.config";
+
+const getCommitHash = (): string => {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  } catch {
+    // Source archives and restricted builders may omit Git metadata; the app must remain buildable there.
+    return "unknown";
+  }
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -16,6 +26,7 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+    __COMMIT_HASH__: JSON.stringify(getCommitHash()),
   },
   build: {
     outDir: "build",


### PR DESCRIPTION
## Summary

- inject the current Git commit hash into the Vite build
- display the full hash in the Settings Advanced section
- keep builds working when Git metadata is unavailable

## Testing

- mise run check
- mise run build