### PR TITLE
No issue: Consolidate retry-safe local upserts

### DIFF
--- a/src/entities/card/model/store.spec.tsx
+++ b/src/entities/card/model/store.spec.tsx
@@ -152,6 +152,16 @@ describe("Card store", () => {
     expect(cardStore.getState().localCards).toEqual([]);
   });
 
+  it("retries a local Card create by appending the latest value without duplicates", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(10).mockReturnValueOnce(20).mockReturnValueOnce(30);
+    createLocalCard({ ...cardInput("target"), backText: "initial" });
+    const otherCard = createLocalCard(cardInput("other"));
+    const retriedCard = createLocalCard({ ...cardInput("target"), backText: "latest" });
+
+    expect(cardStore.getState().localCards).toEqual([otherCard, retriedCard]);
+    expect(retriedCard).toEqual(expect.objectContaining({ backText: "latest", createdAt: 30, updatedAt: 30 }));
+  });
+
   it("restores local progress after a failed storage write before retrying", async () => {
     const storage = useMemoryStorage();
     createLocalCard(cardInput("local"));

--- a/src/entities/card/model/store.ts
+++ b/src/entities/card/model/store.ts
@@ -1,6 +1,7 @@
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
 
+import { upsertById } from "@/shared/lib/upsertById";
 import {
   cardDeckIdSchema,
   cardIdSchema,
@@ -85,8 +86,7 @@ export const createLocalCard = (input: LocalCardCreateInput): LocalCard => {
   const timestamp = Date.now();
   const createdCard = localCardSchema.parse({ ...card, createdAt: timestamp, updatedAt: timestamp });
   // Treat a retried create as an upsert by id so persisted local data cannot accumulate duplicate Cards.
-  const localCards = cardStore.getState().localCards.filter(({ id }) => id !== createdCard.id);
-  cardStore.setState({ localCards: [...localCards, createdCard] });
+  cardStore.setState({ localCards: upsertById(cardStore.getState().localCards, createdCard) });
   return createdCard;
 };
 

--- a/src/entities/deck/model/store.spec.tsx
+++ b/src/entities/deck/model/store.spec.tsx
@@ -155,4 +155,14 @@ describe("Deck store", () => {
     deleteLocalDeck("local");
     expect(deckStore.getState().localDecks).toEqual([]);
   });
+
+  it("retries a local Deck create by appending the latest value without duplicates", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(10).mockReturnValueOnce(20).mockReturnValueOnce(30);
+    createLocalDeck({ id: "target", name: "Initial", localMode: true });
+    const otherDeck = createLocalDeck({ id: "other", name: "Other", localMode: true });
+    const retriedDeck = createLocalDeck({ id: "target", name: "Latest", localMode: true });
+
+    expect(deckStore.getState().localDecks).toEqual([otherDeck, retriedDeck]);
+    expect(retriedDeck).toEqual(expect.objectContaining({ name: "Latest", createdAt: 30, updatedAt: 30 }));
+  });
 });

--- a/src/entities/deck/model/store.ts
+++ b/src/entities/deck/model/store.ts
@@ -3,6 +3,7 @@ import { createStore } from "zustand/vanilla";
 import type { z } from "zod";
 
 import { omitUndefined } from "@/shared/lib/omitUndefined";
+import { upsertById } from "@/shared/lib/upsertById";
 import {
   deckEditSchema,
   deckIdSchema,
@@ -74,8 +75,7 @@ export const createLocalDeck = (input: LocalDeckCreateInput): Extract<Deck, { lo
   const timestamp = Date.now();
   const createdDeck = localDeckSchema.parse({ ...deck, createdAt: timestamp, updatedAt: timestamp });
   // Treat a retried create as an upsert by id so persisted local data cannot accumulate duplicate Decks.
-  const localDecks = deckStore.getState().localDecks.filter(({ id }) => id !== createdDeck.id);
-  deckStore.setState({ localDecks: [...localDecks, createdDeck] });
+  deckStore.setState({ localDecks: upsertById(deckStore.getState().localDecks, createdDeck) });
   return createdDeck;
 };
 

--- a/src/shared/lib/upsertById.ts
+++ b/src/shared/lib/upsertById.ts
@@ -1,0 +1,5 @@
+// Retried appends must converge on one latest value without disturbing unrelated entries; replacements stay last.
+export const upsertById = <Item extends { readonly id: string }>(items: readonly Item[], item: Item): Item[] => [
+  ...items.filter(({ id }) => id !== item.id),
+  item,
+];


### PR DESCRIPTION
## Summary

- centralize retry-safe filter-and-append collection updates in a Shared upsert helper
- verify Deck and Card retries keep one latest value at the end without disturbing unrelated entries

## Testing

- mise run check