### PR TITLE
[No issue] Improve mobile study start filters

### DIFF
--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -17,8 +17,11 @@ import { createDeck as createRemoteDeck, createLocalDeck } from "@/test/factorie
 import { DeckFilterForm } from "../ui/DeckFilterForm";
 import { useDeckFilterState } from "./useDeckFilterState";
 
+type EditDeck = typeof import("@/entities/deck").editDeck;
+
 const writeControls = vi.hoisted(() => ({
-  write: undefined as (() => Promise<void>) | undefined,
+  calls: [] as Parameters<EditDeck>[],
+  write: undefined as ((...args: Parameters<EditDeck>) => Promise<void>) | undefined,
 }));
 
 vi.mock("@/entities/auth", () => ({
@@ -29,8 +32,10 @@ vi.mock("@/entities/deck", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/deck")>();
   return {
     ...actual,
-    editDeck: (...args: Parameters<typeof actual.editDeck>) =>
-      writeControls.write === undefined ? actual.editDeck(...args) : writeControls.write(),
+    editDeck: (...args: Parameters<typeof actual.editDeck>) => {
+      writeControls.calls.push(args);
+      return writeControls.write === undefined ? actual.editDeck(...args) : writeControls.write(...args);
+    },
   };
 });
 
@@ -57,6 +62,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
   const tags = ["tag1", "tag2", "tag3"];
 
   beforeEach(() => {
+    writeControls.calls = [];
     writeControls.write = undefined;
   });
 
@@ -165,6 +171,64 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("3");
   });
 
+  it("clears and rolls back both score limits as one optimistic write", async () => {
+    let failWrite: (error: Error) => void = () => undefined;
+    writeControls.write = () =>
+      new Promise<void>((_resolve, reject) => {
+        failWrite = reject;
+      });
+    const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 2, scoreMin: -2, updatedAt: 1 });
+    render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
+    expect(writeControls.calls).toEqual([["user-id", { id: deckId, scoreMax: null, scoreMin: null }]]);
+
+    await Promise.resolve(act(async () => failWrite(new Error("write failed"))));
+
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
+  });
+
+  it("settles the whole clear action when a subscription changes one score boundary", async () => {
+    let finishWrite: () => void = () => undefined;
+    writeControls.write = () =>
+      new Promise<void>((resolve) => {
+        finishWrite = resolve;
+      });
+    const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 2, scoreMin: -2, updatedAt: 1 });
+    const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+    view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: null, updatedAt: 2 }} tags={tags} />);
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
+
+    await Promise.resolve(act(async () => finishWrite()));
+
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
+  });
+
+  it("keeps a newer individual score choice when an older clear fails", async () => {
+    const writes: Array<{ reject: (error: Error) => void; resolve: () => void }> = [];
+    writeControls.write = () =>
+      new Promise<void>((resolve, reject) => {
+        writes.push({ reject, resolve });
+      });
+    const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 2, scoreMin: -2, updatedAt: 1 });
+    render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "1");
+    await Promise.resolve(act(async () => writes[0]?.reject(new Error("clear failed"))));
+
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("1");
+  });
+
   it("ignores an older response after a newer filter change", async () => {
     const writes: Array<{ reject: (error: Error) => void; resolve: () => void }> = [];
     writeControls.write = () =>
@@ -235,8 +299,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
 
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "");
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "");
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
 
     view.unmount();
     renderFilter();

--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -64,11 +64,11 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 1, updatedAt: 1 });
     const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
 
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("1");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("1");
 
     view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: 2, updatedAt: 2 }} tags={tags} />);
 
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
   });
 
   it("keeps an optimistic value until the next subscription update arrives", async () => {
@@ -80,10 +80,10 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 1, updatedAt: 1 });
     const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Maximum score" }), {
       target: { value: 2 },
     });
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
 
     await Promise.resolve(
       act(async () => {
@@ -91,19 +91,19 @@ describe("DeckFilterForm with useDeckFilterState", () => {
         await Promise.resolve();
       })
     );
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
 
     view.rerender(
       <DeckFilterHarness deck={{ ...remoteDeck, name: "Updated elsewhere", tagAndFilter: true }} tags={tags} />
     );
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
 
     view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: 2, updatedAt: 3 }} tags={tags} />);
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
 
     view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: 3, updatedAt: 4 }} tags={tags} />);
 
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("3");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("3");
   });
 
   it("accepts a newer authoritative value after a successful write", async () => {
@@ -115,14 +115,14 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 1, updatedAt: 1 });
     const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Maximum score" }), {
       target: { value: 2 },
     });
     await Promise.resolve(act(async () => finishWrite()));
 
     view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: 3, updatedAt: 2 }} tags={tags} />);
 
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("3");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("3");
   });
 
   it("accepts an authoritative value observed before the write succeeds", async () => {
@@ -134,15 +134,15 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 1, updatedAt: 1 });
     const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Maximum score" }), {
       target: { value: 2 },
     });
     view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: 3, updatedAt: 2 }} tags={tags} />);
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
 
     await Promise.resolve(act(async () => finishWrite()));
 
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("3");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("3");
   });
 
   it("falls back to the latest saved value when an optimistic write fails", async () => {
@@ -154,15 +154,15 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 1, updatedAt: 1 });
     const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Maximum score" }), {
       target: { value: 2 },
     });
     view.rerender(<DeckFilterHarness deck={{ ...remoteDeck, scoreMax: 3, updatedAt: 2 }} tags={tags} />);
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
 
     await Promise.resolve(act(async () => failWrite(new Error("write failed"))));
 
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("3");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("3");
   });
 
   it("ignores an older response after a newer filter change", async () => {
@@ -174,7 +174,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const remoteDeck = createRemoteDeck({ id: deckId, scoreMax: 1, updatedAt: 1 });
     const view = render(<DeckFilterHarness deck={remoteDeck} tags={tags} />);
 
-    const scoreMax = screen.getByRole("slider", { name: "Maximum score value" });
+    const scoreMax = screen.getByRole("combobox", { name: "Maximum score" });
     fireEvent.change(scoreMax, { target: { value: 2 } });
     fireEvent.change(scoreMax, { target: { value: 3 } });
     expect(scoreMax).toHaveValue("3");
@@ -196,10 +196,10 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     const renderFilter = () => render(<StoredDeckFilterHarness deckId={deckId} tags={tags} />);
     const view = renderFilter();
 
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Maximum score" }), {
       target: { value: 2 },
     });
-    fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Minimum score" }), {
       target: { value: -2 },
     });
     await userEvent.click(screen.getByRole("checkbox", { name: "Match all selected tags" }));
@@ -209,24 +209,22 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     renderFilter();
 
     expect(screen.getByText("−2 to 2")).toBeInTheDocument();
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
-    expect(screen.getByRole("slider", { name: "Minimum score value" })).toHaveValue("-2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
     expect(screen.getByRole("checkbox", { name: "Match all selected tags" })).toBeChecked();
     expect(screen.getByText("AND")).toBeInTheDocument();
     for (const tag of tags) expect(screen.getByRole("checkbox", { name: tag })).toBeChecked();
   });
 
-  it("restores enabled score limits and later restores their removal", async () => {
+  it("restores score limits and later restores their removal", async () => {
     await createDeck("", createLocalDeck({ id: deckId, scoreMax: null, scoreMin: null }));
     const renderFilter = () => render(<StoredDeckFilterHarness deckId={deckId} tags={tags} />);
     let view = renderFilter();
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
-    await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
-    fireEvent.change(screen.getByRole("slider", { name: "Maximum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Maximum score" }), {
       target: { value: 2 },
     });
-    fireEvent.change(screen.getByRole("slider", { name: "Minimum score value" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Minimum score" }), {
       target: { value: -2 },
     });
 
@@ -234,22 +232,18 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view = renderFilter();
 
     expect(screen.getByText("−2 to 2")).toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: "Enable maximum score" })).toBeChecked();
-    expect(screen.getByRole("checkbox", { name: "Enable minimum score" })).toBeChecked();
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toHaveValue("2");
-    expect(screen.getByRole("slider", { name: "Minimum score value" })).toHaveValue("-2");
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Enable maximum score" }));
-    await userEvent.click(screen.getByRole("checkbox", { name: "Enable minimum score" }));
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "");
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "");
 
     view.unmount();
     renderFilter();
 
     expect(screen.getByText("Any score")).toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: "Enable maximum score" })).not.toBeChecked();
-    expect(screen.getByRole("checkbox", { name: "Enable minimum score" })).not.toBeChecked();
-    expect(screen.getByRole("slider", { name: "Maximum score value" })).toBeDisabled();
-    expect(screen.getByRole("slider", { name: "Minimum score value" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });
 
   it("restores individual, all, and cleared tag selections", async () => {
@@ -269,7 +263,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view = renderFilter();
     for (const tag of tags) expect(screen.getByRole("checkbox", { name: tag })).toBeChecked();
 
-    await userEvent.click(screen.getByRole("button", { name: /clear/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Clear" }));
     view.unmount();
     renderFilter();
     for (const tag of tags) expect(screen.getByRole("checkbox", { name: tag })).not.toBeChecked();

--- a/src/features/deck-filter/model/useDeckFilterState.ts
+++ b/src/features/deck-filter/model/useDeckFilterState.ts
@@ -8,6 +8,7 @@ export interface DeckFilterState {
   scoreMin: number | null;
   selectedTags: string[];
   tagAndFilter: boolean;
+  clearScoreRange: () => void;
   setScoreMax: (value: number | null) => void;
   setScoreMin: (value: number | null) => void;
   setSelectedTags: (value: string[]) => void;
@@ -17,6 +18,7 @@ export interface DeckFilterState {
 type DeckFilterValues = Pick<Deck, "scoreMax" | "scoreMin" | "selectedTags" | "tagAndFilter">;
 type DeckFilterKey = keyof DeckFilterValues;
 type DeckFilterValue = DeckFilterValues[DeckFilterKey];
+type DeckFilterPatch = Partial<DeckFilterValues>;
 
 interface OptimisticUpdate {
   revision: number;
@@ -69,11 +71,21 @@ const reconcileStoredFilter = (
   previousFilter: DeckFilterValues,
   storedFilter: DeckFilterValues
 ): FilterModelState["optimisticUpdates"] => {
+  const changedRevisions = new Set<number>();
+
+  for (const key of FILTER_KEYS) {
+    const update = updates[key];
+    if (update !== undefined && !areFilterValuesEqual(previousFilter[key], storedFilter[key])) {
+      changedRevisions.add(update.revision);
+    }
+  }
+
   let nextUpdates = updates;
 
   for (const key of FILTER_KEYS) {
     const update = nextUpdates[key];
-    if (update !== undefined && !areFilterValuesEqual(previousFilter[key], storedFilter[key])) {
+    // All fields written by one action must observe the same subscription confirmation or supersession.
+    if (update !== undefined && changedRevisions.has(update.revision)) {
       nextUpdates = update.writeSucceeded
         ? removeOptimisticUpdate(nextUpdates, key)
         : { ...nextUpdates, [key]: { ...update, sourceChanged: true } };
@@ -81,6 +93,31 @@ const reconcileStoredFilter = (
   }
 
   return nextUpdates;
+};
+
+const settleOptimisticUpdate = (
+  updates: FilterModelState["optimisticUpdates"],
+  key: DeckFilterKey,
+  removeTransaction: boolean
+): FilterModelState["optimisticUpdates"] => {
+  const update = updates[key];
+  if (update === undefined) return updates;
+  if (removeTransaction) return removeOptimisticUpdate(updates, key);
+  return { ...updates, [key]: { ...update, writeSucceeded: true } };
+};
+
+const settleOptimisticTransaction = (
+  updates: FilterModelState["optimisticUpdates"],
+  revision: number,
+  succeeded: boolean
+): FilterModelState["optimisticUpdates"] => {
+  // A later field revision leaves this transaction before an older response can settle it.
+  const activeKeys = FILTER_KEYS.filter((key) => updates[key]?.revision === revision);
+  const removeTransaction = !succeeded || activeKeys.some((key) => updates[key]?.sourceChanged === true);
+  return activeKeys.reduce(
+    (currentUpdates, key) => settleOptimisticUpdate(currentUpdates, key, removeTransaction),
+    updates
+  );
 };
 
 export const useDeckFilterState = (deck: Deck): DeckFilterState => {
@@ -96,7 +133,7 @@ export const useDeckFilterState = (deck: Deck): DeckFilterState => {
   if (filterState.deckId !== deck.id) {
     setFilterState({ deckId: deck.id, optimisticUpdates: {}, storedFilter });
   } else if (!areStoredFiltersEqual(filterState.storedFilter, storedFilter)) {
-    // Only the changed field confirms or supersedes its optimistic write; unrelated Entity updates must keep it intact.
+    // A stored change settles its whole user action while unrelated revisions remain optimistic.
     setFilterState((current) => ({
       ...current,
       optimisticUpdates: reconcileStoredFilter(current.optimisticUpdates, current.storedFilter, storedFilter),
@@ -104,37 +141,34 @@ export const useDeckFilterState = (deck: Deck): DeckFilterState => {
     }));
   }
 
-  const settleUpdate = (key: DeckFilterKey, revision: number, succeeded: boolean) => {
+  const settleTransaction = (revision: number, succeeded: boolean) => {
     setFilterState((current) => {
-      const update = current.optimisticUpdates[key];
-      // A slower response from an older write must not replace the user's newer choice.
-      if (update?.revision !== revision) return current;
-      if (!succeeded || update.sourceChanged) {
-        return { ...current, optimisticUpdates: removeOptimisticUpdate(current.optimisticUpdates, key) };
-      }
-      return {
-        ...current,
-        optimisticUpdates: {
-          ...current.optimisticUpdates,
-          [key]: { ...update, writeSucceeded: true },
-        },
-      };
+      const optimisticUpdates = settleOptimisticTransaction(current.optimisticUpdates, revision, succeeded);
+      return optimisticUpdates === current.optimisticUpdates ? current : { ...current, optimisticUpdates };
     });
   };
 
-  const updateFilter = <Key extends DeckFilterKey>(key: Key, value: DeckFilterValues[Key]) => {
+  const updateFilter = (patch: DeckFilterPatch) => {
+    const keys = FILTER_KEYS.filter((key) => patch[key] !== undefined);
+    if (keys.length === 0) return;
     const revision = nextRevision.current + 1;
     nextRevision.current = revision;
-    setFilterState((current) => ({
-      ...current,
-      optimisticUpdates: {
-        ...current.optimisticUpdates,
-        [key]: { revision, sourceChanged: false, value, writeSucceeded: false },
-      },
-    }));
-    void editDeck(uid, { id: deck.id, [key]: value }).then(
-      () => settleUpdate(key, revision, true),
-      () => settleUpdate(key, revision, false)
+    setFilterState((current) => {
+      const optimisticUpdates = { ...current.optimisticUpdates };
+      // Every field in one user action shares a revision so it is persisted and settled as one patch.
+      for (const key of keys) {
+        optimisticUpdates[key] = {
+          revision,
+          sourceChanged: false,
+          value: patch[key] as DeckFilterValue,
+          writeSucceeded: false,
+        };
+      }
+      return { ...current, optimisticUpdates };
+    });
+    void editDeck(uid, { id: deck.id, ...patch }).then(
+      () => settleTransaction(revision, true),
+      () => settleTransaction(revision, false)
     );
   };
 
@@ -148,9 +182,10 @@ export const useDeckFilterState = (deck: Deck): DeckFilterState => {
     scoreMin: getFilterValue("scoreMin"),
     selectedTags: getFilterValue("selectedTags"),
     tagAndFilter: getFilterValue("tagAndFilter"),
-    setScoreMax: (value) => updateFilter("scoreMax", value),
-    setScoreMin: (value) => updateFilter("scoreMin", value),
-    setSelectedTags: (value) => updateFilter("selectedTags", value),
-    setTagAndFilter: (value) => updateFilter("tagAndFilter", value),
+    clearScoreRange: () => updateFilter({ scoreMax: null, scoreMin: null }),
+    setScoreMax: (value) => updateFilter({ scoreMax: value }),
+    setScoreMin: (value) => updateFilter({ scoreMin: value }),
+    setSelectedTags: (value) => updateFilter({ selectedTags: value }),
+    setTagAndFilter: (value) => updateFilter({ tagAndFilter: value }),
   };
 };

--- a/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
@@ -1,10 +1,9 @@
 /**
  * @file Verifies the "DeckFilterForm" contract with automated examples.
- * The examples make the expected behavior concrete with cases such as "labels score controls and
- * preserves values and callbacks", "shows unrestricted disabled limits".
+ * The examples make the expected behavior concrete for score controls, callbacks, and unrestricted limits.
  */
 
-import { fireEvent, render, within, screen } from "@testing-library/react";
+import { render, within, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -31,36 +30,29 @@ const createProps = (): DeckFilterFormProps => ({
 });
 
 describe("DeckFilterForm", () => {
-  it("labels score controls and preserves values and callbacks", async () => {
+  it("composes score and tag filters and preserves callbacks", async () => {
     const props = createProps();
     render(<DeckFilterForm {...props} />);
     const scoreRegion = screen.getByRole("region", { name: "Score range" });
-    const maxSwitch = within(scoreRegion).getByRole("checkbox", { name: "Enable maximum score" });
-    const minSwitch = within(scoreRegion).getByRole("checkbox", { name: "Enable minimum score" });
-    const maxSlider = within(scoreRegion).getByRole("slider", { name: "Maximum score value" });
-    const minSlider = within(scoreRegion).getByRole("slider", { name: "Minimum score value" });
+    const maximum = within(scoreRegion).getByRole("combobox", { name: "Maximum score" });
+    const minimum = within(scoreRegion).getByRole("combobox", { name: "Minimum score" });
 
     expect(within(scoreRegion).getByText("−2 to 4")).toBeInTheDocument();
-    expect(maxSwitch).toBeChecked();
-    expect(minSwitch).toBeChecked();
-    expect(maxSlider).toHaveValue("4");
-    expect(minSlider).toHaveValue("-2");
+    expect(maximum).toHaveValue("4");
+    expect(minimum).toHaveValue("-2");
 
-    await userEvent.click(maxSwitch);
-    await userEvent.click(minSwitch);
-    fireEvent.change(maxSlider, { target: { value: "5" } });
-    fireEvent.change(minSlider, { target: { value: "-3" } });
+    await userEvent.selectOptions(maximum, "5");
+    await userEvent.selectOptions(minimum, "-3");
 
-    expect(props.setScoreMax).toHaveBeenNthCalledWith(1, null);
-    expect(props.setScoreMin).toHaveBeenNthCalledWith(1, null);
-    expect(props.setScoreMax).toHaveBeenNthCalledWith(2, 5);
-    expect(props.setScoreMin).toHaveBeenNthCalledWith(2, -3);
+    expect(props.setScoreMax).toHaveBeenCalledWith(5);
+    expect(props.setScoreMin).toHaveBeenCalledWith(-3);
+    expect(screen.getByRole("region", { name: "Tags" })).toBeInTheDocument();
   });
 
-  it("shows unrestricted disabled limits", () => {
+  it("shows unrestricted limits", () => {
     render(<DeckFilterForm {...createProps()} scoreMax={null} scoreMin={null} />);
     expect(screen.getByText("Any score")).toBeInTheDocument();
-    expect(screen.getByText("No upper limit")).toBeInTheDocument();
-    expect(screen.getByText("No lower limit")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });
 });

--- a/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
@@ -23,6 +23,7 @@ const createProps = (): DeckFilterFormProps => ({
   tags: ["one", "two"],
   selectedTags: ["one"],
   tagAndFilter: true,
+  clearScoreRange: vi.fn(),
   setScoreMax: vi.fn(),
   setScoreMin: vi.fn(),
   setSelectedTags: vi.fn(),
@@ -46,6 +47,8 @@ describe("DeckFilterForm", () => {
 
     expect(props.setScoreMax).toHaveBeenCalledWith(5);
     expect(props.setScoreMin).toHaveBeenCalledWith(-3);
+    await userEvent.click(within(scoreRegion).getByRole("button", { name: "Clear limits" }));
+    expect(props.clearScoreRange).toHaveBeenCalledOnce();
     expect(screen.getByRole("region", { name: "Tags" })).toBeInTheDocument();
   });
 

--- a/src/features/deck-filter/ui/DeckFilterForm.stories.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.stories.tsx
@@ -13,6 +13,7 @@ const args: DeckFilterFormProps = {
   tags: [...fixture.tags.default],
   selectedTags: [],
   tagAndFilter: false,
+  clearScoreRange: fn(),
   setScoreMax: fn(),
   setScoreMin: fn(),
   setSelectedTags: fn(),
@@ -32,6 +33,11 @@ const InteractiveDeckFilterForm: React.FC<DeckFilterFormProps> = (props) => {
       scoreMin={scoreMin}
       selectedTags={selectedTags}
       tagAndFilter={tagAndFilter}
+      clearScoreRange={() => {
+        props.clearScoreRange();
+        setScoreMax(null);
+        setScoreMin(null);
+      }}
       setScoreMax={(value) => {
         props.setScoreMax(value);
         setScoreMax(value);

--- a/src/features/deck-filter/ui/DeckFilterForm.stories.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.stories.tsx
@@ -89,6 +89,14 @@ export const NoMatchCompatible: Story = {
   },
 };
 
+export const SavedOutsideStandardScoreRange: Story = {
+  args: { scoreMax: 14.25, scoreMin: -12.5 },
+};
+
+export const InvalidSavedScoreRange: Story = {
+  args: { scoreMax: 3, scoreMin: 5 },
+};
+
 export const Mobile: Story = {
   ...ManyTagsSelected,
   globals: { viewport: { value: "iphone5", isRotated: false } },

--- a/src/features/deck-filter/ui/DeckFilterForm.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.tsx
@@ -1,7 +1,6 @@
-import { useId } from "react";
 import type * as React from "react";
 
-import { Form, Slider, Switch } from "@/shared/ui/forms";
+import { ScoreRange } from "./ScoreRange";
 import { TagFilter } from "./TagFilter";
 
 interface DeckFilterFormProps {
@@ -16,123 +15,22 @@ interface DeckFilterFormProps {
   tags: string[];
 }
 
-interface ScoreLimitProps {
-  label: "Maximum score" | "Minimum score";
-  value: number | null;
-  switchId: string;
-  sliderId: string;
-  descriptionId: string;
-  onChange: (value: number | null) => void;
-}
-
-const displayScore = (value: number): string => String(value).replace("-", "−");
-
-const scoreRangeLabel = (min: number | null, max: number | null): string => {
-  if (min != null && max != null) return `${displayScore(min)} to ${displayScore(max)}`;
-  if (min != null) return `${displayScore(min)} and above`;
-  if (max != null) return `${displayScore(max)} and below`;
-  return "Any score";
-};
-
-const ScoreLimit: React.FC<ScoreLimitProps> = (props) => {
-  const boundary = props.label === "Maximum score" ? "upper" : "lower";
-  return (
-    <div className="rounded-control bg-surface-muted p-3">
-      <div className="flex min-h-touch items-center justify-between gap-4">
-        <div className="min-w-0">
-          <label htmlFor={props.switchId} className="text-body font-medium text-ink">
-            {props.label}
-          </label>
-          <p id={props.descriptionId} className="text-caption text-ink-muted">
-            {props.value == null ? `No ${boundary} limit` : `Current limit: ${displayScore(props.value)}`}
-          </p>
-        </div>
-        <Switch
-          id={props.switchId}
-          name={`${props.sliderId}-enabled`}
-          checked={props.value != null}
-          aria-label={`Enable ${props.label.toLowerCase()}`}
-          aria-describedby={props.descriptionId}
-          onChange={(event) => props.onChange(event.currentTarget.checked ? 0 : null)}
-        />
-      </div>
-      <div className="mt-3 flex items-center gap-3">
-        <Slider
-          id={props.sliderId}
-          name={props.sliderId}
-          value={String(props.value ?? 0)}
-          step={1}
-          max={10}
-          min={-10}
-          disabled={props.value == null}
-          aria-label={`${props.label} value`}
-          aria-describedby={props.descriptionId}
-          aria-valuetext={props.value == null ? `${props.label} disabled` : displayScore(props.value)}
-          onChange={(event) => props.onChange(event.currentTarget.valueAsNumber)}
-        />
-        <span className="min-w-12 rounded-control bg-surface px-2 py-1 text-center text-caption font-bold text-accent-primary">
-          {props.value == null ? "Any" : displayScore(props.value)}
-        </span>
-      </div>
-    </div>
-  );
-};
-
-export const DeckFilterForm: React.FC<DeckFilterFormProps> = (props) => {
-  const idPrefix = useId();
-  const headingId = `${idPrefix}-score-heading`;
-  const maximumSwitchId = `${idPrefix}-maximum-enabled`;
-  const maximumSliderId = `${idPrefix}-maximum-value`;
-  const maximumDescriptionId = `${idPrefix}-maximum-description`;
-  const minimumSwitchId = `${idPrefix}-minimum-enabled`;
-  const minimumSliderId = `${idPrefix}-minimum-value`;
-  const minimumDescriptionId = `${idPrefix}-minimum-description`;
-
-  return (
-    <Form div>
-      <section
-        aria-labelledby={headingId}
-        className="space-y-4 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
-      >
-        <header className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h2 id={headingId} className="text-title font-semibold text-ink">
-              Score range
-            </h2>
-            <p className="mt-1 text-caption text-ink-muted">Limit cards by their current score.</p>
-          </div>
-          <span className="rounded-control bg-surface-muted px-2 py-1 text-caption font-bold text-accent-primary">
-            {scoreRangeLabel(props.scoreMin, props.scoreMax)}
-          </span>
-        </header>
-        <div className="space-y-3">
-          <ScoreLimit
-            label="Maximum score"
-            value={props.scoreMax}
-            switchId={maximumSwitchId}
-            sliderId={maximumSliderId}
-            descriptionId={maximumDescriptionId}
-            onChange={props.setScoreMax}
-          />
-          <ScoreLimit
-            label="Minimum score"
-            value={props.scoreMin}
-            switchId={minimumSwitchId}
-            sliderId={minimumSliderId}
-            descriptionId={minimumDescriptionId}
-            onChange={props.setScoreMin}
-          />
-        </div>
-      </section>
-      <TagFilter
-        tags={props.tags}
-        selectedTags={props.selectedTags}
-        tagAndFilter={props.tagAndFilter}
-        onClickFilter={props.setTagAndFilter}
-        onClickAll={() => props.setSelectedTags(props.tags)}
-        onClickClear={() => props.setSelectedTags([])}
-        onClickTag={props.setSelectedTags}
-      />
-    </Form>
-  );
-};
+export const DeckFilterForm: React.FC<DeckFilterFormProps> = (props) => (
+  <div className="w-full space-y-4 text-ink">
+    <ScoreRange
+      maximum={props.scoreMax}
+      minimum={props.scoreMin}
+      onMaximumChange={props.setScoreMax}
+      onMinimumChange={props.setScoreMin}
+    />
+    <TagFilter
+      tags={props.tags}
+      selectedTags={props.selectedTags}
+      tagAndFilter={props.tagAndFilter}
+      onClickFilter={props.setTagAndFilter}
+      onClickAll={() => props.setSelectedTags(props.tags)}
+      onClickClear={() => props.setSelectedTags([])}
+      onClickTag={props.setSelectedTags}
+    />
+  </div>
+);

--- a/src/features/deck-filter/ui/DeckFilterForm.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.tsx
@@ -8,6 +8,7 @@ interface DeckFilterFormProps {
   scoreMin: number | null;
   selectedTags: string[];
   tagAndFilter: boolean;
+  clearScoreRange: () => void;
   setScoreMax: (value: number | null) => void;
   setScoreMin: (value: number | null) => void;
   setSelectedTags: (value: string[]) => void;
@@ -20,6 +21,7 @@ export const DeckFilterForm: React.FC<DeckFilterFormProps> = (props) => (
     <ScoreRange
       maximum={props.scoreMax}
       minimum={props.scoreMin}
+      onClear={props.clearScoreRange}
       onMaximumChange={props.setScoreMax}
       onMinimumChange={props.setScoreMin}
     />

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * @file Verifies the ScoreRange component's native selection and compatibility behavior.
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { ScoreRange } from "./ScoreRange";
+
+const numericOptionValues = (select: HTMLElement): string[] =>
+  within(select)
+    .getAllByRole("option")
+    .map((option) => (option as HTMLOptionElement).value)
+    .filter(Boolean);
+
+describe("ScoreRange", () => {
+  it("offers No limit and scores from −10 through 10 with accessible labels", () => {
+    render(<ScoreRange maximum={null} minimum={null} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />);
+
+    const minimum = screen.getByRole("combobox", { name: "Minimum score" });
+    const maximum = screen.getByRole("combobox", { name: "Maximum score" });
+
+    expect(minimum).toHaveValue("");
+    expect(maximum).toHaveValue("");
+    expect(within(minimum).getByRole("option", { name: "No limit" })).toHaveValue("");
+    expect(within(maximum).getByRole("option", { name: "No limit" })).toHaveValue("");
+    expect(numericOptionValues(minimum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
+    expect(numericOptionValues(maximum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
+    expect(minimum).toHaveAccessibleDescription("Include cards at or above this score.");
+    expect(maximum).toHaveAccessibleDescription("Include cards at or below this score.");
+    expect(screen.getByText("Any score")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear limits" })).toBeDisabled();
+  });
+
+  it("reports native selections and summarizes two-sided and one-sided limits", async () => {
+    const onMinimumChange = vi.fn();
+    const onMaximumChange = vi.fn();
+    const view = render(
+      <ScoreRange maximum={4} minimum={-2} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+    );
+
+    expect(screen.getByText("−2 to 4")).toBeInTheDocument();
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "-1");
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "3");
+    expect(onMinimumChange).toHaveBeenCalledWith(-1);
+    expect(onMaximumChange).toHaveBeenCalledWith(3);
+
+    view.rerender(
+      <ScoreRange maximum={null} minimum={-2} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+    );
+    expect(screen.getByText("−2 and above")).toBeInTheDocument();
+
+    view.rerender(
+      <ScoreRange maximum={4} minimum={null} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+    );
+    expect(screen.getByText("4 and below")).toBeInTheDocument();
+  });
+
+  it("preserves saved scores outside the standard integer choices", () => {
+    render(<ScoreRange maximum={14.25} minimum={-12.5} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />);
+
+    const minimum = screen.getByRole("combobox", { name: "Minimum score" });
+    const maximum = screen.getByRole("combobox", { name: "Maximum score" });
+
+    expect(minimum).toHaveValue("-12.5");
+    expect(maximum).toHaveValue("14.25");
+    expect(within(minimum).getByRole("option", { name: "−12.5" })).toBeInTheDocument();
+    expect(within(maximum).getByRole("option", { name: "14.25" })).toBeInTheDocument();
+    expect(screen.getByText("−12.5 to 14.25")).toBeInTheDocument();
+  });
+
+  it("limits new choices to a valid range while retaining the active choices", () => {
+    render(<ScoreRange maximum={4} minimum={-2} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />);
+
+    const minimumValues = numericOptionValues(screen.getByRole("combobox", { name: "Minimum score" }));
+    const maximumValues = numericOptionValues(screen.getByRole("combobox", { name: "Maximum score" }));
+
+    expect(minimumValues).toEqual(Array.from({ length: 15 }, (_, index) => String(index - 10)));
+    expect(maximumValues).toEqual(Array.from({ length: 13 }, (_, index) => String(index - 2)));
+  });
+
+  it("clears both limits through the existing callbacks", async () => {
+    const onMinimumChange = vi.fn();
+    const onMaximumChange = vi.fn();
+    render(<ScoreRange maximum={4} minimum={-2} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+
+    expect(onMinimumChange).toHaveBeenCalledWith(null);
+    expect(onMaximumChange).toHaveBeenCalledWith(null);
+  });
+
+  it("shows an invalid saved range without mutating it and allows both recovery paths", async () => {
+    const onMinimumChange = vi.fn();
+    const onMaximumChange = vi.fn();
+    const view = render(
+      <ScoreRange maximum={3} minimum={5} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+    );
+
+    const minimum = screen.getByRole("combobox", { name: "Minimum score" });
+    const maximum = screen.getByRole("combobox", { name: "Maximum score" });
+    expect(screen.getByRole("alert")).toHaveTextContent("Minimum score must not be greater than maximum score.");
+    expect(minimum).toHaveValue("5");
+    expect(maximum).toHaveValue("3");
+    expect(minimum).toHaveAccessibleDescription(/Minimum score must not be greater/);
+    expect(maximum).toHaveAccessibleDescription(/Minimum score must not be greater/);
+    expect(onMinimumChange).not.toHaveBeenCalled();
+    expect(onMaximumChange).not.toHaveBeenCalled();
+    expect(numericOptionValues(minimum)).toContain("3");
+    expect(numericOptionValues(minimum)).toContain("5");
+    expect(numericOptionValues(minimum)).not.toContain("4");
+    expect(numericOptionValues(maximum)).toContain("3");
+    expect(numericOptionValues(maximum)).toContain("5");
+    expect(numericOptionValues(maximum)).not.toContain("4");
+
+    await userEvent.selectOptions(minimum, "3");
+    expect(onMinimumChange).toHaveBeenCalledWith(3);
+    await userEvent.selectOptions(maximum, "");
+    expect(onMaximumChange).toHaveBeenCalledWith(null);
+
+    view.rerender(
+      <ScoreRange maximum={3} minimum={3} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -17,7 +17,9 @@ const numericOptionValues = (select: HTMLElement): string[] =>
 
 describe("ScoreRange", () => {
   it("offers No limit and scores from −10 through 10 with accessible labels", () => {
-    render(<ScoreRange maximum={null} minimum={null} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />);
+    render(
+      <ScoreRange maximum={null} minimum={null} onClear={vi.fn()} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />
+    );
 
     const minimum = screen.getByRole("combobox", { name: "Minimum score" });
     const maximum = screen.getByRole("combobox", { name: "Maximum score" });
@@ -38,7 +40,13 @@ describe("ScoreRange", () => {
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
     const view = render(
-      <ScoreRange maximum={4} minimum={-2} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+      <ScoreRange
+        maximum={4}
+        minimum={-2}
+        onClear={vi.fn()}
+        onMaximumChange={onMaximumChange}
+        onMinimumChange={onMinimumChange}
+      />
     );
 
     expect(screen.getByText("−2 to 4")).toBeInTheDocument();
@@ -48,18 +56,38 @@ describe("ScoreRange", () => {
     expect(onMaximumChange).toHaveBeenCalledWith(3);
 
     view.rerender(
-      <ScoreRange maximum={null} minimum={-2} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+      <ScoreRange
+        maximum={null}
+        minimum={-2}
+        onClear={vi.fn()}
+        onMaximumChange={onMaximumChange}
+        onMinimumChange={onMinimumChange}
+      />
     );
     expect(screen.getByText("−2 and above")).toBeInTheDocument();
 
     view.rerender(
-      <ScoreRange maximum={4} minimum={null} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+      <ScoreRange
+        maximum={4}
+        minimum={null}
+        onClear={vi.fn()}
+        onMaximumChange={onMaximumChange}
+        onMinimumChange={onMinimumChange}
+      />
     );
     expect(screen.getByText("4 and below")).toBeInTheDocument();
   });
 
   it("preserves saved scores outside the standard integer choices", () => {
-    render(<ScoreRange maximum={14.25} minimum={-12.5} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />);
+    render(
+      <ScoreRange
+        maximum={14.25}
+        minimum={-12.5}
+        onClear={vi.fn()}
+        onMaximumChange={vi.fn()}
+        onMinimumChange={vi.fn()}
+      />
+    );
 
     const minimum = screen.getByRole("combobox", { name: "Minimum score" });
     const maximum = screen.getByRole("combobox", { name: "Maximum score" });
@@ -72,7 +100,9 @@ describe("ScoreRange", () => {
   });
 
   it("limits new choices to a valid range while retaining the active choices", () => {
-    render(<ScoreRange maximum={4} minimum={-2} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />);
+    render(
+      <ScoreRange maximum={4} minimum={-2} onClear={vi.fn()} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />
+    );
 
     const minimumValues = numericOptionValues(screen.getByRole("combobox", { name: "Minimum score" }));
     const maximumValues = numericOptionValues(screen.getByRole("combobox", { name: "Maximum score" }));
@@ -81,22 +111,38 @@ describe("ScoreRange", () => {
     expect(maximumValues).toEqual(Array.from({ length: 13 }, (_, index) => String(index - 2)));
   });
 
-  it("clears both limits through the existing callbacks", async () => {
+  it("reports one clear action for both limits", async () => {
+    const onClear = vi.fn();
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
-    render(<ScoreRange maximum={4} minimum={-2} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />);
+    render(
+      <ScoreRange
+        maximum={4}
+        minimum={-2}
+        onClear={onClear}
+        onMaximumChange={onMaximumChange}
+        onMinimumChange={onMinimumChange}
+      />
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
 
-    expect(onMinimumChange).toHaveBeenCalledWith(null);
-    expect(onMaximumChange).toHaveBeenCalledWith(null);
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(onMinimumChange).not.toHaveBeenCalled();
+    expect(onMaximumChange).not.toHaveBeenCalled();
   });
 
   it("shows an invalid saved range without mutating it and allows both recovery paths", async () => {
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
     const view = render(
-      <ScoreRange maximum={3} minimum={5} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+      <ScoreRange
+        maximum={3}
+        minimum={5}
+        onClear={vi.fn()}
+        onMaximumChange={onMaximumChange}
+        onMinimumChange={onMinimumChange}
+      />
     );
 
     const minimum = screen.getByRole("combobox", { name: "Minimum score" });
@@ -121,7 +167,13 @@ describe("ScoreRange", () => {
     expect(onMaximumChange).toHaveBeenCalledWith(null);
 
     view.rerender(
-      <ScoreRange maximum={3} minimum={3} onMaximumChange={onMaximumChange} onMinimumChange={onMinimumChange} />
+      <ScoreRange
+        maximum={3}
+        minimum={3}
+        onClear={vi.fn()}
+        onMaximumChange={onMaximumChange}
+        onMinimumChange={onMinimumChange}
+      />
     );
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });

--- a/src/features/deck-filter/ui/ScoreRange.stories.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { fn } from "storybook/test";
+
+import { ScoreRange } from "./ScoreRange";
+
+type ScoreRangeProps = React.ComponentProps<typeof ScoreRange>;
+
+const InteractiveScoreRange: React.FC<ScoreRangeProps> = (props) => {
+  const [maximum, setMaximum] = React.useState(props.maximum);
+  const [minimum, setMinimum] = React.useState(props.minimum);
+
+  return (
+    <ScoreRange
+      {...props}
+      maximum={maximum}
+      minimum={minimum}
+      onMaximumChange={(value) => {
+        props.onMaximumChange(value);
+        setMaximum(value);
+      }}
+      onMinimumChange={(value) => {
+        props.onMinimumChange(value);
+        setMinimum(value);
+      }}
+    />
+  );
+};
+
+const meta = {
+  title: "Features/Deck Filter/ScoreRange",
+  component: ScoreRange,
+  tags: ["autodocs"],
+  args: {
+    maximum: 4,
+    minimum: -2,
+    onMaximumChange: fn(),
+    onMinimumChange: fn(),
+  },
+  render: (args) => <InteractiveScoreRange {...args} />,
+} satisfies Meta<typeof ScoreRange>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoLimits: Story = { args: { maximum: null, minimum: null } };
+
+export const MinimumOnly: Story = { args: { maximum: null, minimum: -3 } };
+
+export const MaximumOnly: Story = { args: { maximum: 5, minimum: null } };
+
+export const SavedOutsideStandardRange: Story = { args: { maximum: 14.25, minimum: -12.5 } };
+
+export const InvalidSavedRange: Story = { args: { maximum: 3, minimum: 5 } };
+
+export const Mobile320: Story = {
+  globals: { viewport: { value: "iphone5", isRotated: false } },
+};
+
+export const Mobile375: Story = {
+  args: { maximum: 14.25, minimum: -12.5 },
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+};
+
+export const Dark: Story = {
+  args: { maximum: 3, minimum: 5 },
+  globals: { theme: "dark" },
+};

--- a/src/features/deck-filter/ui/ScoreRange.stories.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.stories.tsx
@@ -15,6 +15,11 @@ const InteractiveScoreRange: React.FC<ScoreRangeProps> = (props) => {
       {...props}
       maximum={maximum}
       minimum={minimum}
+      onClear={() => {
+        props.onClear();
+        setMaximum(null);
+        setMinimum(null);
+      }}
       onMaximumChange={(value) => {
         props.onMaximumChange(value);
         setMaximum(value);
@@ -34,6 +39,7 @@ const meta = {
   args: {
     maximum: 4,
     minimum: -2,
+    onClear: fn(),
     onMaximumChange: fn(),
     onMinimumChange: fn(),
   },

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -19,6 +19,7 @@ const STANDARD_SCORES = Array.from(
 export interface ScoreRangeProps {
   maximum: number | null;
   minimum: number | null;
+  onClear: () => void;
   onMaximumChange: (value: number | null) => void;
   onMinimumChange: (value: number | null) => void;
 }
@@ -124,10 +125,7 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
             size="sm"
             label="Clear limits"
             disabled={props.minimum == null && props.maximum == null}
-            onClick={() => {
-              props.onMinimumChange(null);
-              props.onMaximumChange(null);
-            }}
+            onClick={props.onClear}
           />
         </div>
       </header>

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -1,0 +1,163 @@
+/**
+ * @file Defines the deck filter's score range presentation component.
+ */
+
+import { useId } from "react";
+import type * as React from "react";
+
+import { Button } from "@/shared/ui/button";
+import { Select } from "@/shared/ui/forms";
+
+const NO_LIMIT_VALUE = "";
+const MINIMUM_STANDARD_SCORE = -10;
+const MAXIMUM_STANDARD_SCORE = 10;
+const STANDARD_SCORES = Array.from(
+  { length: MAXIMUM_STANDARD_SCORE - MINIMUM_STANDARD_SCORE + 1 },
+  (_, index) => MINIMUM_STANDARD_SCORE + index
+);
+
+export interface ScoreRangeProps {
+  maximum: number | null;
+  minimum: number | null;
+  onMaximumChange: (value: number | null) => void;
+  onMinimumChange: (value: number | null) => void;
+}
+
+interface ScoreSelectProps {
+  describedBy: string;
+  description: string;
+  id: string;
+  invalid: boolean;
+  label: "Maximum" | "Minimum";
+  onChange: (value: number | null) => void;
+  scores: number[];
+  value: number | null;
+}
+
+const displayScore = (value: number): string => String(value).replace("-", "−");
+
+const scoreRangeLabel = (minimum: number | null, maximum: number | null): string => {
+  if (minimum != null && maximum != null) return `${displayScore(minimum)} to ${displayScore(maximum)}`;
+  if (minimum != null) return `${displayScore(minimum)} and above`;
+  if (maximum != null) return `${displayScore(maximum)} and below`;
+  return "Any score";
+};
+
+const scoreOptions = (
+  current: number | null,
+  otherBoundary: number | null,
+  isAllowed: (score: number, boundary: number) => boolean
+): number[] => {
+  const candidates = new Set(STANDARD_SCORES);
+
+  // Persisted values can predate the current UI range or form an invalid pair. Keeping the active
+  // value visible prevents rendering from silently normalizing saved data and leaves a recovery path.
+  if (current != null) candidates.add(current);
+
+  return [...candidates]
+    .filter((score) => score === current || otherBoundary == null || isAllowed(score, otherBoundary))
+    .sort((left, right) => left - right);
+};
+
+const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
+  <div className="rounded-control bg-surface-muted p-3">
+    <label htmlFor={props.id} className="text-body font-medium text-ink">
+      {props.label}
+    </label>
+    <Select
+      id={props.id}
+      className="mt-2"
+      value={props.value == null ? NO_LIMIT_VALUE : String(props.value)}
+      aria-label={`${props.label} score`}
+      aria-describedby={props.describedBy}
+      aria-invalid={props.invalid || undefined}
+      options={[
+        { label: "No limit", value: NO_LIMIT_VALUE },
+        ...props.scores.map((score) => ({ label: displayScore(score), value: String(score) })),
+      ]}
+      onChange={(event) =>
+        props.onChange(event.currentTarget.value === NO_LIMIT_VALUE ? null : Number(event.currentTarget.value))
+      }
+    />
+    <p id={`${props.id}-description`} className="mt-1 text-caption text-ink-muted">
+      {props.description}
+    </p>
+  </div>
+);
+
+/**
+ * Lets the user choose independent inclusive score boundaries without changing persisted values on render.
+ */
+export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
+  const idPrefix = useId();
+  const headingId = `${idPrefix}-score-heading`;
+  const minimumId = `${idPrefix}-minimum-score`;
+  const maximumId = `${idPrefix}-maximum-score`;
+  const warningId = `${idPrefix}-score-warning`;
+  const invalid = props.minimum != null && props.maximum != null && props.minimum > props.maximum;
+  const minimumScores = scoreOptions(props.minimum, props.maximum, (score, maximum) => score <= maximum);
+  const maximumScores = scoreOptions(props.maximum, props.minimum, (score, minimum) => score >= minimum);
+  const minimumDescribedBy = `${minimumId}-description${invalid ? ` ${warningId}` : ""}`;
+  const maximumDescribedBy = `${maximumId}-description${invalid ? ` ${warningId}` : ""}`;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="space-y-4 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
+    >
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id={headingId} className="text-title font-semibold text-ink">
+            Score range
+          </h2>
+          <p className="mt-1 text-caption text-ink-muted">Limit cards by their current score.</p>
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <span
+            aria-live="polite"
+            className="rounded-control bg-surface-muted px-2 py-1 text-caption font-bold text-accent-primary"
+          >
+            {scoreRangeLabel(props.minimum, props.maximum)}
+          </span>
+          <Button
+            variant="quiet"
+            size="sm"
+            label="Clear limits"
+            disabled={props.minimum == null && props.maximum == null}
+            onClick={() => {
+              props.onMinimumChange(null);
+              props.onMaximumChange(null);
+            }}
+          />
+        </div>
+      </header>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <ScoreSelect
+          id={minimumId}
+          label="Minimum"
+          value={props.minimum}
+          scores={minimumScores}
+          invalid={invalid}
+          describedBy={minimumDescribedBy}
+          description="Include cards at or above this score."
+          onChange={props.onMinimumChange}
+        />
+        <ScoreSelect
+          id={maximumId}
+          label="Maximum"
+          value={props.maximum}
+          scores={maximumScores}
+          invalid={invalid}
+          describedBy={maximumDescribedBy}
+          description="Include cards at or below this score."
+          onChange={props.onMaximumChange}
+        />
+      </div>
+      {invalid ? (
+        <p id={warningId} role="alert" className="rounded-control border border-danger p-3 text-caption text-danger">
+          Minimum score must not be greater than maximum score.
+        </p>
+      ) : null}
+    </section>
+  );
+};

--- a/src/pages/study-session-start/ui/StudySessionStart.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStart.spec.tsx
@@ -51,4 +51,15 @@ describe("StudySessionStart", () => {
     expect(screen.getByText("No cards match your filters.")).toBeVisible();
     expect(screen.getByRole("button", { name: "Start 0 cards" })).toBeDisabled();
   });
+
+  it("places filter controls before the start action in keyboard order", async () => {
+    const user = userEvent.setup();
+    renderView({ filterSlot: <button type="button">Filter control</button> });
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Filter control" })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Start 24 cards" })).toHaveFocus();
+  });
 });

--- a/src/pages/study-session-start/ui/StudySessionStart.stories.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStart.stories.tsx
@@ -8,7 +8,11 @@ import * as fixture from "@/storybook/fixture";
 
 import { StudySessionStart } from "./StudySessionStart";
 
-const Filters: React.FC<{ initialSelectedTags: string[]; initialTagAndFilter: boolean }> = (props) => {
+const Filters: React.FC<{
+  initialSelectedTags: string[];
+  initialTagAndFilter: boolean;
+  tags: readonly string[];
+}> = (props) => {
   const [scoreMax, setScoreMax] = React.useState<number | null>(1);
   const [scoreMin, setScoreMin] = React.useState<number | null>(-1);
   const [selectedTags, setSelectedTags] = React.useState(props.initialSelectedTags);
@@ -18,7 +22,7 @@ const Filters: React.FC<{ initialSelectedTags: string[]; initialTagAndFilter: bo
     <DeckFilterForm
       scoreMax={scoreMax}
       scoreMin={scoreMin}
-      tags={[...fixture.tags.default]}
+      tags={[...props.tags]}
       selectedTags={selectedTags}
       tagAndFilter={tagAndFilter}
       setScoreMax={setScoreMax}
@@ -29,8 +33,8 @@ const Filters: React.FC<{ initialSelectedTags: string[]; initialTagAndFilter: bo
   );
 };
 
-const filters = (selectedTags: string[] = [], tagAndFilter = false) => (
-  <Filters initialSelectedTags={selectedTags} initialTagAndFilter={tagAndFilter} />
+const filters = (selectedTags: string[] = [], tagAndFilter = false, tags: readonly string[] = fixture.tags.default) => (
+  <Filters initialSelectedTags={selectedTags} initialTagAndFilter={tagAndFilter} tags={tags} />
 );
 
 const meta = {
@@ -59,14 +63,29 @@ export const ManyCardsAndCombinedFilters: Story = {
   args: {
     cardsLength: 1247,
     maxNumberOfCardsToLearn: 0,
-    filterSlot: filters(["tag 1", "tag 3"], true),
+    filterSlot: filters([...fixture.tags.toolong.slice(0, 12)], true, fixture.tags.toolong),
   },
 };
 export const DisabledStart: Story = {
   args: { cardsLength: 0, filterSlot: filters(["tag 1", "tag 3"], true) },
 };
 export const Dark: Story = { ...ManyCardsAndCombinedFilters, globals: { theme: "dark" } };
-export const Mobile: Story = {
-  ...Long,
+export const Mobile320LongDeck: Story = {
+  args: {
+    deckName: fixture.deck.tooLongName.name,
+    filterSlot: filters([...fixture.tags.toolong.slice(0, 12)], true, fixture.tags.toolong),
+  },
+  globals: { viewport: { value: "iphone5", isRotated: false } },
+};
+export const Mobile375SafeArea: Story = {
+  ...ManyCardsAndCombinedFilters,
   globals: { viewport: { value: "iphonex", isRotated: false } },
+};
+export const Mobile375DarkEmpty: Story = {
+  args: {
+    cardsLength: 0,
+    deckName: fixture.deck.tooLongName.name,
+    filterSlot: filters([...fixture.tags.toolong.slice(0, 12)], true, fixture.tags.toolong),
+  },
+  globals: { theme: "dark", viewport: { value: "iphonex", isRotated: false } },
 };

--- a/src/pages/study-session-start/ui/StudySessionStart.stories.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStart.stories.tsx
@@ -25,6 +25,10 @@ const Filters: React.FC<{
       tags={[...props.tags]}
       selectedTags={selectedTags}
       tagAndFilter={tagAndFilter}
+      clearScoreRange={() => {
+        setScoreMax(null);
+        setScoreMin(null);
+      }}
       setScoreMax={setScoreMax}
       setScoreMin={setScoreMin}
       setSelectedTags={setSelectedTags}

--- a/src/pages/study-session-start/ui/StudySessionStart.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStart.tsx
@@ -21,33 +21,45 @@ export const StudySessionStart: React.FC<StudySessionStartProps> = (props) => {
     : "No cards match your filters.";
 
   return (
-    <div className="mx-auto w-full max-w-content space-y-section-gap">
+    <div className="mx-auto w-full max-w-content space-y-section-gap pb-[calc(8.5rem+env(safe-area-inset-bottom))] md:pb-0">
       <header className="max-w-reading">
         <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Study setup</p>
         <h1 className="mt-1 line-clamp-3 break-words text-display font-bold text-ink">{props.deckName}</h1>
         <p className="mt-2 text-body text-ink-muted">Choose what to review, then begin a focused session.</p>
       </header>
       <div className="grid items-start gap-section-gap lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)]">
+        {/* One responsive summary keeps live updates and keyboard focus attached to a single CTA. */}
         <section
           aria-labelledby="study-session-summary"
-          className="rounded-surface border border-border bg-surface p-4 shadow-surface lg:sticky lg:top-section-gap lg:col-start-2 lg:row-start-1 lg:p-5"
+          className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface-elevated/95 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))] pt-3 shadow-elevated backdrop-blur-md md:static md:rounded-surface md:border md:bg-surface md:p-4 md:shadow-surface md:backdrop-blur-none lg:sticky lg:top-section-gap lg:col-start-2 lg:row-start-1 lg:p-5"
         >
-          <div aria-live="polite" className="min-w-0">
-            <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Session</p>
-            <h2 id="study-session-summary" className="mt-1 break-words text-title font-bold text-ink">
-              {cardsLabel(sessionCardsLength)} in this session
-            </h2>
-            <p className="mt-2 text-body text-ink-muted">{matchingCopy}</p>
+          <div className="mx-auto flex w-full max-w-content min-w-0 items-center gap-3 md:block md:max-w-none">
+            <div aria-live="polite" className="min-w-0 flex-1">
+              <p className="hidden text-caption font-bold uppercase tracking-wider text-accent-primary md:block">
+                Session
+              </p>
+              <h2
+                id="study-session-summary"
+                aria-label={`${cardsLabel(sessionCardsLength)} in this session`}
+                className="break-words text-body font-bold text-ink md:mt-1 md:text-title"
+              >
+                {cardsLabel(sessionCardsLength)}
+                <span className="hidden md:inline"> in this session</span>
+              </h2>
+              <p className="mt-0.5 line-clamp-2 text-caption text-ink-muted md:mt-2 md:line-clamp-none md:text-body">
+                {matchingCopy}
+              </p>
+            </div>
+            <Button
+              variant="primary"
+              size="md"
+              className="shrink-0 whitespace-nowrap md:mt-5 md:w-full md:px-6 md:py-3 md:text-lg"
+              disabled={!hasCards}
+              {...(props.onClickStart !== undefined ? { onClick: props.onClickStart } : {})}
+            >
+              Start {cardsLabel(sessionCardsLength)}
+            </Button>
           </div>
-          <Button
-            variant="primary"
-            size="lg"
-            className="mt-5 w-full"
-            disabled={!hasCards}
-            {...(props.onClickStart !== undefined ? { onClick: props.onClickStart } : {})}
-          >
-            Start {cardsLabel(sessionCardsLength)}
-          </Button>
         </section>
         <section aria-label="Study filters" className="min-w-0 lg:col-start-1 lg:row-start-1">
           {props.filterSlot}

--- a/src/pages/study-session-start/ui/StudySessionStart.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStart.tsx
@@ -28,6 +28,9 @@ export const StudySessionStart: React.FC<StudySessionStartProps> = (props) => {
         <p className="mt-2 text-body text-ink-muted">Choose what to review, then begin a focused session.</p>
       </header>
       <div className="grid items-start gap-section-gap lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)]">
+        <section aria-label="Study filters" className="min-w-0 lg:col-start-1 lg:row-start-1">
+          {props.filterSlot}
+        </section>
         {/* One responsive summary keeps live updates and keyboard focus attached to a single CTA. */}
         <section
           aria-labelledby="study-session-summary"
@@ -60,9 +63,6 @@ export const StudySessionStart: React.FC<StudySessionStartProps> = (props) => {
               Start {cardsLabel(sessionCardsLength)}
             </Button>
           </div>
-        </section>
-        <section aria-label="Study filters" className="min-w-0 lg:col-start-1 lg:row-start-1">
-          {props.filterSlot}
         </section>
       </div>
     </div>

--- a/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   deck: null as Deck | null,
   cards: [] as Card[],
   setDarkMode: vi.fn(),
+  editDeck: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@/entities/card", () => ({
@@ -23,7 +24,7 @@ vi.mock("@/entities/card", () => ({
 }));
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
 vi.mock("@/entities/deck", () => ({
-  editDeck: vi.fn(),
+  editDeck: mocks.editDeck,
   isDeckTagSelectionMatching: () => true,
   useDeck: () => mocks.deck ?? undefined,
 }));
@@ -80,12 +81,33 @@ describe("StudySessionStartPage", () => {
   it("starts from Enter only outside interactive controls", () => {
     renderPage();
 
-    fireEvent.keyDown(screen.getByRole("slider", { name: "Maximum score value" }), { key: "Enter" });
+    fireEvent.keyDown(screen.getByRole("combobox", { name: "Maximum score" }), { key: "Enter" });
     expect(screen.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeVisible();
 
     fireEvent.keyDown(document.body, { key: "Enter" });
     expect(screen.getByRole("heading", { level: 1, name: "Study session" })).toBeVisible();
     expect(screen.getByText(`Studying ${cardId}`)).toBeVisible();
+  });
+
+  it("updates the session size immediately when a score limit changes", async () => {
+    mocks.preferences = createPreferences({ appearance: { darkMode: false }, study: { maxNumberOfCardsToLearn: 0 } });
+    mocks.cards = [
+      createCard({ id: "low-score-card", deckId, score: 0 }),
+      createCard({ id: "high-score-card", deckId, score: 2 }),
+    ];
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "Start 2 cards" })).toBeVisible();
+    const minimumScore = screen.getByRole("combobox", { name: "Minimum score" });
+
+    fireEvent.keyDown(minimumScore, { key: "Enter" });
+    expect(screen.getByRole("heading", { level: 1, name: "Japanese vocabulary" })).toBeVisible();
+
+    await userEvent.selectOptions(minimumScore, "1");
+
+    expect(screen.getByRole("button", { name: "Start 1 card" })).toBeVisible();
+    expect(screen.getByText("1 card matches your filters.")).toBeVisible();
+    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deckId, scoreMin: 1 });
   });
 
   it("creates a study session before navigating to it", async () => {

--- a/test/e2e/card.spec.ts
+++ b/test/e2e/card.spec.ts
@@ -232,8 +232,7 @@ test("CARD-10 persists score and tag filters and applies both after reload", asy
 
   await page.goto(`/deck/${deck.id}`);
   await page.getByText("Filters", { exact: true }).click();
-  await clickCheckboxLabel(page, "Enable minimum score");
-  await page.getByRole("slider", { name: "Minimum score value" }).fill("1");
+  await page.getByRole("combobox", { name: "Minimum score" }).selectOption("1");
   await clickCheckboxLabel(page, selectedTag);
   await expect.poll(async () => (await requireDocument("deck", deck.id)).fields.scoreMin?.integerValue).toBe("1");
   await expect
@@ -243,8 +242,7 @@ test("CARD-10 persists score and tag filters and applies both after reload", asy
 
   await expect(page.getByText("score ≥ 1 · 1 tag")).toBeVisible();
   await page.getByText("Filters", { exact: true }).click();
-  await expect(page.getByRole("checkbox", { name: "Enable minimum score" })).toBeChecked();
-  await expect(page.getByRole("slider", { name: "Minimum score value" })).toHaveValue("1");
+  await expect(page.getByRole("combobox", { name: "Minimum score" })).toHaveValue("1");
   await expect(page.getByRole("checkbox", { name: selectedTag })).toBeChecked();
   await expect(page.getByRole("button", { name: `View ${matching.frontText}` })).toBeVisible();
   await expect(page.getByRole("button", { name: `View ${lowScore.frontText}` })).toHaveCount(0);


### PR DESCRIPTION
## Related issue

None

## Summary

- Add shared native Minimum/Maximum score selects with no-limit, stored-value compatibility, boundary constraints, invalid-range warnings, and a clear action.
- Add a safe-area-aware fixed mobile Study Start action bar while preserving the desktop summary card and sticky layout.
- Align the Score and Tags cards and update component, page, Storybook, and CARD-10 coverage.

## Testing

- mise run check
- Targeted Storybook tests: 25 passed
- CARD-10 Playwright E2E: passed
- Manual Storybook QA at 320px, 375px, dark theme, zero matches, long deck names, and desktop