### PR TITLE
No issue: Improve settings slider layout

### DIFF
--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -112,8 +112,9 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             inputId={inputIds.maxNumberOfCardsToLearn}
             label="Maximum cards"
             description="Limit the size of a study session"
+            controlPosition="second-row"
           >
-            <div className="flex w-32 items-center gap-2 sm:w-52">
+            <div className="flex w-full items-center gap-2">
               <Slider
                 {...props.fields.maxNumberOfCardsToLearn}
                 id={inputIds.maxNumberOfCardsToLearn}
@@ -147,8 +148,13 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
               aria-describedby={descriptionId(inputIds.defaultAutoPlay)}
             />
           </SettingsRow>
-          <SettingsRow inputId={inputIds.cardInterval} label="Autoplay interval" description="Seconds between cards">
-            <div className="flex w-32 items-center gap-2 sm:w-52">
+          <SettingsRow
+            inputId={inputIds.cardInterval}
+            label="Autoplay interval"
+            description="Seconds between cards"
+            controlPosition="second-row"
+          >
+            <div className="flex w-full items-center gap-2">
               <Slider
                 {...props.fields.cardInterval}
                 id={inputIds.cardInterval}

--- a/src/pages/settings/ui/SettingsSection.tsx
+++ b/src/pages/settings/ui/SettingsSection.tsx
@@ -38,11 +38,22 @@ export interface SettingsRowProps {
   inputId: string;
   label: string;
   description: string;
+  controlPosition?: "inline" | "second-row";
   children: React.ReactNode;
 }
 
-export const SettingsRow: React.FC<SettingsRowProps> = ({ inputId, label, description, children }) => (
-  <div className="flex min-h-touch items-center justify-between gap-4 px-4 py-3">
+export const SettingsRow: React.FC<SettingsRowProps> = ({
+  inputId,
+  label,
+  description,
+  controlPosition = "inline",
+  children,
+}) => (
+  <div
+    className={`flex min-h-touch gap-4 px-4 py-3 ${
+      controlPosition === "second-row" ? "flex-col" : "items-center justify-between"
+    }`}
+  >
     <div className="min-w-0">
       <label htmlFor={inputId} className="block break-words text-body font-medium text-ink">
         {label}
@@ -51,6 +62,8 @@ export const SettingsRow: React.FC<SettingsRowProps> = ({ inputId, label, descri
         {description}
       </p>
     </div>
-    <div className="flex shrink-0 items-center justify-end">{children}</div>
+    <div className={`flex items-center justify-end ${controlPosition === "second-row" ? "w-full" : "shrink-0"}`}>
+      {children}
+    </div>
   </div>
 );


### PR DESCRIPTION
## Summary

- move settings sliders below their labels and descriptions
- expand slider controls to the full available row width
- preserve the inline layout for switch controls

## Testing

- `mise run check`