### PR TITLE
feat(#340): Enforce Storybook accessibility checks

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,7 +9,13 @@ const storybookFirebase = fileURLToPath(new URL("./support/firebase.ts", import.
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.tsx"],
   staticDirs: ["../public"],
-  addons: ["@storybook/addon-docs", "@storybook/addon-themes", "@storybook/addon-vitest", "msw-storybook-addon"],
+  addons: [
+    "@storybook/addon-a11y",
+    "@storybook/addon-docs",
+    "@storybook/addon-themes",
+    "@storybook/addon-vitest",
+    "msw-storybook-addon",
+  ],
   framework: "@storybook/react-vite",
   viteFinal: async (viteConfig) =>
     mergeConfig(

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -30,6 +30,9 @@ const preview: Preview = {
     }),
   ],
   parameters: {
+    a11y: {
+      test: "error",
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/test": "^1.61.1",
         "@rolldown/plugin-babel": "^0.2.3",
+        "@storybook/addon-a11y": "^10.5.10",
         "@storybook/addon-docs": "^10.5.10",
         "@storybook/addon-themes": "^10.5.10",
         "@storybook/addon-vitest": "^10.5.10",
@@ -2162,22 +2163,34 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6417,9 +6430,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6435,9 +6445,6 @@
       "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6455,9 +6462,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6473,9 +6477,6 @@
       "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -6493,9 +6494,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6511,9 +6509,6 @@
       "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7136,6 +7131,24 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.10.tgz",
+      "integrity": "sha512-RpRQV5xUbrl6hCiNrd5FSMIo6pnRZ0VZxWvEW/ASLcreGkKUW5jl2AeLCe5YROE2i80s/dU+6VPzOYKrwWNFbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.10"
+      }
     },
     "node_modules/@storybook/addon-docs": {
       "version": "10.5.10",
@@ -9103,6 +9116,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -24453,9 +24476,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24475,9 +24495,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -24499,9 +24516,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24521,9 +24535,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/test": "^1.61.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@storybook/addon-a11y": "^10.5.10",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-themes": "^10.5.10",
     "@storybook/addon-vitest": "^10.5.10",

--- a/src/pages/deck-create/ui/DeckCreateView.tsx
+++ b/src/pages/deck-create/ui/DeckCreateView.tsx
@@ -31,6 +31,7 @@ export const DeckCreateView: React.FC<DeckCreateViewProps> = ({
   const idPrefix = useId();
   const nameInputId = `${idPrefix}-deck-name`;
   const nameErrorId = `${nameInputId}-error`;
+  const categoryInputId = `${idPrefix}-deck-category`;
 
   return (
     <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
@@ -66,8 +67,8 @@ export const DeckCreateView: React.FC<DeckCreateViewProps> = ({
               autoFocus
             />
           </FormItem>
-          <FormItem col label="Category">
-            <Select empty {...form.register("category")} options={categoryOptions} />
+          <FormItem col label="Category" inputId={categoryInputId}>
+            <Select id={categoryInputId} empty {...form.register("category")} options={categoryOptions} />
           </FormItem>
           <FormItem label="Local only" help="Keep this deck and its cards on this device.">
             <Switch {...form.register("localMode")} aria-label="Local only" disabled={isLocalModeLocked} />

--- a/src/pages/deck-form/ui/DeckForm.tsx
+++ b/src/pages/deck-form/ui/DeckForm.tsx
@@ -32,6 +32,7 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
   const importHeadingId = `${sectionHeadingIdPrefix}-deck-import-heading`;
   const nameInputId = `${sectionHeadingIdPrefix}-deck-name`;
   const nameErrorId = `${nameInputId}-error`;
+  const categoryInputId = `${sectionHeadingIdPrefix}-deck-category`;
   const urlInputId = `${sectionHeadingIdPrefix}-deck-url`;
   const urlErrorId = `${urlInputId}-error`;
   const localModeHelp = props.isLocalOnly
@@ -78,8 +79,8 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
             aria-describedby={formState.errors.name !== undefined ? nameErrorId : undefined}
           />
         </FormItem>
-        <FormItem col label="Category">
-          <Select empty {...props.form.register("category")} options={categoryOptions} />
+        <FormItem col label="Category" inputId={categoryInputId}>
+          <Select id={categoryInputId} empty {...props.form.register("category")} options={categoryOptions} />
         </FormItem>
       </section>
       <section

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -256,6 +256,8 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       ) : null}
       {showStudyChrome ? <SwipeFeedback swipeFeedback={props.swipeFeedback} /> : null}
       <div
+        // The answer surface owns vertical scrolling and must remain reachable when its content has no focusable elements.
+        tabIndex={props.showBackText ? 0 : undefined}
         className={cx(
           "relative min-h-0 flex-1",
           props.showBackText ? "overflow-y-auto pt-[env(safe-area-inset-top)]" : "overflow-hidden"

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -30,6 +30,14 @@ const studyLayoutStyles: StudyLayoutStyles = {
   "--study-feedback-top": "calc(var(--study-card-top) + 2.5rem)",
 };
 
+// The marker reserves Space for answer scrolling, while the named region makes the focus target discoverable.
+const answerSurfaceProps = {
+  role: "region",
+  "aria-label": "Card answer",
+  "data-study-answer-scroll": "",
+  tabIndex: 0,
+} as const;
+
 export interface StudySessionProps {
   showBackText?: boolean;
   showSwipeControls: boolean;
@@ -256,10 +264,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       ) : null}
       {showStudyChrome ? <SwipeFeedback swipeFeedback={props.swipeFeedback} /> : null}
       <div
-        // The marker lets Page shortcuts leave Space to this scrolling surface and its focusable descendants.
-        data-study-answer-scroll={props.showBackText ? "" : undefined}
-        // The answer surface must remain reachable when its content has no focusable elements.
-        tabIndex={props.showBackText ? 0 : undefined}
+        {...(props.showBackText ? answerSurfaceProps : {})}
         className={cx(
           "relative min-h-0 flex-1",
           props.showBackText ? "overflow-y-auto pt-[env(safe-area-inset-top)]" : "overflow-hidden"

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -256,7 +256,9 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       ) : null}
       {showStudyChrome ? <SwipeFeedback swipeFeedback={props.swipeFeedback} /> : null}
       <div
-        // The answer surface owns vertical scrolling and must remain reachable when its content has no focusable elements.
+        // The marker lets Page shortcuts leave Space to this scrolling surface and its focusable descendants.
+        data-study-answer-scroll={props.showBackText ? "" : undefined}
+        // The answer surface must remain reachable when its content has no focusable elements.
         tabIndex={props.showBackText ? 0 : undefined}
         className={cx(
           "relative min-h-0 flex-1",

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -147,9 +147,8 @@ describe("StudySessionPage", () => {
     const user = userEvent.setup();
     renderPage();
     await user.keyboard("{Enter}");
-    const answerSurface = screen.getByText("Back one").closest<HTMLElement>("[data-study-answer-scroll]");
-    expect(answerSurface).not.toBeNull();
-    answerSurface?.focus();
+    const answerSurface = screen.getByRole("region", { name: "Card answer" });
+    answerSurface.focus();
 
     await user.keyboard(" ");
     await user.keyboard("{Enter}");

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -143,6 +143,20 @@ describe("StudySessionPage", () => {
     expect(getStudySession(deckId)?.currentIndex).toBe(0);
   });
 
+  it("keeps Space native while the answer scrolling surface is focused", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.keyboard("{Enter}");
+    const answerSurface = screen.getByText("Back one").closest<HTMLElement>("[data-study-answer-scroll]");
+    expect(answerSurface).not.toBeNull();
+    answerSurface?.focus();
+
+    await user.keyboard(" ");
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("button", { name: "Play" })).toBeVisible();
+  });
+
   it("keeps the ArrowRight shortcut active while the front card is focused", async () => {
     const user = userEvent.setup();
     renderPage();

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -25,6 +25,7 @@ const studyShortcutTextEntryTarget =
 const studyShortcutButtonTarget =
   "a[href], button, summary, input[type='button'], input[type='submit'], input[type='reset'], input[type='checkbox'], input[type='radio'], [role='button'], [role='link'], [role='switch'], [role='checkbox'], [role='radio'], [role='tab']";
 const studyShortcutSliderTarget = "input[type='range'], [role='slider']";
+const studyShortcutAnswerScrollTarget = "[data-study-answer-scroll]";
 
 const shouldIgnoreStudyShortcut = (event: KeyboardEvent): boolean => {
   if (!(event.target instanceof Element)) return false;
@@ -34,6 +35,7 @@ const shouldIgnoreStudyShortcut = (event: KeyboardEvent): boolean => {
   if ((event.key === "Enter" || event.key === " ") && event.target.closest(studyShortcutButtonTarget) !== null) {
     return true;
   }
+  if (event.key === " " && event.target.closest(studyShortcutAnswerScrollTarget) !== null) return true;
   return event.key.startsWith("Arrow") && event.target.closest(studyShortcutSliderTarget) !== null;
 };
 

--- a/src/shared/ui/content/Code.scss
+++ b/src/shared/ui/content/Code.scss
@@ -8,6 +8,19 @@
 
 code[data-theme="light"] {
   @include meta.load-css("highlight.js/styles/github");
+
+  // GitHub's defaults miss WCAG AA against the app's muted code surface.
+  .hljs-built_in {
+    color: #b04700;
+  }
+
+  .hljs-comment {
+    color: #59636e;
+  }
+
+  .hljs-keyword {
+    color: #c02738;
+  }
 }
 code[data-theme="dark"] {
   @include meta.load-css("highlight.js/styles/atom-one-dark-reasonable");

--- a/src/shared/ui/content/Code.tsx
+++ b/src/shared/ui/content/Code.tsx
@@ -39,6 +39,8 @@ const Highlight: React.FC<{ category: string; dark: boolean; text: string }> = (
 
   return (
     <pre
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users must be able to reach horizontally scrolling code.
+      tabIndex={0}
       className={cx(
         "max-w-full overflow-x-auto rounded-control border border-border bg-surface-muted p-3 text-ink dark:bg-black",
         category

--- a/src/shared/ui/content/Math.tsx
+++ b/src/shared/ui/content/Math.tsx
@@ -7,12 +7,25 @@
 import "github-markdown-css/github-markdown.css";
 import "katex/dist/katex.min.css";
 import type * as React from "react";
-import Markdown from "react-markdown";
+import Markdown, { type Components } from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
 import { Style } from "./Style";
+
+const MarkdownLink: NonNullable<Components["a"]> = ({ node: _node, style, ...props }) => (
+  <a {...props} style={{ ...style, textDecoration: "underline" }} />
+);
+
+const MarkdownInput: NonNullable<Components["input"]> = ({ node: _node, ...props }) => (
+  <input {...props} aria-label={props["aria-label"] ?? (props.type === "checkbox" ? "Task status" : undefined)} />
+);
+
+const markdownComponents = {
+  a: MarkdownLink,
+  input: MarkdownInput,
+} satisfies Components;
 
 /**
  * Renders the Math Content user interface.
@@ -21,7 +34,7 @@ import { Style } from "./Style";
  */
 export const MathContent: React.FC<{ text: string }> = (props) => (
   <Style className="markdown-body max-w-full overflow-x-auto rounded-control bg-surface p-1 text-ink">
-    <Markdown remarkPlugins={[remarkMath, remarkGfm]} rehypePlugins={[rehypeKatex]}>
+    <Markdown components={markdownComponents} remarkPlugins={[remarkMath, remarkGfm]} rehypePlugins={[rehypeKatex]}>
       {props.text}
     </Markdown>
   </Style>

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.spec.tsx
@@ -34,18 +34,21 @@ describe("DestructiveActionDialog", () => {
     render(<DestructiveActionDialog {...defaultProps} onCancel={onCancel} />);
     const cancel = screen.getByRole("button", { name: "Cancel" });
     const confirm = screen.getByRole("button", { name: "Delete deck" });
+    const target = screen.getByText("Japanese verbs");
 
     expect(cancel).toHaveFocus();
     await userEvent.tab({ shift: true });
+    expect(target).toHaveFocus();
+    await userEvent.tab({ shift: true });
     expect(confirm).toHaveFocus();
     await userEvent.tab();
-    expect(cancel).toHaveFocus();
+    expect(target).toHaveFocus();
 
     fireEvent.keyDown(cancel, { key: "Escape" });
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
-  it("excludes disabled controls and includes explicit tab stops in the focus trap", () => {
+  it("excludes disabled controls and includes explicit tab stops in the focus trap", async () => {
     render(
       <DestructiveActionDialog
         {...defaultProps}
@@ -61,11 +64,17 @@ describe("DestructiveActionDialog", () => {
         }
       />
     );
+    const cancel = screen.getByRole("button", { name: "Cancel" });
     const detail = screen.getByText("Focusable detail");
     const confirm = screen.getByRole("button", { name: "Delete deck" });
-    detail.focus();
+    const target = screen.getByText("Japanese verbs");
 
-    expect(fireEvent.keyDown(detail, { key: "Tab", shiftKey: true })).toBe(false);
+    expect(cancel).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(detail).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(target).toHaveFocus();
+    await userEvent.tab({ shift: true });
     expect(confirm).toHaveFocus();
   });
 

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -107,7 +107,10 @@ export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (
           <span className="block text-caption font-bold uppercase tracking-wide text-ink-muted">
             {props.targetLabel}
           </span>
-          <span className="mt-1 block max-h-24 overflow-y-auto break-words font-semibold">{props.targetName}</span>
+          {/* biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users must be able to reach a long scrolling target name. */}
+          <span tabIndex={0} className="mt-1 block max-h-24 overflow-y-auto break-words font-semibold">
+            {props.targetName}
+          </span>
         </div>
         <div id={descriptionId} className="mt-4 space-y-2 text-body text-ink-muted">
           {props.description}

--- a/src/shared/ui/feedback/Overlay.tsx
+++ b/src/shared/ui/feedback/Overlay.tsx
@@ -26,6 +26,8 @@ export const Overlay: React.FC<{
   return (
     <div
       {...clickInteraction}
+      // Overlays own their overflow, so they must remain keyboard reachable even without a click action.
+      tabIndex={clickInteraction.tabIndex ?? 0}
       {...(props.onClick !== undefined && props.ariaLabel !== undefined ? { "aria-label": props.ariaLabel } : {})}
       className={cx(
         "absolute z-30 max-h-full max-w-full overflow-x-hidden overflow-y-auto rounded-control text-ink",

--- a/src/shared/ui/forms/Form.stories.tsx
+++ b/src/shared/ui/forms/Form.stories.tsx
@@ -8,14 +8,24 @@ import { Switch } from "./Switch";
 
 const reviewForm = () => (
   <Form div>
-    <FormItem col label="Deck name" help="Shown in your library and study history.">
-      <Input defaultValue="Japanese verbs" />
+    <FormItem col label="Deck name" inputId="storybook-form-name" help="Shown in your library and study history.">
+      <Input id="storybook-form-name" defaultValue="Japanese verbs" />
     </FormItem>
-    <FormItem label="Shuffle cards" extra="The existing extra copy uses the same supporting hierarchy.">
-      <Switch checked onChange={fn()} />
+    <FormItem
+      label="Shuffle cards"
+      inputId="storybook-form-shuffle"
+      extra="The existing extra copy uses the same supporting hierarchy."
+    >
+      <Switch id="storybook-form-shuffle" checked onChange={fn()} />
     </FormItem>
-    <FormItem col label="Daily review target" help="Choose a value between 1 and 100." error="Enter a whole number.">
-      <Input defaultValue="One hundred and twenty" />
+    <FormItem
+      col
+      label="Daily review target"
+      inputId="storybook-form-target"
+      help="Choose a value between 1 and 100."
+      error="Enter a whole number."
+    >
+      <Input id="storybook-form-target" defaultValue="One hundred and twenty" />
     </FormItem>
   </Form>
 );

--- a/src/shared/ui/forms/Form.stories.tsx
+++ b/src/shared/ui/forms/Form.stories.tsx
@@ -1,31 +1,31 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "storybook/test";
+import { expect, fn } from "storybook/test";
 
 import { Form } from "./Form";
 import { FormItem } from "./FormItem";
 import { Input } from "./Input";
 import { Switch } from "./Switch";
 
-const reviewForm = () => (
+const reviewForm = (idPrefix: string) => (
   <Form div>
-    <FormItem col label="Deck name" inputId="storybook-form-name" help="Shown in your library and study history.">
-      <Input id="storybook-form-name" defaultValue="Japanese verbs" />
+    <FormItem col label="Deck name" inputId={`${idPrefix}-name`} help="Shown in your library and study history.">
+      <Input id={`${idPrefix}-name`} defaultValue="Japanese verbs" />
     </FormItem>
     <FormItem
       label="Shuffle cards"
-      inputId="storybook-form-shuffle"
+      inputId={`${idPrefix}-shuffle`}
       extra="The existing extra copy uses the same supporting hierarchy."
     >
-      <Switch id="storybook-form-shuffle" checked onChange={fn()} />
+      <Switch id={`${idPrefix}-shuffle`} checked onChange={fn()} />
     </FormItem>
     <FormItem
       col
       label="Daily review target"
-      inputId="storybook-form-target"
+      inputId={`${idPrefix}-target`}
       help="Choose a value between 1 and 100."
       error="Enter a whole number."
     >
-      <Input id="storybook-form-target" defaultValue="One hundred and twenty" />
+      <Input id={`${idPrefix}-target`} defaultValue="One hundred and twenty" />
     </FormItem>
   </Form>
 );
@@ -40,19 +40,24 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => reviewForm(),
+  render: () => reviewForm("storybook-form-default"),
 };
 
 export const LightAndDark: Story = {
   render: () => (
     <div className="grid gap-6">
-      <div className="bg-canvas p-4 text-ink">{reviewForm()}</div>
-      <div className="dark bg-canvas p-4 text-ink">{reviewForm()}</div>
+      <div className="bg-canvas p-4 text-ink">{reviewForm("storybook-form-light")}</div>
+      <div className="dark bg-canvas p-4 text-ink">{reviewForm("storybook-form-dark")}</div>
     </div>
   ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getAllByRole("textbox", { name: "Deck name" })).toHaveLength(2);
+    await expect(canvas.getAllByRole("checkbox", { name: "Shuffle cards" })).toHaveLength(2);
+    await expect(canvas.getAllByRole("textbox", { name: "Daily review target" })).toHaveLength(2);
+  },
 };
 
 export const NarrowMobile: Story = {
-  render: () => reviewForm(),
+  render: () => reviewForm("storybook-form-mobile"),
   globals: { viewport: { value: "iphone5", isRotated: false } },
 };

--- a/src/shared/ui/forms/FormItem.stories.tsx
+++ b/src/shared/ui/forms/FormItem.stories.tsx
@@ -26,9 +26,11 @@ export const Default: Story = {};
 export const HelpAndError: Story = {
   args: {
     label: "Deck name",
+    inputId: "storybook-deck-name",
+    errorId: "storybook-deck-name-error",
     help: "Shown in your library and study history.",
     error: "A deck name is required.",
-    children: <Input defaultValue="" />,
+    children: <Input id="storybook-deck-name" aria-describedby="storybook-deck-name-error" defaultValue="" />,
     col: true,
   },
 };
@@ -42,13 +44,15 @@ export const LongLabelAndValue: Story = {
 
 export const ItemSwitch: Story = {
   args: {
-    children: <Switch />,
+    inputId: "storybook-item-switch",
+    children: <Switch id="storybook-item-switch" />,
   },
 };
 
 export const ItemSelect: Story = {
   args: {
-    children: <Select />,
+    inputId: "storybook-item-select",
+    children: <Select id="storybook-item-select" />,
   },
 };
 
@@ -60,13 +64,15 @@ export const ItemButton: Story = {
 
 export const ItemSlider: Story = {
   args: {
-    children: <Slider />,
+    inputId: "storybook-item-slider",
+    children: <Slider id="storybook-item-slider" />,
   },
 };
 
 export const ItemInput: Story = {
   args: {
-    children: <Input defaultValue="value" />,
+    inputId: "storybook-item-input",
+    children: <Input id="storybook-item-input" defaultValue="value" />,
   },
 };
 
@@ -91,8 +97,9 @@ export const NarrowMobile: Story = {
   args: {
     col: true,
     label: "A long mobile label that wraps before the control",
+    inputId: "storybook-mobile-input",
     help: "The item stacks at narrow widths.",
-    children: <Input defaultValue="Compact value" />,
+    children: <Input id="storybook-mobile-input" defaultValue="Compact value" />,
   },
   globals: { viewport: { value: "iphone5", isRotated: false } },
 };

--- a/src/shared/ui/forms/Input.stories.tsx
+++ b/src/shared/ui/forms/Input.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   component: Input,
   tags: ["autodocs"],
   args: {
+    "aria-label": "Text input",
     defaultValue: "this is a value",
   },
 } satisfies Meta<typeof Input>;
@@ -19,9 +20,9 @@ export const Default: Story = {};
 export const States: Story = {
   render: () => (
     <div className="grid gap-4">
-      <Input placeholder="Placeholder value" />
-      <Input defaultValue="Read-only value" readOnly />
-      <Input defaultValue="Disabled value" disabled />
+      <Input aria-label="Placeholder input" placeholder="Placeholder value" />
+      <Input aria-label="Read-only input" defaultValue="Read-only value" readOnly />
+      <Input aria-label="Disabled input" defaultValue="Disabled value" disabled />
     </div>
   ),
 };
@@ -41,10 +42,10 @@ export const LightAndDark: Story = {
   render: () => (
     <div className="grid gap-4">
       <div className="bg-canvas p-4 text-ink">
-        <Input defaultValue="Light surface" />
+        <Input aria-label="Light surface input" defaultValue="Light surface" />
       </div>
       <div className="dark bg-canvas p-4 text-ink">
-        <Input defaultValue="Dark surface" />
+        <Input aria-label="Dark surface input" defaultValue="Dark surface" />
       </div>
     </div>
   ),

--- a/src/shared/ui/forms/Select.stories.tsx
+++ b/src/shared/ui/forms/Select.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   component: Select,
   tags: ["autodocs"],
   args: {
+    "aria-label": "Option selector",
     options: fixture.form.options.default,
   },
 } satisfies Meta<typeof Select>;
@@ -29,9 +30,9 @@ export const Invalid: Story = {
 export const States: Story = {
   render: () => (
     <div className="grid gap-4">
-      <Select options={fixture.form.options.default} />
-      <Select options={fixture.form.options.default} empty />
-      <Select options={fixture.form.options.default} disabled />
+      <Select aria-label="Default selector" options={fixture.form.options.default} />
+      <Select aria-label="Empty selector" options={fixture.form.options.default} empty />
+      <Select aria-label="Disabled selector" options={fixture.form.options.default} disabled />
     </div>
   ),
 };
@@ -52,10 +53,10 @@ export const LightAndDark: Story = {
   render: () => (
     <div className="grid gap-4">
       <div className="bg-canvas p-4 text-ink">
-        <Select options={fixture.form.options.default} />
+        <Select aria-label="Light surface selector" options={fixture.form.options.default} />
       </div>
       <div className="dark bg-canvas p-4 text-ink">
-        <Select options={fixture.form.options.default} />
+        <Select aria-label="Dark surface selector" options={fixture.form.options.default} />
       </div>
     </div>
   ),

--- a/src/shared/ui/forms/Slider.stories.tsx
+++ b/src/shared/ui/forms/Slider.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   title: "Shared/Forms/Slider",
   component: Slider,
   tags: ["autodocs"],
-  args: { onChange: fn() },
+  args: { "aria-label": "Slider", onChange: fn() },
 } satisfies Meta<typeof Slider>;
 
 export default meta;

--- a/src/shared/ui/forms/Switch.stories.tsx
+++ b/src/shared/ui/forms/Switch.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
   title: "Shared/Forms/Switch",
   component: Switch,
   tags: ["autodocs"],
-  args: { onChange: fn() },
+  args: { "aria-label": "Switch", onChange: fn() },
 } satisfies Meta<typeof Switch>;
 
 export default meta;

--- a/src/shared/ui/forms/Textarea.stories.tsx
+++ b/src/shared/ui/forms/Textarea.stories.tsx
@@ -6,7 +6,7 @@ const meta = {
   title: "Shared/Forms/Textarea",
   component: Textarea,
   tags: ["autodocs"],
-  args: { rows: 4 },
+  args: { "aria-label": "Text area", rows: 4 },
 } satisfies Meta<typeof Textarea>;
 
 export default meta;
@@ -21,9 +21,9 @@ export const Invalid: Story = {
 export const States: Story = {
   render: () => (
     <div className="grid gap-4">
-      <Textarea rows={3} placeholder="Placeholder content" />
-      <Textarea rows={3} defaultValue="Read-only content" readOnly />
-      <Textarea rows={3} defaultValue="Disabled content" disabled />
+      <Textarea aria-label="Placeholder text area" rows={3} placeholder="Placeholder content" />
+      <Textarea aria-label="Read-only text area" rows={3} defaultValue="Read-only content" readOnly />
+      <Textarea aria-label="Disabled text area" rows={3} defaultValue="Disabled content" disabled />
     </div>
   ),
 };
@@ -39,10 +39,10 @@ export const LightAndDark: Story = {
   render: () => (
     <div className="grid gap-4">
       <div className="bg-canvas p-4 text-ink">
-        <Textarea rows={3} defaultValue="Light surface" />
+        <Textarea aria-label="Light surface text area" rows={3} defaultValue="Light surface" />
       </div>
       <div className="dark bg-canvas p-4 text-ink">
-        <Textarea rows={3} defaultValue="Dark surface" />
+        <Textarea aria-label="Dark surface text area" rows={3} defaultValue="Dark surface" />
       </div>
     </div>
   ),

--- a/src/shared/ui/full-screen/FullScreen.tsx
+++ b/src/shared/ui/full-screen/FullScreen.tsx
@@ -26,6 +26,8 @@ export const FullScreen: React.FC<{
   return (
     <div
       {...clickInteraction}
+      // A scrolling full-screen surface must remain keyboard reachable when it has no focusable children.
+      tabIndex={props.scroll ? 0 : clickInteraction.tabIndex}
       className={cx([
         "bg-canvas",
         "text-ink",

--- a/src/shared/ui/outer/Outer.tsx
+++ b/src/shared/ui/outer/Outer.tsx
@@ -15,6 +15,8 @@ import type * as React from "react";
 export const Outer: React.FC<{ children?: React.ReactNode; className?: string }> = (props) => (
   <section
     aria-label="Application shell"
+    // biome-ignore lint/a11y/noNoninteractiveTabindex: The application shell owns viewport scrolling and must be keyboard reachable.
+    tabIndex={0}
     className={cx(
       "bg-canvas",
       "text-ink",


### PR DESCRIPTION
## Related issue

Fixes #340

## Summary

- add `@storybook/addon-a11y` 10.5.10 and register it in the existing Storybook setup
- enforce project-wide `a11y.test: "error"` checks through the existing Vitest browser project
- resolve current accessible-name, keyboard-scroll, link-identification, and syntax-highlight contrast violations without blanket exceptions

## Testing

- `npm run build:storybook`
- `npm run test:storybook` (57 files, 350 tests)
- `mise run check` (106 unit files, 548 tests, lint, FSD, and E2E contract)
- temporary negative control: removed an Input story accessible name, confirmed the Storybook test exited non-zero with axe `label` violations, then restored it and confirmed the targeted story passed