### PR TITLE
[No issue] Improve study session action overlay

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -68,6 +68,7 @@ describe("StudySession", () => {
     expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study actions" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Swipe controls" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Playback controls" })).not.toBeInTheDocument();
@@ -75,7 +76,7 @@ describe("StudySession", () => {
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
-  it("reports toolbar actions through accessible controls", () => {
+  it("opens the study actions overlay and reports its controls", () => {
     const onBack = vi.fn();
     const onToggleSwipeControls = vi.fn();
     const onTogglePlaybackControls = vi.fn();
@@ -90,15 +91,27 @@ describe("StudySession", () => {
       />
     );
 
+    const openActions = screen.getByRole("button", { name: "Open study actions" });
+    expect(openActions).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
+
+    fireEvent.click(openActions);
+
+    const closeActions = screen.getByRole("button", { name: "Close study actions" });
     const back = screen.getByRole("button", { name: "Back to deck list" });
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
+    const detailsToggle = screen.getByRole("button", { name: "Card details" });
     const actions = screen.getByRole("group", { name: "Study actions" });
+    expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
     expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
+    expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
+    expect(detailsToggle).toHaveAttribute("title", "Hide card details");
     expect(actions).toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
@@ -109,6 +122,34 @@ describe("StudySession", () => {
     expect(onBack).toHaveBeenCalledOnce();
     expect(onToggleSwipeControls).toHaveBeenCalledOnce();
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
+
+    fireEvent.keyDown(closeActions, { key: "Escape" });
+    expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
+    expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+  });
+
+  it("shows and hides all card details with one overlay control", () => {
+    render(
+      <StudySession
+        {...toolbarProps()}
+        cardOverlaySlot={<div>Score, seen count, and last seen</div>}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+
+    expect(screen.getByText("Score, seen count, and last seen")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
+
+    const detailsToggle = screen.getByRole("button", { name: "Card details" });
+    fireEvent.click(detailsToggle);
+    expect(detailsToggle).toHaveAttribute("aria-pressed", "false");
+    expect(detailsToggle).toHaveAttribute("title", "Show card details");
+    expect(screen.queryByText("Score, seen count, and last seen")).not.toBeInTheDocument();
+
+    fireEvent.click(detailsToggle);
+    expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
+    expect(detailsToggle).toHaveAttribute("title", "Hide card details");
+    expect(screen.getByText("Score, seen count, and last seen")).toBeVisible();
   });
 
   it("describes hidden controls and keeps the unavailable playback toggle disabled", () => {
@@ -123,6 +164,8 @@ describe("StudySession", () => {
         frontTextSlot={<div>Front</div>}
       />
     );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
 
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     expect(swipeToggle).toHaveAttribute("aria-pressed", "false");

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -1,6 +1,13 @@
 import cx from "classnames";
 import * as React from "react";
-import { AiOutlineLeft, AiOutlinePlayCircle } from "react-icons/ai";
+import {
+  AiOutlineClose,
+  AiOutlineEllipsis,
+  AiOutlineEye,
+  AiOutlineEyeInvisible,
+  AiOutlineLeft,
+  AiOutlinePlayCircle,
+} from "react-icons/ai";
 import { MdSwipe } from "react-icons/md";
 import { useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
@@ -54,73 +61,155 @@ export interface StudySessionProps {
 const toolbarButtonClass =
   "pointer-events-auto inline-flex size-touch shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
-const StudyToolbar: React.FC<{
+interface StudyModeActionsProps {
+  showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
-  onBack: () => void;
+  playbackDescriptionId: string;
+  onEscape: React.KeyboardEventHandler<HTMLButtonElement>;
+  onToggleCardDetails: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
-}> = (props) => {
-  const playbackDescriptionId = React.useId();
+}
+
+const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
   const swipeTitle = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
   const playbackTitle = props.playbackControlsAvailable
     ? props.showPlaybackControls
       ? "Hide playback controls"
       : "Show playback controls"
     : PLAYBACK_UNAVAILABLE_DESCRIPTION;
+  const cardDetailsTitle = props.showCardDetails ? "Hide card details" : "Show card details";
 
   return (
-    <fieldset
-      aria-label="Study actions"
-      className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 m-0 flex min-w-0 items-center justify-between border-0 p-0 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]"
-    >
+    <div className="flex items-center gap-1">
       <button
         type="button"
-        aria-label="Back to deck list"
+        aria-label="Swipe controls"
+        aria-pressed={props.showSwipeControls}
+        title={swipeTitle}
+        className={cx(toolbarButtonClass, props.showSwipeControls && "bg-surface-muted text-accent-primary")}
+        onClick={props.onToggleSwipeControls}
+        onKeyDown={props.onEscape}
+      >
+        <MdSwipe aria-hidden="true" className="text-xl" />
+      </button>
+      <button
+        type="button"
+        aria-label="Playback controls"
+        aria-pressed={props.showPlaybackControls}
+        aria-disabled={!props.playbackControlsAvailable}
+        aria-describedby={!props.playbackControlsAvailable ? props.playbackDescriptionId : undefined}
+        title={playbackTitle}
         className={cx(
           toolbarButtonClass,
-          "border border-border bg-surface-elevated/90 shadow-elevated backdrop-blur-md"
+          props.showPlaybackControls && "bg-surface-muted text-accent-primary",
+          !props.playbackControlsAvailable && "cursor-not-allowed opacity-50"
         )}
-        onClick={props.onBack}
+        onClick={props.playbackControlsAvailable ? props.onTogglePlaybackControls : undefined}
+        onKeyDown={props.onEscape}
       >
-        <AiOutlineLeft aria-hidden="true" className="text-xl" />
+        <AiOutlinePlayCircle aria-hidden="true" className="text-xl" />
       </button>
-      <div className="pointer-events-auto flex items-center rounded-pill border border-border bg-surface-elevated/90 p-0.5 shadow-elevated backdrop-blur-md">
-        <button
-          type="button"
-          aria-label="Swipe controls"
-          aria-pressed={props.showSwipeControls}
-          title={swipeTitle}
-          className={cx(toolbarButtonClass, props.showSwipeControls && "bg-surface-muted text-accent-primary")}
-          onClick={props.onToggleSwipeControls}
+      <button
+        type="button"
+        aria-label="Card details"
+        aria-pressed={props.showCardDetails}
+        title={cardDetailsTitle}
+        className={cx(toolbarButtonClass, props.showCardDetails && "bg-surface-muted text-accent-primary")}
+        onClick={props.onToggleCardDetails}
+        onKeyDown={props.onEscape}
+      >
+        {props.showCardDetails ? (
+          <AiOutlineEye aria-hidden="true" className="text-xl" />
+        ) : (
+          <AiOutlineEyeInvisible aria-hidden="true" className="text-xl" />
+        )}
+      </button>
+    </div>
+  );
+};
+
+const StudyToolbar: React.FC<{
+  open: boolean;
+  showCardDetails: boolean;
+  showSwipeControls: boolean;
+  showPlaybackControls: boolean;
+  playbackControlsAvailable: boolean;
+  onToggleOpen: () => void;
+  onToggleCardDetails: () => void;
+  onBack: () => void;
+  onToggleSwipeControls: () => void;
+  onTogglePlaybackControls: () => void;
+}> = (props) => {
+  const actionsId = React.useId();
+  const playbackDescriptionId = React.useId();
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  const closeOnEscape: React.KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    if (event.key !== "Escape" || !props.open) return;
+    event.preventDefault();
+    props.onToggleOpen();
+    triggerRef.current?.focus();
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 h-touch">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={props.open ? "Close study actions" : "Open study actions"}
+        aria-expanded={props.open}
+        aria-controls={actionsId}
+        className={cx(
+          toolbarButtonClass,
+          "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))] top-0"
+        )}
+        onClick={props.onToggleOpen}
+        onKeyDown={closeOnEscape}
+      >
+        {props.open ? (
+          <AiOutlineClose aria-hidden="true" className="text-xl" />
+        ) : (
+          <AiOutlineEllipsis aria-hidden="true" className="text-xl" />
+        )}
+      </button>
+      {props.open ? (
+        // The overlay stays out of document flow so opening it cannot move the centered prompt.
+        <fieldset
+          id={actionsId}
+          aria-label="Study actions"
+          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-between border-0 p-0 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)]"
         >
-          <MdSwipe aria-hidden="true" className="text-xl" />
-        </button>
-        <span aria-hidden="true" className="h-6 w-px bg-border" />
-        <button
-          type="button"
-          aria-label="Playback controls"
-          aria-pressed={props.showPlaybackControls}
-          aria-disabled={!props.playbackControlsAvailable}
-          aria-describedby={!props.playbackControlsAvailable ? playbackDescriptionId : undefined}
-          title={playbackTitle}
-          className={cx(
-            toolbarButtonClass,
-            props.showPlaybackControls && "bg-surface-muted text-accent-primary",
-            !props.playbackControlsAvailable && "cursor-not-allowed opacity-50"
-          )}
-          onClick={props.playbackControlsAvailable ? props.onTogglePlaybackControls : undefined}
-        >
-          <AiOutlinePlayCircle aria-hidden="true" className="text-xl" />
-        </button>
-        {!props.playbackControlsAvailable ? (
-          <span id={playbackDescriptionId} className="sr-only">
-            {PLAYBACK_UNAVAILABLE_DESCRIPTION}
-          </span>
-        ) : null}
-      </div>
-    </fieldset>
+          <button
+            type="button"
+            aria-label="Back to deck list"
+            className={toolbarButtonClass}
+            onClick={props.onBack}
+            onKeyDown={closeOnEscape}
+          >
+            <AiOutlineLeft aria-hidden="true" className="text-xl" />
+          </button>
+          <StudyModeActions
+            showCardDetails={props.showCardDetails}
+            showSwipeControls={props.showSwipeControls}
+            showPlaybackControls={props.showPlaybackControls}
+            playbackControlsAvailable={props.playbackControlsAvailable}
+            playbackDescriptionId={playbackDescriptionId}
+            onEscape={closeOnEscape}
+            onToggleCardDetails={props.onToggleCardDetails}
+            onToggleSwipeControls={props.onToggleSwipeControls}
+            onTogglePlaybackControls={props.onTogglePlaybackControls}
+          />
+        </fieldset>
+      ) : null}
+      {!props.playbackControlsAvailable ? (
+        <span id={playbackDescriptionId} className="sr-only">
+          {PLAYBACK_UNAVAILABLE_DESCRIPTION}
+        </span>
+      ) : null}
+    </div>
   );
 };
 
@@ -188,6 +277,8 @@ const Controls: React.FC<{
 };
 
 export const StudySession: React.FC<StudySessionProps> = (props) => {
+  const [studyActionsOpen, setStudyActionsOpen] = React.useState(false);
+  const [showCardDetails, setShowCardDetails] = React.useState(true);
   const suppressCardClick = React.useRef(false);
   const suppressCardClickTimer = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -246,9 +337,13 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       {showStudyChrome ? props.feedbackSlot : null}
       {showStudyChrome ? (
         <StudyToolbar
+          open={studyActionsOpen}
+          showCardDetails={showCardDetails}
           showSwipeControls={props.showSwipeControls}
           showPlaybackControls={props.showPlaybackControls}
           playbackControlsAvailable={props.playbackControlsAvailable}
+          onToggleOpen={() => setStudyActionsOpen((open) => !open)}
+          onToggleCardDetails={() => setShowCardDetails((visible) => !visible)}
           onBack={props.onBack}
           onToggleSwipeControls={props.onToggleSwipeControls}
           onTogglePlaybackControls={props.onTogglePlaybackControls}
@@ -266,7 +361,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
           showBackText={props.showBackText}
           backTextSlot={props.backTextSlot}
           frontTextSlot={props.frontTextSlot}
-          cardOverlaySlot={props.cardOverlaySlot}
+          cardOverlaySlot={showCardDetails ? props.cardOverlaySlot : undefined}
         />
       </div>
       <Controls

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -78,6 +78,10 @@ describe("StudySessionPage", () => {
         </Routes>
       </MemoryRouter>
     );
+  const openStudyActions = () => {
+    fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
+    return screen.getByRole("group", { name: "Study actions" });
+  };
 
   beforeEach(async () => {
     clearStudySessions();
@@ -100,8 +104,9 @@ describe("StudySessionPage", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-    expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open study actions" })).toBeVisible();
+    expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
     expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });
@@ -159,6 +164,7 @@ describe("StudySessionPage", () => {
   it("returns from a deep-linked Study to the Deck list without changing the resumable session", () => {
     renderPage();
     const sessionBeforeExit = getStudySession(deckId);
+    openStudyActions();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
 
@@ -171,9 +177,10 @@ describe("StudySessionPage", () => {
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
 
     renderPage();
+    const actions = openStudyActions();
 
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
-    expect(screen.getByRole("group", { name: "Study actions" })).toBeVisible();
+    expect(actions).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
     expect(screen.getByLabelText("Score 2, positive")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
@@ -181,6 +188,7 @@ describe("StudySessionPage", () => {
 
   it("delegates visibility toggles to persisted preference actions", () => {
     renderPage();
+    openStudyActions();
 
     fireEvent.click(screen.getByRole("button", { name: "Swipe controls" }));
     fireEvent.click(screen.getByRole("button", { name: "Playback controls" }));
@@ -197,6 +205,7 @@ describe("StudySessionPage", () => {
   ] as const)("uses %s visibility with %s without running a Study shortcut", async (control, label, key) => {
     const user = userEvent.setup();
     renderPage();
+    openStudyActions();
 
     screen.getByRole("button", { name: label }).focus();
     await user.keyboard(key);
@@ -210,6 +219,7 @@ describe("StudySessionPage", () => {
   it("keeps the swipe visibility shortcut active while a toolbar button is focused", async () => {
     const user = userEvent.setup();
     renderPage();
+    openStudyActions();
 
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     swipeToggle.focus();
@@ -247,6 +257,7 @@ describe("StudySessionPage", () => {
     });
 
     renderPage();
+    openStudyActions();
 
     expect(screen.getByRole("button", { name: "Swipe controls" })).not.toBePressed();
     expect(screen.getByRole("button", { name: "Playback controls" })).not.toBePressed();
@@ -258,6 +269,7 @@ describe("StudySessionPage", () => {
     mocks.preferences = createPreferences({ cardInterval: 0 });
 
     renderPage();
+    openStudyActions();
 
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     expect(playbackToggle).toHaveAttribute("aria-disabled", "true");


### PR DESCRIPTION
## Related issue

None

## Summary

- Replace the persistent study toolbar with an ellipsis-triggered overlay that switches to a close icon while open.
- Keep Back isolated on the left and group Swipe, Playback, and Card details on the right without an outlined overlay container.
- Toggle score, seen count, and last-seen metadata together from one Card details control.
- Update component and page behavior tests for the new interaction.

## Testing

- mise run check