### PR TITLE
[No issue] Add Japanese architecture decision records

### DIFF
--- a/docs/adr/20260715-adopt-biome.md
+++ b/docs/adr/20260715-adopt-biome.md
@@ -1,11 +1,13 @@
-# Adopt Biome
+# Biomeを採用する
 
-Status: Accepted
+Status: Superseded
 
 ## Context
 
-ESLint and Prettier require separate dependencies and configuration. Biome combines formatting and linting, reduces dependencies, is written in Rust, and is fast and widely adopted.
+ESLintとPrettierは、依存関係と設定を別々に管理する必要がある。Biomeはformatとlintを1つにまとめ、依存関係を減らせる。また、Rustで実装されており高速で、広く採用されている。
 
 ## Decision
 
-Replace ESLint and Prettier with Biome. See [PR #223](https://github.com/her0e1c1/tango/pull/223).
+ESLintとPrettierをBiomeに置き換える。[PR #223](https://github.com/her0e1c1/tango/pull/223)を参照する。
+
+この決定は、[静的解析の責務をツールごとに分担する](./20260830-divide-static-analysis-responsibilities.md)により置き換えられた。

--- a/docs/adr/20260716-use-tanstack-query-for-server-state.md
+++ b/docs/adr/20260716-use-tanstack-query-for-server-state.md
@@ -1,19 +1,13 @@
-# Use TanStack Query for Server State
+# サーバー状態にTanStack Queryを使用する
 
 Status: Superseded
 
 ## Context
 
-TanStack Query manages server state, so Redux selectors for Deck and Card data duplicate that responsibility.
+TanStack Queryはサーバー状態を管理するため、DeckとCardのデータにRedux selectorを併用すると責務が重複する。
 
 ## Decision
 
-Use TanStack Query for server state, access the remaining local Redux state directly, and remove `src/selector`. See [PR #278](https://github.com/her0e1c1/tango/pull/278).
+サーバー状態にはTanStack Queryを使用し、残るローカルRedux状態へは直接アクセスする。`src/selector`は削除する。[PR #278](https://github.com/her0e1c1/tango/pull/278)を参照する。
 
-This decision is superseded. Firestore subscriptions now feed an application-owned read model in
-`src/store/remoteStore.ts`. The latest metadata for each collection remains private, but the Store
-replaces it in the same atomic internal snapshot update as normalized Deck and Card data and the
-public read and sync status. React consumes the stable public state from that snapshot directly.
-Remote mutations follow one-way data flow: write through the Firestore adapter, let Firestore notify
-the `onSnapshot` listener, then let the read controller call `remoteStore.applySnapshot`. Entity
-results enter the Store only through that listener path; there is no optimistic mutation exception.
+この決定は、[Firestoreの購読をリモート状態の正とする](./20260830-use-firestore-subscriptions-as-remote-state-source.md)により置き換えられた。

--- a/docs/adr/20260718-separate-application-and-feature-stores.md
+++ b/docs/adr/20260718-separate-application-and-feature-stores.md
@@ -1,11 +1,13 @@
-# Separate Application and Feature Stores
+# アプリケーション状態とFeature状態のStoreを分ける
 
-Status: Accepted
+Status: Superseded
 
 ## Context
 
-The persisted configuration is consumed by `App` and multiple features. Keeping it under the settings feature makes application-wide consumers depend on a feature implementation.
+永続化された設定は`App`と複数のFeatureから使用される。設定Featureの配下に置くと、アプリケーション全体の利用側がFeature実装へ依存する。
 
 ## Decision
 
-Place application-wide stores in `src/store` and their shared hooks in `src/hooks`. Keep feature-specific stores, such as the study store, within their owning feature even when they are singletons. See [PR #312](https://github.com/her0e1c1/tango/pull/312).
+アプリケーション全体で使用するStoreは`src/store`、共有hookは`src/hooks`に置く。study StoreのようなFeature固有のStoreは、singletonであっても所有するFeature内に置く。[PR #312](https://github.com/her0e1c1/tango/pull/312)を参照する。
+
+この決定は、[Page-first FSDの責務境界を採用する](./20260830-adopt-page-first-fsd-boundaries.md)により置き換えられた。

--- a/docs/adr/20260830-adopt-page-first-fsd-boundaries.md
+++ b/docs/adr/20260830-adopt-page-first-fsd-boundaries.md
@@ -1,0 +1,17 @@
+# Page-first FSDの責務境界を採用する
+
+Status: Accepted
+
+## Context
+
+画面固有の表示コンポーネントを置くためだけにFeature sliceを作ると、Featureが独立したユーザー機能ではなく、技術的な置き場になる。その結果、Page、Feature、Entityの所有責務が曖昧になり、再利用されないsliceや迂回した依存が増える。
+
+## Decision
+
+FSD v2.1のPage-first方針を採用し、画面固有の表示、状態接続、ワークフロー、構成は、その画面を所有するPage sliceに置く。
+
+複数のPageから再利用される独立したユーザーワークフローだけをFeaturesに置く。再利用可能なドメイン状態とルールはEntities、広く再利用する技術・UI primitiveはShared、アプリケーションの起動とlifecycleの調停はAppに置く。
+
+Page UIでアプリケーション、Feature、Entityの状態へ接続できる境界は`*Page`と`*Container`に限定し、それ以外のUIコンポーネントはprops-drivenとする。
+
+FSDの依存方向はSteigerの推奨ルールで検証する。[PR #1199](https://github.com/her0e1c1/tango/pull/1199)と[PR #1200](https://github.com/her0e1c1/tango/pull/1200)を参照する。

--- a/docs/adr/20260830-divide-static-analysis-responsibilities.md
+++ b/docs/adr/20260830-divide-static-analysis-responsibilities.md
@@ -1,0 +1,21 @@
+# 静的解析の責務をツールごとに分担する
+
+Status: Accepted
+
+## Context
+
+format、一般的なlint、型情報を使う規則、React Compilerの方針、FSD境界、型検査、未使用コード検出を、1つのツールだけで同じ品質で扱うことはできない。一方、同じ検査を複数のツールで重複させると、設定と保守の負担が増える。
+
+## Decision
+
+検査の種類ごとに主担当を1つ定める。
+
+- Biomeはformatと一般的な構文・styleの検査を担当する。
+- ESLintは型情報を使うTypeScript規則、React HooksとReact Compilerの方針、テスト固有の規則、およびプロジェクト固有のUI境界を担当する。
+- SteigerはFSDのarchitecture constraintを担当する。
+- TypeScriptはcompileと型検査を担当する。
+- Knipは未使用のfile、export、dependencyの検出を担当する。
+
+React Compilerはapplication buildで有効にする。通常のmemoizationを目的とした`useMemo`と`useCallback`は追加せず、明示的に方針を変更しない限りCompilerへ委ねる。
+
+[PR #424](https://github.com/her0e1c1/tango/pull/424)、[PR #1200](https://github.com/her0e1c1/tango/pull/1200)、[PR #1240](https://github.com/her0e1c1/tango/pull/1240)を参照する。

--- a/docs/adr/20260830-use-firestore-subscriptions-as-remote-state-source.md
+++ b/docs/adr/20260830-use-firestore-subscriptions-as-remote-state-source.md
@@ -1,0 +1,17 @@
+# Firestoreの購読をリモート状態の正とする
+
+Status: Accepted
+
+## Context
+
+リモートEntityの状態を、query cache、mutation完了時のStore更新、Firestore listenerなど複数の経路から更新すると、状態の反映順序と同期元が分かれ、同じデータが食い違う可能性がある。
+
+## Decision
+
+Firestoreの`onSnapshot`から受け取るsnapshotを、リモートEntity状態の正とする。
+
+SharedはFirebaseの汎用初期化を所有する。対象Entityは、自身に関係するFirestore schema、parse、CRUD、query、subscription adapter、およびリモートEntity Storeを所有する。Appは、認証状態に応じてsubscriptionを開始・停止するlifecycleを所有する。
+
+リモートmutationはEntityのFirestore API経由で書き込む。リモートEntity Storeをoptimistic updateまたはmutation完了時に直接更新せず、Firestore subscriptionのsnapshotによって更新する。
+
+この一方向のdata flowに例外を設ける場合は、別のarchitecture decisionとして記録する。[PR #1200](https://github.com/her0e1c1/tango/pull/1200)を参照する。


### PR DESCRIPTION
## Related issue

None

## Summary

- add Japanese ADRs for Page-first FSD boundaries, Firestore subscription-driven remote state, and static-analysis ownership
- mark the former Biome-only and `src/store` placement decisions as superseded
- replace the stale TanStack Query follow-up text with a link to the current Firestore state-flow decision
- translate every ADR modified by this change into Japanese

## Testing

- documentation-only change
- reviewed the complete diff for ADR status values, replacement links, and referenced pull requests