### PR TITLE
refactor(#1250): Centralize Deck ownership boundary

### DIFF
--- a/src/entities/deck/api/document.spec.ts
+++ b/src/entities/deck/api/document.spec.ts
@@ -39,11 +39,11 @@ describe("Deck Firestore document mapping", () => {
   });
 
   it("maps a remote create command to the Firestore boundary", () => {
-    const deck = createDeck({ id: "deck", uid: "owner" });
+    const { uid: _uid, createdAt: _createdAt, updatedAt: _updatedAt, ...deck } = createDeck({ id: "deck" });
 
-    expect(toDeckDocument(deck, 10)).toEqual({
+    expect(toDeckDocument("actor", deck, 10)).toEqual({
       id: "deck",
-      uid: "owner",
+      uid: "actor",
       name: "Deck",
       isPublic: false,
       scoreMax: null,

--- a/src/entities/deck/api/document.ts
+++ b/src/entities/deck/api/document.ts
@@ -48,10 +48,14 @@ export const toDeck = (id: DeckId, document: DeckDocument): Extract<Deck, { loca
   updatedAt: document.updatedAt,
 });
 
-// Converts a validated create input to the Firestore representation and adds server-owned timestamps.
-export const toDeckDocument = (deck: z.infer<typeof deckCreateSchema>, timestamp: number): DeckDocument => ({
+// Adds the authenticated actor as physical owner only when crossing the Firestore persistence boundary.
+export const toDeckDocument = (
+  uid: string,
+  deck: z.infer<typeof deckCreateSchema>,
+  timestamp: number
+): DeckDocument => ({
   id: deck.id,
-  uid: deck.uid,
+  uid,
   name: deck.name,
   ...(deck.url === undefined ? {} : { url: deck.url }),
   isPublic: deck.isPublic,

--- a/src/entities/deck/api/firestore.spec.ts
+++ b/src/entities/deck/api/firestore.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createDeck as createDeckFixture } from "@/test/factories";
+import { createDeck as createDeckFixture, createRemoteDeckInput } from "@/test/factories";
 
 vi.mock("@/shared/firebase", () => ({ db: {} }));
 
@@ -9,9 +9,8 @@ import { createDeck, deleteDeck, editDeck } from "./firestore";
 describe("Deck Firestore persistence", () => {
   const deck = createDeckFixture({ id: "deck", uid: "uid-a" });
 
-  it("rejects create requests without a confirmed matching owner", async () => {
-    await expect(createDeck("", deck)).rejects.toThrow("confirmed user");
-    await expect(createDeck("uid-b", deck)).rejects.toThrow("owner does not match");
+  it("rejects create requests without a confirmed actor", async () => {
+    await expect(createDeck("", createRemoteDeckInput({ id: deck.id }))).rejects.toThrow("confirmed user");
   });
 
   it("rejects edit requests without a confirmed user", async () => {

--- a/src/entities/deck/api/firestore.ts
+++ b/src/entities/deck/api/firestore.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { DeckCreateInput, DeckId } from "../model/types";
+import type { DeckId, RemoteDeckCreateInput } from "../model/types";
 
 import {
   collection,
@@ -55,16 +55,16 @@ export const subscribeDecks = (uid: string, onError: (error: Error) => void): ((
   );
 
 // Writes a new Deck document with synchronized creation and update timestamps.
-const createDeckDocument = async (deck: z.infer<typeof createDeckSchema>["deck"]): Promise<void> => {
+const createDeckDocument = async (uid: string, deck: z.infer<typeof createDeckSchema>["deck"]): Promise<void> => {
   const createdAt = getCurrentTimeMillis();
-  const document = toDeckDocument(deck, createdAt);
+  const document = toDeckDocument(uid, deck, createdAt);
   await setDoc(doc(db, DECK_COLLECTION, deck.id), document);
 };
 
-// Validates Deck ownership before creating its Firestore document.
-export const createDeck = async (uid: string, deck: DeckCreateInput): Promise<void> => {
+// Validates the actor and owner-free command before creating an actor-owned Firestore document.
+export const createDeck = async (uid: string, deck: RemoteDeckCreateInput): Promise<void> => {
   const input = createDeckSchema.parse({ uid, deck });
-  await createDeckDocument(input.deck);
+  await createDeckDocument(input.uid, input.deck);
 };
 
 // Writes editable Deck fields and advances the update timestamp.

--- a/src/entities/deck/api/mutations.spec.ts
+++ b/src/entities/deck/api/mutations.spec.ts
@@ -45,6 +45,29 @@ describe("Deck mutations", () => {
     deckStore.setState({ remoteDecks: [deck] });
 
     await expect(deleteDeck("other-user", deck.id)).rejects.toThrow("owner does not match");
+    expect(mocks.deleteRemoteDeck).not.toHaveBeenCalled();
+  });
+
+  it("rejects remote edits before writing when the authenticated user does not own the Deck", async () => {
+    const deck = createDeckFixture({ id: "remote", uid: "owner" });
+    deckStore.setState({ remoteDecks: [deck] });
+
+    await expect(editDeck("other-user", { id: deck.id, name: "Renamed" })).rejects.toThrow("owner does not match");
+    expect(mocks.editRemoteDeck).not.toHaveBeenCalled();
+  });
+
+  it("routes matching-owner edits and deletes to remote persistence", async () => {
+    const deck = createDeckFixture({ id: "remote", uid: "owner" });
+    deckStore.setState({ remoteDecks: [deck] });
+
+    await editDeck("owner", { id: deck.id, name: "Renamed" });
+    await deleteDeck("owner", deck.id);
+
+    expect(mocks.editRemoteDeck).toHaveBeenCalledExactlyOnceWith("owner", {
+      id: deck.id,
+      name: "Renamed",
+    });
+    expect(mocks.deleteRemoteDeck).toHaveBeenCalledExactlyOnceWith("owner", deck.id);
   });
 
   it("moves a local Deck and its Cards to remote persistence when local mode is disabled", async () => {
@@ -55,9 +78,10 @@ describe("Deck mutations", () => {
 
     expect(mocks.createRemoteDeck).toHaveBeenCalledExactlyOnceWith(
       "uid",
-      expect.objectContaining({ id: deck.id, uid: "uid", name: "Synced Deck", localMode: false })
+      expect.objectContaining({ id: deck.id, name: "Synced Deck", localMode: false })
     );
     const remoteInput = mocks.createRemoteDeck.mock.calls[0]?.[1];
+    expect(remoteInput).not.toHaveProperty("uid");
     expect(remoteInput).not.toHaveProperty("createdAt");
     expect(remoteInput).not.toHaveProperty("updatedAt");
     expect(remoteInput).not.toHaveProperty("url");

--- a/src/entities/deck/api/mutations.ts
+++ b/src/entities/deck/api/mutations.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { DeckCreateInput, DeckId, LocalDeckCreateInput } from "../model/types";
+import type { Deck, DeckId, LocalDeckCreateInput, RemoteDeckCreateInput } from "../model/types";
 
 import { deleteLocalCardsByDeckId, moveLocalCardsToRemote } from "@/entities/card/@x/deck";
 import { removeStudySession } from "@/entities/study-session/@x/deck";
@@ -18,6 +18,14 @@ const requireDeck = (id: DeckId) => {
   return deck;
 };
 
+// Remote writes must be authorized from current Entity state before reaching Firestore.
+const requireOwnedRemoteDeck = (uid: string, deck: Deck): Extract<Deck, { localMode: false }> => {
+  const userId = authenticatedUidSchema.parse(uid);
+  if (deck.localMode) throw new Error("A local Deck cannot be used for a remote write");
+  if (deck.uid !== userId) throw new Error("Deck owner does not match the authenticated user");
+  return deck;
+};
+
 const moveLocalDeckToRemote = async (
   uid: string,
   currentDeck: Extract<ReturnType<typeof requireDeck>, { localMode: true }>,
@@ -28,9 +36,8 @@ const moveLocalDeckToRemote = async (
   const { createdAt: _createdAt, updatedAt: _updatedAt, localMode: _localMode, ...remoteValues } = localDeck;
   const remoteDeck = {
     ...remoteValues,
-    uid: userId,
     localMode: false as const,
-  } satisfies DeckCreateInput;
+  } satisfies RemoteDeckCreateInput;
 
   // Firestore rules require the parent Deck to exist before its Cards can be created.
   await createRemoteDeck(userId, remoteDeck);
@@ -39,7 +46,7 @@ const moveLocalDeckToRemote = async (
 };
 
 // Routes a Deck create through the payload's persistence mode.
-export const createDeck = async (uid: string, deck: DeckCreateInput | LocalDeckCreateInput): Promise<void> => {
+export const createDeck = async (uid: string, deck: RemoteDeckCreateInput | LocalDeckCreateInput): Promise<void> => {
   if (deck.localMode) {
     createLocalDeck(deck);
     return;
@@ -60,7 +67,8 @@ export const editDeck = async (uid: string, deck: z.input<typeof deckEditSchema>
     return;
   }
   if (edit.localMode === true) throw new Error("A remote Deck cannot be moved to local storage");
-  await editRemoteDeck(uid, edit);
+  const ownedDeck = requireOwnedRemoteDeck(uid, currentDeck);
+  await editRemoteDeck(ownedDeck.uid, edit);
 };
 
 // Deletes a Deck and its owned local or remote resources before clearing its study session.
@@ -70,9 +78,8 @@ export const deleteDeck = async (uid: string, deckId: DeckId): Promise<void> => 
     deleteLocalCardsByDeckId(deckId);
     deleteLocalDeck(deckId);
   } else {
-    const userId = authenticatedUidSchema.parse(uid);
-    if (currentDeck.uid !== userId) throw new Error("Deck owner does not match the authenticated user");
-    await deleteRemoteDeck(userId, deckId);
+    const ownedDeck = requireOwnedRemoteDeck(uid, currentDeck);
+    await deleteRemoteDeck(ownedDeck.uid, deckId);
   }
 
   // A deleted Deck must not leave a resumable session behind in persisted client state.

--- a/src/entities/deck/index.ts
+++ b/src/entities/deck/index.ts
@@ -7,7 +7,7 @@ export { deckFormSchema } from "./model/schema";
 export { clearRemoteDecks } from "./model/store";
 export type {
   Deck,
-  DeckCreateInput,
   DeckId,
   LocalDeckCreateInput,
+  RemoteDeckCreateInput,
 } from "./model/types";

--- a/src/entities/deck/model/schema.spec.ts
+++ b/src/entities/deck/model/schema.spec.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import type { RemoteDeckCreateInput } from "./types";
 
 import { createDeck as createDeckFixture } from "@/test/factories";
 
@@ -9,11 +11,10 @@ describe("Deck operation schemas", () => {
 
   describe("createDeckSchema", () => {
     it("applies entity defaults without adding persistence timestamps", () => {
-      expect(createDeckSchema.parse({ uid: "uid-a", deck: { id: "deck", uid: "uid-a", name: " Deck " } })).toEqual({
+      expect(createDeckSchema.parse({ uid: "uid-a", deck: { id: "deck", name: " Deck " } })).toEqual({
         uid: "uid-a",
         deck: {
           id: "deck",
-          uid: "uid-a",
           name: "Deck",
           localMode: false,
           isPublic: false,
@@ -25,18 +26,23 @@ describe("Deck operation schemas", () => {
           convertToBr: false,
         },
       });
+      expectTypeOf<RemoteDeckCreateInput>().not.toHaveProperty("uid");
     });
 
     it.each([
       ["authenticated uid", { uid: "", deck }, "confirmed user"],
       ["Deck id", { uid: "uid-a", deck: { ...deck, id: "" } }, "Deck id"],
-      ["Deck uid", { uid: "uid-a", deck: { ...deck, uid: "" } }, "Deck owner"],
       ["Deck name", { uid: "uid-a", deck: { ...deck, name: "   " } }, "Deck name"],
       ["Deck URL", { uid: "uid-a", deck: { ...deck, url: "not-a-url" } }, "valid URL"],
       ["local mode", { uid: "uid-a", deck: { ...deck, localMode: true } }, "Invalid input"],
-      ["owner relationship", { uid: "uid-b", deck }, "owner does not match"],
     ])("rejects an invalid %s", (_case, input, message) => {
       expect(() => createDeckSchema.parse(input)).toThrow(message);
+    });
+
+    it("drops caller-provided owner metadata from the command", () => {
+      const parsed = createDeckSchema.parse({ uid: "actor", deck: { ...deck, uid: "other-user" } });
+
+      expect(parsed.deck).not.toHaveProperty("uid");
     });
   });
 

--- a/src/entities/deck/model/schema.ts
+++ b/src/entities/deck/model/schema.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export const authenticatedUidSchema = z.string().min(1, "A confirmed user is required for remote Deck writes");
 export const deckIdSchema = z.string().min(1, "Deck id is required");
-const deckUidSchema = z.string().min(1, "Deck owner is required");
 
 const editableDeckFieldsSchema = z.object({
   name: z.string().trim().min(1, "Deck name is required."),
@@ -37,7 +36,6 @@ const deckCreateFieldsSchema = editableDeckFieldsSchema.extend({
 });
 
 export const deckCreateSchema = deckCreateFieldsSchema.extend({
-  uid: deckUidSchema,
   localMode: z.literal(false).default(false),
 });
 
@@ -57,20 +55,7 @@ export const deckEditSchema = editableDeckFieldsSchema.partial().extend({
   localMode: z.boolean().optional(),
 });
 
-// Rejects remote Deck commands whose stored owner differs from the authenticated user.
-const validateDeckOwner = (input: { uid: string; deck: { uid: string } }, context: z.RefinementCtx): void => {
-  if (input.deck.uid !== input.uid) {
-    context.addIssue({
-      code: "custom",
-      message: "Deck owner does not match the authenticated user",
-      path: ["deck", "uid"],
-    });
-  }
-};
-
-export const createDeckSchema = z
-  .object({ uid: authenticatedUidSchema, deck: deckCreateSchema })
-  .superRefine(validateDeckOwner);
+export const createDeckSchema = z.object({ uid: authenticatedUidSchema, deck: deckCreateSchema });
 
 export const editDeckSchema = z.object({
   uid: authenticatedUidSchema,

--- a/src/entities/deck/model/types.ts
+++ b/src/entities/deck/model/types.ts
@@ -35,7 +35,7 @@ export type Deck = {
   updatedAt: number;
 } & ({ localMode: true } | { uid: string; localMode: false });
 
-/** Input accepted at the remote Deck creation boundary. */
-export type DeckCreateInput = z.input<typeof deckCreateSchema>;
+/** Owner-free input accepted at the remote Deck creation boundary. */
+export type RemoteDeckCreateInput = z.input<typeof deckCreateSchema>;
 /** Input accepted at the local Deck creation boundary. */
 export type LocalDeckCreateInput = z.input<typeof localDeckCreateSchema>;

--- a/src/features/sample-deck/model/useAddSampleDeck.spec.ts
+++ b/src/features/sample-deck/model/useAddSampleDeck.spec.ts
@@ -1,5 +1,5 @@
 import type { Card, CardMutation } from "@/entities/card";
-import type { Deck, DeckCreateInput, LocalDeckCreateInput } from "@/entities/deck";
+import type { Deck, LocalDeckCreateInput, RemoteDeckCreateInput } from "@/entities/deck";
 
 import { renderHook, waitFor } from "@testing-library/react";
 import React, { type ReactNode } from "react";
@@ -33,7 +33,7 @@ vi.mock("@/entities/deck", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/deck")>();
   return {
     ...actual,
-    createDeck: (_uid: string, deck: DeckCreateInput | LocalDeckCreateInput) => {
+    createDeck: (_uid: string, deck: RemoteDeckCreateInput | LocalDeckCreateInput) => {
       const fields = {
         id: deck.id,
         name: deck.name,
@@ -49,7 +49,7 @@ vi.mock("@/entities/deck", async (importOriginal) => {
       };
       const savedDeck: Deck = deck.localMode
         ? { ...fields, localMode: true }
-        : { ...fields, uid: deck.uid, localMode: false };
+        : { ...fields, uid: repository.uid, localMode: false };
       repository.decks = [...repository.decks.filter(({ id }) => id !== savedDeck.id), savedDeck];
       return Promise.resolve();
     },

--- a/src/pages/deck-create/model/useDeckCreateForm.ts
+++ b/src/pages/deck-create/model/useDeckCreateForm.ts
@@ -34,7 +34,7 @@ export const useDeckCreateForm = ({ onCreated }: UseDeckCreateFormOptions) => {
         category: values.category,
         convertToBr: values.convertToBr,
       };
-      await createDeck(uid, values.localMode ? { ...deck, localMode: true } : { ...deck, uid, localMode: false });
+      await createDeck(uid, values.localMode ? { ...deck, localMode: true } : { ...deck, localMode: false });
       // A Deck write may finish after the user leaves this Page; prevent that stale completion from navigating them.
       if (isMounted()) onCreated(deckId);
     } catch (error) {

--- a/src/pages/deck-create/ui/DeckCreatePage.spec.tsx
+++ b/src/pages/deck-create/ui/DeckCreatePage.spec.tsx
@@ -68,7 +68,6 @@ describe("DeckCreatePage", () => {
 
     expect(mocks.createDeck).toHaveBeenCalledExactlyOnceWith("user-id", {
       id: "new-deck",
-      uid: "user-id",
       localMode: false,
       name: "New deck",
       category: "",
@@ -111,7 +110,6 @@ describe("DeckCreatePage", () => {
     expect(mocks.generateDeckId).toHaveBeenCalledOnce();
     expect(mocks.createDeck).toHaveBeenNthCalledWith(1, "user-id", {
       id: "new-deck",
-      uid: "user-id",
       localMode: false,
       name: "Retry deck",
       category: "",
@@ -119,7 +117,6 @@ describe("DeckCreatePage", () => {
     });
     expect(mocks.createDeck).toHaveBeenNthCalledWith(2, "user-id", {
       id: "new-deck",
-      uid: "user-id",
       localMode: false,
       name: "Retry deck",
       category: "",

--- a/src/pages/deck-import/model/useDeckImportExecution.spec.ts
+++ b/src/pages/deck-import/model/useDeckImportExecution.spec.ts
@@ -21,7 +21,7 @@ describe("prepareDeckImport", () => {
       }
     );
 
-    expect(preparedImport.destination).toEqual({ id: "deck", uid: "uid", name: "deck.csv" });
+    expect(preparedImport.destination).toEqual({ id: "deck", name: "deck.csv", localMode: false });
     expect(preparedImport.mutations).toEqual([
       {
         kind: "create",

--- a/src/pages/deck-import/model/useDeckImportExecution.ts
+++ b/src/pages/deck-import/model/useDeckImportExecution.ts
@@ -1,5 +1,5 @@
 import type { CardMutation } from "@/entities/card";
-import type { DeckCreateInput, DeckId, LocalDeckCreateInput } from "@/entities/deck";
+import type { DeckId, LocalDeckCreateInput, RemoteDeckCreateInput } from "@/entities/deck";
 
 import { useState } from "react";
 
@@ -8,7 +8,7 @@ import { createDeck as persistDeck } from "@/entities/deck";
 
 import type { DeckImportRow } from "../lib/cardCsv";
 
-type DeckImportCreateInput = DeckCreateInput | LocalDeckCreateInput;
+type DeckImportCreateInput = RemoteDeckCreateInput | LocalDeckCreateInput;
 export type DeckImportStorageMode = "local" | "remote";
 
 export interface PreparedDeckImport {
@@ -37,12 +37,13 @@ interface DeckImportExecutionDependencies {
 
 const createDestination = (
   source: DeckImportSource,
-  uid: string,
   storageMode: DeckImportStorageMode,
   generateDeckId: () => DeckId
 ): DeckImportCreateInput => {
   const id = generateDeckId();
-  return storageMode === "local" ? { id, name: source.name, localMode: true } : { id, uid, name: source.name };
+  return storageMode === "local"
+    ? { id, name: source.name, localMode: true }
+    : { id, name: source.name, localMode: false };
 };
 
 const prepareCardCreations = ({
@@ -72,7 +73,7 @@ export const prepareDeckImport = (
   const storageMode = source.storageMode ?? "remote";
   if (storageMode === "remote" && uid === "") throw new Error("A confirmed user is required for remote imports");
 
-  const destination = createDestination(source, uid, storageMode, generateDeckId);
+  const destination = createDestination(source, storageMode, generateDeckId);
 
   return {
     uid,

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -5,7 +5,7 @@
  */
 
 import type { LocalCard, RemoteCard } from "@/entities/card/testing";
-import type { Deck } from "@/entities/deck";
+import type { Deck, RemoteDeckCreateInput } from "@/entities/deck";
 import type { Preferences } from "@/entities/preference";
 
 type AppearancePreferences = Preferences["appearance"];
@@ -33,6 +33,14 @@ export const createDeck = (
   tagAndFilter: false,
   category: "",
   convertToBr: false,
+  ...overrides,
+});
+
+/** Builds an owner-free command for creating a remote Deck. */
+export const createRemoteDeckInput = (overrides: Partial<RemoteDeckCreateInput> = {}): RemoteDeckCreateInput => ({
+  id: "deck-id",
+  name: "Deck",
+  localMode: false,
   ...overrides,
 });
 

--- a/test/integration/firestore/card.spec.ts
+++ b/test/integration/firestore/card.spec.ts
@@ -17,7 +17,7 @@ import { replaceRemoteDecks } from "@/entities/deck/model/store";
 import { editRemoteStudyProgress } from "@/entities/study-progress/api/firestore";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as Uuid from "uuid";
-import { createCard, createDeck } from "@/test/factories";
+import { createCard, createDeck, createRemoteDeckInput } from "@/test/factories";
 
 const uuid = Uuid.v4;
 
@@ -45,7 +45,7 @@ describe.concurrent("firestore/card", { retry: 3 }, () => {
   // card needs to belong to its deck
   const initDeck = async () => {
     const id = uuid();
-    await createDeckCommand("uid", createDeck({ uid: "uid", id }));
+    await createDeckCommand("uid", createRemoteDeckInput({ id }));
     return id;
   };
 

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -3,7 +3,7 @@
  * The examples cover creating, updating, checking, and deleting Deck documents.
  */
 
-import type { Deck, DeckCreateInput } from "@/entities/deck";
+import type { Deck, RemoteDeckCreateInput } from "@/entities/deck";
 
 import "@/test/initializeTestFirestore";
 import { expect, it, describe, vi, beforeEach, type Mock } from "vitest";
@@ -15,7 +15,13 @@ import { editDeck as editStoredDeck } from "@/entities/deck";
 import { deckStore } from "@/entities/deck/model/store";
 import { getCurrentTimeMillis } from "@/shared/lib/currentTime";
 import * as Uuid from "uuid";
-import { createCard, createDeck as createDeckFixture, createLocalCard, createLocalDeck } from "@/test/factories";
+import {
+  createCard,
+  createDeck as createDeckFixture,
+  createLocalCard,
+  createLocalDeck,
+  createRemoteDeckInput,
+} from "@/test/factories";
 
 const uuid = Uuid.v4;
 
@@ -47,11 +53,11 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
   it("should create a deck and check if exists", async () => {
     const d = {
       id: uuid(),
-      uid: "uid",
       name: "new deck name",
+      localMode: false,
       currentIndex: 1,
       cardOrderIds: ["card-1"],
-    } satisfies DeckCreateInput & { currentIndex: number; cardOrderIds: string[] };
+    } satisfies RemoteDeckCreateInput & { currentIndex: number; cardOrderIds: string[] };
     await createDeck("uid", d);
     const data = (await getDoc(doc(db, "deck", d.id))).data();
     expect(data).toEqual({ ...toFirestoreDeck(newDeck), id: d.id });
@@ -62,24 +68,28 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
   });
 
   it("should update a deck", async () => {
-    const d = { ...newDeck, id: uuid() };
+    const d = createRemoteDeckInput({ id: uuid(), name: newDeck.name });
     await createDeck("uid", d);
     const n = {
       ...d,
       name: "updated",
       currentIndex: 1,
       cardOrderIds: ["card-1"],
-    } satisfies Deck & { currentIndex: number; cardOrderIds: string[] };
+    };
     await editDeck("uid", n);
     const data = (await getDoc(doc(db, "deck", d.id))).data();
-    expect(data).toEqual({ ...toFirestoreDeck(d), name: "updated" });
+    expect(data).toEqual({ ...toFirestoreDeck(newDeck), id: d.id, name: "updated" });
     expect(data).not.toHaveProperty("localMode");
     expect(data).not.toHaveProperty("currentIndex");
     expect(data).not.toHaveProperty("cardOrderIds");
   });
 
   it("preserves an omitted URL and removes a cleared URL", async () => {
-    const deck = { ...newDeck, id: uuid(), url: "https://example.com/deck" };
+    const deck = createRemoteDeckInput({
+      id: uuid(),
+      name: newDeck.name,
+      url: "https://example.com/deck",
+    });
     await createDeck("uid", deck);
 
     await editDeck("uid", { id: deck.id, name: "updated" });
@@ -90,10 +100,10 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
   });
 
   it("should delete a deck and its Cards", async () => {
-    const d = { ...newDeck, id: uuid() };
+    const d = createRemoteDeckInput({ id: uuid(), name: newDeck.name });
     const cards = [
-      createCard({ id: uuid(), deckId: d.id, uid: d.uid }),
-      createCard({ id: uuid(), deckId: d.id, uid: d.uid }),
+      createCard({ id: uuid(), deckId: d.id, uid: "uid" }),
+      createCard({ id: uuid(), deckId: d.id, uid: "uid" }),
     ];
     await createDeck("uid", d);
     await Promise.all(cards.map((card) => createCardCommand("uid", card)));

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -12,7 +12,7 @@ import { deleteCard, editCard, fetchCardReads, mutateCards, subscribeCards } fro
 import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
-import { createCard, createDeck as createDeckFixture } from "@/test/factories";
+import { createCard, createDeck as createDeckFixture, createRemoteDeckInput } from "@/test/factories";
 
 vi.mock("@/shared/lib/currentTime", () => ({ getCurrentTimeMillis: vi.fn(() => 100) }));
 vi.mock("@/shared/firebase", async () => ({
@@ -40,7 +40,7 @@ describe("Query realtime subscriptions", () => {
       score: 2,
       numberOfSeen: 3,
     });
-    await createDeck(uid, deck);
+    await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
     await mutateCards(uid, [{ kind: "create", card }]);
 
     const reads = await fetchCardReads(uid);
@@ -60,7 +60,7 @@ describe("Query realtime subscriptions", () => {
     try {
       const deck = createDeckFixture({ id: crypto.randomUUID(), uid });
       const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid });
-      await createDeck(uid, deck);
+      await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
       await mutateCards(uid, [{ kind: "create", card }]);
       await vi.waitFor(() => {
         expect(deckStore.getState().remoteDecks).toContainEqual(expect.objectContaining({ id: deck.id }));
@@ -99,7 +99,7 @@ describe("Query realtime subscriptions", () => {
     const deck = createDeckFixture({ id: crypto.randomUUID(), uid, name: "Before stop" });
     const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid, frontText: "Before stop" });
 
-    await createDeck(uid, deck);
+    await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
     await mutateCards(uid, [{ kind: "create", card }]);
     await vi.waitFor(() => {
       expect(deckStore.getState().remoteDecks).toContainEqual(


### PR DESCRIPTION
## Related issue

Fixes #1250

## Summary

- remove owner UID from public remote Deck create commands and call sites
- derive the physical Firestore owner from the authenticated actor at the persistence boundary
- reject mismatched remote Deck edits and deletes before starting remote writes
- separate owner-free command fixtures from owner-bearing read and physical document fixtures

## Testing

- `mise run check` (107 test files, 561 tests)