### PR TITLE
[No issue] Add accepted architecture decision records

### DIFF
--- a/docs/adr/20260830-discard-incompatible-persisted-store-state.md
+++ b/docs/adr/20260830-discard-incompatible-persisted-store-state.md
@@ -1,0 +1,15 @@
+# 互換性のない永続Store状態を破棄する
+
+Status: Accepted
+
+## Context
+
+開発中のStore shapeに対して継続的にmigrationとlegacy formatの読み取りを追加すると、現在の設計より互換性layerの保守が大きくなる。現段階では、client-sideの永続Store shapeを安定した公開互換性契約として扱っていない。
+
+## Decision
+
+プロダクトがactive development中である間、互換性のないclient-side persisted Store stateを維持するためのmigrationやlegacy readerを原則追加しない。
+
+互換性のない変更ではpersist versionを更新し、古いstateを破棄してvalidated default stateへ戻す。
+
+特定の永続データについて互換性維持が明示的に要求された場合だけ例外とする。永続Storeをstable compatibility contractにするときは、この決定を再評価する。[PR #993](https://github.com/her0e1c1/tango/pull/993)を参照する。

--- a/docs/adr/20260830-prefer-minimal-entity-boundaries.md
+++ b/docs/adr/20260830-prefer-minimal-entity-boundaries.md
@@ -1,0 +1,17 @@
+# Entity境界では重複したデータ表現を作らない
+
+Status: Accepted
+
+## Context
+
+同じEntityデータをDomain、DTO、Store、Viewなど複数のほぼ同一な型で表現すると、型を分けたこと自体を理由とするmapperやwrapperが増える。その結果、項目の追加や変更が複数の型、schema、mapper、testへ波及し、型安全性以上に理解と保守のコストが増える。
+
+## Decision
+
+アプリケーション内で同じ意味と形式を持つEntityデータには、原則として1つの基本型を使用する。
+
+Domain、DTO、Store、View、Command、Repository、Value Objectなどの概念は、異なる振る舞い、制約、またはデータ形式を表現する必要がある場合だけ導入する。
+
+mapperは入力と出力の形式が実際に異なる境界だけに置き、その境界の近くで管理する。FSDやDDDの役割を埋めるためだけの型、wrapper、service、directoryは追加しない。
+
+新しい抽象化を追加する前に、既存の型や処理を削除または直接再利用できないか確認する。[PR #1191](https://github.com/her0e1c1/tango/pull/1191)を参照する。

--- a/docs/adr/20260830-treat-documented-e2e-cases-as-the-test-contract.md
+++ b/docs/adr/20260830-treat-documented-e2e-cases-as-the-test-contract.md
@@ -1,0 +1,17 @@
+# 文書化したE2Eケースをテスト契約の正とする
+
+Status: Accepted
+
+## Context
+
+Playwright testだけをE2E仕様として扱うと、期待する利用者向け振る舞いとtest codeが分離されず、仕様の欠落や不要なtestを判断しにくい。また、共有する永続データを使うE2Eを並列実行すると、test間やretry間のidentity衝突によって結果が不安定になる。
+
+## Decision
+
+`docs/e2e/**`をE2Eで保証する利用者向け振る舞いの正とする。
+
+各文書化test case IDはexactly one Playwright testに対応し、各Playwright testもexactly one文書化IDに対応させる。文書化されていないE2E testは追加しない。
+
+各testはsame-categoryのYAML fixtureをexactly one参照する。fixtureはseed前にschemaと参照整合性をすべて検証し、UID、document ID、session IDなどのidentityをtest caseとretry単位で分離する。
+
+fixtureの具体的なschema、継承、merge、命名規則は`docs/e2e/AGENTS.md`と`test/e2e/AGENTS.md`で管理する。[PR #1256](https://github.com/her0e1c1/tango/pull/1256)、[PR #1260](https://github.com/her0e1c1/tango/pull/1260)、[PR #1299](https://github.com/her0e1c1/tango/pull/1299)を参照する。

--- a/docs/adr/20260830-use-workload-identity-federation-for-production-deployments.md
+++ b/docs/adr/20260830-use-workload-identity-federation-for-production-deployments.md
@@ -1,0 +1,17 @@
+# 本番デプロイにWorkload Identity Federationを使用する
+
+Status: Accepted
+
+## Context
+
+長期間有効なFirebase CLI tokenやservice-account JSON keyをGitHubへ保存すると、漏えい時の影響が長く続き、production deploymentが個人credentialへ依存する。
+
+## Decision
+
+GitHub ActionsからGoogle Cloudへのproduction deploymentには、GitHub OIDCとGoogle Workload Identity Federationによる短期credentialを使用する。
+
+長期のFirebase CLI tokenまたはservice-account JSON keyをdeployment credentialとして使用しない。
+
+federated identityはimmutable repository identity、`main` branch、およびGitHubの`production` Environmentへ制限する。production deploy専用のleast-privilege service accountを使用し、OIDC token発行権限はdeployment jobだけに与える。
+
+具体的なresource ID、IAM role、setup手順はsetup scriptとworkflowで管理する。[PR #1238](https://github.com/her0e1c1/tango/pull/1238)と[PR #1259](https://github.com/her0e1c1/tango/pull/1259)を参照する。


### PR DESCRIPTION
## Related issue

None

## Summary

- add an accepted ADR that prefers one canonical Entity representation over duplicate Domain, DTO, Store, and View layers
- record the documented E2E case, Playwright, validated YAML fixture, and parallel identity-isolation contract
- record the active-development policy for discarding incompatible client-side persisted Store state
- record GitHub OIDC and Google Workload Identity Federation as the production deployment credential model
- leave unresolved Study-operation, FSRS, trusted-delete, and verified-artifact decisions out until their implementation choices are adopted

## Testing

- documentation-only change
- reviewed the complete diff against `docs/adr/AGENTS.md` and the referenced implementation pull requests