### PR TITLE
feat(#950): Add study controls help dialog

### DIFF
--- a/docs/e2e/fixture/study-session-help.yaml
+++ b/docs/e2e/fixture/study-session-help.yaml
@@ -1,0 +1,10 @@
+extends: study-session-start.yaml
+browser:
+  preferences:
+    controls:
+      showSwipeButtonList: false
+      showPlaybackControls: false
+      cardSwipeUp: GoBack
+      cardSwipeDown: DoNothing
+      cardSwipeLeft: GoToNextCardToggleMastered
+      cardSwipeRight: GoToPrevCard

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -25,6 +25,7 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-15 | read | [裏面 text を選択しても Card の状態を維持できる](#swipe-15) |
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
+| SWIPE-18 | read | [Help dialog に現在の操作 mapping を表示できる](#swipe-18) |
 
 <a id="swipe-01"></a>
 
@@ -413,4 +414,32 @@ Then:
 - 現在だった Card の mastered 学習結果が browser storage に維持されている。
 - session の位置が次の Card に維持されている。
 - 次の Card の front text が表示され、back text は表示されない。
+- browser error が発生しない。
+
+<a id="swipe-18"></a>
+
+### SWIPE-18 Help dialog に現在の操作 mapping を表示できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-help`](./fixture/study-session-help.yaml)
+- 認証済みユーザーが所有する Deck に進行中の学習 session が存在する。
+- 方向操作には既定値と異なる action が設定され、操作ボタンの一部は非表示に設定されている。
+- document locale は English に設定されている。
+
+When:
+
+- 学習画面から Help dialog を開く。
+- dialog 内で方向キーと操作ボタン表示切り替えキーを入力し、focus を移動する。
+- Escape で Help dialog を閉じる。
+
+Then:
+
+- Help dialog に現在設定されている方向操作の意味が semantic label で表示される。
+- Card の表示、autoplay、操作ボタン表示、Card details、Deck 一覧へ戻る操作が表示される。
+- 非表示の操作ボタンは現在の設定と一致する説明で表示される。
+- dialog 内のキー入力で Card、学習結果、session の位置が変更されない。
+- focus が dialog 内に維持され、閉じた後は Help trigger へ戻る。
 - browser error が発生しない。

--- a/src/pages/study-session/model/studyHelp.spec.ts
+++ b/src/pages/study-session/model/studyHelp.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { createPreferences } from "@/test/factories";
+
+import { buildStudyHelpContent } from "./studyHelp";
+
+describe("buildStudyHelpContent", () => {
+  it("maps configured directions to semantic user-facing actions", () => {
+    const preferences = createPreferences({
+      controls: {
+        cardSwipeUp: "GoBack",
+        cardSwipeDown: "DoNothing",
+        cardSwipeLeft: "GoToNextCardToggleMastered",
+        cardSwipeRight: "GoToPrevCard",
+      },
+    });
+
+    const content = buildStudyHelpContent(preferences, "en-US");
+
+    expect(content.rows.slice(0, 4)).toEqual([
+      { control: "Arrow Up / Swipe Up", action: "End the current session and return to the deck list" },
+      { control: "Arrow Down / Swipe Down", action: "No action" },
+      { control: "Arrow Left / Swipe Left", action: "Toggle mastered and go to the next card" },
+      { control: "Arrow Right / Swipe Right", action: "Go to the previous card" },
+    ]);
+    expect(content.rows.map((row) => row.action).join(" ")).not.toContain("GoTo");
+  });
+
+  it("describes hidden and unavailable controls from current preferences", () => {
+    const preferences = createPreferences({
+      cardInterval: 0,
+      controls: { showSwipeButtonList: false, showPlaybackControls: false },
+    });
+
+    const content = buildStudyHelpContent(preferences, "en");
+
+    expect(content.rows).toEqual(
+      expect.arrayContaining([
+        { control: "Space / Play or Pause button", action: "Autoplay is unavailable while the card interval is 0" },
+        { control: "B / Swipe controls button", action: "Show the currently hidden swipe buttons" },
+        {
+          control: "Playback controls button",
+          action: "Playback controls are unavailable while the card interval is 0",
+        },
+      ])
+    );
+  });
+
+  it("uses Japanese semantic resources without changing mapping identity", () => {
+    const preferences = createPreferences({ controls: { cardSwipeRight: "GoToNextCardMastered" } });
+
+    const content = buildStudyHelpContent(preferences, "ja-JP");
+
+    expect(content.title).toBe("学習画面の操作");
+    expect(content.rows).toContainEqual({
+      control: "右矢印 / 右へスワイプ",
+      action: "習得済みにして次のカードへ移動",
+    });
+  });
+});

--- a/src/pages/study-session/model/studyHelp.ts
+++ b/src/pages/study-session/model/studyHelp.ts
@@ -1,0 +1,170 @@
+import type { Preferences, SwipeDirection } from "@/entities/preference";
+
+type SwipeAction = Preferences["controls"][SwipeDirection];
+
+interface StudyHelpRow {
+  control: string;
+  action: string;
+}
+
+export interface StudyHelpContent {
+  triggerLabel: string;
+  title: string;
+  description: string;
+  closeLabel: string;
+  rows: readonly StudyHelpRow[];
+}
+
+interface StudyHelpResources {
+  triggerLabel: string;
+  title: string;
+  description: string;
+  closeLabel: string;
+  directions: Record<SwipeDirection, string>;
+  actions: Record<SwipeAction, string>;
+  controls: {
+    flip: string;
+    flipAction: string;
+    autoPlay: string;
+    autoPlayAction: string;
+    autoPlayUnavailable: string;
+    swipeButtons: string;
+    swipeButtonsVisible: string;
+    swipeButtonsHidden: string;
+    playbackControls: string;
+    playbackControlsVisible: string;
+    playbackControlsHidden: string;
+    playbackControlsUnavailable: string;
+    cardDetails: string;
+    cardDetailsAction: string;
+    exit: string;
+    exitAction: string;
+  };
+}
+
+const resources = {
+  en: {
+    triggerLabel: "Open study help",
+    title: "Study controls",
+    description: "Review the controls available for this study session and their current actions.",
+    closeLabel: "Close help",
+    directions: {
+      cardSwipeUp: "Arrow Up / Swipe Up",
+      cardSwipeDown: "Arrow Down / Swipe Down",
+      cardSwipeLeft: "Arrow Left / Swipe Left",
+      cardSwipeRight: "Arrow Right / Swipe Right",
+    },
+    actions: {
+      DoNothing: "No action",
+      GoBack: "End the current session and return to the deck list",
+      GoToPrevCard: "Go to the previous card",
+      GoToNextCard: "Go to the next card",
+      GoToNextCardMastered: "Mark mastered and go to the next card",
+      GoToNextCardNotMastered: "Mark not mastered and go to the next card",
+      GoToNextCardToggleMastered: "Toggle mastered and go to the next card",
+    },
+    controls: {
+      flip: "Enter / Select Card",
+      flipAction: "Flip or reveal the current card",
+      autoPlay: "Space / Play or Pause button",
+      autoPlayAction: "Play or pause autoplay",
+      autoPlayUnavailable: "Autoplay is unavailable while the card interval is 0",
+      swipeButtons: "B / Swipe controls button",
+      swipeButtonsVisible: "Hide the currently visible swipe buttons",
+      swipeButtonsHidden: "Show the currently hidden swipe buttons",
+      playbackControls: "Playback controls button",
+      playbackControlsVisible: "Hide the currently visible playback controls",
+      playbackControlsHidden: "Show the currently hidden playback controls",
+      playbackControlsUnavailable: "Playback controls are unavailable while the card interval is 0",
+      cardDetails: "Card details button",
+      cardDetailsAction: "Show or hide score and study history",
+      exit: "Back to deck list button",
+      exitAction: "Exit without ending the current study session",
+    },
+  },
+  ja: {
+    triggerLabel: "学習ヘルプを開く",
+    title: "学習画面の操作",
+    description: "この学習セッションで利用できる操作と、現在割り当てられている動作を確認できます。",
+    closeLabel: "ヘルプを閉じる",
+    directions: {
+      cardSwipeUp: "上矢印 / 上へスワイプ",
+      cardSwipeDown: "下矢印 / 下へスワイプ",
+      cardSwipeLeft: "左矢印 / 左へスワイプ",
+      cardSwipeRight: "右矢印 / 右へスワイプ",
+    },
+    actions: {
+      DoNothing: "何もしない",
+      GoBack: "現在の学習セッションを終了してデッキ一覧へ戻る",
+      GoToPrevCard: "前のカードへ移動",
+      GoToNextCard: "次のカードへ移動",
+      GoToNextCardMastered: "習得済みにして次のカードへ移動",
+      GoToNextCardNotMastered: "未習得にして次のカードへ移動",
+      GoToNextCardToggleMastered: "習得状態を切り替えて次のカードへ移動",
+    },
+    controls: {
+      flip: "Enter / カードを選択",
+      flipAction: "現在のカードを裏返す、または答えを表示する",
+      autoPlay: "Space / 再生・一時停止ボタン",
+      autoPlayAction: "自動再生を開始または一時停止する",
+      autoPlayUnavailable: "カード間隔が0のため自動再生は利用できません",
+      swipeButtons: "B / スワイプ操作ボタン",
+      swipeButtonsVisible: "表示中のスワイプ操作ボタンを隠す",
+      swipeButtonsHidden: "非表示のスワイプ操作ボタンを表示する",
+      playbackControls: "再生コントロールボタン",
+      playbackControlsVisible: "表示中の再生コントロールを隠す",
+      playbackControlsHidden: "非表示の再生コントロールを表示する",
+      playbackControlsUnavailable: "カード間隔が0のため再生コントロールは利用できません",
+      cardDetails: "カード詳細ボタン",
+      cardDetailsAction: "スコアと学習履歴を表示または非表示にする",
+      exit: "デッキ一覧へ戻るボタン",
+      exitAction: "現在の学習セッションを終了せずに画面を離れる",
+    },
+  },
+} satisfies Record<"en" | "ja", StudyHelpResources>;
+
+const directionOrder: readonly SwipeDirection[] = ["cardSwipeUp", "cardSwipeDown", "cardSwipeLeft", "cardSwipeRight"];
+
+const resolveResources = (locale: string): StudyHelpResources =>
+  locale.toLowerCase().startsWith("ja") ? resources.ja : resources.en;
+
+export const buildStudyHelpContent = (preferences: Preferences, locale: string): StudyHelpContent => {
+  const copy = resolveResources(locale);
+  const playbackAvailable = preferences.study.cardInterval > 0;
+  const rows: StudyHelpRow[] = directionOrder.map((direction) => ({
+    control: copy.directions[direction],
+    action: copy.actions[preferences.controls[direction]],
+  }));
+
+  rows.push(
+    { control: copy.controls.flip, action: copy.controls.flipAction },
+    {
+      control: copy.controls.autoPlay,
+      action: playbackAvailable ? copy.controls.autoPlayAction : copy.controls.autoPlayUnavailable,
+    },
+    {
+      control: copy.controls.swipeButtons,
+      action: preferences.controls.showSwipeButtonList
+        ? copy.controls.swipeButtonsVisible
+        : copy.controls.swipeButtonsHidden,
+    },
+    {
+      control: copy.controls.playbackControls,
+      action: playbackAvailable
+        ? preferences.controls.showPlaybackControls
+          ? copy.controls.playbackControlsVisible
+          : copy.controls.playbackControlsHidden
+        : copy.controls.playbackControlsUnavailable,
+    },
+    { control: copy.controls.cardDetails, action: copy.controls.cardDetailsAction },
+    { control: copy.controls.exit, action: copy.controls.exitAction }
+  );
+
+  return {
+    triggerLabel: copy.triggerLabel,
+    title: copy.title,
+    description: copy.description,
+    closeLabel: copy.closeLabel,
+    rows,
+  };
+};

--- a/src/pages/study-session/model/useAutoPlay.ts
+++ b/src/pages/study-session/model/useAutoPlay.ts
@@ -7,18 +7,20 @@ import type { StudySessionState } from "./useStudySessionState";
 interface AutoPlayOptions {
   defaultAutoPlay: boolean;
   cardInterval: number;
+  paused: boolean;
   onAdvance: () => void;
 }
 
 export const useAutoPlay = (
   sessionState: StudySessionState,
-  { defaultAutoPlay, cardInterval, onAdvance }: AutoPlayOptions
+  { defaultAutoPlay, cardInterval, paused, onAdvance }: AutoPlayOptions
 ) => {
   const [autoPlay, setAutoPlay] = React.useState(defaultAutoPlay);
   const onAdvanceEvent = React.useEffectEvent(onAdvance);
   const autoPlaySession =
     sessionState.status === "studying" &&
     autoPlay &&
+    !paused &&
     cardInterval > 0 &&
     canMoveStudySession(sessionState.session, "next")
       ? sessionState.session

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -11,6 +11,7 @@ import {
 import { setStudySessionIndex } from "@/entities/study-session";
 
 import { useAutoPlay } from "./useAutoPlay";
+import { buildStudyHelpContent } from "./studyHelp";
 import { useStudySessionState } from "./useStudySessionState";
 import { useSwipe } from "./useSwipe";
 
@@ -20,10 +21,13 @@ export const useStudy = (deckId: string) => {
   const preferences = usePreferences();
   const sessionState = useStudySessionState(deckId, cards);
   const [showBackText, setShowBackText] = React.useState(false);
+  const [helpOpen, setHelpOpen] = React.useState(false);
   const hideBackText = () => setShowBackText(false);
   const { autoPlay, toggleAutoPlay } = useAutoPlay(sessionState, {
     defaultAutoPlay: preferences.study.defaultAutoPlay,
     cardInterval: preferences.study.cardInterval,
+    // Keep the user's explicit play/pause state while preventing a modal from advancing the hidden Card.
+    paused: helpOpen,
     onAdvance: hideBackText,
   });
   // The answer is a reading surface; directional study actions resume after returning to the front.
@@ -47,6 +51,12 @@ export const useStudy = (deckId: string) => {
     showSwipeButtonList: preferences.controls.showSwipeButtonList,
     autoPlay,
     updateIndex,
+    help: {
+      ...buildStudyHelpContent(preferences, document.documentElement.lang),
+      open: helpOpen,
+      openHelp: () => setHelpOpen(true),
+      closeHelp: () => setHelpOpen(false),
+    },
   };
 
   if (deck == null) return;

--- a/src/pages/study-session/ui/StudyHelpDialog.spec.tsx
+++ b/src/pages/study-session/ui/StudyHelpDialog.spec.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { StudyHelpDialog } from "./StudyHelpDialog";
+
+const dialogProps = {
+  title: "Study controls",
+  description: "Current controls and actions.",
+  closeLabel: "Close help",
+  rows: [
+    { control: "Arrow Up / Swipe Up", action: "Mark mastered and go to the next card" },
+    { control: "Enter / Select Card", action: "Flip or reveal the current card" },
+  ],
+};
+
+const Harness: React.FC = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open study help
+      </button>
+      {open ? <StudyHelpDialog {...dialogProps} onClose={() => setOpen(false)} /> : null}
+    </>
+  );
+};
+
+describe("StudyHelpDialog", () => {
+  it("provides modal semantics and focuses a safe close control", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Open study help" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Study controls" });
+    expect(dialog).toHaveAccessibleDescription("Current controls and actions.");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByText("Arrow Up / Swipe Up")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close help" })).toHaveFocus();
+  });
+
+  it("traps focus, closes on Escape, and returns focus to the Help trigger", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "Open study help" });
+    await user.click(trigger);
+
+    const close = screen.getByRole("button", { name: "Close help" });
+    expect(fireEvent.keyDown(close, { key: "Tab" })).toBe(false);
+    expect(close).toHaveFocus();
+    expect(fireEvent.keyDown(close, { key: "Tab", shiftKey: true })).toBe(false);
+    expect(close).toHaveFocus();
+
+    fireEvent.keyDown(close, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/src/pages/study-session/ui/StudyHelpDialog.spec.tsx
+++ b/src/pages/study-session/ui/StudyHelpDialog.spec.tsx
@@ -18,12 +18,19 @@ const dialogProps = {
 
 const Harness: React.FC = () => {
   const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
   return (
     <>
-      <button type="button" onClick={() => setOpen(true)}>
+      <button ref={triggerRef} type="button" onClick={() => setOpen(true)}>
         Open study help
       </button>
-      {open ? <StudyHelpDialog {...dialogProps} onClose={() => setOpen(false)} /> : null}
+      {open ? (
+        <StudyHelpDialog
+          {...dialogProps}
+          restoreTriggerFocus={() => triggerRef.current?.focus()}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
     </>
   );
 };
@@ -42,11 +49,11 @@ describe("StudyHelpDialog", () => {
     expect(screen.getByRole("button", { name: "Close help" })).toHaveFocus();
   });
 
-  it("traps focus, closes on Escape, and returns focus to the Help trigger", async () => {
-    const user = userEvent.setup();
+  it("traps focus, closes on Escape, and returns focus to the Help trigger after a pointer click", async () => {
     render(<Harness />);
     const trigger = screen.getByRole("button", { name: "Open study help" });
-    await user.click(trigger);
+    fireEvent.click(trigger);
+    expect(trigger).not.toHaveFocus();
 
     const close = screen.getByRole("button", { name: "Close help" });
     expect(fireEvent.keyDown(close, { key: "Tab" })).toBe(false);

--- a/src/pages/study-session/ui/StudyHelpDialog.stories.tsx
+++ b/src/pages/study-session/ui/StudyHelpDialog.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+
+import { StudyHelpDialog } from "./StudyHelpDialog";
+
+const englishRows = [
+  { control: "Arrow Up / Swipe Up", action: "Mark mastered and go to the next card" },
+  { control: "Arrow Down / Swipe Down", action: "Mark not mastered and go to the next card" },
+  { control: "Arrow Left / Swipe Left", action: "Go to the previous card" },
+  { control: "Arrow Right / Swipe Right", action: "Go to the next card" },
+  { control: "Enter / Select Card", action: "Flip or reveal the current card" },
+  { control: "Space / Play or Pause button", action: "Play or pause autoplay" },
+  { control: "B / Swipe controls button", action: "Hide the currently visible swipe buttons" },
+  { control: "Playback controls button", action: "Hide the currently visible playback controls" },
+  { control: "Card details button", action: "Show or hide score and study history" },
+  { control: "Back to deck list button", action: "Exit without ending the current study session" },
+];
+
+const meta = {
+  title: "Pages/Study Session/StudyHelpDialog",
+  component: StudyHelpDialog,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  args: {
+    title: "Study controls",
+    description: "Review the controls available for this study session and their current actions.",
+    closeLabel: "Close help",
+    rows: englishRows,
+    onClose: fn(),
+  },
+} satisfies Meta<typeof StudyHelpDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = {};
+
+export const Japanese: Story = {
+  args: {
+    title: "学習画面の操作",
+    description: "この学習セッションで利用できる操作と、現在割り当てられている動作を確認できます。",
+    closeLabel: "ヘルプを閉じる",
+    rows: [
+      { control: "上矢印 / 上へスワイプ", action: "習得済みにして次のカードへ移動" },
+      { control: "下矢印 / 下へスワイプ", action: "未習得にして次のカードへ移動" },
+      { control: "左矢印 / 左へスワイプ", action: "前のカードへ移動" },
+      { control: "右矢印 / 右へスワイプ", action: "次のカードへ移動" },
+      { control: "Enter / カードを選択", action: "現在のカードを裏返す、または答えを表示する" },
+      { control: "Space / 再生・一時停止ボタン", action: "自動再生を開始または一時停止する" },
+    ],
+  },
+};
+
+export const LongLabels: Story = {
+  args: {
+    rows: englishRows.map((row) => ({ ...row, action: `${row.action}. ${row.action}.` })),
+  },
+};
+
+export const Mobile: Story = {
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+};
+
+export const Dark: Story = {
+  globals: { theme: "dark" },
+};

--- a/src/pages/study-session/ui/StudyHelpDialog.stories.tsx
+++ b/src/pages/study-session/ui/StudyHelpDialog.stories.tsx
@@ -26,6 +26,7 @@ const meta = {
     description: "Review the controls available for this study session and their current actions.",
     closeLabel: "Close help",
     rows: englishRows,
+    restoreTriggerFocus: fn(),
     onClose: fn(),
   },
 } satisfies Meta<typeof StudyHelpDialog>;

--- a/src/pages/study-session/ui/StudyHelpDialog.tsx
+++ b/src/pages/study-session/ui/StudyHelpDialog.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
+
+interface StudyHelpDialogRow {
+  control: string;
+  action: string;
+}
+
+export interface StudyHelpDialogProps {
+  title: string;
+  description: string;
+  closeLabel: string;
+  rows: readonly StudyHelpDialogRow[];
+  onClose: () => void;
+}
+
+export const StudyHelpDialog: React.FC<StudyHelpDialogProps> = (props) => {
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const closeRef = React.useRef<HTMLButtonElement>(null);
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+
+  React.useEffect(() => {
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, []);
+
+  const trapFocus = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableElementSelector) ?? []);
+    const [first] = focusable;
+    const last = focusable.at(-1);
+    if (first == null || last == null) {
+      event.preventDefault();
+      return;
+    }
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onClose();
+    } else if (event.key === "Tab") {
+      trapFocus(event);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center overflow-y-auto bg-canvas/75 px-shell-gutter py-6 backdrop-blur-sm">
+      {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: The modal owns Escape and focus-trap keyboard handling. */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="max-h-full w-full max-w-reading overflow-y-auto rounded-surface border border-border bg-surface-elevated p-4 text-ink shadow-elevated sm:p-6"
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 id={titleId} className="text-title font-bold">
+              {props.title}
+            </h2>
+            <p id={descriptionId} className="mt-2 text-body text-ink-muted">
+              {props.description}
+            </p>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            className="inline-flex min-h-touch min-w-touch shrink-0 items-center justify-center rounded-control border border-border px-3 py-2 font-bold text-ink hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+            onClick={props.onClose}
+          >
+            {props.closeLabel}
+          </button>
+        </div>
+        <dl className="mt-6 divide-y divide-border border-y border-border">
+          {props.rows.map((row) => (
+            <div key={row.control} className="grid gap-1 py-3 sm:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] sm:gap-4">
+              <dt className="font-bold text-ink">{row.control}</dt>
+              <dd className="text-body text-ink-muted">{row.action}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/study-session/ui/StudyHelpDialog.tsx
+++ b/src/pages/study-session/ui/StudyHelpDialog.tsx
@@ -12,26 +12,27 @@ export interface StudyHelpDialogProps {
   description: string;
   closeLabel: string;
   rows: readonly StudyHelpDialogRow[];
+  restoreTriggerFocus: () => void;
   onClose: () => void;
 }
 
 export const StudyHelpDialog: React.FC<StudyHelpDialogProps> = (props) => {
+  const { restoreTriggerFocus } = props;
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const closeRef = React.useRef<HTMLButtonElement>(null);
   const titleId = React.useId();
   const descriptionId = React.useId();
 
   React.useEffect(() => {
-    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     closeRef.current?.focus();
 
     return () => {
       document.body.style.overflow = previousOverflow;
-      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+      restoreTriggerFocus();
     };
-  }, []);
+  }, [restoreTriggerFocus]);
 
   const trapFocus = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableElementSelector) ?? []);

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -17,6 +17,16 @@ const toolbarProps = () => ({
   onToggleCardDetails: vi.fn(),
   onToggleSwipeControls: vi.fn(),
   onTogglePlaybackControls: vi.fn(),
+  help: {
+    open: false,
+    triggerLabel: "Open study help",
+    title: "Study controls",
+    description: "Review the current controls.",
+    closeLabel: "Close help",
+    rows: [{ control: "Arrow Up / Swipe Up", action: "Go to the next card" }],
+    onOpen: vi.fn(),
+    onClose: vi.fn(),
+  },
 });
 
 const swipeLeft = (target: HTMLElement) => {

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -31,6 +31,16 @@ const meta = {
     showPlaybackControls: true,
     showCardDetails: true,
     playbackControlsAvailable: true,
+    help: {
+      open: false,
+      triggerLabel: "Open study help",
+      title: "Study controls",
+      description: "Review the current controls.",
+      closeLabel: "Close help",
+      rows: [{ control: "Arrow Up / Swipe Up", action: "Mark mastered and go to the next card" }],
+      onOpen: fn(),
+      onClose: fn(),
+    },
     frontTextSlot: <FrontText text={fixture.card.default.frontText} />,
     cardOverlaySlot: (
       <CardOverlay
@@ -63,6 +73,10 @@ const centeredFrontTextPlay: Story["play"] = async ({ canvasElement }) => {
 
 export const Default: Story = {
   play: centeredFrontTextPlay,
+};
+
+export const HelpOpen: Story = {
+  args: { help: { ...meta.args.help, open: true } },
 };
 
 export const SwipeFeedback: Story = {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -7,12 +7,14 @@ import {
   AiOutlineEyeInvisible,
   AiOutlineLeft,
   AiOutlinePlayCircle,
+  AiOutlineQuestionCircle,
 } from "react-icons/ai";
 import { MdSwipe } from "react-icons/md";
 import { useSwipeable } from "react-swipeable";
 import type { SwipeDirection } from "@/entities/preference";
 
 import { Controller, type ControllerProps } from "./Controller";
+import { StudyHelpDialog, type StudyHelpDialogProps } from "./StudyHelpDialog";
 import { SwipeButtonList, type SwipeButtonListProps } from "./SwipeButtonList";
 
 const SWIPE_FEEDBACK_LABEL: Record<SwipeDirection, string> = {
@@ -62,6 +64,12 @@ export interface StudySessionProps {
   controller?: ControllerProps;
   swipeButtonList?: SwipeButtonListProps;
   feedbackSlot?: React.ReactNode;
+  help: Omit<StudyHelpDialogProps, "onClose"> & {
+    open: boolean;
+    triggerLabel: string;
+    onOpen: () => void;
+    onClose: () => void;
+  };
   onSwipeLeft?: () => void;
   onSwipeUp?: () => void;
   onSwipeRight?: () => void;
@@ -151,6 +159,8 @@ const StudyToolbar: React.FC<{
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
+  helpTriggerLabel: string;
+  onOpenHelp: () => void;
   onToggleOpen: () => void;
   onToggleCardDetails: () => void;
   onBack: () => void;
@@ -170,6 +180,17 @@ const StudyToolbar: React.FC<{
 
   return (
     <div className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 h-touch">
+      <button
+        type="button"
+        aria-label={props.helpTriggerLabel}
+        className={cx(
+          toolbarButtonClass,
+          "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+        )}
+        onClick={props.onOpenHelp}
+      >
+        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
+      </button>
       <button
         ref={triggerRef}
         type="button"
@@ -194,7 +215,7 @@ const StudyToolbar: React.FC<{
         <fieldset
           id={actionsId}
           aria-label="Study actions"
-          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-between border-0 p-0 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)]"
+          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-between border-0 p-0 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
         >
           <button
             type="button"
@@ -358,6 +379,8 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
           showSwipeControls={props.showSwipeControls}
           showPlaybackControls={props.showPlaybackControls}
           playbackControlsAvailable={props.playbackControlsAvailable}
+          helpTriggerLabel={props.help.triggerLabel}
+          onOpenHelp={props.help.onOpen}
           onToggleOpen={() => setStudyActionsOpen((open) => !open)}
           onToggleCardDetails={props.onToggleCardDetails}
           onBack={props.onBack}
@@ -389,6 +412,15 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
         swipeButtonList={props.swipeButtonList}
         controller={props.controller}
       />
+      {props.help.open ? (
+        <StudyHelpDialog
+          title={props.help.title}
+          description={props.help.description}
+          closeLabel={props.help.closeLabel}
+          rows={props.help.rows}
+          onClose={props.help.onClose}
+        />
+      ) : null}
     </div>
   );
 };

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -64,7 +64,7 @@ export interface StudySessionProps {
   controller?: ControllerProps;
   swipeButtonList?: SwipeButtonListProps;
   feedbackSlot?: React.ReactNode;
-  help: Omit<StudyHelpDialogProps, "onClose"> & {
+  help: Omit<StudyHelpDialogProps, "onClose" | "restoreTriggerFocus"> & {
     open: boolean;
     triggerLabel: string;
     onOpen: () => void;
@@ -153,7 +153,8 @@ const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
   );
 };
 
-const StudyToolbar: React.FC<{
+interface StudyToolbarProps {
+  ref?: React.RefObject<HTMLButtonElement | null>;
   open: boolean;
   showCardDetails: boolean;
   showSwipeControls: boolean;
@@ -166,7 +167,9 @@ const StudyToolbar: React.FC<{
   onBack: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
-}> = (props) => {
+}
+
+const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...props }) => {
   const actionsId = React.useId();
   const playbackDescriptionId = React.useId();
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -181,6 +184,7 @@ const StudyToolbar: React.FC<{
   return (
     <div className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 h-touch">
       <button
+        ref={helpTriggerRef}
         type="button"
         aria-label={props.helpTriggerLabel}
         className={cx(
@@ -316,6 +320,11 @@ const Controls: React.FC<{
 
 export const StudySession: React.FC<StudySessionProps> = (props) => {
   const [studyActionsOpen, setStudyActionsOpen] = React.useState(false);
+  // Safari does not focus pointer-activated buttons by default, so Help must restore this explicit trigger.
+  const helpTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const restoreHelpTriggerFocus = () => {
+    if (helpTriggerRef.current?.isConnected) helpTriggerRef.current.focus();
+  };
   const suppressCardClick = React.useRef(false);
   const suppressCardClickTimer = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -374,6 +383,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       {showStudyChrome ? props.feedbackSlot : null}
       {showStudyChrome ? (
         <StudyToolbar
+          ref={helpTriggerRef}
           open={studyActionsOpen}
           showCardDetails={props.showCardDetails}
           showSwipeControls={props.showSwipeControls}
@@ -418,6 +428,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
           description={props.help.description}
           closeLabel={props.help.closeLabel}
           rows={props.help.rows}
+          restoreTriggerFocus={restoreHelpTriggerFocus}
           onClose={props.help.onClose}
         />
       ) : null}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -193,8 +193,8 @@ describe("StudySessionPage", () => {
     const sessionBeforeHelp = getStudySession(deckId);
 
     const trigger = screen.getByRole("button", { name: "Open study help" });
-    trigger.focus();
     fireEvent.click(trigger);
+    expect(trigger).not.toHaveFocus();
 
     const dialog = screen.getByRole("dialog", { name: "Study controls" });
     expect(dialog).toHaveTextContent("Arrow Up / Swipe UpEnd the current session and return to the deck list");

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -1,6 +1,6 @@
 import type { Preferences } from "@/entities/preference";
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -86,6 +86,7 @@ describe("StudySessionPage", () => {
   };
 
   beforeEach(async () => {
+    document.documentElement.lang = "en";
     clearStudySessions();
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
     mocks.editStudyProgress.mockReset().mockResolvedValue(undefined);
@@ -175,6 +176,86 @@ describe("StudySessionPage", () => {
     await waitFor(() => expect(screen.getByText("Front two")).toBeVisible());
     expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
     expect(screen.queryByText("Front one")).not.toBeInTheDocument();
+  });
+
+  it("shows configured Help rows without letting dialog keys change Study state", () => {
+    mocks.preferences = createPreferences({
+      controls: {
+        cardSwipeUp: "GoBack",
+        cardSwipeDown: "DoNothing",
+        cardSwipeLeft: "GoToNextCardToggleMastered",
+        cardSwipeRight: "GoToPrevCard",
+      },
+    });
+    clearStudySessions();
+    startStudy(deckId, [firstCard, secondCard], mocks.preferences.study);
+    renderPage();
+    const sessionBeforeHelp = getStudySession(deckId);
+
+    const trigger = screen.getByRole("button", { name: "Open study help" });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Study controls" });
+    expect(dialog).toHaveTextContent("Arrow Up / Swipe UpEnd the current session and return to the deck list");
+    expect(dialog).toHaveTextContent("Arrow Down / Swipe DownNo action");
+    expect(dialog).toHaveTextContent("Arrow Left / Swipe LeftToggle mastered and go to the next card");
+    expect(dialog).toHaveTextContent("Enter / Select CardFlip or reveal the current card");
+    expect(dialog).toHaveTextContent("Space / Play or Pause buttonPlay or pause autoplay");
+    expect(dialog).toHaveTextContent("B / Swipe controls buttonHide the currently visible swipe buttons");
+    expect(dialog).toHaveTextContent("Card details buttonShow or hide score and study history");
+    expect(dialog).toHaveTextContent("Back to deck list buttonExit without ending the current study session");
+    expect(screen.getByRole("button", { name: "Close help" })).toHaveFocus();
+
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    fireEvent.keyDown(window, { key: "Enter" });
+    fireEvent.keyDown(window, { key: "b" });
+    fireEvent.keyDown(window, { key: " " });
+
+    expect(screen.getByText("Front one")).toBeVisible();
+    expect(getStudySession(deckId)).toEqual(sessionBeforeHelp);
+    expect(mocks.editStudyProgress).not.toHaveBeenCalled();
+    expect(mocks.toggleShowSwipeButtonList).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Close help" }), { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("uses the current document locale for semantic Help labels", () => {
+    document.documentElement.lang = "ja-JP";
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "学習ヘルプを開く" }));
+
+    expect(screen.getByRole("dialog", { name: "学習画面の操作" })).toHaveTextContent(
+      "上矢印 / 上へスワイプ習得済みにして次のカードへ移動"
+    );
+  });
+
+  it("pauses autoplay while Help is open and resumes without changing its explicit state", () => {
+    mocks.preferences = createPreferences({ defaultAutoPlay: true, cardInterval: 1 });
+    clearStudySessions();
+    startStudy(deckId, [firstCard, secondCard], mocks.preferences.study);
+    vi.useFakeTimers();
+
+    try {
+      renderPage();
+      fireEvent.click(screen.getByRole("button", { name: "Open study help" }));
+
+      act(() => vi.advanceTimersByTime(1000));
+
+      expect(screen.getByText("Front one")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Pause" })).toBePressed();
+
+      fireEvent.click(screen.getByRole("button", { name: "Close help" }));
+      act(() => vi.advanceTimersByTime(1000));
+
+      expect(screen.getByText("Front two")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Pause" })).toBePressed();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns from a deep-linked Study to the Deck list without changing the resumable session", () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -71,6 +71,16 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
         showSwipeControls={state.showSwipeButtonList}
         showPlaybackControls={state.showPlaybackControls}
         playbackControlsAvailable={state.playbackControlsAvailable}
+        help={{
+          open: state.help.open,
+          triggerLabel: state.help.triggerLabel,
+          title: state.help.title,
+          description: state.help.description,
+          closeLabel: state.help.closeLabel,
+          rows: state.help.rows,
+          onOpen: state.help.openHelp,
+          onClose: state.help.closeHelp,
+        }}
         onSwipeUp={swipeActions.onClickUp}
         onSwipeDown={swipeActions.onClickDown}
         onSwipeLeft={swipeActions.onClickLeft}
@@ -108,9 +118,10 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
   const runWhileStudying = (action: StudyShortcutAction) => (event: KeyboardEvent) => {
     // Native editing and activation keys take precedence, while unrelated Study shortcuts remain
     // available after a user moves focus into the card or floating controls.
-    if (shouldIgnoreStudyShortcut(event)) return;
     const currentStudy = latestStudy.current;
-    if (currentStudy?.status === "studying") void currentStudy[action]();
+    // A modal Help surface owns every key while open, including keys without native dialog behavior.
+    if (currentStudy?.status !== "studying" || currentStudy.help.open || shouldIgnoreStudyShortcut(event)) return;
+    void currentStudy[action]();
   };
 
   // useKey retains its initial handler, so that handler reads current Page state through one stable ref.

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -411,3 +411,45 @@ test("SWIPE-17 preserves local-only progress and session position across reload"
     });
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex + 1);
 });
+
+test("SWIPE-18 shows configured Study controls without changing the active session", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  const currentCard = fixture.card("card-1");
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+  const progressBeforeHelp = await readProgress(currentCard.id);
+  await page.getByRole("button", { name: "Open study help" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Study controls" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText("Arrow Up / Swipe UpEnd the current session and return to the deck list");
+  await expect(dialog).toContainText("Arrow Down / Swipe DownNo action");
+  await expect(dialog).toContainText("Arrow Left / Swipe LeftToggle mastered and go to the next card");
+  await expect(dialog).toContainText("Arrow Right / Swipe RightGo to the previous card");
+  await expect(dialog).toContainText("Enter / Select CardFlip or reveal the current card");
+  await expect(dialog).toContainText("Space / Play or Pause buttonPlay or pause autoplay");
+  await expect(dialog).toContainText("B / Swipe controls buttonShow the currently hidden swipe buttons");
+  await expect(dialog).toContainText("Playback controls buttonShow the currently hidden playback controls");
+  await expect(dialog).toContainText("Card details buttonShow or hide score and study history");
+  await expect(dialog).toContainText("Back to deck list buttonExit without ending the current study session");
+
+  const close = dialog.getByRole("button", { name: "Close help" });
+  await expect(close).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(close).toBeFocused();
+  await page.keyboard.press("ArrowLeft");
+  await page.keyboard.press("b");
+
+  await expect(dialog).toContainText("B / Swipe controls buttonShow the currently hidden swipe buttons");
+  await expect(page.getByText(currentCard.frontText, { exact: true })).toBeVisible();
+  await expect.poll(() => readProgress(currentCard.id)).toEqual(progressBeforeHelp);
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+
+  await page.keyboard.press("Escape");
+
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole("button", { name: "Open study help" })).toBeFocused();
+  await expect(page.getByRole("button", { name: "Swipe left" })).toHaveCount(0);
+});


### PR DESCRIPTION
## Related issue

Fixes #950

## Summary

- Add a localized, page-local Study controls Help dialog that reflects the current directional mappings and control visibility.
- Trap and restore focus, suppress Study shortcuts, and pause autoplay without changing its explicit state while Help is open.
- Document the behavior and add the SWIPE-18 fixture and browser coverage.

## Testing

- mise exec -- npm run test:unit (570 passed)
- TypeScript, ESLint, Biome, FSD, Knip, E2E contract, and Markdown checks passed
- mise run e2e (SWIPE-18 passed; the full run had 13 existing remote-suite failures after Firestore timeouts)
- mise run check was attempted; its Docker sample step is blocked by a Docker Desktop containerd metadata I/O error after host disk exhaustion, while all non-Docker checks passed individually
- Mandatory reviewer round 2: no P0, P1, or P2 findings