### PR TITLE
[No issue] Save sample deck and return to deck list

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -87,7 +87,7 @@
 | IMPORT-03 | batch | [CSV を remote に import して reload 後も利用できる](./import.md#import-03) |
 | IMPORT-04 | batch | [CSV を local-only に import して reload 後に学習できる](./import.md#import-04) |
 | IMPORT-05 | batch | [失敗した import を同じ保存先へ重複なく再試行できる](./import.md#import-05) |
-| IMPORT-06 | batch | [Sample Deck を繰り返し追加しても重複しない](./import.md#import-06) |
+| IMPORT-06 | batch | [Sample Deck を保存して一覧へ戻り、再追加しても重複しない](./import.md#import-06) |
 
 ### Deck
 

--- a/docs/e2e/import.md
+++ b/docs/e2e/import.md
@@ -13,7 +13,7 @@ CSV の検証から保存先別の import、失敗後の再試行、Sample Deck 
 | IMPORT-03 | batch | [CSV を remote に import して reload 後も利用できる](#import-03) |
 | IMPORT-04 | batch | [CSV を local-only に import して reload 後に学習できる](#import-04) |
 | IMPORT-05 | batch | [失敗した import を同じ保存先へ重複なく再試行できる](#import-05) |
-| IMPORT-06 | batch | [Sample Deck を繰り返し追加しても重複しない](#import-06) |
+| IMPORT-06 | batch | [Sample Deck を保存して一覧へ戻り、再追加しても重複しない](#import-06) |
 
 <a id="import-01"></a>
 
@@ -132,23 +132,25 @@ Then:
 
 <a id="import-06"></a>
 
-### IMPORT-06 Sample Deck を繰り返し追加しても重複しない
+### IMPORT-06 Sample Deck を保存して一覧へ戻り、再追加しても重複しない
 
 カテゴリ: `batch`
 
 Given:
 
-- Fixture: [`sample-deck-present`](./fixture/sample-deck-present.yaml)
-- Sample Deck が明示的な追加操作によって local storage に保存されている。
-- Sample Deck とその Card の識別子および件数が記録されている。
-- Deck 一覧から Import 画面を開いている。
+- Fixture: [`empty`](./fixture/empty.yaml)
+- Sample Deck とその Card は local storage に存在しない。
+- Import 画面を開いている。
 
 When:
 
-- Import 画面から Sample Deck を再度追加し、`Back to decks` で Deck 一覧へ戻った後、画面を reload して Sample Deck を開く。
+- `Add sample deck` を実行し、Deck 一覧へ戻った後に Sample Deck と Card の識別子および件数を記録する。
+- Import 画面を再度開いて Sample Deck を追加し、Deck 一覧を reload して Sample Deck を開く。
 
 Then:
 
+- Sample Deck の保存中は `Add sample deck` が loading 表示になり、競合する操作が無効になる。
+- Sample Deck の追加では CSV の preview や完了確認を表示せず、保存完了後に Deck 一覧へ自動的に戻る。
 - local storage に存在する Sample Deck は一つだけである。
-- Sample Deck の Card の識別子と件数は追加前から変わらず、重複していない。
+- Sample Deck に Card が保存され、再追加後もその識別子と件数は変わらず重複していない。
 - 未処理の browser error が発生しない。

--- a/src/pages/deck-import/model/useDeckImport.ts
+++ b/src/pages/deck-import/model/useDeckImport.ts
@@ -7,7 +7,8 @@ import type { DeckImportResult, DeckImportStorageMode } from "./useDeckImportExe
 import { useDeckImportExecution } from "./useDeckImportExecution";
 import { useDeckImportPreview } from "./useDeckImportPreview";
 
-type DeckImportStatus = "idle" | "validating" | "importing";
+type DeckImportStatus = "idle" | "validating" | "importing" | "adding-sample";
+type DeckImportSaveStatus = Extract<DeckImportStatus, "importing" | "adding-sample">;
 
 export const useDeckImport = () => {
   const uid = useAuthUid();
@@ -30,9 +31,9 @@ export const useDeckImport = () => {
     if (preview.setStorageMode(storageMode)) execution.clear();
   };
 
-  const runImport = async (operation: () => Promise<DeckImportResult | undefined>) => {
+  const runSave = async (nextStatus: DeckImportSaveStatus, operation: () => Promise<DeckImportResult | undefined>) => {
     preview.clearError();
-    setStatus("importing");
+    setStatus(nextStatus);
     try {
       return await operation();
     } finally {
@@ -41,14 +42,14 @@ export const useDeckImport = () => {
   };
 
   const importPreview = async () => {
-    const result = await runImport(() => execution.runPrepared(preview.getPreparedImport));
+    const result = await runSave("importing", () => execution.runPrepared(preview.getPreparedImport));
     if (result === undefined) return;
     // Failed writes retain generated IDs so retrying cannot create another partial Deck.
     preview.completePreparedImport();
     return result;
   };
 
-  const addSample = () => runImport(() => execution.run(() => addSampleDeck(uid)));
+  const addSample = () => runSave("adding-sample", () => execution.run(() => addSampleDeck(uid)));
 
   return {
     selectFile,
@@ -59,6 +60,7 @@ export const useDeckImport = () => {
     preview: preview.preview,
     validating: status === "validating",
     pending: status === "importing",
+    addingSample: status === "adding-sample",
     error: execution.error,
     previewError: preview.error,
     result: execution.result,

--- a/src/pages/deck-import/ui/DeckImportPage.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.spec.tsx
@@ -9,6 +9,7 @@ import { useDecks } from "@/entities/deck";
 
 const controls = vi.hoisted(() => ({
   nextMutationError: undefined as unknown,
+  nextMutationWait: undefined as Promise<void> | undefined,
   setDarkMode: vi.fn(),
 }));
 
@@ -17,20 +18,27 @@ vi.mock("@/entities/card", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/card")>();
   return {
     ...actual,
-    mutateCards: (...arguments_: Parameters<typeof actual.mutateCards>) => {
+    mutateCards: async (...arguments_: Parameters<typeof actual.mutateCards>) => {
+      const wait = controls.nextMutationWait;
+      controls.nextMutationWait = undefined;
+      if (wait !== undefined) await wait;
       if (controls.nextMutationError !== undefined) {
         const error = controls.nextMutationError;
         controls.nextMutationError = undefined;
-        return Promise.reject(error);
+        throw error;
       }
       return actual.mutateCards(...arguments_);
     },
   };
 });
-vi.mock("@/entities/preference", () => ({
-  usePreferences: () => ({ appearance: { darkMode: false } }),
-  setDarkMode: controls.setDarkMode,
-}));
+vi.mock("@/entities/preference", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/preference")>();
+  return {
+    ...actual,
+    usePreferences: () => ({ appearance: { darkMode: false } }),
+    setDarkMode: controls.setDarkMode,
+  };
+});
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { DeckImportPage } from "./DeckImportPage";
@@ -76,6 +84,7 @@ const selectLocalFile = async (name: string, backText = "back") => {
 describe("DeckImportPage", () => {
   beforeEach(() => {
     controls.nextMutationError = undefined;
+    controls.nextMutationWait = undefined;
     controls.setDarkMode.mockReset();
   });
 
@@ -131,6 +140,26 @@ describe("DeckImportPage", () => {
     expect(screen.getByText("front: retry back")).toBeVisible();
   });
 
+  it("loads the sample action, saves the Sample Deck, and navigates without a preview", async () => {
+    const request = Promise.withResolvers<void>();
+    controls.nextMutationWait = request.promise;
+    renderPage();
+
+    const addSample = screen.getByRole("button", { name: "Add sample deck" });
+    await userEvent.click(addSample);
+
+    expect(addSample).toBeDisabled();
+    expect(addSample).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByRole("heading", { level: 2, name: "Review import" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Import decks" })).toBeVisible();
+
+    request.resolve();
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+    expect(screen.getByText("Sample Deck")).toBeVisible();
+    expect(screen.getAllByText(/: /u).length).toBeGreaterThan(0);
+  });
+
   it("shows a failed sample add in place", async () => {
     renderPage();
     controls.nextMutationError = new Error("sample mutation failed");
@@ -140,5 +169,7 @@ describe("DeckImportPage", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("Import failed");
     expect(screen.getByRole("alert")).toHaveTextContent("sample mutation failed");
     expect(screen.getByRole("heading", { level: 1, name: "Import decks" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Add sample deck" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add sample deck" })).not.toHaveAttribute("aria-busy");
   });
 });

--- a/src/pages/deck-import/ui/DeckImportPage.tsx
+++ b/src/pages/deck-import/ui/DeckImportPage.tsx
@@ -23,7 +23,9 @@ export const DeckImportPage: React.FC = () => {
           void deckImport.selectFile(file);
         }}
         onAddSample={() => {
-          void deckImport.addSample();
+          void deckImport.addSample().then((result) => {
+            if (result !== undefined) void navigate(routes.deckList.to());
+          });
         }}
         onImport={() => {
           void deckImport.importPreview().then((result) => {
@@ -34,6 +36,7 @@ export const DeckImportPage: React.FC = () => {
         onDownloadSample={downloadSampleCsv}
         validating={deckImport.validating}
         pending={deckImport.pending}
+        addingSample={deckImport.addingSample}
         preview={deckImport.preview}
         result={deckImport.result}
         error={deckImport.error}

--- a/src/pages/deck-import/ui/DeckImportView.spec.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.spec.tsx
@@ -95,6 +95,20 @@ describe("DeckImportView", () => {
     expect(onDownloadSample).toHaveBeenCalledOnce();
   });
 
+  it("loads only the sample action while a Sample Deck is being added", () => {
+    render(<DeckImportView sampleText="front,back,,key" preview={preview} addingSample />);
+
+    const addSample = screen.getByRole("button", { name: "Add sample deck" });
+    const importDeck = screen.getByRole("button", { name: "Import" });
+
+    expect(addSample).toBeDisabled();
+    expect(addSample).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("status")).toHaveTextContent("Loading Add sample deck");
+    expect(importDeck).toBeDisabled();
+    expect(importDeck).not.toHaveAttribute("aria-busy");
+    expect(screen.getByLabelText(/Upload a csv file/u)).toBeDisabled();
+  });
+
   it("activates the CSV sample download with Enter", async () => {
     const onDownloadSample = vi.fn();
     const user = userEvent.setup();

--- a/src/pages/deck-import/ui/DeckImportView.stories.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.stories.tsx
@@ -74,6 +74,13 @@ export const Pending: Story = {
   },
 };
 
+export const AddingSample: Story = {
+  args: {
+    addingSample: true,
+    preview,
+  },
+};
+
 export const Success: Story = {
   args: {
     preview,

--- a/src/pages/deck-import/ui/DeckImportView.tsx
+++ b/src/pages/deck-import/ui/DeckImportView.tsx
@@ -48,6 +48,7 @@ export interface DeckImportViewProps {
   dark?: boolean;
   validating?: boolean;
   pending?: boolean;
+  addingSample?: boolean;
   preview?: DeckImportPreview | undefined;
   result?: DeckImportResult | undefined;
   error?: unknown;
@@ -108,8 +109,8 @@ const PreviewError = ({ error }: { error: unknown }) => {
 
 interface ImportPreviewProps {
   preview: DeckImportPreview | undefined;
+  busy: boolean;
   pending: boolean | undefined;
-  validating: boolean | undefined;
   onImport: (() => void) | undefined;
 }
 
@@ -117,8 +118,7 @@ const ImportPreview = (props: ImportPreviewProps) => {
   const { preview } = props;
   if (preview == null) return null;
 
-  const busy = Boolean(props.pending || props.validating);
-  const canImport = preview.analysis.rows.length > 0 && preview.analysis.invalidCount === 0 && !busy;
+  const canImport = preview.analysis.rows.length > 0 && preview.analysis.invalidCount === 0 && !props.busy;
   const visibleRows = preview.analysis.rows.slice(0, 10);
   const hiddenRowCount = preview.analysis.rows.length - visibleRows.length;
 
@@ -211,7 +211,7 @@ const ImportPreview = (props: ImportPreviewProps) => {
 };
 
 export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
-  const busy = Boolean(props.pending || props.validating);
+  const busy = Boolean(props.pending || props.validating || props.addingSample);
   const storageMode = props.storageMode ?? "remote";
 
   return (
@@ -266,12 +266,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
             {...(props.onChange !== undefined ? { onChange: props.onChange } : {})}
           />
         </section>
-        <ImportPreview
-          preview={props.preview}
-          pending={props.pending}
-          validating={props.validating}
-          onImport={props.onImport}
-        />
+        <ImportPreview preview={props.preview} busy={busy} pending={props.pending} onImport={props.onImport} />
         <section>
           <h2 className="mb-2 break-words text-title font-bold text-ink">CSV format</h2>
           <div className="space-y-2">
@@ -288,6 +283,7 @@ export const DeckImportView: React.FC<DeckImportViewProps> = (props) => {
               <Button
                 size="sm"
                 disabled={busy}
+                loading={props.addingSample ?? false}
                 {...(props.onAddSample !== undefined ? { onClick: props.onAddSample } : {})}
               >
                 Add sample deck

--- a/test/e2e/import.spec.ts
+++ b/test/e2e/import.spec.ts
@@ -161,41 +161,54 @@ test("IMPORT-05 A partial remote import retries without duplicates", async ({
   expect(cardsAfterRetry[0]?.fields.deckId?.stringValue).toBe(partialDeckId);
 });
 
-test("IMPORT-06 Adding Sample Deck repeatedly remains idempotent", async ({ fixture, page }) => {
-  const sampleDeck = fixture.deck("sample-v1");
-  const expectedCardIds = fixture.state.browser.localCards
-    .filter(({ deckId }) => deckId === sampleDeck.id)
-    .map(({ id }) => id)
-    .sort();
-  expect(expectedCardIds.length).toBeGreaterThan(0);
-
+test("IMPORT-06 Adding Sample Deck saves it, returns to the list, and remains idempotent", async ({
+  fixture,
+  page,
+}) => {
   await fixture.apply(page);
-  await page.goto("/");
-  const before = await readLocalData(page);
-  const beforeDecks = before.decks.filter(({ name }: { name?: string }) => name === sampleDeck.name);
-  expect(beforeDecks).toHaveLength(1);
-  expect((beforeDecks[0] as { id: string }).id).toBe(sampleDeck.id);
-  expect(
-    before.cards
-      .filter(({ deckId }: { deckId?: string }) => deckId === sampleDeck.id)
-      .map(({ id }: { id: string }) => id)
-      .sort()
-  ).toEqual(expectedCardIds);
+  await page.goto("/import");
+  const addSample = page.getByRole("button", { name: "Add sample deck" });
+  // Local persistence can finish before Playwright polls again, so observe loading before clicking.
+  await addSample.evaluate((element) => {
+    if (!(element instanceof HTMLButtonElement)) throw new Error("Add sample deck control is not a button");
+    const { documentElement } = element.ownerDocument;
+    documentElement.dataset.sampleDeckLoadingObserved = "false";
+    const observer = new MutationObserver(() => {
+      if (element.getAttribute("aria-busy") === "true" && element.disabled) {
+        documentElement.dataset.sampleDeckLoadingObserved = "true";
+        observer.disconnect();
+      }
+    });
+    observer.observe(element, { attributeFilter: ["aria-busy", "disabled"], attributes: true });
+  });
+
+  await addSample.click();
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.locator("html").getAttribute("data-sample-deck-loading-observed")).toBe("true");
+  await expect(page.getByRole("button", { name: "View Sample Deck" })).toBeVisible();
+
+  const first = await readLocalData(page);
+  const firstDecks = first.decks.filter(({ id }: { id: string }) => id === "sample-v1");
+  const firstCardIds = first.cards
+    .filter(({ deckId }: { deckId?: string }) => deckId === "sample-v1")
+    .map(({ id }: { id: string }) => id)
+    .sort();
+  expect(firstDecks).toHaveLength(1);
+  expect(firstCardIds.length).toBeGreaterThan(0);
 
   await page.getByRole("button", { name: "Import decks" }).click();
   await page.getByRole("button", { name: "Add sample deck" }).click();
-  await page.getByRole("button", { name: "Back to decks" }).click();
+  await expect(page).toHaveURL(/\/$/);
   await page.reload();
-  await page.getByRole("button", { name: `View ${sampleDeck.name}` }).click();
+  await page.getByRole("button", { name: "View Sample Deck" }).click();
 
   const after = await readLocalData(page);
-  const afterDecks = after.decks.filter(({ name }: { name?: string }) => name === sampleDeck.name);
+  const afterDecks = after.decks.filter(({ id }: { id: string }) => id === "sample-v1");
   expect(afterDecks).toHaveLength(1);
-  expect((afterDecks[0] as { id: string }).id).toBe(sampleDeck.id);
   expect(
     after.cards
-      .filter(({ deckId }: { deckId?: string }) => deckId === sampleDeck.id)
+      .filter(({ deckId }: { deckId?: string }) => deckId === "sample-v1")
       .map(({ id }: { id: string }) => id)
       .sort()
-  ).toEqual(expectedCardIds);
+  ).toEqual(firstCardIds);
 });


### PR DESCRIPTION
## Related issue

None.

## Summary

- Show loading only on Add sample deck while disabling competing import actions.
- Save the Sample Deck locally and navigate directly to the deck list only after a successful write.
- Keep the import page visible on failure and cover loading, persistence, direct navigation, and idempotent re-add behavior in unit tests, E2E tests, and E2E documentation.

## Testing

- Targeted Deck Import unit tests passed.
- Import E2E passed with one worker: 6 passed.
- mise run check passed before the final Storybook and intent-comment review follow-ups.
- After those follow-ups, application checks and all 562 unit tests passed; the final full retry stopped at the unchanged sample-formatter step because Docker Desktop returned HTTP 500.