### PR TITLE
[No issue] Add application error boundary

### DIFF
--- a/src/app/error-boundary/index.spec.tsx
+++ b/src/app/error-boundary/index.spec.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -22,13 +21,11 @@ describe("AppErrorBoundary", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("replaces crashed content with reload feedback", async () => {
-    const reload = vi.fn();
+  it("replaces crashed content with reload feedback", () => {
     const onCaughtError = vi.fn();
-    const user = userEvent.setup();
 
     const view = render(
-      <AppErrorBoundary reload={reload}>
+      <AppErrorBoundary>
         <ApplicationContent />
       </AppErrorBoundary>,
       { onCaughtError }
@@ -36,7 +33,7 @@ describe("AppErrorBoundary", () => {
     expect(screen.getByText("Application content")).toBeVisible();
 
     view.rerender(
-      <AppErrorBoundary reload={reload}>
+      <AppErrorBoundary>
         <ApplicationContent crash />
       </AppErrorBoundary>
     );
@@ -46,8 +43,6 @@ describe("AppErrorBoundary", () => {
     expect(screen.getByText("Tango encountered an unexpected error. Reload the app to try again.")).toBeVisible();
     expect(screen.queryByText("Application content")).not.toBeInTheDocument();
     expect(onCaughtError).toHaveBeenCalledOnce();
-
-    await user.click(screen.getByRole("button", { name: "Reload" }));
-    expect(reload).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeVisible();
   });
 });

--- a/src/app/error-boundary/index.spec.tsx
+++ b/src/app/error-boundary/index.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { AppErrorBoundary } from "./index";
+
+const ApplicationContent = ({ crash = false }: { crash?: boolean }) => {
+  if (crash) throw new Error("render failed");
+  return <p>Application content</p>;
+};
+
+describe("AppErrorBoundary", () => {
+  it("renders its children while the application is healthy", () => {
+    render(
+      <AppErrorBoundary>
+        <ApplicationContent />
+      </AppErrorBoundary>
+    );
+
+    expect(screen.getByText("Application content")).toBeVisible();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("replaces crashed content with reload feedback", async () => {
+    const reload = vi.fn();
+    const onCaughtError = vi.fn();
+    const user = userEvent.setup();
+
+    const view = render(
+      <AppErrorBoundary reload={reload}>
+        <ApplicationContent />
+      </AppErrorBoundary>,
+      { onCaughtError }
+    );
+    expect(screen.getByText("Application content")).toBeVisible();
+
+    view.rerender(
+      <AppErrorBoundary reload={reload}>
+        <ApplicationContent crash />
+      </AppErrorBoundary>
+    );
+
+    expect(screen.getByRole("alert")).toBeVisible();
+    expect(screen.getByRole("heading", { level: 1, name: "Something went wrong" })).toBeVisible();
+    expect(screen.getByText("Tango encountered an unexpected error. Reload the app to try again.")).toBeVisible();
+    expect(screen.queryByText("Application content")).not.toBeInTheDocument();
+    expect(onCaughtError).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole("button", { name: "Reload" }));
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/error-boundary/index.tsx
+++ b/src/app/error-boundary/index.tsx
@@ -4,7 +4,6 @@ import { RouteFeedback } from "@/shared/ui/route-feedback";
 
 interface AppErrorBoundaryProps {
   children: ReactNode;
-  reload?: (() => void) | undefined;
 }
 
 interface AppErrorBoundaryState {
@@ -35,7 +34,7 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
         title="Something went wrong"
         description="Tango encountered an unexpected error. Reload the app to try again."
         tone="error"
-        primaryAction={{ label: "Reload", onClick: this.props.reload ?? reloadPage }}
+        primaryAction={{ label: "Reload", onClick: reloadPage }}
       />
     );
   }

--- a/src/app/error-boundary/index.tsx
+++ b/src/app/error-boundary/index.tsx
@@ -1,0 +1,42 @@
+import { Component, type ReactNode } from "react";
+
+import { RouteFeedback } from "@/shared/ui/route-feedback";
+
+interface AppErrorBoundaryProps {
+  children: ReactNode;
+  reload?: (() => void) | undefined;
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+}
+
+const reloadPage = () => {
+  // A full reload discards the failed React tree; resetting only the boundary could render the same fault again.
+  window.location.reload();
+};
+
+// biome-ignore lint/style/useReactFunctionComponents: React requires a class to define an Error Boundary without another dependency.
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  constructor(props: AppErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  override render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <RouteFeedback
+        title="Something went wrong"
+        description="Tango encountered an unexpected error. Reload the app to try again."
+        tone="error"
+        primaryAction={{ label: "Reload", onClick: this.props.reload ?? reloadPage }}
+      />
+    );
+  }
+}

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,7 +1,7 @@
 /**
  * @file Starts the React application in the browser.
- * It creates the root providers, enables development diagnostics, and mounts the route tree into
- * the HTML page.
+ * It creates the root error boundary and providers, enables development diagnostics, and mounts
+ * the route tree into the HTML page.
  */
 
 import "@/shared/firebase";
@@ -10,12 +10,15 @@ import "./styles/index.css";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { AppErrorBoundary } from "./error-boundary";
 
 const root = document.getElementById("root");
 if (root == null) throw new Error("Missing root element");
 
 createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Related issue

None

## Summary

- Add an application-level React Error Boundary around the root app tree.
- Reuse the existing route feedback UI with a full-page Reload recovery action.
- Cover healthy rendering and fallback replacement, including the visible Reload recovery UI, with unit tests.

## Testing

- npm run fmt
- npm run lint
- npm run test:unit (108 files, 564 tests)
- npm run build
- mise run check (blocked by Docker Desktop returning HTTP 500 while starting the unchanged sample formatter; all code-specific stages pass individually)