### PR TITLE
fix(No issue): keep score range selectors on one row

### DIFF
--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -129,7 +129,7 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           />
         </div>
       </header>
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid grid-cols-2 gap-3">
         <ScoreSelect
           id={minimumId}
           label="Minimum"


### PR DESCRIPTION
## Related issue

None

## Summary

- keep the shared Minimum and Maximum score selectors in one horizontal row at every viewport width
- preserve the existing labels, descriptions, accessibility attributes, filtering behavior, and public API
- apply the layout consistently to Study Start and Card List through the shared ScoreRange component

## Testing

- npm run fmt
- npm run lint
- npm run test:unit (562 tests passed)
- targeted ScoreRange, DeckFilterForm, and Study Start tests (21 tests passed)
- Storybook visual verification at 320px and 375px for ScoreRange and Study Start; selectors remained aligned and no horizontal overflow was detected
- mise run check attempted, but Docker Desktop returned HTTP 500 for Docker API calls during the sample build/format tasks