### PR TITLE
[No issue] Keep the application header fixed

### DIFF
--- a/src/app/AppLayout.stories.tsx
+++ b/src/app/AppLayout.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "storybook/test";
+
+import { type PageStoryParameters, preparePageStory, withPageStory } from "@/storybook/PageDecorator";
+import { AppLayout } from "@/widgets/app-layout";
+
+const meta = {
+  title: "Integration/AppLayout",
+  component: AppLayout,
+  decorators: [withPageStory],
+  loaders: [
+    ({ parameters }) => {
+      preparePageStory(parameters.page as PageStoryParameters);
+      return {};
+    },
+  ],
+  parameters: {
+    layout: "fullscreen",
+    page: { path: "/" } satisfies PageStoryParameters,
+  },
+  args: {
+    showHeader: true,
+  },
+} satisfies Meta<typeof AppLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FixedByDefault: Story = {
+  args: {
+    children: [1, 2, 3, 4, 5, 6, 7, 8].map((section) => (
+      <section key={section} className="rounded-control bg-surface-muted p-shell-gutter">
+        <h2 className="font-semibold text-ink">Application section {section}</h2>
+        <p className="mt-2 text-ink-muted">Application navigation remains available while this content scrolls.</p>
+      </section>
+    )),
+  },
+  play: async ({ canvas }) => {
+    const shell = canvas.getByRole("region", { name: "Application shell" });
+    const header = canvas.getByRole("banner");
+    const firstSection = canvas.getByRole("heading", { name: "Application section 1" }).closest("section");
+
+    await expect(firstSection).not.toBeNull();
+    if (firstSection === null) return;
+
+    await expect(getComputedStyle(header).position).toBe("fixed");
+    const initialHeaderTop = header.getBoundingClientRect().top;
+    await expect(firstSection.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      header.getBoundingClientRect().bottom
+    );
+
+    shell.scrollTop = shell.scrollHeight;
+
+    await expect(shell.scrollTop).toBeGreaterThan(0);
+    await expect(header.getBoundingClientRect().top).toBe(initialHeaderTop);
+    shell.scrollTop = 0;
+  },
+};
+
+export const FixedHeaderDisabled: Story = {
+  args: {
+    fixedHeader: false,
+    children: <h1 className="text-title font-bold text-ink">Non-fixed application content</h1>,
+  },
+  play: async ({ canvas }) => {
+    const header = canvas.getByRole("banner");
+    const content = canvas.getByRole("heading", { name: "Non-fixed application content" });
+
+    await expect(getComputedStyle(header).position).toBe("static");
+    await expect(content.getBoundingClientRect().top).toBeGreaterThanOrEqual(header.getBoundingClientRect().bottom);
+  },
+};

--- a/src/shared/ui/layout/Layout.stories.tsx
+++ b/src/shared/ui/layout/Layout.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "storybook/test";
 
 import { Layout } from "./Layout";
 
@@ -35,6 +36,25 @@ export const FixedHeaderLongContent: Story = {
         <p className="mt-2 text-ink-muted">Scroll to observe the elevated header remain fixed above long content.</p>
       </section>
     )),
+  },
+  play: async ({ canvas }) => {
+    const shell = canvas.getByRole("region", { name: "Application shell" });
+    const header = canvas.getByRole("banner");
+    const firstSection = canvas.getByRole("heading", { name: "Section 1" }).closest("section");
+
+    await expect(firstSection).not.toBeNull();
+    if (firstSection === null) return;
+
+    const initialHeaderTop = header.getBoundingClientRect().top;
+    await expect(firstSection.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      header.getBoundingClientRect().bottom
+    );
+
+    shell.scrollTop = shell.scrollHeight;
+
+    await expect(shell.scrollTop).toBeGreaterThan(0);
+    await expect(header.getBoundingClientRect().top).toBe(initialHeaderTop);
+    shell.scrollTop = 0;
   },
 };
 

--- a/src/widgets/app-layout/ui/AppLayout.tsx
+++ b/src/widgets/app-layout/ui/AppLayout.tsx
@@ -10,10 +10,13 @@ type AppLayoutProps = Omit<React.ComponentProps<typeof Layout>, "headerProps">;
 export const AppLayout: React.FC<AppLayoutProps> = (props) => {
   const navigate = useNavigate();
   const preferences = usePreferences();
+  // Application navigation must remain available while the page-owned shell scrolls.
+  const { fixedHeader = true, ...layoutProps } = props;
 
   return (
     <Layout
-      {...props}
+      {...layoutProps}
+      fixedHeader={fixedHeader}
       headerProps={{
         dark: preferences.appearance.darkMode,
         onClickDarkMode: setDarkMode,


### PR DESCRIPTION
## Related issue
None

## Summary

- Keep the application header fixed by default on pages that show it.
- Preserve the explicit fixed-header opt-out and existing header-hidden fullscreen behavior.
- Verify fixed positioning, content clearance, scrolling, and the opt-out in Storybook browser tests.

## Testing

- `npm run test:storybook` — passed (59 files, 365 tests)
- `npm run test:unit` — passed (107 files, 564 tests)
- `CHOKIDAR_USEPOLLING=1 npm run lint` — passed
- `npm run fmt` — passed
- `mise exec -- hadolint --failure-threshold warning Dockerfile sample/Dockerfile` — passed
- `uvx ruff==0.8.6 format --check` — passed (12 files)
- `mise run test-storybook` — blocked before Storybook by Docker Desktop HTTP 500 during sample generation; the direct Storybook suite above passed
- `mise run check` — blocked by the same Docker Desktop HTTP 500 during `sample:fmt`; all non-Docker checks and the equivalent pinned Ruff check above passed