### PR TITLE
[No issue] Center study prompt on iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" sizes="64x64" type="image/x-icon" />
     <link rel="icon" href="/tango-mark.svg" sizes="any" type="image/svg+xml" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#f7f8fa" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)" />
     <meta

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -45,14 +45,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const expectFrontTextCentered = async (canvasElement: HTMLElement) => {
+const expectFrontTextCentered = async (canvasElement: HTMLElement, expectedOffset = 0) => {
   const frontText = canvasElement.querySelector<HTMLElement>("#frontText > *");
   await expect(frontText).not.toBeNull();
   if (frontText === null) return;
 
   const frontTextBounds = frontText.getBoundingClientRect();
   const frontTextCenter = frontTextBounds.top + frontTextBounds.height / 2;
-  await expect(Math.abs(frontTextCenter - window.innerHeight / 2)).toBeLessThan(1);
+  await expect(Math.abs(frontTextCenter - window.innerHeight / 2 - expectedOffset)).toBeLessThan(1);
 };
 
 const centeredFrontTextPlay: Story["play"] = async ({ canvasElement }) => {
@@ -130,6 +130,19 @@ export const AutoPlay: Story = {
 export const Mobile: Story = {
   globals: { viewport: { value: "iphonex", isRotated: false } },
   play: centeredFrontTextPlay,
+};
+
+export const MobileSafeArea: Story = {
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const studySession = canvasElement.querySelector<HTMLElement>("[style*='--study-safe-area-top']");
+    await expect(studySession).not.toBeNull();
+    if (studySession === null) return;
+
+    studySession.style.setProperty("--study-safe-area-top", "47px");
+    studySession.style.setProperty("--study-safe-area-bottom", "34px");
+    await expectFrontTextCentered(canvasElement, (34 - 47) / 2);
+  },
 };
 
 export const MobileLongAnswer: Story = {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -25,13 +25,17 @@ const SWIPE_FEEDBACK_LABEL: Record<SwipeDirection, string> = {
 const PLAYBACK_UNAVAILABLE_DESCRIPTION = "Playback controls unavailable because the card interval is set to 0";
 
 type StudyLayoutStyles = React.CSSProperties & {
+  "--study-safe-area-top": string;
+  "--study-safe-area-bottom": string;
   "--study-toolbar-top": string;
   "--study-card-top": string;
   "--study-feedback-top": string;
 };
 
 const studyLayoutStyles: StudyLayoutStyles = {
-  "--study-toolbar-top": "calc(0.75rem + env(safe-area-inset-top))",
+  "--study-safe-area-top": "env(safe-area-inset-top)",
+  "--study-safe-area-bottom": "env(safe-area-inset-bottom)",
+  "--study-toolbar-top": "calc(0.75rem + var(--study-safe-area-top))",
   "--study-card-top": "calc(var(--study-toolbar-top) + var(--spacing-touch) + 0.75rem)",
   // Card metadata is fixed at h-10; feedback starts immediately after it so neither surface overlaps.
   "--study-feedback-top": "calc(var(--study-card-top) + 2.5rem)",
@@ -249,7 +253,10 @@ const CardContent: React.FC<{
           // Metadata stays below the toolbar without reserving space in the centered prompt surface.
           <div className="absolute inset-x-0 top-[var(--study-card-top)] h-touch">{cardOverlaySlot}</div>
         ) : null}
-        {frontTextSlot}
+        {/* Reversed vertical insets optically center the prompt when iPhone safe areas are asymmetric. */}
+        <div className="h-full min-h-0 pb-[var(--study-safe-area-top)] pt-[var(--study-safe-area-bottom)]">
+          {frontTextSlot}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Related issue

None

## Summary

- enable full iPhone viewport coverage so CSS safe-area insets are available
- offset the study prompt by the asymmetric vertical safe-area difference
- add Storybook coverage for an iPhone-style top and bottom inset

## Testing

- mise run check
- npm run test:storybook -- src/pages/study-session/ui/StudySession.stories.tsx