### PR TITLE
[No issue] Persist study card detail visibility

### DIFF
--- a/src/entities/preference/index.ts
+++ b/src/entities/preference/index.ts
@@ -4,4 +4,10 @@ export type {
   Preferences,
   SwipeDirection,
 } from "./model/types";
-export { setDarkMode, toggleShowPlaybackControls, toggleShowSwipeButtonList, updatePreferences } from "./model/store";
+export {
+  setDarkMode,
+  toggleShowCardDetails,
+  toggleShowPlaybackControls,
+  toggleShowSwipeButtonList,
+  updatePreferences,
+} from "./model/store";

--- a/src/entities/preference/model/schema.ts
+++ b/src/entities/preference/model/schema.ts
@@ -24,6 +24,7 @@ const DEFAULT_STUDY = {
 const DEFAULT_CONTROLS = {
   showSwipeButtonList: true,
   showPlaybackControls: true,
+  showCardDetails: true,
   showScoreSlider: false,
   cardSwipeUp: "GoToNextCardMastered" as const,
   cardSwipeDown: "GoToNextCardNotMastered" as const,
@@ -78,6 +79,7 @@ export const controlPreferencesSchema = z
   .object({
     showSwipeButtonList: z.boolean().catch(DEFAULT_CONTROLS.showSwipeButtonList),
     showPlaybackControls: z.boolean().catch(DEFAULT_CONTROLS.showPlaybackControls),
+    showCardDetails: z.boolean().catch(DEFAULT_CONTROLS.showCardDetails),
     showScoreSlider: z.boolean().catch(DEFAULT_CONTROLS.showScoreSlider),
     cardSwipeUp: swipeActionSchema.catch(DEFAULT_CONTROLS.cardSwipeUp),
     cardSwipeDown: swipeActionSchema.catch(DEFAULT_CONTROLS.cardSwipeDown),

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -5,6 +5,7 @@ import { defaultPreferences } from "./defaults";
 import {
   preferencesStore,
   setDarkMode,
+  toggleShowCardDetails,
   toggleShowPlaybackControls,
   toggleShowSwipeButtonList,
   updatePreferences,
@@ -45,7 +46,7 @@ describe("preferences store", () => {
       loadSample: false,
       appearance: { darkMode: true },
       study: { cardInterval: 15 },
-      controls: { showScoreSlider: true },
+      controls: { showCardDetails: false, showScoreSlider: true },
     });
     store.getState().updatePreferences({ controls: { showSwipeButtonList: false } });
     store.getState().updatePreferences({ controls: { showPlaybackControls: false } });
@@ -57,6 +58,7 @@ describe("preferences store", () => {
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       controls: {
         ...defaultPreferences.controls,
+        showCardDetails: false,
         showScoreSlider: true,
         showSwipeButtonList: false,
         showPlaybackControls: false,
@@ -84,20 +86,30 @@ describe("preferences store", () => {
     updatePreferences({ loadSample: false, study: { cardInterval: 15 } });
     toggleShowSwipeButtonList();
     toggleShowPlaybackControls();
+    toggleShowCardDetails();
 
     expect(preferencesStore.getState().preferences).toEqual({
       ...defaultPreferences,
       loadSample: false,
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, cardInterval: 15 },
-      controls: { ...defaultPreferences.controls, showSwipeButtonList: false, showPlaybackControls: false },
+      controls: {
+        ...defaultPreferences.controls,
+        showSwipeButtonList: false,
+        showPlaybackControls: false,
+        showCardDetails: false,
+      },
     });
   });
 
   it("persists preference changes", () => {
     const storage = useMemoryStorage();
 
-    preferencesStore.getState().updatePreferences({ loadSample: false, appearance: { darkMode: true } });
+    preferencesStore.getState().updatePreferences({
+      loadSample: false,
+      appearance: { darkMode: true },
+      controls: { showCardDetails: false },
+    });
 
     expect(JSON.parse(storage.getItem("tango-config") ?? "{}")).toEqual({
       state: {
@@ -105,9 +117,10 @@ describe("preferences store", () => {
           ...defaultPreferences,
           loadSample: false,
           appearance: { ...defaultPreferences.appearance, darkMode: true },
+          controls: { ...defaultPreferences.controls, showCardDetails: false },
         },
       },
-      version: 1,
+      version: 2,
     });
   });
 
@@ -119,7 +132,7 @@ describe("preferences store", () => {
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
     };
     useMemoryStorage({
-      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 1 }),
+      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 2 }),
     });
 
     await preferencesStore.persist.rehydrate();
@@ -127,8 +140,8 @@ describe("preferences store", () => {
     expect(preferencesStore.getState().preferences).toEqual(persistedPreferences);
   });
 
-  it("discards version 0 preferences after the persisted shape changes", async () => {
-    const { showPlaybackControls: _showPlaybackControls, ...legacyControls } = defaultPreferences.controls;
+  it("discards version 1 preferences after the persisted shape changes", async () => {
+    const { showCardDetails: _showCardDetails, ...legacyControls } = defaultPreferences.controls;
     useMemoryStorage({
       "tango-config": JSON.stringify({
         state: {
@@ -140,7 +153,7 @@ describe("preferences store", () => {
             controls: { ...legacyControls, showSwipeButtonList: false },
           },
         },
-        version: 0,
+        version: 1,
       }),
     });
 
@@ -157,8 +170,8 @@ describe("preferences store", () => {
 
   it.each([
     ["malformed JSON", "not-json"],
-    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 1 })],
-    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 1 })],
+    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 2 })],
+    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 2 })],
   ])("uses current defaults for %s", async (_case, persistedValue) => {
     useMemoryStorage({ "tango-config": persistedValue });
 

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -8,7 +8,7 @@ import type { Preferences } from "./types";
 
 const PREFERENCES_STORAGE_KEY = "tango-config";
 // No migration is registered: changing this version deliberately invalidates older state shapes.
-const PREFERENCES_STORAGE_VERSION = 1;
+const PREFERENCES_STORAGE_VERSION = 2;
 
 /** @internal Partial updates for each top-level preference field. */
 export type PartialPreferences = {
@@ -97,4 +97,10 @@ export const toggleShowSwipeButtonList = (): void => {
 export const toggleShowPlaybackControls = (): void => {
   const { showPlaybackControls } = preferencesStore.getState().preferences.controls;
   updatePreferences({ controls: { showPlaybackControls: !showPlaybackControls } });
+};
+
+// Toggles whether study card details are shown.
+export const toggleShowCardDetails = (): void => {
+  const { showCardDetails } = preferencesStore.getState().preferences.controls;
+  updatePreferences({ controls: { showCardDetails: !showCardDetails } });
 };

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -44,14 +44,18 @@ describe("SettingsForm", () => {
   it("renders and updates switches and numeric sliders through RHF registration", async () => {
     render(<SettingsFormHarness />);
     const playback = screen.getByRole("checkbox", { name: "Show playback controls" });
+    const cardDetails = screen.getByRole("checkbox", { name: "Show card details" });
     const maximumCards = screen.getByRole("slider", { name: "Maximum cards" });
     expect(playback).toBeChecked();
+    expect(cardDetails).toBeChecked();
     expect(maximumCards).toHaveValue("24");
 
     await userEvent.click(playback);
+    await userEvent.click(cardDetails);
     fireEvent.change(maximumCards, { target: { value: "31" } });
 
     expect(playback).not.toBeChecked();
+    expect(cardDetails).not.toBeChecked();
     expect(maximumCards).toHaveValue("31");
     expect(maximumCards).toHaveAttribute("aria-valuetext", "31 cards");
     expect(screen.getByText("31")).toBeInTheDocument();

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -27,6 +27,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
   const inputIds = {
     showSwipeButtonList: `${idPrefix}-show-swipe-controls`,
     showPlaybackControls: `${idPrefix}-show-playback-controls`,
+    showCardDetails: `${idPrefix}-show-card-details`,
     showSwipeFeedback: `${idPrefix}-show-swipe-feedback`,
     darkMode: `${idPrefix}-dark-mode`,
     shuffled: `${idPrefix}-shuffle-cards`,
@@ -71,6 +72,17 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
               {...props.form.register("controls.showPlaybackControls")}
               id={inputIds.showPlaybackControls}
               aria-describedby={descriptionId(inputIds.showPlaybackControls)}
+            />
+          </SettingsRow>
+          <SettingsRow
+            inputId={inputIds.showCardDetails}
+            label="Show card details"
+            description="Display score and study history during a session"
+          >
+            <Switch
+              {...props.form.register("controls.showCardDetails")}
+              id={inputIds.showCardDetails}
+              aria-describedby={descriptionId(inputIds.showCardDetails)}
             />
           </SettingsRow>
           <SettingsRow

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -109,6 +109,7 @@ describe("useStudy", () => {
       session: { currentIndex: 0, cardCount: 2 },
       card: { frontText: "card-1" },
       showBackText: false,
+      showCardDetails: true,
       showPlaybackControls: true,
       playbackControlsAvailable: true,
     });
@@ -143,7 +144,7 @@ describe("useStudy", () => {
   it("reports persisted control visibility and playback availability", () => {
     mocks.preferences = createPreferences({
       cardInterval: 0,
-      controls: { showSwipeButtonList: false, showPlaybackControls: false },
+      controls: { showCardDetails: false, showSwipeButtonList: false, showPlaybackControls: false },
     });
 
     const { result } = renderHook(() => useStudy(deckId));
@@ -151,6 +152,7 @@ describe("useStudy", () => {
     expect(result.current).toMatchObject({
       showSwipeButtonList: false,
       showPlaybackControls: false,
+      showCardDetails: false,
       playbackControlsAvailable: false,
     });
   });

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -2,7 +2,12 @@ import * as React from "react";
 
 import { useCards } from "@/entities/card";
 import { getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
-import { toggleShowPlaybackControls, toggleShowSwipeButtonList, usePreferences } from "@/entities/preference";
+import {
+  toggleShowCardDetails,
+  toggleShowPlaybackControls,
+  toggleShowSwipeButtonList,
+  usePreferences,
+} from "@/entities/preference";
 import { setStudySessionIndex } from "@/entities/study-session";
 
 import { useAutoPlay } from "./useAutoPlay";
@@ -32,10 +37,12 @@ export const useStudy = (deckId: string) => {
     ...swipe,
     toggleBackText: () => setShowBackText((visible) => !visible),
     toggleAutoPlay,
+    toggleShowCardDetails,
     toggleShowPlaybackControls,
     toggleSwipeButtonList: toggleShowSwipeButtonList,
     showBackText,
     playbackControlsAvailable: preferences.study.cardInterval > 0,
+    showCardDetails: preferences.controls.showCardDetails,
     showPlaybackControls: preferences.controls.showPlaybackControls,
     showSwipeButtonList: preferences.controls.showSwipeButtonList,
     autoPlay,

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -9,10 +9,12 @@ import { StudySession } from "./StudySession";
 const playbackUnavailableDescription = "Playback controls unavailable because the card interval is set to 0";
 
 const toolbarProps = () => ({
+  showCardDetails: true,
   showSwipeControls: true,
   showPlaybackControls: true,
   playbackControlsAvailable: true,
   onBack: vi.fn(),
+  onToggleCardDetails: vi.fn(),
   onToggleSwipeControls: vi.fn(),
   onTogglePlaybackControls: vi.fn(),
 });
@@ -78,12 +80,14 @@ describe("StudySession", () => {
 
   it("opens the study actions overlay and reports its controls", () => {
     const onBack = vi.fn();
+    const onToggleCardDetails = vi.fn();
     const onToggleSwipeControls = vi.fn();
     const onTogglePlaybackControls = vi.fn();
     render(
       <StudySession
         {...toolbarProps()}
         onBack={onBack}
+        onToggleCardDetails={onToggleCardDetails}
         onToggleSwipeControls={onToggleSwipeControls}
         onTogglePlaybackControls={onTogglePlaybackControls}
         cardOverlaySlot={<div>Card metadata</div>}
@@ -118,18 +122,20 @@ describe("StudySession", () => {
     fireEvent.click(back);
     fireEvent.click(swipeToggle);
     fireEvent.click(playbackToggle);
+    fireEvent.click(detailsToggle);
 
     expect(onBack).toHaveBeenCalledOnce();
     expect(onToggleSwipeControls).toHaveBeenCalledOnce();
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
+    expect(onToggleCardDetails).toHaveBeenCalledOnce();
 
     fireEvent.keyDown(closeActions, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
   });
 
-  it("shows and hides all card details with one overlay control", () => {
-    render(
+  it("shows and hides all card details from the persisted preference value", () => {
+    const { rerender } = render(
       <StudySession
         {...toolbarProps()}
         cardOverlaySlot={<div>Score, seen count, and last seen</div>}
@@ -140,15 +146,27 @@ describe("StudySession", () => {
     expect(screen.getByText("Score, seen count, and last seen")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
 
-    const detailsToggle = screen.getByRole("button", { name: "Card details" });
-    fireEvent.click(detailsToggle);
-    expect(detailsToggle).toHaveAttribute("aria-pressed", "false");
-    expect(detailsToggle).toHaveAttribute("title", "Show card details");
+    rerender(
+      <StudySession
+        {...toolbarProps()}
+        showCardDetails={false}
+        cardOverlaySlot={<div>Score, seen count, and last seen</div>}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Card details" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Card details" })).toHaveAttribute("title", "Show card details");
     expect(screen.queryByText("Score, seen count, and last seen")).not.toBeInTheDocument();
 
-    fireEvent.click(detailsToggle);
-    expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
-    expect(detailsToggle).toHaveAttribute("title", "Hide card details");
+    rerender(
+      <StudySession
+        {...toolbarProps()}
+        cardOverlaySlot={<div>Score, seen count, and last seen</div>}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Card details" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Card details" })).toHaveAttribute("title", "Hide card details");
     expect(screen.getByText("Score, seen count, and last seen")).toBeVisible();
   });
 

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -24,10 +24,12 @@ const meta = {
   },
   args: {
     onBack: fn(),
+    onToggleCardDetails: fn(),
     onToggleSwipeControls: fn(),
     onTogglePlaybackControls: fn(),
     showSwipeControls: true,
     showPlaybackControls: true,
+    showCardDetails: true,
     playbackControlsAvailable: true,
     frontTextSlot: <FrontText text={fixture.card.default.frontText} />,
     cardOverlaySlot: (
@@ -75,6 +77,11 @@ export const SwipeControlsHidden: Story = {
 
 export const PlaybackControlsHidden: Story = {
   args: { showPlaybackControls: false },
+  play: centeredFrontTextPlay,
+};
+
+export const CardDetailsHidden: Story = {
+  args: { showCardDetails: false },
   play: centeredFrontTextPlay,
 };
 

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -47,6 +47,7 @@ const answerSurfaceProps = {
 
 export interface StudySessionProps {
   showBackText?: boolean;
+  showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
@@ -62,6 +63,7 @@ export interface StudySessionProps {
   onSwipeRight?: () => void;
   onSwipeDown?: () => void;
   onBack: () => void;
+  onToggleCardDetails: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
 }
@@ -286,7 +288,6 @@ const Controls: React.FC<{
 
 export const StudySession: React.FC<StudySessionProps> = (props) => {
   const [studyActionsOpen, setStudyActionsOpen] = React.useState(false);
-  const [showCardDetails, setShowCardDetails] = React.useState(true);
   const suppressCardClick = React.useRef(false);
   const suppressCardClickTimer = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -346,12 +347,12 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       {showStudyChrome ? (
         <StudyToolbar
           open={studyActionsOpen}
-          showCardDetails={showCardDetails}
+          showCardDetails={props.showCardDetails}
           showSwipeControls={props.showSwipeControls}
           showPlaybackControls={props.showPlaybackControls}
           playbackControlsAvailable={props.playbackControlsAvailable}
           onToggleOpen={() => setStudyActionsOpen((open) => !open)}
-          onToggleCardDetails={() => setShowCardDetails((visible) => !visible)}
+          onToggleCardDetails={props.onToggleCardDetails}
           onBack={props.onBack}
           onToggleSwipeControls={props.onToggleSwipeControls}
           onTogglePlaybackControls={props.onTogglePlaybackControls}
@@ -370,7 +371,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
           showBackText={props.showBackText}
           backTextSlot={props.backTextSlot}
           frontTextSlot={props.frontTextSlot}
-          cardOverlaySlot={showCardDetails ? props.cardOverlaySlot : undefined}
+          cardOverlaySlot={props.showCardDetails ? props.cardOverlaySlot : undefined}
         />
       </div>
       <Controls

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   removeStudySession: vi.fn(),
   setDarkMode: vi.fn(),
   touchStudySession: vi.fn(),
+  toggleShowCardDetails: vi.fn(),
   toggleShowPlaybackControls: vi.fn(),
   toggleShowSwipeButtonList: vi.fn(),
 }));
@@ -25,6 +26,7 @@ vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
+  toggleShowCardDetails: mocks.toggleShowCardDetails,
   toggleShowPlaybackControls: mocks.toggleShowPlaybackControls,
   toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
 }));
@@ -90,6 +92,7 @@ describe("StudySessionPage", () => {
     mocks.removeStudySession.mockReset();
     mocks.setDarkMode.mockReset();
     mocks.touchStudySession.mockReset();
+    mocks.toggleShowCardDetails.mockReset();
     mocks.toggleShowPlaybackControls.mockReset();
     mocks.toggleShowSwipeButtonList.mockReset();
     await createDeck("", deck);
@@ -205,9 +208,11 @@ describe("StudySessionPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Swipe controls" }));
     fireEvent.click(screen.getByRole("button", { name: "Playback controls" }));
+    fireEvent.click(screen.getByRole("button", { name: "Card details" }));
 
     expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
     expect(mocks.toggleShowPlaybackControls).toHaveBeenCalledOnce();
+    expect(mocks.toggleShowCardDetails).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -266,7 +271,7 @@ describe("StudySessionPage", () => {
 
   it("renders the selected visibility combination", () => {
     mocks.preferences = createPreferences({
-      controls: { showSwipeButtonList: false, showPlaybackControls: false },
+      controls: { showCardDetails: false, showSwipeButtonList: false, showPlaybackControls: false },
     });
 
     renderPage();
@@ -274,8 +279,11 @@ describe("StudySessionPage", () => {
 
     expect(screen.getByRole("button", { name: "Swipe controls" })).not.toBePressed();
     expect(screen.getByRole("button", { name: "Playback controls" })).not.toBePressed();
+    expect(screen.getByRole("button", { name: "Card details" })).not.toBePressed();
     expect(screen.queryByRole("button", { name: "Swipe left" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Score 2, positive")).not.toBeInTheDocument();
+    expect(screen.queryByText(/3 times/)).not.toBeInTheDocument();
   });
 
   it("disables playback visibility when the card interval is zero", () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -63,9 +63,11 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
     <AppLayout fullscreen showHeader={false}>
       <StudySession
         onBack={onBack}
+        onToggleCardDetails={state.toggleShowCardDetails}
         onToggleSwipeControls={state.toggleSwipeButtonList}
         onTogglePlaybackControls={state.toggleShowPlaybackControls}
         showBackText={state.showBackText}
+        showCardDetails={state.showCardDetails}
         showSwipeControls={state.showSwipeButtonList}
         showPlaybackControls={state.showPlaybackControls}
         playbackControlsAvailable={state.playbackControlsAvailable}

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -253,6 +253,7 @@ export const e2eConfig = {
   controls: {
     showSwipeButtonList: true,
     showPlaybackControls: true,
+    showCardDetails: true,
     showScoreSlider: false,
     cardSwipeUp: "GoToNextCardMastered",
     cardSwipeDown: "GoToNextCardNotMastered",
@@ -282,7 +283,7 @@ export const seedConfig = async (page: Page, overrides: E2EConfigOverrides = {})
     // Seed only the first app document so reload assertions observe mutations made by the application.
     if (!window.location.origin.startsWith("http")) return;
     if (window.sessionStorage.getItem("tango-e2e-config-seeded") !== null) return;
-    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 1 }));
+    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 2 }));
     window.sessionStorage.setItem("tango-e2e-config-seeded", "true");
   }, config);
 };

--- a/test/e2e/yaml-fixture.ts
+++ b/test/e2e/yaml-fixture.ts
@@ -85,6 +85,7 @@ export interface FixturePreferences {
   controls: {
     showSwipeButtonList: boolean;
     showPlaybackControls: boolean;
+    showCardDetails: boolean;
     showScoreSlider: boolean;
     cardSwipeUp: SwipeAction;
     cardSwipeDown: SwipeAction;
@@ -271,6 +272,7 @@ const preferencesSchema = z.strictObject({
     .strictObject({
       showSwipeButtonList: z.boolean().optional(),
       showPlaybackControls: z.boolean().optional(),
+      showCardDetails: z.boolean().optional(),
       showScoreSlider: z.boolean().optional(),
       cardSwipeUp: swipeActionSchema.optional(),
       cardSwipeDown: swipeActionSchema.optional(),
@@ -630,6 +632,7 @@ const applicationPreferences: FixturePreferences = {
   controls: {
     showSwipeButtonList: true,
     showPlaybackControls: true,
+    showCardDetails: true,
     showScoreSlider: false,
     cardSwipeUp: "GoToNextCardMastered",
     cardSwipeDown: "GoToNextCardNotMastered",

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -116,6 +116,7 @@ export type PreferencesOverrides = {
   selectedTags?: string[];
   showSwipeButtonList?: boolean;
   showPlaybackControls?: boolean;
+  showCardDetails?: boolean;
   showScoreSlider?: boolean;
   cardSwipeUp?: SwipeAction;
   cardSwipeDown?: SwipeAction;
@@ -150,6 +151,7 @@ const createControls = (
 ): ControlPreferences => ({
   showSwipeButtonList: controls?.showSwipeButtonList ?? flat?.showSwipeButtonList ?? true,
   showPlaybackControls: controls?.showPlaybackControls ?? flat?.showPlaybackControls ?? true,
+  showCardDetails: controls?.showCardDetails ?? flat?.showCardDetails ?? true,
   showScoreSlider: controls?.showScoreSlider ?? flat?.showScoreSlider ?? false,
   cardSwipeUp: controls?.cardSwipeUp ?? flat?.cardSwipeUp ?? "GoToNextCardMastered",
   cardSwipeDown: controls?.cardSwipeDown ?? flat?.cardSwipeDown ?? "GoToNextCardNotMastered",


### PR DESCRIPTION
## Related issue

None

## Summary

- Persist card detail visibility in user preferences
- Use the shared setting for Study Session score and history visibility
- Expose the same control in Settings and invalidate the prior preference storage shape

## Testing

- mise run check
- Mandatory reviewer gate: no P0, P1, or P2 findings