### PR TITLE
[No issue] Keep study back button visible

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -88,7 +88,7 @@ describe("StudySession", () => {
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
-  it("opens the study actions overlay and reports its controls", () => {
+  it("keeps the back action visible and opens the remaining study actions", () => {
     const onBack = vi.fn();
     const onToggleCardDetails = vi.fn();
     const onToggleSwipeControls = vi.fn();
@@ -108,7 +108,7 @@ describe("StudySession", () => {
     const openActions = screen.getByRole("button", { name: "Open study actions" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
 
@@ -126,7 +126,7 @@ describe("StudySession", () => {
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
-    expect(actions).toContainElement(back);
+    expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
     fireEvent.click(back);

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -184,6 +184,18 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
   return (
     <div className="pointer-events-none absolute inset-x-0 top-[var(--study-toolbar-top)] z-50 h-touch">
       <button
+        type="button"
+        aria-label="Back to deck list"
+        className={cx(
+          toolbarButtonClass,
+          "absolute left-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] top-0"
+        )}
+        onClick={props.onBack}
+        onKeyDown={closeOnEscape}
+      >
+        <AiOutlineLeft aria-hidden="true" className="text-xl" />
+      </button>
+      <button
         ref={helpTriggerRef}
         type="button"
         aria-label={props.helpTriggerLabel}
@@ -219,17 +231,8 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
         <fieldset
           id={actionsId}
           aria-label="Study actions"
-          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-between border-0 p-0 pl-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-left))] pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
+          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
         >
-          <button
-            type="button"
-            aria-label="Back to deck list"
-            className={toolbarButtonClass}
-            onClick={props.onBack}
-            onKeyDown={closeOnEscape}
-          >
-            <AiOutlineLeft aria-hidden="true" className="text-xl" />
-          </button>
           <StudyModeActions
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -110,7 +110,7 @@ describe("StudySessionPage", () => {
     expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open study actions" })).toBeVisible();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Back to deck list" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
     expect(screen.getByText("Front one")).toBeVisible();
     expect(screen.getByText(/3 times/)).toBeVisible();
   });


### PR DESCRIPTION
## Related issue

None.

## Summary

- keep the Back to deck list button visible while the study card front is shown
- keep the remaining study actions inside the expandable actions menu
- update component and page behavior coverage

## Testing

- npm run test:unit -- src/pages/study-session/ui/StudySession.spec.tsx src/pages/study-session/ui/StudySessionPage.spec.tsx
- npm run fmt
- reviewer: 18 StudySession Storybook tests passed; ESLint and Biome passed for changed files
- mise run check attempted twice; blocked by Docker EOF while generating sample/build/output.json
- full unit run: 554 tests passed; 3 suites could not load because the generated sample/build/output.json was unavailable