### PR TITLE
[No issue] Link short settings hash to its commit

### DIFF
--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -68,7 +68,12 @@ describe("SettingsForm", () => {
     expect(screen.getByRole("slider", { name: "Autoplay interval" })).toHaveAttribute("aria-valuetext", "7 seconds");
     const details = screen.getByRole("group", { name: "Advanced" });
     expect(details).toHaveTextContent("1.2.3");
-    expect(details).toHaveTextContent("0123456789abcdef0123456789abcdef01234567");
+    expect(details).toHaveTextContent("0123456");
+    expect(details).not.toHaveTextContent("01234567");
+    expect(screen.getByRole("link", { name: "main" })).toHaveAttribute(
+      "href",
+      "https://github.com/her0e1c1/tango/tree/main"
+    );
   });
 
   it("keeps section heading relationships unique across multiple instances", () => {

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -11,6 +11,7 @@ import { createPreferences } from "@/test/factories";
 
 import { SettingsForm } from "./SettingsForm";
 
+const commitHash = "0123456789abcdef0123456789abcdef01234567";
 const defaultValues = createPreferences({
   showPlaybackControls: true,
   useCardInterval: true,
@@ -21,12 +22,7 @@ const defaultValues = createPreferences({
 const SettingsFormHarness: React.FC<{ values?: Preferences }> = ({ values = defaultValues }) => {
   const form = useForm<Preferences>({ defaultValues: values });
   return (
-    <SettingsForm
-      form={form}
-      studyPreferencesLimits={studyPreferencesLimits}
-      version="1.2.3"
-      commitHash="0123456789abcdef0123456789abcdef01234567"
-    />
+    <SettingsForm form={form} studyPreferencesLimits={studyPreferencesLimits} version="1.2.3" commitHash={commitHash} />
   );
 };
 
@@ -70,10 +66,11 @@ describe("SettingsForm", () => {
     expect(details).toHaveTextContent("1.2.3");
     expect(details).toHaveTextContent("0123456");
     expect(details).not.toHaveTextContent("01234567");
-    expect(screen.getByRole("link", { name: "main" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "0123456" })).toHaveAttribute(
       "href",
-      "https://github.com/her0e1c1/tango/tree/main"
+      `https://github.com/her0e1c1/tango/commit/${commitHash}`
     );
+    expect(details).not.toHaveTextContent("Main branch");
   });
 
   it("keeps section heading relationships unique across multiple instances", () => {

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -7,7 +7,7 @@ import type { Preferences } from "@/entities/preference";
 import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Slider, Switch } from "@/shared/ui/forms";
 
-const mainBranchUrl = "https://github.com/her0e1c1/tango/tree/main";
+const repositoryUrl = "https://github.com/her0e1c1/tango";
 
 export interface SettingsFormProps {
   form: UseFormReturn<Preferences>;
@@ -21,6 +21,8 @@ export interface SettingsFormProps {
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
   const shortCommitHash = props.commitHash?.slice(0, 7);
+  const commitUrl =
+    props.commitHash && props.commitHash !== "unknown" ? `${repositoryUrl}/commit/${props.commitHash}` : undefined;
   const maxNumberOfCardsToLearn = useWatch({
     control: props.form.control,
     name: "study.maxNumberOfCardsToLearn",
@@ -213,18 +215,18 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             </div>
             <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
               <span className="text-body font-medium text-ink">Commit hash</span>
-              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{shortCommitHash}</span>
-            </div>
-            <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
-              <span className="text-body font-medium text-ink">Main branch</span>
-              <a
-                className="text-caption text-accent-primary underline underline-offset-2"
-                href={mainBranchUrl}
-                rel="noreferrer"
-                target="_blank"
-              >
-                main
-              </a>
+              {commitUrl ? (
+                <a
+                  className="min-w-0 break-all text-right text-caption text-accent-primary underline underline-offset-2"
+                  href={commitUrl}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {shortCommitHash}
+                </a>
+              ) : (
+                <span className="min-w-0 break-all text-right text-caption text-ink-muted">{shortCommitHash}</span>
+              )}
             </div>
           </div>
         </details>

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -7,6 +7,8 @@ import type { Preferences } from "@/entities/preference";
 import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Slider, Switch } from "@/shared/ui/forms";
 
+const mainBranchUrl = "https://github.com/her0e1c1/tango/tree/main";
+
 export interface SettingsFormProps {
   form: UseFormReturn<Preferences>;
   studyPreferencesLimits: {
@@ -18,6 +20,7 @@ export interface SettingsFormProps {
 }
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
+  const shortCommitHash = props.commitHash?.slice(0, 7);
   const maxNumberOfCardsToLearn = useWatch({
     control: props.form.control,
     name: "study.maxNumberOfCardsToLearn",
@@ -210,7 +213,18 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             </div>
             <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
               <span className="text-body font-medium text-ink">Commit hash</span>
-              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{props.commitHash}</span>
+              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{shortCommitHash}</span>
+            </div>
+            <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
+              <span className="text-body font-medium text-ink">Main branch</span>
+              <a
+                className="text-caption text-accent-primary underline underline-offset-2"
+                href={mainBranchUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                main
+              </a>
             </div>
           </div>
         </details>


### PR DESCRIPTION
## Related issue

None

## Summary

- Display the Settings commit hash as seven characters.
- Link the displayed hash to the corresponding full GitHub commit URL.
- Leave unavailable commit metadata unlinked and cover the behavior with a unit test.

## Testing

- npm run test:unit -- src/pages/settings/ui/SettingsForm.spec.tsx
- ESLint and Biome checks for the changed files
- Reviewer: no findings
- mise run check could not complete because the local Docker daemon returned EOF during the sample build.