### PR TITLE
ci(#229): aggregate canonical checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - "**"
 
+# Only superseded runs for the same PR share a group. Reusable and manual runs remain unique.
+concurrency:
+  group: test-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -96,13 +101,19 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Run after every dependency conclusion and fail closed unless every canonical job succeeded.
   test:
     name: Test
     if: ${{ always() }}
-    needs: checks
+    needs: [checks, e2e, integration]
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         env:
-          RESULT: ${{ needs.checks.result }}
-        run: test "$RESULT" = success
+          CHECKS_RESULT: ${{ needs.checks.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+        run: |
+          test "$CHECKS_RESULT" = success
+          test "$E2E_RESULT" = success
+          test "$INTEGRATION_RESULT" = success


### PR DESCRIPTION
## Related issue

Fixes #229

## Summary

- aggregate Build, Code quality, Unit coverage, Storybook, Sample, E2E, and Integration behind the stable `Test` check
- fail closed when any canonical dependency fails, is cancelled, or is unexpectedly skipped
- cancel only superseded Test runs for the same pull request while keeping manual and reusable runs independent

## Testing

- `git diff --check`
- parsed `.github/workflows/test.yml` with the `yaml` package
- three mandatory reviewer rounds; no unresolved findings
- [PR success and cancelled negative control](https://github.com/her0e1c1/tango/actions/runs/33299215074): attempt 2 cancelled dependencies and aggregate `Test` failed; attempt 3 fully succeeded
- [simultaneous manual run](https://github.com/her0e1c1/tango/actions/runs/33299652437): succeeded without cancellation
- local `mise run check` could not complete because the Docker Desktop daemon was unavailable; the equivalent canonical GitHub jobs passed

## Repository gate

- active ruleset `20674876` targets the default branch and requires only aggregate `Test`
- pending/failing aggregate blocked merge; final successful aggregate returned the PR to a clean merge state
- detailed evidence and remaining isolated controls are recorded in [Issue #229](https://github.com/her0e1c1/tango/issues/229#issuecomment-5467456999)