### PR TITLE
[No issue] Configure repository URL through environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,6 @@
 VITE_PROJECT_ID=demo-tango
 VITE_WEB_API_KEY=dummy-api-key-for-local-development
+VITE_REPOSITORY_URL=https://github.com/her0e1c1/tango
 VITE_DB_HOST=localhost
 VITE_DB_PORT=8080
 VITE_AUTH_HOST=localhost

--- a/.env.e2e
+++ b/.env.e2e
@@ -1,5 +1,6 @@
 VITE_PROJECT_ID=tango-e2e
 VITE_WEB_API_KEY=e2e-api-key
+VITE_REPOSITORY_URL=https://github.com/her0e1c1/tango
 VITE_USE_FIREBASE_EMULATORS=true
 VITE_AUTH_HOST=auth.app.test
 VITE_AUTH_PORT=9099

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 VITE_PROJECT_ID=
 VITE_WEB_API_KEY=
+VITE_REPOSITORY_URL=https://github.com/her0e1c1/tango
 
 VITE_DB_HOST=localhost
 VITE_DB_PORT=8080
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
 
       - run: echo VITE_PROJECT_ID="${{ secrets.VITE_PROJECT_ID }}" >> .env
       - run: echo VITE_WEB_API_KEY="${{ secrets.VITE_WEB_API_KEY }}" >> .env
+      - run: echo VITE_REPOSITORY_URL="https://github.com/her0e1c1/tango" >> .env
 
       - run: mise run init
 

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -68,7 +68,12 @@ describe("SettingsForm", () => {
     expect(screen.getByRole("slider", { name: "Autoplay interval" })).toHaveAttribute("aria-valuetext", "7 seconds");
     const details = screen.getByRole("group", { name: "Advanced" });
     expect(details).toHaveTextContent("1.2.3");
-    expect(details).toHaveTextContent("0123456789abcdef0123456789abcdef01234567");
+    expect(details).toHaveTextContent("0123456");
+    expect(details).not.toHaveTextContent("01234567");
+    expect(screen.getByRole("link", { name: "main" })).toHaveAttribute(
+      "href",
+      "https://github.com/her0e1c1/tango/tree/main"
+    );
   });
 
   it("keeps section heading relationships unique across multiple instances", () => {

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -11,6 +11,7 @@ import { createPreferences } from "@/test/factories";
 
 import { SettingsForm } from "./SettingsForm";
 
+const commitHash = "0123456789abcdef0123456789abcdef01234567";
 const defaultValues = createPreferences({
   showPlaybackControls: true,
   useCardInterval: true,
@@ -21,12 +22,7 @@ const defaultValues = createPreferences({
 const SettingsFormHarness: React.FC<{ values?: Preferences }> = ({ values = defaultValues }) => {
   const form = useForm<Preferences>({ defaultValues: values });
   return (
-    <SettingsForm
-      form={form}
-      studyPreferencesLimits={studyPreferencesLimits}
-      version="1.2.3"
-      commitHash="0123456789abcdef0123456789abcdef01234567"
-    />
+    <SettingsForm form={form} studyPreferencesLimits={studyPreferencesLimits} version="1.2.3" commitHash={commitHash} />
   );
 };
 
@@ -70,10 +66,11 @@ describe("SettingsForm", () => {
     expect(details).toHaveTextContent("1.2.3");
     expect(details).toHaveTextContent("0123456");
     expect(details).not.toHaveTextContent("01234567");
-    expect(screen.getByRole("link", { name: "main" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "0123456" })).toHaveAttribute(
       "href",
-      "https://github.com/her0e1c1/tango/tree/main"
+      `https://github.com/her0e1c1/tango/commit/${commitHash}`
     );
+    expect(details).not.toHaveTextContent("Main branch");
   });
 
   it("keeps section heading relationships unique across multiple instances", () => {

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -12,6 +12,7 @@ import { createPreferences } from "@/test/factories";
 import { SettingsForm } from "./SettingsForm";
 
 const commitHash = "0123456789abcdef0123456789abcdef01234567";
+const repositoryUrl = "https://github.com/her0e1c1/tango";
 const defaultValues = createPreferences({
   showPlaybackControls: true,
   useCardInterval: true,
@@ -22,7 +23,13 @@ const defaultValues = createPreferences({
 const SettingsFormHarness: React.FC<{ values?: Preferences }> = ({ values = defaultValues }) => {
   const form = useForm<Preferences>({ defaultValues: values });
   return (
-    <SettingsForm form={form} studyPreferencesLimits={studyPreferencesLimits} version="1.2.3" commitHash={commitHash} />
+    <SettingsForm
+      form={form}
+      studyPreferencesLimits={studyPreferencesLimits}
+      version="1.2.3"
+      commitHash={commitHash}
+      repositoryUrl={repositoryUrl}
+    />
   );
 };
 
@@ -68,7 +75,7 @@ describe("SettingsForm", () => {
     expect(details).not.toHaveTextContent("01234567");
     expect(screen.getByRole("link", { name: "0123456" })).toHaveAttribute(
       "href",
-      `https://github.com/her0e1c1/tango/commit/${commitHash}`
+      `${repositoryUrl}/commit/${commitHash}`
     );
     expect(details).not.toHaveTextContent("Main branch");
   });

--- a/src/pages/settings/ui/SettingsForm.stories.tsx
+++ b/src/pages/settings/ui/SettingsForm.stories.tsx
@@ -12,9 +12,10 @@ interface SettingsFormStoryProps {
   preferences: Preferences;
   version: string;
   commitHash: string;
+  repositoryUrl: string;
 }
 
-const SettingsFormStory = ({ preferences, version, commitHash }: SettingsFormStoryProps) => {
+const SettingsFormStory = ({ preferences, version, commitHash, repositoryUrl }: SettingsFormStoryProps) => {
   const form = useForm<Preferences>({ defaultValues: preferences });
   return (
     <SettingsForm
@@ -22,6 +23,7 @@ const SettingsFormStory = ({ preferences, version, commitHash }: SettingsFormSto
       studyPreferencesLimits={studyPreferencesLimits}
       version={version}
       commitHash={commitHash}
+      repositoryUrl={repositoryUrl}
     />
   );
 };
@@ -36,6 +38,7 @@ const meta = {
     preferences: fixture.preferences.default,
     version: "1.2.3",
     commitHash: "0123456789abcdef0123456789abcdef01234567",
+    repositoryUrl: "https://github.com/her0e1c1/tango",
   },
 } satisfies Meta<typeof SettingsFormStory>;
 

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -7,7 +7,7 @@ import type { Preferences } from "@/entities/preference";
 import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Slider, Switch } from "@/shared/ui/forms";
 
-const mainBranchUrl = "https://github.com/her0e1c1/tango/tree/main";
+const repositoryUrl = "https://github.com/her0e1c1/tango";
 
 export interface SettingsFormProps {
   form: UseFormReturn<Preferences>;
@@ -21,6 +21,8 @@ export interface SettingsFormProps {
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
   const shortCommitHash = props.commitHash?.slice(0, 7);
+  const commitUrl =
+    props.commitHash && props.commitHash !== "unknown" ? `${repositoryUrl}/commit/${props.commitHash}` : undefined;
   const maxNumberOfCardsToLearn = useWatch({
     control: props.form.control,
     name: "study.maxNumberOfCardsToLearn",
@@ -213,18 +215,18 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             </div>
             <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
               <span className="text-body font-medium text-ink">Commit hash</span>
-              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{shortCommitHash}</span>
-            </div>
-            <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
-              <span className="text-body font-medium text-ink">Main branch</span>
-              <a
-                className="text-caption text-accent-primary underline underline-offset-2"
-                href={mainBranchUrl}
-                rel="noreferrer"
-                target="_blank"
-              >
-                main
-              </a>
+              {commitUrl ? (
+                <a
+                  className="min-w-0 break-all text-right text-caption text-accent-primary underline underline-offset-2"
+                  href={commitUrl}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {shortCommitHash}
+                </a>
+              ) : (
+                <span className="min-w-0 break-all text-right text-caption text-ink-muted">{shortCommitHash}</span>
+              )}
             </div>
           </div>
         </details>

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -7,6 +7,8 @@ import type { Preferences } from "@/entities/preference";
 import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Slider, Switch } from "@/shared/ui/forms";
 
+const mainBranchUrl = "https://github.com/her0e1c1/tango/tree/main";
+
 export interface SettingsFormProps {
   form: UseFormReturn<Preferences>;
   studyPreferencesLimits: {
@@ -18,6 +20,7 @@ export interface SettingsFormProps {
 }
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
+  const shortCommitHash = props.commitHash?.slice(0, 7);
   const maxNumberOfCardsToLearn = useWatch({
     control: props.form.control,
     name: "study.maxNumberOfCardsToLearn",
@@ -210,7 +213,18 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             </div>
             <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
               <span className="text-body font-medium text-ink">Commit hash</span>
-              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{props.commitHash}</span>
+              <span className="min-w-0 break-all text-right text-caption text-ink-muted">{shortCommitHash}</span>
+            </div>
+            <div className="flex min-h-touch items-center justify-between gap-4 border-t border-border px-4 py-3">
+              <span className="text-body font-medium text-ink">Main branch</span>
+              <a
+                className="text-caption text-accent-primary underline underline-offset-2"
+                href={mainBranchUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                main
+              </a>
             </div>
           </div>
         </details>

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -7,8 +7,6 @@ import type { Preferences } from "@/entities/preference";
 import { SettingsRow, SettingsSection } from "./SettingsSection";
 import { Slider, Switch } from "@/shared/ui/forms";
 
-const repositoryUrl = "https://github.com/her0e1c1/tango";
-
 export interface SettingsFormProps {
   form: UseFormReturn<Preferences>;
   studyPreferencesLimits: {
@@ -17,12 +15,15 @@ export interface SettingsFormProps {
   };
   version?: string;
   commitHash?: string;
+  repositoryUrl?: string;
 }
 
 export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
   const shortCommitHash = props.commitHash?.slice(0, 7);
   const commitUrl =
-    props.commitHash && props.commitHash !== "unknown" ? `${repositoryUrl}/commit/${props.commitHash}` : undefined;
+    props.repositoryUrl && props.commitHash && props.commitHash !== "unknown"
+      ? `${props.repositoryUrl.replace(/\/+$/, "")}/commit/${props.commitHash}`
+      : undefined;
   const maxNumberOfCardsToLearn = useWatch({
     control: props.form.control,
     name: "study.maxNumberOfCardsToLearn",

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -20,6 +20,7 @@ export const SettingsPage: React.FC = () => {
         studyPreferencesLimits={state.studyPreferencesLimits}
         version={__APP_VERSION__}
         commitHash={__COMMIT_HASH__}
+        repositoryUrl={import.meta.env.VITE_REPOSITORY_URL}
       />
     </AppLayout>
   );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,7 @@ declare const __COMMIT_HASH__: string;
 interface ImportMetaEnv {
   readonly VITE_PROJECT_ID: string;
   readonly VITE_WEB_API_KEY: string;
+  readonly VITE_REPOSITORY_URL: string;
   readonly VITE_USE_FIREBASE_EMULATORS?: string;
   readonly VITE_AUTH_HOST: string;
   readonly VITE_AUTH_PORT: string;


### PR DESCRIPTION
## Related issue

None

## Summary

- Configure the Settings commit-link repository through VITE_REPOSITORY_URL.
- Provide the value for local development, E2E, and production deployment.
- Pass the environment value through the Settings page boundary and update tests and stories.
- Update the branch used by #1340, which cannot receive direct pushes under the repository rules.

## Testing

- mise run check
- 112 test files and 584 tests passed
- Reviewer: no findings