### PR TITLE
[No issue] Simplify study session score range UI

### DIFF
--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -272,7 +272,6 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     renderFilter();
 
-    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
     expect(screen.getByRole("checkbox", { name: "Match all selected tags" })).toBeChecked();
@@ -295,7 +294,6 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     view = renderFilter();
 
-    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
 
@@ -304,7 +302,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     renderFilter();
 
-    expect(screen.getByText("Any score")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });

--- a/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
@@ -38,7 +38,6 @@ describe("DeckFilterForm", () => {
     const maximum = within(scoreRegion).getByRole("combobox", { name: "Maximum score" });
     const minimum = within(scoreRegion).getByRole("combobox", { name: "Minimum score" });
 
-    expect(within(scoreRegion).getByText("−2 to 4")).toBeInTheDocument();
     expect(maximum).toHaveValue("4");
     expect(minimum).toHaveValue("-2");
 
@@ -54,7 +53,8 @@ describe("DeckFilterForm", () => {
 
   it("shows unrestricted limits", () => {
     render(<DeckFilterForm {...createProps()} scoreMax={null} scoreMin={null} />);
-    expect(screen.getByText("Any score")).toBeInTheDocument();
+    const scoreRegion = screen.getByRole("region", { name: "Score range" });
+    expect(within(scoreRegion).queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen, within } from "@testing-library/react";
+import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -32,14 +33,13 @@ describe("ScoreRange", () => {
     expect(numericOptionValues(maximum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
     expect(minimum).toHaveAccessibleDescription("Include cards at or above this score.");
     expect(maximum).toHaveAccessibleDescription("Include cards at or below this score.");
-    expect(screen.getByText("Any score")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Clear limits" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
-  it("reports native selections and summarizes two-sided and one-sided limits", async () => {
+  it("reports native selections", async () => {
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
-    const view = render(
+    render(
       <ScoreRange
         maximum={4}
         minimum={-2}
@@ -49,33 +49,10 @@ describe("ScoreRange", () => {
       />
     );
 
-    expect(screen.getByText("−2 to 4")).toBeInTheDocument();
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "-1");
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "3");
     expect(onMinimumChange).toHaveBeenCalledWith(-1);
     expect(onMaximumChange).toHaveBeenCalledWith(3);
-
-    view.rerender(
-      <ScoreRange
-        maximum={null}
-        minimum={-2}
-        onClear={vi.fn()}
-        onMaximumChange={onMaximumChange}
-        onMinimumChange={onMinimumChange}
-      />
-    );
-    expect(screen.getByText("−2 and above")).toBeInTheDocument();
-
-    view.rerender(
-      <ScoreRange
-        maximum={4}
-        minimum={null}
-        onClear={vi.fn()}
-        onMaximumChange={onMaximumChange}
-        onMinimumChange={onMinimumChange}
-      />
-    );
-    expect(screen.getByText("4 and below")).toBeInTheDocument();
   });
 
   it("preserves saved scores outside the standard integer choices", () => {
@@ -96,7 +73,6 @@ describe("ScoreRange", () => {
     expect(maximum).toHaveValue("14.25");
     expect(within(minimum).getByRole("option", { name: "−12.5" })).toBeInTheDocument();
     expect(within(maximum).getByRole("option", { name: "14.25" })).toBeInTheDocument();
-    expect(screen.getByText("−12.5 to 14.25")).toBeInTheDocument();
   });
 
   it("limits new choices to a valid range while retaining the active choices", () => {
@@ -130,6 +106,33 @@ describe("ScoreRange", () => {
     expect(onClear).toHaveBeenCalledOnce();
     expect(onMinimumChange).not.toHaveBeenCalled();
     expect(onMaximumChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps focus in the range controls and announces when limits are cleared", async () => {
+    const ControlledScoreRange = () => {
+      const [maximum, setMaximum] = useState<number | null>(4);
+      const [minimum, setMinimum] = useState<number | null>(-2);
+
+      return (
+        <ScoreRange
+          maximum={maximum}
+          minimum={minimum}
+          onClear={() => {
+            setMaximum(null);
+            setMinimum(null);
+          }}
+          onMaximumChange={setMaximum}
+          onMinimumChange={setMinimum}
+        />
+      );
+    };
+
+    render(<ControlledScoreRange />);
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveFocus();
+    expect(screen.getByRole("status")).toHaveTextContent("No score limits.");
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
   it("shows an invalid saved range without mutating it and allows both recovery paths", async () => {

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -2,7 +2,7 @@
  * @file Defines the deck filter's score range presentation component.
  */
 
-import { useId } from "react";
+import { useId, useRef } from "react";
 import type * as React from "react";
 
 import { Button } from "@/shared/ui/button";
@@ -37,11 +37,11 @@ interface ScoreSelectProps {
 
 const displayScore = (value: number): string => String(value).replace("-", "−");
 
-const scoreRangeLabel = (minimum: number | null, maximum: number | null): string => {
-  if (minimum != null && maximum != null) return `${displayScore(minimum)} to ${displayScore(maximum)}`;
-  if (minimum != null) return `${displayScore(minimum)} and above`;
-  if (maximum != null) return `${displayScore(maximum)} and below`;
-  return "Any score";
+const scoreRangeStatus = (minimum: number | null, maximum: number | null): string => {
+  if (minimum != null && maximum != null) return `Score range: ${displayScore(minimum)} to ${displayScore(maximum)}.`;
+  if (minimum != null) return `Minimum score: ${displayScore(minimum)}. No maximum score.`;
+  if (maximum != null) return `Maximum score: ${displayScore(maximum)}. No minimum score.`;
+  return "No score limits.";
 };
 
 const scoreOptions = (
@@ -60,14 +60,18 @@ const scoreOptions = (
     .sort((left, right) => left - right);
 };
 
-const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
-  <div className="rounded-control bg-surface-muted p-3">
-    <label htmlFor={props.id} className="text-body font-medium text-ink">
+const ScoreSelect = ({
+  ref: selectRef,
+  ...props
+}: ScoreSelectProps & { ref?: React.RefObject<HTMLSelectElement | null> }) => (
+  <div className="min-w-0">
+    <label htmlFor={props.id} className="text-caption font-medium text-ink-muted">
       {props.label}
     </label>
     <Select
+      ref={selectRef}
       id={props.id}
-      className="mt-2"
+      className="mt-1"
       value={props.value == null ? NO_LIMIT_VALUE : String(props.value)}
       aria-label={`${props.label} score`}
       aria-describedby={props.describedBy}
@@ -80,7 +84,7 @@ const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
         props.onChange(event.currentTarget.value === NO_LIMIT_VALUE ? null : Number(event.currentTarget.value))
       }
     />
-    <p id={`${props.id}-description`} className="mt-1 text-caption text-ink-muted">
+    <p id={`${props.id}-description`} className="sr-only">
       {props.description}
     </p>
   </div>
@@ -91,6 +95,7 @@ const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
  */
 export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
   const idPrefix = useId();
+  const minimumSelectRef = useRef<HTMLSelectElement>(null);
   const headingId = `${idPrefix}-score-heading`;
   const minimumId = `${idPrefix}-minimum-score`;
   const maximumId = `${idPrefix}-maximum-score`;
@@ -104,33 +109,30 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
   return (
     <section
       aria-labelledby={headingId}
-      className="space-y-4 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
+      className="space-y-3 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
     >
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 id={headingId} className="text-title font-semibold text-ink">
-            Score range
-          </h2>
-          <p className="mt-1 text-caption text-ink-muted">Limit cards by their current score.</p>
-        </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <span
-            aria-live="polite"
-            className="rounded-control bg-surface-muted px-2 py-1 text-caption font-bold text-accent-primary"
-          >
-            {scoreRangeLabel(props.minimum, props.maximum)}
-          </span>
-          <Button
-            variant="quiet"
-            size="sm"
-            label="Clear limits"
-            disabled={props.minimum == null && props.maximum == null}
-            onClick={props.onClear}
-          />
-        </div>
+      <header className="flex items-center justify-between gap-3">
+        <h2 id={headingId} className="text-title font-semibold text-ink">
+          Score range
+        </h2>
+        <Button
+          variant="quiet"
+          size="sm"
+          className="border-0 text-accent-primary"
+          hidden={props.minimum == null && props.maximum == null}
+          onClick={() => {
+            props.onClear();
+            // The clear action hides its own button on the next render, so keyboard focus must move
+            // to a stable control before that render commits.
+            minimumSelectRef.current?.focus();
+          }}
+        >
+          Clear <span className="sr-only">limits</span>
+        </Button>
       </header>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2 sm:gap-3">
         <ScoreSelect
+          ref={minimumSelectRef}
           id={minimumId}
           label="Minimum"
           value={props.minimum}
@@ -140,6 +142,9 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           description="Include cards at or above this score."
           onChange={props.onMinimumChange}
         />
+        <span aria-hidden="true" className="flex min-h-touch items-center text-caption text-ink-muted">
+          to
+        </span>
         <ScoreSelect
           id={maximumId}
           label="Maximum"
@@ -151,6 +156,9 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           onChange={props.onMaximumChange}
         />
       </div>
+      <p role="status" aria-live="polite" className="sr-only">
+        {scoreRangeStatus(props.minimum, props.maximum)}
+      </p>
       {invalid ? (
         <p id={warningId} role="alert" className="rounded-control border border-danger p-3 text-caption text-danger">
           Minimum score must not be greater than maximum score.


### PR DESCRIPTION
## Summary

- condense the score range filter into one quiet row of minimum and maximum selects
- remove duplicate visible range summaries and explanatory panels
- preserve accessible descriptions, clear-state announcements, and keyboard focus

## Testing

- mise run check
- mandatory reviewer completed with no P0, P1, or P2 findings