### PR TITLE
[No issue] Show study help only when actions are open

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -151,7 +152,8 @@ describe("StudySession", () => {
     expect(onClickLeft).not.toHaveBeenCalled();
   });
 
-  it("keeps the back action visible and opens the remaining study actions", () => {
+  it("keeps the back action visible and opens the remaining study actions", async () => {
+    const user = userEvent.setup();
     const onBack = vi.fn();
     const onToggleCardDetails = vi.fn();
     const onToggleSwipeControls = vi.fn();
@@ -171,6 +173,7 @@ describe("StudySession", () => {
     const openActions = screen.getByRole("button", { name: "Open study actions" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
@@ -180,17 +183,24 @@ describe("StudySession", () => {
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const detailsToggle = screen.getByRole("button", { name: "Card details" });
+    const help = screen.getByRole("button", { name: "Open study help" });
     const actions = screen.getByRole("group", { name: "Study actions" });
     expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
+    expect(help).toBeVisible();
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
     expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
     expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
+    expect(actions).toContainElement(help);
     expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
+
+    closeActions.focus();
+    await user.tab();
+    expect(help).toHaveFocus();
 
     fireEvent.click(back);
     fireEvent.click(swipeToggle);
@@ -202,9 +212,10 @@ describe("StudySession", () => {
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
     expect(onToggleCardDetails).toHaveBeenCalledOnce();
 
-    fireEvent.keyDown(closeActions, { key: "Escape" });
+    fireEvent.keyDown(help, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
   });
 
   it("shows and hides all card details from the persisted preference value", () => {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -201,18 +201,6 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
         <AiOutlineLeft aria-hidden="true" className="text-xl" />
       </button>
       <button
-        ref={helpTriggerRef}
-        type="button"
-        aria-label={props.helpTriggerLabel}
-        className={cx(
-          toolbarButtonClass,
-          "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
-        )}
-        onClick={props.onOpenHelp}
-      >
-        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
-      </button>
-      <button
         ref={triggerRef}
         type="button"
         aria-label={props.open ? "Close study actions" : "Open study actions"}
@@ -238,6 +226,19 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
           aria-label="Study actions"
           className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
         >
+          <button
+            ref={helpTriggerRef}
+            type="button"
+            aria-label={props.helpTriggerLabel}
+            className={cx(
+              toolbarButtonClass,
+              "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+            )}
+            onClick={props.onOpenHelp}
+            onKeyDown={closeOnEscape}
+          >
+            <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
+          </button>
           <StudyModeActions
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -214,6 +214,8 @@ describe("StudySessionPage", () => {
     renderPage();
     const sessionBeforeHelp = getStudySession(deckId);
 
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
+    openStudyActions();
     const trigger = screen.getByRole("button", { name: "Open study help" });
     fireEvent.click(trigger);
     expect(trigger).not.toHaveFocus();
@@ -248,6 +250,7 @@ describe("StudySessionPage", () => {
     document.documentElement.lang = "ja-JP";
     renderPage();
 
+    openStudyActions();
     fireEvent.click(screen.getByRole("button", { name: "学習ヘルプを開く" }));
 
     expect(screen.getByRole("dialog", { name: "学習画面の操作" })).toHaveTextContent(
@@ -263,6 +266,7 @@ describe("StudySessionPage", () => {
 
     try {
       renderPage();
+      openStudyActions();
       fireEvent.click(screen.getByRole("button", { name: "Open study help" }));
 
       act(() => vi.advanceTimersByTime(1000));

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -349,6 +349,8 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
 
   await page.goto(`/deck/${deck.id}/study`);
   const progressBeforeHelp = await readProgress(currentCard.id);
+  await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Open study actions" }).click();
   await page.getByRole("button", { name: "Open study help" }).click();
 
   const dialog = page.getByRole("dialog", { name: "Study controls" });


### PR DESCRIPTION
## Related issue

None

## Summary

- hide the Study help button until Study actions are expanded
- keep Help inside the accessible Study actions group with predictable Tab and Escape behavior
- update unit, Page, and end-to-end coverage for the new visibility flow

## Testing

- mise run check