### PR TITLE
fix(#1345): Reset Preferences persist version to 1

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,4 +19,9 @@
 
 - The product is under active development. Do not preserve backward compatibility for store state unless explicitly requested.
 - Breaking changes to store state shape and behavior are allowed. Prefer the simplest current design over compatibility layers.
-- In particular, do not add migrations or retain legacy state formats for Zustand `persist`. Invalidate or discard incompatible persisted state instead.
+- Do not add migrations or retain legacy Zustand `persist` formats unless explicitly requested.
+- Keep the Preferences persist version at 1 unless a dedicated task explicitly changes it.
+- Do not bump a persist version solely because an additive field was introduced.
+- Additive fields that the current schema can safely default must remain compatible with the current version.
+- If existing state must be invalidated, document the reason and impact in a dedicated Issue.
+- Invalidate or discard persisted state that is genuinely incompatible with the current schema.

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -129,32 +129,33 @@ describe("preferences store", () => {
           },
         },
       },
-      version: 2,
+      version: 1,
     });
   });
 
-  it("hydrates persisted preferences", async () => {
+  it("hydrates version 1 preferences with defaults for additive fields", async () => {
+    const { showBackTextSwipeOverlays: _showBackTextSwipeOverlays, ...controlsBeforeSwipeOverlays } =
+      defaultPreferences.controls;
     const persistedPreferences = {
       ...defaultPreferences,
       loadSample: false,
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
+      controls: { ...controlsBeforeSwipeOverlays, showSwipeButtonList: false },
     };
     useMemoryStorage({
-      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 2 }),
+      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 1 }),
     });
 
     await preferencesStore.persist.rehydrate();
 
-    expect(preferencesStore.getState().preferences).toEqual(persistedPreferences);
+    expect(preferencesStore.getState().preferences).toEqual({
+      ...persistedPreferences,
+      controls: { ...persistedPreferences.controls, showBackTextSwipeOverlays: false },
+    });
   });
 
-  it("discards version 1 preferences after the persisted shape changes", async () => {
-    const {
-      showCardDetails: _showCardDetails,
-      showBackTextSwipeOverlays: _showBackTextSwipeOverlays,
-      ...legacyControls
-    } = defaultPreferences.controls;
+  it("discards version 2 preferences without migration", async () => {
     useMemoryStorage({
       "tango-config": JSON.stringify({
         state: {
@@ -163,10 +164,10 @@ describe("preferences store", () => {
             loadSample: false,
             appearance: { ...defaultPreferences.appearance, darkMode: true },
             study: { ...defaultPreferences.study, cardInterval: 15, selectedTags: ["legacy"] },
-            controls: { ...legacyControls, showSwipeButtonList: false },
+            controls: { ...defaultPreferences.controls, showSwipeButtonList: false },
           },
         },
-        version: 1,
+        version: 2,
       }),
     });
 
@@ -183,8 +184,8 @@ describe("preferences store", () => {
 
   it.each([
     ["malformed JSON", "not-json"],
-    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 2 })],
-    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 2 })],
+    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 1 })],
+    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 1 })],
   ])("uses current defaults for %s", async (_case, persistedValue) => {
     useMemoryStorage({ "tango-config": persistedValue });
 

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -7,8 +7,8 @@ import { preferencesSchema } from "./schema";
 import type { Preferences } from "./types";
 
 const PREFERENCES_STORAGE_KEY = "tango-config";
-// No migration is registered: changing this version deliberately invalidates older state shapes.
-const PREFERENCES_STORAGE_VERSION = 2;
+// Keep this stable for safely defaultable additions; a dedicated task must justify invalidating existing preferences.
+const PREFERENCES_STORAGE_VERSION = 1;
 
 /** @internal Partial updates for each top-level preference field. */
 export type PartialPreferences = {

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -284,7 +284,7 @@ export const seedConfig = async (page: Page, overrides: E2EConfigOverrides = {})
     // Seed only the first app document so reload assertions observe mutations made by the application.
     if (!window.location.origin.startsWith("http")) return;
     if (window.sessionStorage.getItem("tango-e2e-config-seeded") !== null) return;
-    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 2 }));
+    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 1 }));
     window.sessionStorage.setItem("tango-e2e-config-seeded", "true");
   }, config);
 };


### PR DESCRIPTION
## Related issue

Fixes #1345

## Summary

- reset the Preferences persist version to 1 without adding a migration
- keep version 1 snapshots compatible when additive fields have safe schema defaults
- align unit and E2E persistence fixtures and clarify Store Compatibility guidance

## Testing

- `npm run test:unit -- src/entities/preference/model/store.spec.ts`
- `mise run check`