### PR TITLE
fix(#947): Verify missing Study session cards

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -141,6 +141,9 @@
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](./study.md#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](./study.md#swipe-24) |
+| SWIPE-25 | read | [remote target Card の欠損を確認して unavailable と表示できる](./study.md#swipe-25) |
+| SWIPE-26 | read | [remote target Card の確認失敗時に session を維持できる](./study.md#swipe-26) |
+| SWIPE-27 | read | [local target Card の欠損を unavailable と表示できる](./study.md#swipe-27) |
 
 ### Study Back Text
 

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -75,7 +75,8 @@
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
 | SETTINGS-01 | write | [Dark mode を自動保存して reload 後も反映できる](./settings.md#settings-01) |
-| SETTINGS-02 | write | [Maximum cards 設定を次の学習 session に反映できる](./settings.md#settings-02) |
+| SETTINGS-02 | write | [Maximum cards 設定を学習開始画面に反映できる](./settings.md#settings-02) |
+| SETTINGS-03 | batch | [Respect review schedule を次の学習 session に反映できる](./settings.md#settings-03) |
 
 ### Import
 
@@ -103,6 +104,7 @@
 | DECK-08 | read | [Deck の Card を CSV で export できる](./deck.md#deck-08) |
 | DECK-09 | write | [空の remote Deck を作成して reload 後も確認できる](./deck.md#deck-09) |
 | DECK-10 | write | [remote Deck の作成失敗後に重複なく再試行できる](./deck.md#deck-10) |
+| DECK-11 | write | [空の local-only Deck を作成して reload 後も確認できる](./creation.md#deck-11) |
 
 ### Card
 
@@ -120,6 +122,9 @@
 | CARD-10 | write | [score と tag の filter を保存して Card 一覧へ反映できる](./card.md#card-10) |
 | CARD-11 | read | [Card view を直接開ける](./card.md#card-11) |
 | CARD-12 | read | [存在しない Card から復帰できる](./card.md#card-12) |
+| CARD-13 | write | [remote Deck に Card を作成できる](./card.md#card-13) |
+| CARD-14 | write | [local-only Deck に Card を作成できる](./card.md#card-14) |
+| CARD-15 | write | [remote Card の作成失敗後に重複なく再試行できる](./creation.md#card-15) |
 
 ### Study
 
@@ -133,7 +138,7 @@
 | SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](./study.md#swipe-07) |
 | SWIPE-08 | write | [学習画面から戻った後に同じ位置から Continue できる](./study.md#swipe-08) |
 | SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](./study.md#swipe-09) |
-| SWIPE-10 | write | [最後の Card を完了して session を終了できる](./study.md#swipe-10) |
+| SWIPE-10 | write | [最後の Card を完了して completion screen を表示できる](./study.md#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](./study.md#swipe-11) |
 | SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](./study.md#swipe-12) |
 | SWIPE-13 | write | [remote Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-13) |
@@ -155,7 +160,7 @@
 | SWIPE-19 | read | [長い裏面 text を scroll しても Card の状態を維持できる](./study-back-text.md#swipe-19) |
 | SWIPE-20 | write | [左 overlay から設定済み action を実行できる](./study-back-text.md#swipe-20) |
 | SWIPE-21 | write | [右 overlay から設定済み action を実行できる](./study-back-text.md#swipe-21) |
-| SWIPE-22 | read | [狭い画面で overlay と重ならずに端の裏面 text を選択できる](./study-back-text.md#swipe-22) |
+| SWIPE-22 | read | [狭い画面でも overlay の下で裏面を全幅表示できる](./study-back-text.md#swipe-22) |
 | SWIPE-23 | read | [overlay 上から長い裏面 text を scroll できる](./study-back-text.md#swipe-23) |
 
 ### Persistence

--- a/docs/e2e/creation.md
+++ b/docs/e2e/creation.md
@@ -1,0 +1,62 @@
+# Creation E2E テスト仕様書
+
+## 目的
+
+Deck / Card の作成が保存先の境界を守り、失敗後の再試行でも同じ identity を維持して重複しないことを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| DECK-11 | write | [空の local-only Deck を作成して reload 後も確認できる](#deck-11) |
+| CARD-15 | write | [remote Card の作成失敗後に重複なく再試行できる](#card-15) |
+
+<a id="deck-11"></a>
+
+### DECK-11 空の local-only Deck を作成して reload 後も確認できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`empty`](./fixture/empty.yaml)
+- ユーザーとして認証されている。
+- 作成対象の Deck は現在の UID の remote data と local-only data のどちらにも存在しない。
+
+When:
+
+- Deck の作成画面で name と category を入力し、Local only を有効にして保存した後、Deck 一覧を reload する。
+
+Then:
+
+- 作成した空の Deck が reload 後も Deck 一覧に表示される。
+- 作成した Deck は browser storage に一つだけ存在する。
+- remote data に同じ Deck が存在しない。
+- 対象 Deck に Card が存在しない。
+- browser error が発生しない。
+
+<a id="card-15"></a>
+
+### CARD-15 remote Card の作成失敗後に重複なく再試行できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`remote-deck-with-cards`](./fixture/remote-deck-with-cards.yaml)
+- 認証済みユーザーが所有する remote Deck が存在する。
+- remote Card の最初の作成要求が失敗している。
+- 作成失敗が画面内で処理され、入力内容と作成対象の Card ID が維持されている。
+- 次の作成要求は成功できる。
+
+When:
+
+- 入力内容を変更せずに同じ Card の作成を再試行し、Card 一覧を reload する。
+
+Then:
+
+- 最初の要求と再試行で同じ Card ID が使用される。
+- 作成した Card が対象 Deck の remote data に一つだけ存在する。
+- Card の front text、back text、deck ID、owner、unique key が最初の作成要求から維持されている。
+- browser storage に同じ Card の local-only duplicate が存在しない。
+- 最初の作成失敗に伴う未処理の browser error が発生しない。

--- a/docs/e2e/fixture/study-review-schedule.yaml
+++ b/docs/e2e/fixture/study-review-schedule.yaml
@@ -1,0 +1,23 @@
+extends: remote-deck-with-cards.yaml
+remote:
+  cards:
+    - id: card-due
+      deckId: deck-1
+      uid: user-1
+      frontText: due card
+      backText: due answer
+      uniqueKey: due-card
+      nextSeeingAt: "2000-01-01T00:00:00.000Z"
+    - id: card-future
+      deckId: deck-1
+      uid: user-1
+      frontText: future card
+      backText: future answer
+      uniqueKey: future-card
+      nextSeeingAt: "2999-01-01T00:00:00.000Z"
+    - id: card-unscheduled
+      deckId: deck-1
+      uid: user-1
+      frontText: unscheduled card
+      backText: unscheduled answer
+      uniqueKey: unscheduled-card

--- a/docs/e2e/fixture/study-session-last.yaml
+++ b/docs/e2e/fixture/study-session-last.yaml
@@ -1,4 +1,4 @@
-extends: study-session-start.yaml
+extends: study-session-middle.yaml
 browser:
   studySessions:
     deck-1:

--- a/docs/e2e/fixture/study-session-local-absent.yaml
+++ b/docs/e2e/fixture/study-session-local-absent.yaml
@@ -1,0 +1,11 @@
+extends: local-deck-with-cards.yaml
+browser:
+  absentCards:
+    - id: missing-card
+      deckId: deck-1
+  studySessions:
+    deck-1:
+      sessionId: session-1
+      deckId: deck-1
+      cardOrderIds: [missing-card]
+      currentIndex: 0

--- a/docs/e2e/fixture/study-session-remote-absent.yaml
+++ b/docs/e2e/fixture/study-session-remote-absent.yaml
@@ -1,0 +1,11 @@
+extends: study-session-start.yaml
+remote:
+  absentCards:
+    - id: missing-card
+      uid: user-1
+      deckId: deck-1
+browser:
+  studySessions:
+    deck-1:
+      cardOrderIds: [missing-card]
+      currentIndex: 0

--- a/docs/e2e/settings.md
+++ b/docs/e2e/settings.md
@@ -2,14 +2,15 @@
 
 ## 目的
 
-Settings の自動保存が reload を越えて維持され、保存した学習設定が次の学習 session に反映されることを確認する。
+Settings の自動保存が reload を越えて維持され、保存した学習設定が学習開始画面や次の学習 session に反映されることを確認する。
 
 ## テストケース
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
 | SETTINGS-01 | write | [Dark mode を自動保存して reload 後も反映できる](#settings-01) |
-| SETTINGS-02 | write | [Maximum cards 設定を次の学習 session に反映できる](#settings-02) |
+| SETTINGS-02 | write | [Maximum cards 設定を学習開始画面に反映できる](#settings-02) |
+| SETTINGS-03 | batch | [Respect review schedule を次の学習 session に反映できる](#settings-03) |
 
 <a id="settings-01"></a>
 
@@ -34,7 +35,7 @@ Then:
 
 <a id="settings-02"></a>
 
-### SETTINGS-02 Maximum cards 設定を次の学習 session に反映できる
+### SETTINGS-02 Maximum cards 設定を学習開始画面に反映できる
 
 カテゴリ: `write`
 
@@ -50,6 +51,31 @@ When:
 
 Then:
 
-- 学習開始画面に表示される session の Card 数が変更後の上限と一致する。
+- 学習開始画面に表示される対象 Card 数が変更後の上限と一致する。
 - start action に変更後の上限と同じ Card 数が表示される。
+- browser error が発生しない。
+
+<a id="settings-03"></a>
+
+### SETTINGS-03 Respect review schedule を次の学習 session に反映できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`study-review-schedule`](./fixture/study-review-schedule.yaml)
+- 認証済みユーザーが所有する Deck に、過去または将来の next seeing time を持つ Card と、next seeing time を持たない Card が存在する。
+- `Respect review schedule` は無効である。
+- 対象 Deck に進行中の学習 session が存在しない。
+
+When:
+
+- Settings 画面で `Respect review schedule` を有効にし、自動保存後にページを reload する。
+- 対象 Deck の学習開始画面から session を開始する。
+
+Then:
+
+- `Respect review schedule` が reload 後も有効である。
+- 過去の next seeing time を持つ Card と、next seeing time を持たない Card が session に含まれる。
+- 将来の next seeing time を持つ Card は session に含まれない。
 - browser error が発生しない。

--- a/docs/e2e/study-back-text.md
+++ b/docs/e2e/study-back-text.md
@@ -160,7 +160,7 @@ Then:
 
 <a id="swipe-22"></a>
 
-### SWIPE-22 狭い画面で overlay と重ならずに端の裏面 text を選択できる
+### SWIPE-22 狭い画面でも overlay の下で裏面を全幅表示できる
 
 カテゴリ: `read`
 
@@ -173,13 +173,13 @@ Given:
 
 When:
 
-- 現在の Card を裏面へ切り替え、左端から始まる back text を primary mouse button の drag で選択する。
+- 現在の Card を裏面へ切り替える。
 
 Then:
 
-- back text の表示領域が左右 overlay と重ならない。
-- 選択範囲に対象 Card の back text が含まれる。
-- 対象 Card の back text と左右 overlay が引き続き表示される。
+- back text の表示領域が answer region と同じ幅を維持する。
+- 左右 overlay が back text の上に浮いた状態で表示される。
+- 対象 Card の back text が表示される。
 - Card の学習結果と session の位置が変更されない。
 - browser error が発生しない。
 

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -16,7 +16,7 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](#swipe-07) |
 | SWIPE-08 | write | [学習画面から戻った後に同じ位置から Continue できる](#swipe-08) |
 | SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](#swipe-09) |
-| SWIPE-10 | write | [最後の Card を完了して session を終了できる](#swipe-10) |
+| SWIPE-10 | write | [最後の Card を完了して completion screen を表示できる](#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
 | SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](#swipe-12) |
 | SWIPE-13 | write | [remote Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-13) |
@@ -212,7 +212,7 @@ Then:
 
 <a id="swipe-10"></a>
 
-### SWIPE-10 最後の Card を完了して session を終了できる
+### SWIPE-10 最後の Card を完了して completion screen を表示できる
 
 カテゴリ: `write`
 
@@ -229,7 +229,9 @@ Then:
 
 - 最後の Card の学習結果が保存される。
 - 対象 Deck の学習 session が削除される。
-- Deck 一覧へ戻り、対象 Deck に Continue action が表示されない。
+- Study completion screen に完了 message と学習した Card 数が表示される。
+- Deck 一覧へ automatic redirect せず、Deck 一覧へ戻る action が利用できる。
+- Deck 一覧へ戻った後、対象 Deck に Continue action が表示されない。
 - browser error が発生しない。
 
 <a id="swipe-11"></a>

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -24,6 +24,9 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](#swipe-24) |
+| SWIPE-25 | read | [remote target Card の欠損を確認して unavailable と表示できる](#swipe-25) |
+| SWIPE-26 | read | [remote target Card の確認失敗時に session を維持できる](#swipe-26) |
+| SWIPE-27 | read | [local target Card の欠損を unavailable と表示できる](#swipe-27) |
 
 <a id="swipe-02"></a>
 
@@ -395,4 +398,70 @@ Then:
 - 非表示の操作ボタンは現在の設定と一致する説明で表示される。
 - dialog 内のキー入力で Card、学習結果、session の位置が変更されない。
 - focus が dialog 内に維持され、閉じた後は Help trigger へ戻る。
+- browser error が発生しない。
+
+<a id="swipe-25"></a>
+
+### SWIPE-25 remote target Card の欠損を確認して unavailable と表示できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-remote-absent`](./fixture/study-session-remote-absent.yaml)
+- 認証済みユーザーが所有する remote Deck に、物理 document が存在しない Card を参照する session が存在する。
+
+When:
+
+- 対象の学習画面を開く。
+
+Then:
+
+- target Card が server で missing と確認された後、現在の Card が利用できないことが表示される。
+- Deck 一覧へ自動 redirect されない。
+- recovery UI が追加されるまで active session は維持される。
+- browser error が発生しない。
+
+<a id="swipe-26"></a>
+
+### SWIPE-26 remote target Card の確認失敗時に session を維持できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-remote-absent`](./fixture/study-session-remote-absent.yaml)
+- 認証済みユーザーが所有する remote Deck に、target Card の server verification が permission error になる session が存在する。
+
+When:
+
+- 対象の学習画面を開く。
+
+Then:
+
+- target Card を確認できなかったことが表示される。
+- missing または unavailable として扱われず、Deck 一覧へ自動 redirect されない。
+- active session と現在位置が維持される。
+- browser error が発生しない。
+
+<a id="swipe-27"></a>
+
+### SWIPE-27 local target Card の欠損を unavailable と表示できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-local-absent`](./fixture/study-session-local-absent.yaml)
+- browser storage の local-only Deck に、永続 Card が存在しない target を参照する session が存在する。
+
+When:
+
+- 対象の学習画面を開く。
+
+Then:
+
+- local Card hydration 完了後、現在の Card が利用できないことが表示される。
+- remote verification を待たず、Deck 一覧へ自動 redirect されない。
+- recovery UI が追加されるまで active session は維持される。
 - browser error が発生しない。

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,10 @@ service cloud.firestore {
       function belongsToDeck() {
         return getDeck(request.resource.data.deckId).data.uid == request.auth.uid
       }
-      allow read: if isOwner() || isPublic();
+      // Authenticated single-document verification must distinguish an absent target from a forbidden existing Card.
+      allow get: if (request.auth != null && !exists(/databases/$(database)/documents/card/$(cardId))) ||
+                    isOwner() || isPublic();
+      allow list: if isOwner() || isPublic();
       allow create: if isValid() && belongsToDeck();
       allow update: if isValidOwner() && belongsToDeck();
       allow delete: if isOwner();

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,4 +19,9 @@
 
 - The product is under active development. Do not preserve backward compatibility for store state unless explicitly requested.
 - Breaking changes to store state shape and behavior are allowed. Prefer the simplest current design over compatibility layers.
-- In particular, do not add migrations or retain legacy state formats for Zustand `persist`. Invalidate or discard incompatible persisted state instead.
+- Do not add migrations or retain legacy Zustand `persist` formats unless explicitly requested.
+- Keep the Preferences persist version at 1 unless a dedicated task explicitly changes it.
+- Do not bump a persist version solely because an additive field was introduced.
+- Additive fields that the current schema can safely default must remain compatible with the current version.
+- If existing state must be invalidated, document the reason and impact in a dedicated Issue.
+- Invalidate or discard persisted state that is genuinely incompatible with the current schema.

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -9,7 +9,17 @@ import type {
   RemoteCardRead,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  onSnapshot,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 
 import { mapStudyProgressDocument, type StudyProgress } from "@/entities/study-progress/@x/card";
 import { db } from "@/shared/firebase";
@@ -27,6 +37,12 @@ export interface CardRead {
   card: RemoteCardRead;
   progress: StudyProgress;
 }
+
+/** Server-confirmed physical state for one remote Card document. */
+export type RemoteCardReadResult =
+  | { status: "active"; read: CardRead }
+  | { status: "missing" }
+  | { status: "tombstoned" };
 
 /** Maps one physical Card document into independent Card and StudyProgress read models. */
 const mapCardRead = (id: CardId, value: unknown): CardRead => {
@@ -81,6 +97,16 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
 export const fetchCardReads = async (uid: string): Promise<CardRead[]> => {
   const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return mapActiveCardReads(snapshot.docs);
+};
+
+/** Reads one Card from the server without treating a collection snapshot miss as deletion. */
+export const fetchRemoteCardRead = async (uid: string, cardId: CardId): Promise<RemoteCardReadResult> => {
+  const snapshot = await getDocFromServer(doc(db, CARD_COLLECTION, cardId));
+  if (!snapshot.exists()) return { status: "missing" };
+
+  const read = mapCardRead(cardId, snapshot.data());
+  if (read.card.uid !== uid) throw new Error("Card owner does not match the authenticated user");
+  return read.card.deletedAt === null ? { status: "active", read } : { status: "tombstoned" };
 };
 
 /** Writes a new physical Card document with synchronized creation and update timestamps. */

--- a/src/entities/card/api/remote-read.spec.ts
+++ b/src/entities/card/api/remote-read.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn((...parts: unknown[]) => parts),
+  getDocFromServer: vi.fn(),
+  getDocsFromServer: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  doc: mocks.doc,
+  getDocFromServer: mocks.getDocFromServer,
+  getDocsFromServer: mocks.getDocsFromServer,
+  onSnapshot: vi.fn(),
+  query: mocks.query,
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  where: vi.fn(),
+}));
+vi.mock("@/shared/firebase", () => ({ db: "db" }));
+
+import { fetchRemoteCardRead } from "./firestore";
+
+const cardDocument = (overrides: Record<string, unknown> = {}) => ({
+  frontText: "Front",
+  backText: "Back",
+  tags: [],
+  uniqueKey: "key-card",
+  deckId: "deck-a",
+  uid: "uid-a",
+  createdAt: 1,
+  updatedAt: 2,
+  deletedAt: null,
+  score: 3,
+  numberOfSeen: 4,
+  ...overrides,
+});
+
+const resolveDocument = (value: unknown) => {
+  mocks.getDocFromServer.mockResolvedValue({ exists: () => true, data: () => value });
+};
+
+describe("single remote Card read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns one separated active Card read without querying the collection", async () => {
+    resolveDocument(cardDocument({ lastSeenAt: 5 }));
+
+    await expect(fetchRemoteCardRead("uid-a", "card-a")).resolves.toEqual({
+      status: "active",
+      read: {
+        card: expect.objectContaining({ id: "card-a", deckId: "deck-a", uid: "uid-a" }),
+        progress: expect.objectContaining({ cardId: "card-a", score: 3, numberOfSeen: 4, lastSeenAt: 5 }),
+      },
+    });
+    expect(mocks.doc).toHaveBeenCalledWith("db", "card", "card-a");
+    expect(mocks.getDocsFromServer).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes a missing document from a tombstone", async () => {
+    mocks.getDocFromServer.mockResolvedValueOnce({ exists: () => false });
+    await expect(fetchRemoteCardRead("uid-a", "missing")).resolves.toEqual({ status: "missing" });
+
+    resolveDocument(cardDocument({ deletedAt: 3 }));
+    await expect(fetchRemoteCardRead("uid-a", "deleted")).resolves.toEqual({ status: "tombstoned" });
+  });
+
+  it("rejects owner mismatches and malformed physical documents", async () => {
+    resolveDocument(cardDocument({ uid: "uid-b" }));
+    await expect(fetchRemoteCardRead("uid-a", "foreign")).rejects.toThrow("owner does not match");
+
+    resolveDocument(cardDocument({ tags: [42] }));
+    await expect(fetchRemoteCardRead("uid-a", "invalid")).rejects.toThrow('Invalid Firestore card document "invalid"');
+  });
+});

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,11 +1,11 @@
 export { subscribeCards } from "./api/firestore";
 /** @public Separated read operations for the cross-Entity Card document boundary. */
-export { fetchCardReads, subscribeCardReads } from "./api/firestore";
+export { fetchCardReads, fetchRemoteCardRead, subscribeCardReads } from "./api/firestore";
 /** @public Separated read contract for the cross-Entity Card document boundary. */
-export type { CardRead } from "./api/firestore";
+export type { CardRead, RemoteCardReadResult } from "./api/firestore";
 export { generateCardId } from "./api/id";
 export { createCard, deleteCard, editCard, mutateCards } from "./api/mutations";
-export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
+export { useCard, useCards, useCardsByDeckId, useLocalCardsHydrated } from "./model/hooks";
 export { cardContentSchema } from "./model/schema";
 export { clearRemoteCards } from "./model/store";
 export type {

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -1,8 +1,18 @@
+import * as React from "react";
 import { useStore } from "zustand";
 
 import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
 import { cardStore } from "./store";
 import type { Card, CardId } from "./types";
+
+const subscribeLocalCardsHydration = (onStoreChange: () => void): (() => void) => {
+  const stopHydrating = cardStore.persist.onHydrate(onStoreChange);
+  const stopHydrated = cardStore.persist.onFinishHydration(onStoreChange);
+  return () => {
+    stopHydrating();
+    stopHydrated();
+  };
+};
 
 // Reads remote and local Cards as one ordered collection.
 export const useCards = (): Card[] => {
@@ -16,6 +26,10 @@ export const useCard = (id: CardId | undefined): Card | undefined =>
     cardStore,
     (state) => state.remoteCards.find((card) => card.id === id) ?? state.localCards.find((card) => card.id === id)
   );
+
+// Local absence becomes authoritative only after persisted Cards have finished hydrating.
+export const useLocalCardsHydrated = (): boolean =>
+  React.useSyncExternalStore(subscribeLocalCardsHydration, cardStore.persist.hasHydrated, () => false);
 
 // Reads the Cards and available tags owned by one Deck.
 export const useCardsByDeckId = (deckId: string): { cards: Card[]; tags: string[] } => {

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -129,32 +129,33 @@ describe("preferences store", () => {
           },
         },
       },
-      version: 2,
+      version: 1,
     });
   });
 
-  it("hydrates persisted preferences", async () => {
+  it("hydrates version 1 preferences with defaults for additive fields", async () => {
+    const { showBackTextSwipeOverlays: _showBackTextSwipeOverlays, ...controlsBeforeSwipeOverlays } =
+      defaultPreferences.controls;
     const persistedPreferences = {
       ...defaultPreferences,
       loadSample: false,
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
+      controls: { ...controlsBeforeSwipeOverlays, showSwipeButtonList: false },
     };
     useMemoryStorage({
-      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 2 }),
+      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 1 }),
     });
 
     await preferencesStore.persist.rehydrate();
 
-    expect(preferencesStore.getState().preferences).toEqual(persistedPreferences);
+    expect(preferencesStore.getState().preferences).toEqual({
+      ...persistedPreferences,
+      controls: { ...persistedPreferences.controls, showBackTextSwipeOverlays: false },
+    });
   });
 
-  it("discards version 1 preferences after the persisted shape changes", async () => {
-    const {
-      showCardDetails: _showCardDetails,
-      showBackTextSwipeOverlays: _showBackTextSwipeOverlays,
-      ...legacyControls
-    } = defaultPreferences.controls;
+  it("discards version 2 preferences without migration", async () => {
     useMemoryStorage({
       "tango-config": JSON.stringify({
         state: {
@@ -163,10 +164,10 @@ describe("preferences store", () => {
             loadSample: false,
             appearance: { ...defaultPreferences.appearance, darkMode: true },
             study: { ...defaultPreferences.study, cardInterval: 15, selectedTags: ["legacy"] },
-            controls: { ...legacyControls, showSwipeButtonList: false },
+            controls: { ...defaultPreferences.controls, showSwipeButtonList: false },
           },
         },
-        version: 1,
+        version: 2,
       }),
     });
 
@@ -183,8 +184,8 @@ describe("preferences store", () => {
 
   it.each([
     ["malformed JSON", "not-json"],
-    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 2 })],
-    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 2 })],
+    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 1 })],
+    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 1 })],
   ])("uses current defaults for %s", async (_case, persistedValue) => {
     useMemoryStorage({ "tango-config": persistedValue });
 

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -7,8 +7,8 @@ import { preferencesSchema } from "./schema";
 import type { Preferences } from "./types";
 
 const PREFERENCES_STORAGE_KEY = "tango-config";
-// No migration is registered: changing this version deliberately invalidates older state shapes.
-const PREFERENCES_STORAGE_VERSION = 2;
+// Keep this stable for safely defaultable additions; a dedicated task must justify invalidating existing preferences.
+const PREFERENCES_STORAGE_VERSION = 1;
 
 /** @internal Partial updates for each top-level preference field. */
 export type PartialPreferences = {

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -53,6 +53,25 @@ describe("StudyProgress mutations", () => {
     expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
   });
 
+  it("writes progress for a verified remote Card before the Card store catches up", async () => {
+    await editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "remote" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editRemoteStudyProgress).toHaveBeenCalledExactlyOnceWith("user", {
+      cardId: "remote",
+      score: 2,
+    });
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a verified remote identity for another Card", async () => {
+    await expect(
+      editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "other-card" })
+    ).rejects.toThrow("Verified Card identity does not match progress");
+
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
   it("rejects progress for an unknown Card", async () => {
     await expect(editStudyProgress("user", { cardId: "missing", score: 2 })).rejects.toThrow(
       'Card "missing" was not found'

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -64,10 +64,20 @@ describe("StudyProgress mutations", () => {
     expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
   });
 
-  it("rejects a verified remote identity for another Card", async () => {
+  it("writes progress for a resolved local Card despite an ambiguous global lookup", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "local", score: 2 }, { persistence: "local", cardId: "local" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({ id: "local", score: 2 });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a resolved persistence identity for another Card", async () => {
     await expect(
       editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "other-card" })
-    ).rejects.toThrow("Verified Card identity does not match progress");
+    ).rejects.toThrow("Resolved Card identity does not match progress");
 
     expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
   });

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,19 +1,25 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { studyProgressEditSchema } from "../model/schema";
-import type { RemoteStudyProgressTarget, StudyProgressEdit } from "../model/types";
+import type { StudyProgressEdit, StudyProgressTarget } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
 export const editStudyProgress = async (
   uid: string,
   progress: StudyProgressEdit,
-  verifiedTarget?: RemoteStudyProgressTarget
+  target?: StudyProgressTarget
 ): Promise<void> => {
   const edit = studyProgressEditSchema.parse(progress);
-  if (verifiedTarget !== undefined) {
-    if (verifiedTarget.cardId !== edit.cardId) throw new Error("Verified Card identity does not match progress");
-    await editRemoteStudyProgress(uid, edit);
+  if (target !== undefined) {
+    if (target.cardId !== edit.cardId) throw new Error("Resolved Card identity does not match progress");
+    if (target.persistence === "remote") {
+      await editRemoteStudyProgress(uid, edit);
+      return;
+    }
+
+    const { cardId: id, ...fields } = edit;
+    editLocalCardStudyProgress(omitUndefined({ id, ...fields }));
     return;
   }
 

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,12 +1,22 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { studyProgressEditSchema } from "../model/schema";
-import type { StudyProgressEdit } from "../model/types";
+import type { RemoteStudyProgressTarget, StudyProgressEdit } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
-export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
+export const editStudyProgress = async (
+  uid: string,
+  progress: StudyProgressEdit,
+  verifiedTarget?: RemoteStudyProgressTarget
+): Promise<void> => {
   const edit = studyProgressEditSchema.parse(progress);
+  if (verifiedTarget !== undefined) {
+    if (verifiedTarget.cardId !== edit.cardId) throw new Error("Verified Card identity does not match progress");
+    await editRemoteStudyProgress(uid, edit);
+    return;
+  }
+
   const card = findCardById(edit.cardId);
   if (card === undefined) throw new Error(`Card "${edit.cardId}" was not found`);
 

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,1 +1,2 @@
 export { editStudyProgress } from "./api/mutations";
+export type { StudyProgressEdit } from "./model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,2 +1,2 @@
 export { editStudyProgress } from "./api/mutations";
-export type { StudyProgressEdit } from "./model/types";
+export type { StudyProgressEdit, StudyProgressTarget } from "./model/types";

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -29,6 +29,12 @@ export interface StudyProgressDocumentFields {
 /** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
+/** Server-verified remote identity that permits a write before the Card subscription publishes its snapshot. */
+export interface RemoteStudyProgressTarget {
+  persistence: "remote";
+  cardId: CardId;
+}
+
 /** Learning outcome derived from one study interaction. */
 export type StudyRating = "mastered" | "not-mastered" | "unrated";
 

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -29,11 +29,8 @@ export interface StudyProgressDocumentFields {
 /** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
-/** Server-verified remote identity that permits a write before the Card subscription publishes its snapshot. */
-export interface RemoteStudyProgressTarget {
-  persistence: "remote";
-  cardId: CardId;
-}
+/** Persistence identity already resolved by the consuming model, independent of ambiguous same-ID store entries. */
+export type StudyProgressTarget = { persistence: "local"; cardId: CardId } | { persistence: "remote"; cardId: CardId };
 
 /** Learning outcome derived from one study interaction. */
 export type StudyRating = "mastered" | "not-mastered" | "unrated";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -13,6 +13,7 @@ export {
   getStudySession,
   moveStudySession,
   removeStudySession,
+  removeStudySessionIfCurrent,
   setStudySessionIndex,
   startStudy,
   touchStudySession,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -85,14 +85,15 @@ describe("resolveStudySession", () => {
     });
   });
 
-  it("waits while Cards have not loaded", () => {
-    expect(resolveStudySession(session, [])).toEqual({ status: "preparing" });
+  it("reports target absence without inferring whether the snapshot has loaded", () => {
+    expect(resolveStudySession(session, [])).toEqual({ status: "absent", session, cardId: "card-2" });
+    expect(resolveStudySession(session, cards)).toEqual({ status: "absent", session, cardId: "card-2" });
   });
 
-  it("rejects a missing session, empty position, or absent loaded Card", () => {
+  it("rejects a missing session or empty position", () => {
     expect(resolveStudySession(undefined, cards)).toEqual({ status: "invalid" });
-    expect(resolveStudySession({ ...session, cardOrderIds: [] }, [])).toEqual({ status: "invalid" });
-    expect(resolveStudySession(session, cards)).toEqual({ status: "invalid" });
+    const emptySession = { ...session, cardOrderIds: [] };
+    expect(resolveStudySession(emptySession, [])).toEqual({ status: "invalid", session: emptySession });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -103,7 +103,7 @@ export const selectStudyCards = <TCard extends StudyCardSelectionCard>(
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
-// Resolves whether an active session can study now, is waiting for Cards, or is invalid.
+// Reports snapshot absence without guessing whether an external read has completed.
 export const resolveStudySession = <Card extends StudySessionCard>(
   session: StudySession | undefined,
   cards: readonly Card[]
@@ -111,13 +111,12 @@ export const resolveStudySession = <Card extends StudySessionCard>(
   if (session == null) return { status: "invalid" };
 
   const cardId = getCurrentStudySessionCardId(session);
-  if (cardId == null) return { status: "invalid" };
+  if (cardId == null) return { status: "invalid", session };
 
   const card = cards.find(({ id }) => id === cardId);
   if (card != null) return { status: "studying", session, card };
 
-  // An empty collection can still be an in-flight read; loaded Cards prove that the persisted Card is absent.
-  return { status: cards.length === 0 ? "preparing" : "invalid" };
+  return { status: "absent", session, cardId };
 };
 
 // Collapses control actions into the movement, exit, or no-op effects understood by a study session.

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -11,6 +11,7 @@ import {
   getStudySession,
   moveStudySession,
   removeStudySession,
+  removeStudySessionIfCurrent,
   setStudySessionIndex,
   startStudy,
   studySessionStore,
@@ -179,6 +180,21 @@ describe("study store", () => {
     expect(store.getState().sessionsByDeckId).toEqual({
       "deck-2": expect.objectContaining({ deckId: "deck-2" }),
     });
+  });
+
+  it("removes only the session identity and position that were verified", () => {
+    startSession("deck-1", ["card-1", "card-2"]);
+    const verified = getStudySession("deck-1");
+    if (verified == null) throw new Error("Expected an active study session");
+
+    setStudySessionIndex("deck-1", 1);
+    expect(removeStudySessionIfCurrent(verified)).toBe(false);
+    expect(getStudySession("deck-1")?.currentIndex).toBe(1);
+
+    const current = getStudySession("deck-1");
+    if (current == null) throw new Error("Expected an active study session");
+    expect(removeStudySessionIfCurrent(current)).toBe(true);
+    expect(getStudySession("deck-1")).toBeUndefined();
   });
 
   it("clears both memory and persisted storage", () => {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -140,6 +140,18 @@ export const removeStudySession = (deckId: DeckId): void => {
   });
 };
 
+// Destructive recovery must not remove a session that changed after the invalid state was observed.
+export const removeStudySessionIfCurrent = (previous: StudySession): boolean => {
+  let removed = false;
+  studySessionStore.setState((state) => {
+    const current = state.sessionsByDeckId[previous.deckId];
+    if (!isStudySessionPositionUnchanged(previous, current)) return;
+    delete state.sessionsByDeckId[previous.deckId];
+    removed = true;
+  });
+  return removed;
+};
+
 // Clears every live and persisted study session.
 export const clearStudySessions = (): void => {
   // Publish the empty state before durable cleanup so auth changes cannot expose the previous user's sessions.

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -50,7 +50,8 @@ export type StudySessionSwipePlan =
 /** Minimal Card identity needed to resolve a study session position. */
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
 
-/** Resolution of an active study session against the currently loaded Cards. */
+/** Resolution of an active study session against one provided Card snapshot. */
 export type ResolvedStudySession<Card extends StudySessionCard> =
-  | { status: "preparing" | "invalid" }
+  | { status: "invalid"; session?: StudySession }
+  | { status: "absent"; session: StudySession; cardId: StudySession["cardOrderIds"][number] }
   | { status: "studying"; session: StudySession; card: Card };

--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -272,7 +272,6 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     renderFilter();
 
-    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
     expect(screen.getByRole("checkbox", { name: "Match all selected tags" })).toBeChecked();
@@ -295,7 +294,6 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     view = renderFilter();
 
-    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
 
@@ -304,7 +302,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     renderFilter();
 
-    expect(screen.getByText("Any score")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });

--- a/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
@@ -38,7 +38,6 @@ describe("DeckFilterForm", () => {
     const maximum = within(scoreRegion).getByRole("combobox", { name: "Maximum score" });
     const minimum = within(scoreRegion).getByRole("combobox", { name: "Minimum score" });
 
-    expect(within(scoreRegion).getByText("−2 to 4")).toBeInTheDocument();
     expect(maximum).toHaveValue("4");
     expect(minimum).toHaveValue("-2");
 
@@ -54,7 +53,8 @@ describe("DeckFilterForm", () => {
 
   it("shows unrestricted limits", () => {
     render(<DeckFilterForm {...createProps()} scoreMax={null} scoreMin={null} />);
-    expect(screen.getByText("Any score")).toBeInTheDocument();
+    const scoreRegion = screen.getByRole("region", { name: "Score range" });
+    expect(within(scoreRegion).queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen, within } from "@testing-library/react";
+import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -32,14 +33,13 @@ describe("ScoreRange", () => {
     expect(numericOptionValues(maximum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
     expect(minimum).toHaveAccessibleDescription("Include cards at or above this score.");
     expect(maximum).toHaveAccessibleDescription("Include cards at or below this score.");
-    expect(screen.getByText("Any score")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Clear limits" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
-  it("reports native selections and summarizes two-sided and one-sided limits", async () => {
+  it("reports native selections", async () => {
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
-    const view = render(
+    render(
       <ScoreRange
         maximum={4}
         minimum={-2}
@@ -49,33 +49,10 @@ describe("ScoreRange", () => {
       />
     );
 
-    expect(screen.getByText("−2 to 4")).toBeInTheDocument();
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "-1");
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "3");
     expect(onMinimumChange).toHaveBeenCalledWith(-1);
     expect(onMaximumChange).toHaveBeenCalledWith(3);
-
-    view.rerender(
-      <ScoreRange
-        maximum={null}
-        minimum={-2}
-        onClear={vi.fn()}
-        onMaximumChange={onMaximumChange}
-        onMinimumChange={onMinimumChange}
-      />
-    );
-    expect(screen.getByText("−2 and above")).toBeInTheDocument();
-
-    view.rerender(
-      <ScoreRange
-        maximum={4}
-        minimum={null}
-        onClear={vi.fn()}
-        onMaximumChange={onMaximumChange}
-        onMinimumChange={onMinimumChange}
-      />
-    );
-    expect(screen.getByText("4 and below")).toBeInTheDocument();
   });
 
   it("preserves saved scores outside the standard integer choices", () => {
@@ -96,7 +73,6 @@ describe("ScoreRange", () => {
     expect(maximum).toHaveValue("14.25");
     expect(within(minimum).getByRole("option", { name: "−12.5" })).toBeInTheDocument();
     expect(within(maximum).getByRole("option", { name: "14.25" })).toBeInTheDocument();
-    expect(screen.getByText("−12.5 to 14.25")).toBeInTheDocument();
   });
 
   it("limits new choices to a valid range while retaining the active choices", () => {
@@ -130,6 +106,33 @@ describe("ScoreRange", () => {
     expect(onClear).toHaveBeenCalledOnce();
     expect(onMinimumChange).not.toHaveBeenCalled();
     expect(onMaximumChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps focus in the range controls and announces when limits are cleared", async () => {
+    const ControlledScoreRange = () => {
+      const [maximum, setMaximum] = useState<number | null>(4);
+      const [minimum, setMinimum] = useState<number | null>(-2);
+
+      return (
+        <ScoreRange
+          maximum={maximum}
+          minimum={minimum}
+          onClear={() => {
+            setMaximum(null);
+            setMinimum(null);
+          }}
+          onMaximumChange={setMaximum}
+          onMinimumChange={setMinimum}
+        />
+      );
+    };
+
+    render(<ControlledScoreRange />);
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveFocus();
+    expect(screen.getByRole("status")).toHaveTextContent("No score limits.");
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
   it("shows an invalid saved range without mutating it and allows both recovery paths", async () => {

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -2,7 +2,7 @@
  * @file Defines the deck filter's score range presentation component.
  */
 
-import { useId } from "react";
+import { useId, useRef } from "react";
 import type * as React from "react";
 
 import { Button } from "@/shared/ui/button";
@@ -37,11 +37,11 @@ interface ScoreSelectProps {
 
 const displayScore = (value: number): string => String(value).replace("-", "−");
 
-const scoreRangeLabel = (minimum: number | null, maximum: number | null): string => {
-  if (minimum != null && maximum != null) return `${displayScore(minimum)} to ${displayScore(maximum)}`;
-  if (minimum != null) return `${displayScore(minimum)} and above`;
-  if (maximum != null) return `${displayScore(maximum)} and below`;
-  return "Any score";
+const scoreRangeStatus = (minimum: number | null, maximum: number | null): string => {
+  if (minimum != null && maximum != null) return `Score range: ${displayScore(minimum)} to ${displayScore(maximum)}.`;
+  if (minimum != null) return `Minimum score: ${displayScore(minimum)}. No maximum score.`;
+  if (maximum != null) return `Maximum score: ${displayScore(maximum)}. No minimum score.`;
+  return "No score limits.";
 };
 
 const scoreOptions = (
@@ -60,14 +60,18 @@ const scoreOptions = (
     .sort((left, right) => left - right);
 };
 
-const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
-  <div className="rounded-control bg-surface-muted p-3">
-    <label htmlFor={props.id} className="text-body font-medium text-ink">
+const ScoreSelect = ({
+  ref: selectRef,
+  ...props
+}: ScoreSelectProps & { ref?: React.RefObject<HTMLSelectElement | null> }) => (
+  <div className="min-w-0">
+    <label htmlFor={props.id} className="text-caption font-medium text-ink-muted">
       {props.label}
     </label>
     <Select
+      ref={selectRef}
       id={props.id}
-      className="mt-2"
+      className="mt-1"
       value={props.value == null ? NO_LIMIT_VALUE : String(props.value)}
       aria-label={`${props.label} score`}
       aria-describedby={props.describedBy}
@@ -80,7 +84,7 @@ const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
         props.onChange(event.currentTarget.value === NO_LIMIT_VALUE ? null : Number(event.currentTarget.value))
       }
     />
-    <p id={`${props.id}-description`} className="mt-1 text-caption text-ink-muted">
+    <p id={`${props.id}-description`} className="sr-only">
       {props.description}
     </p>
   </div>
@@ -91,6 +95,7 @@ const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
  */
 export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
   const idPrefix = useId();
+  const minimumSelectRef = useRef<HTMLSelectElement>(null);
   const headingId = `${idPrefix}-score-heading`;
   const minimumId = `${idPrefix}-minimum-score`;
   const maximumId = `${idPrefix}-maximum-score`;
@@ -104,33 +109,30 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
   return (
     <section
       aria-labelledby={headingId}
-      className="space-y-4 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
+      className="space-y-3 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
     >
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 id={headingId} className="text-title font-semibold text-ink">
-            Score range
-          </h2>
-          <p className="mt-1 text-caption text-ink-muted">Limit cards by their current score.</p>
-        </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <span
-            aria-live="polite"
-            className="rounded-control bg-surface-muted px-2 py-1 text-caption font-bold text-accent-primary"
-          >
-            {scoreRangeLabel(props.minimum, props.maximum)}
-          </span>
-          <Button
-            variant="quiet"
-            size="sm"
-            label="Clear limits"
-            disabled={props.minimum == null && props.maximum == null}
-            onClick={props.onClear}
-          />
-        </div>
+      <header className="flex items-center justify-between gap-3">
+        <h2 id={headingId} className="text-title font-semibold text-ink">
+          Score range
+        </h2>
+        <Button
+          variant="quiet"
+          size="sm"
+          className="border-0 text-accent-primary"
+          hidden={props.minimum == null && props.maximum == null}
+          onClick={() => {
+            props.onClear();
+            // The clear action hides its own button on the next render, so keyboard focus must move
+            // to a stable control before that render commits.
+            minimumSelectRef.current?.focus();
+          }}
+        >
+          Clear <span className="sr-only">limits</span>
+        </Button>
       </header>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2 sm:gap-3">
         <ScoreSelect
+          ref={minimumSelectRef}
           id={minimumId}
           label="Minimum"
           value={props.minimum}
@@ -140,6 +142,9 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           description="Include cards at or above this score."
           onChange={props.onMinimumChange}
         />
+        <span aria-hidden="true" className="flex min-h-touch items-center text-caption text-ink-muted">
+          to
+        </span>
         <ScoreSelect
           id={maximumId}
           label="Maximum"
@@ -151,6 +156,9 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           onChange={props.onMaximumChange}
         />
       </div>
+      <p role="status" aria-live="polite" className="sr-only">
+        {scoreRangeStatus(props.minimum, props.maximum)}
+      </p>
       {invalid ? (
         <p id={warningId} role="alert" className="rounded-control border border-danger p-3 text-caption text-danger">
           Minimum score must not be greater than maximum score.

--- a/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
@@ -108,6 +108,7 @@ describe("CardListPage interactions", () => {
   it("builds the list presentation and coordinates filter, view, and edit interactions", async () => {
     renderCardList();
 
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     expect(screen.getByText("score -2–4 · 2 tags")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Remove typescript filter" }));
     expect(screen.queryByRole("button", { name: "Remove typescript filter" })).not.toBeInTheDocument();
@@ -115,8 +116,10 @@ describe("CardListPage interactions", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "View Front" }));
     expect(screen.getByText("Back")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Close card" }));
     expect(screen.queryByText("Back")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
 
     await userEvent.click(screen.getByRole("button", { name: "Open actions for Front" }));
     await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -27,7 +27,7 @@ const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
   });
 
   return (
-    <AppLayout showHeader>
+    <AppLayout showHeader={state.answer == null}>
       <Feedback tone="error">{state.mutationError == null ? null : "Unable to save changes. Try again."}</Feedback>
       <Feedback tone="success">{state.successMessage}</Feedback>
       {state.deletionTarget != null ? (

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -13,7 +13,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
-import { createDeck, createLocalDeck, createPreferences } from "@/test/factories";
+import { createDeck, createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
@@ -129,7 +129,10 @@ describe("useStudy", () => {
 
     await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-2" } }));
     expect(result.current).toMatchObject({ showBackText: false, swipeFeedback: "cardSwipeRight" });
-    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
   });
 
   it("reports unavailable after the server confirms a missing remote target", async () => {
@@ -157,10 +160,27 @@ describe("useStudy", () => {
     expect(getStudySession(deckId)).toBeDefined();
   });
 
-  it("uses an active server result while the Card subscription catches up", async () => {
+  it("writes the displayed local Card while a same-ID remote copy overlaps migration", async () => {
+    const localCard = createLocalCard({ id: "card-1", deckId, frontText: "local card" });
+    mocks.deck = createLocalDeck({ id: deckId });
+    mocks.cards = [cards[0] as Card, localCard];
+    clearStudySessions();
+    startStudy(deckId, [localCard], { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current).toMatchObject({ status: "studying", card: { frontText: "local card" } });
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "local",
+      cardId: "card-1",
+    });
+  });
+
+  it("writes the verified remote Card while a same-ID local copy overlaps subscription catch-up", async () => {
     const [currentCard] = cards;
     if (currentCard == null || !("uid" in currentCard)) throw new Error("Expected a remote Card");
-    mocks.cards = [];
+    mocks.cards = [createLocalCard({ id: currentCard.id, deckId, frontText: "same-ID local copy" })];
     mocks.fetchRemoteCardRead.mockResolvedValue({
       status: "active",
       read: {

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -13,13 +13,15 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
-import { createDeck, createPreferences } from "@/test/factories";
+import { createDeck, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
   cards: [] as Card[],
   deck: undefined as Deck | undefined,
   editStudyProgress: vi.fn(),
+  fetchRemoteCardRead: vi.fn(),
+  localCardsHydrated: true,
   touchStudySession: vi.fn(),
 }));
 
@@ -34,7 +36,9 @@ vi.mock("@/entities/preference", async (importOriginal) => ({
 }));
 vi.mock("@/entities/card", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/card")>()),
+  fetchRemoteCardRead: mocks.fetchRemoteCardRead,
   useCards: () => mocks.cards,
+  useLocalCardsHydrated: () => mocks.localCardsHydrated,
 }));
 vi.mock("@/entities/deck", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/deck")>()),
@@ -86,8 +90,10 @@ describe("useStudy", () => {
     localStorage.clear();
     vi.clearAllMocks();
     mocks.editStudyProgress.mockResolvedValue(undefined);
+    mocks.fetchRemoteCardRead.mockReset();
+    mocks.localCardsHydrated = true;
     mocks.cards = cards;
-    mocks.deck = createDeck({ id: deckId, category: "raw" });
+    mocks.deck = createDeck({ id: deckId, uid: "user-1", category: "raw" });
     mocks.preferences = createPreferences({
       cardInterval: 1,
       defaultAutoPlay: false,
@@ -126,10 +132,114 @@ describe("useStudy", () => {
     expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
   });
 
-  it("reports preparing while the session card is not available", () => {
+  it("reports unavailable after the server confirms a missing remote target", async () => {
     mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
     const { result } = renderHook(() => useStudy(deckId));
-    expect(result.current.status).toBe("preparing");
+    expect(result.current.status).toBe("verifying");
+
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("waits for local hydration before treating a missing Card as authoritative", () => {
+    mocks.cards = [];
+    mocks.deck = createLocalDeck({ id: deckId });
+    mocks.localCardsHydrated = false;
+    const { result, rerender } = renderHook(() => useStudy(deckId));
+    expect(result.current.status).toBe("verifying");
+
+    mocks.localCardsHydrated = true;
+    rerender();
+
+    expect(result.current.status).toBe("unavailable");
+    expect(mocks.fetchRemoteCardRead).not.toHaveBeenCalled();
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("uses an active server result while the Card subscription catches up", async () => {
+    const [currentCard] = cards;
+    if (currentCard == null || !("uid" in currentCard)) throw new Error("Expected a remote Card");
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({
+      status: "active",
+      read: {
+        card: {
+          id: currentCard.id,
+          deckId: currentCard.deckId,
+          uid: currentCard.uid,
+          frontText: currentCard.frontText,
+          backText: currentCard.backText,
+          tags: currentCard.tags,
+          uniqueKey: currentCard.uniqueKey,
+          createdAt: currentCard.createdAt,
+          updatedAt: currentCard.updatedAt,
+          deletedAt: currentCard.deletedAt,
+        },
+        progress: {
+          cardId: currentCard.id,
+          score: currentCard.score,
+          numberOfSeen: currentCard.numberOfSeen,
+          lastSeenAt: currentCard.lastSeenAt,
+        },
+      },
+    });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-1" } }));
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
+    expect(getStudySession(deckId)?.currentIndex).toBe(1);
+  });
+
+  it("preserves the session when remote target verification fails", async () => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockRejectedValue(new Error("network failure"));
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await waitFor(() => expect(result.current.status).toBe("verification-error"));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("does not treat another Deck's loaded Cards as proof that the target is missing", async () => {
+    const otherCard = { ...cards[0], id: "other-card", deckId: "other-deck" } as Card;
+    mocks.cards = [otherCard];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current.status).toBe("verifying");
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("ignores a verification result after the session target is replaced", async () => {
+    let resolveOldVerification: (result: { status: "missing" }) => void = () => undefined;
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockImplementation((_uid: string, cardId: string) => {
+      if (cardId === "card-1") {
+        return new Promise((resolve) => {
+          resolveOldVerification = resolve;
+        });
+      }
+      return new Promise(() => undefined);
+    });
+    const { result } = renderHook(() => useStudy(deckId));
+    const previousSessionId = getStudySession(deckId)?.sessionId;
+
+    act(() => startStudy(deckId, cards.slice(1), { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    await waitFor(() => expect(mocks.fetchRemoteCardRead).toHaveBeenCalledWith("user-1", "card-2"));
+    await actAsync(async () => {
+      resolveOldVerification({ status: "missing" });
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe("verifying");
+    expect(getStudySession(deckId)?.sessionId).not.toBe(previousSessionId);
+    expect(getStudySession(deckId)?.cardOrderIds).toEqual(["card-2"]);
   });
 
   it("reports persisted control visibility and playback availability", () => {

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -61,9 +61,15 @@ vi.mock("@/entities/study-session", async (importOriginal) => {
 
 import { useStudy as useStudyState } from "./useStudy";
 
-const useStudy = (routeDeckId: string) => {
+const useAnyStudy = (routeDeckId: string) => {
   const study = useStudyState(routeDeckId);
   if (study == null) throw new Error("Expected the test Deck to exist");
+  return study;
+};
+
+const useStudy = (routeDeckId: string) => {
+  const study = useAnyStudy(routeDeckId);
+  if (study.status === "completed") throw new Error("Expected an active Study state");
   return study;
 };
 
@@ -162,10 +168,11 @@ describe("useStudy", () => {
 
   it("writes the displayed local Card while a same-ID remote copy overlaps migration", async () => {
     const localCard = createLocalCard({ id: "card-1", deckId, frontText: "local card" });
+    const nextLocalCard = createLocalCard({ id: "card-2", deckId, frontText: "next local card" });
     mocks.deck = createLocalDeck({ id: deckId });
-    mocks.cards = [cards[0] as Card, localCard];
+    mocks.cards = [cards[0] as Card, localCard, nextLocalCard];
     clearStudySessions();
-    startStudy(deckId, [localCard], { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    startStudy(deckId, [localCard, nextLocalCard], { shuffled: false, maxNumberOfCardsToLearn: 0 });
     const { result } = renderHook(() => useStudy(deckId));
 
     expect(result.current).toMatchObject({ status: "studying", card: { frontText: "local card" } });
@@ -344,6 +351,17 @@ describe("useStudy", () => {
     expect(result.current).not.toHaveProperty("swipeFeedback");
   });
 
+  it("does not complete the final Card when persistence fails", async () => {
+    setStudySessionIndex(deckId, 1);
+    mocks.editStudyProgress.mockRejectedValueOnce(new Error("write failed"));
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await actAsync(() => result.current.swipeRight());
+
+    expect(result.current.status).toBe("studying");
+    expect(getStudySession(deckId)?.currentIndex).toBe(1);
+  });
+
   it("blocks a second swipe while the first write is unresolved", async () => {
     let finishWrite: () => void = () => undefined;
     mocks.editStudyProgress.mockReturnValueOnce(
@@ -383,6 +401,29 @@ describe("useStudy", () => {
     expect(result.current).not.toHaveProperty("swipeFeedback");
   });
 
+  it("does not complete a final Card when the active session is replaced during the write", async () => {
+    clearStudySessions();
+    startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    mocks.cards = cards.slice(0, 1);
+    let finishWrite: () => void = () => undefined;
+    mocks.editStudyProgress.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishWrite = resolve;
+      })
+    );
+    const { result } = renderHook(() => useStudy(deckId));
+
+    const swipe = result.current.swipeRight();
+    act(() => startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    await actAsync(async () => {
+      finishWrite();
+      await swipe;
+    });
+
+    expect(result.current.status).toBe("studying");
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
   it("advances after a timestamp-only session touch during the write", async () => {
     vi.spyOn(Date, "now").mockReturnValue(946_684_800_000);
     let finishWrite: () => void = () => undefined;
@@ -417,15 +458,26 @@ describe("useStudy", () => {
     expect(getStudySession(deckId)).toBeUndefined();
   });
 
-  it("removes the session after the final card is persisted", async () => {
-    clearStudySessions();
-    startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 });
-    mocks.cards = cards.slice(0, 1);
+  it("does not complete when previous crosses the first Card boundary", async () => {
+    mocks.preferences = createPreferences({ cardSwipeLeft: "GoToPrevCard" });
     const { result } = renderHook(() => useStudy(deckId));
 
-    await actAsync(() => result.current.swipeRight());
+    await actAsync(() => result.current.swipeLeft());
+
+    expect(result.current.status).toBe("invalid");
+    expect(getStudySession(deckId)).toBeUndefined();
+  });
+
+  it("completes after the final Card is persisted and preserves the session Card count", async () => {
+    setStudySessionIndex(deckId, 1);
+    const { result } = renderHook(() => useAnyStudy(deckId));
+
+    if (result.current.status !== "studying") throw new Error("Expected an active Study state");
+    const { swipeRight } = result.current;
+    await actAsync(swipeRight);
 
     expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
     expect(getStudySession(deckId)).toBeUndefined();
+    expect(result.current).toEqual({ status: "completed", completion: { cardCount: 2 } });
   });
 });

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useCards } from "@/entities/card";
+import { useCards, useLocalCardsHydrated } from "@/entities/card";
 import { getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
 import {
   toggleShowCardDetails,
@@ -17,9 +17,10 @@ import { useSwipe } from "./useSwipe";
 
 export const useStudy = (deckId: string) => {
   const cards = useCards();
+  const localCardsHydrated = useLocalCardsHydrated();
   const deck = useDeck(deckId);
   const preferences = usePreferences();
-  const sessionState = useStudySessionState(deckId, cards);
+  const sessionState = useStudySessionState(deck, cards, localCardsHydrated);
   const [showBackText, setShowBackText] = React.useState(false);
   const [helpOpen, setHelpOpen] = React.useState(false);
   const hideBackText = () => setShowBackText(false);
@@ -30,7 +31,17 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipe = useSwipe(deckId, cards, hideBackText);
+  const swipeCards =
+    sessionState.status === "studying" && !cards.some(({ id }) => id === sessionState.card.id)
+      ? [...cards, sessionState.card]
+      : cards;
+  const verifiedRemoteCardId =
+    sessionState.status === "studying" &&
+    "uid" in sessionState.card &&
+    !cards.some(({ id }) => id === sessionState.card.id)
+      ? sessionState.card.id
+      : undefined;
+  const swipe = useSwipe(deckId, swipeCards, hideBackText, verifiedRemoteCardId);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -13,7 +13,7 @@ import { setStudySessionIndex } from "@/entities/study-session";
 import { useAutoPlay } from "./useAutoPlay";
 import { buildStudyHelpContent } from "./studyHelp";
 import { useStudySessionState } from "./useStudySessionState";
-import { useSwipe } from "./useSwipe";
+import { type StudyCompletion, useSwipe } from "./useSwipe";
 
 export const useStudy = (deckId: string) => {
   const cards = useCards();
@@ -21,6 +21,7 @@ export const useStudy = (deckId: string) => {
   const deck = useDeck(deckId);
   const preferences = usePreferences();
   const sessionState = useStudySessionState(deck, cards, localCardsHydrated);
+  const [completion, setCompletion] = React.useState<StudyCompletion>();
   const [showBackText, setShowBackText] = React.useState(false);
   const [helpOpen, setHelpOpen] = React.useState(false);
   const hideBackText = () => setShowBackText(false);
@@ -40,7 +41,11 @@ export const useStudy = (deckId: string) => {
         ? { persistence: "remote" as const, cardId: sessionState.card.id }
         : { persistence: "local" as const, cardId: sessionState.card.id }
       : undefined;
-  const swipe = useSwipe(deckId, swipeCards, hideBackText, persistenceTarget);
+  const swipe = useSwipe(deckId, swipeCards, {
+    onCardChanged: hideBackText,
+    onCompleted: setCompletion,
+    target: persistenceTarget,
+  });
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;
@@ -70,6 +75,7 @@ export const useStudy = (deckId: string) => {
   };
 
   if (deck == null) return;
+  if (completion != null) return { status: "completed" as const, completion };
   if (sessionState.status !== "studying") return { ...controls, status: sessionState.status };
 
   const category = getCategory(deck.category, sessionState.card.tags);

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -31,17 +31,16 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipeCards =
-    sessionState.status === "studying" && !cards.some(({ id }) => id === sessionState.card.id)
-      ? [...cards, sessionState.card]
-      : cards;
-  const verifiedRemoteCardId =
-    sessionState.status === "studying" &&
-    "uid" in sessionState.card &&
-    !cards.some(({ id }) => id === sessionState.card.id)
-      ? sessionState.card.id
+  // Use the exact displayed Card because local-to-remote migration can temporarily leave both persistence modes
+  // with the same ID; swipe planning and writes must follow the Deck-scoped Card selected above.
+  const swipeCards = sessionState.status === "studying" ? [sessionState.card] : [];
+  const persistenceTarget =
+    sessionState.status === "studying"
+      ? "uid" in sessionState.card
+        ? { persistence: "remote" as const, cardId: sessionState.card.id }
+        : { persistence: "local" as const, cardId: sessionState.card.id }
       : undefined;
-  const swipe = useSwipe(deckId, swipeCards, hideBackText, verifiedRemoteCardId);
+  const swipe = useSwipe(deckId, swipeCards, hideBackText, persistenceTarget);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;

--- a/src/pages/study-session/model/useStudySessionState.ts
+++ b/src/pages/study-session/model/useStudySessionState.ts
@@ -1,25 +1,174 @@
-import type { Card } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
-import { removeStudySession, resolveStudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+import { type Card, type CardRead, fetchRemoteCardRead, type RemoteCardReadResult } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import {
+  removeStudySessionIfCurrent,
+  resolveStudySession,
+  type StudySession,
+  touchStudySession,
+  useStudySession,
+} from "@/entities/study-session";
 
 import * as React from "react";
 
-export type StudySessionState = ReturnType<typeof resolveStudySession<Card>>;
+type RemoteVerification = RemoteCardReadResult | { status: "error" };
 
-export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
-  const session = useStudySession(deckId);
-  const sessionState = resolveStudySession(session, cards);
+interface VerificationState {
+  key: string;
+  result: RemoteVerification;
+}
+
+type RemoteDeck = Extract<Deck, { localMode: false }>;
+type SnapshotState = ReturnType<typeof resolveStudySession<Card>>;
+type AbsentSnapshotState = Extract<SnapshotState, { status: "absent" }>;
+
+interface RemoteVerificationTarget {
+  uid: string;
+  cardId: string;
+  key: string;
+}
+
+interface PageStateInputs {
+  deck: Deck | undefined;
+  session: StudySession | undefined;
+  snapshotState: SnapshotState;
+  localCardsHydrated: boolean;
+  verification: RemoteVerification | undefined;
+}
+
+export type StudySessionState =
+  | { status: "verifying" }
+  | { status: "unavailable"; reason: "local-missing" | "remote-missing" | "remote-tombstoned" }
+  | { status: "verification-error" }
+  | { status: "invalid" }
+  | { status: "studying"; session: StudySession; card: Card };
+
+const combineCardRead = ({ card, progress }: CardRead): Card => ({
+  ...card,
+  score: progress.score,
+  numberOfSeen: progress.numberOfSeen,
+  ...(progress.lastSeenAt !== undefined ? { lastSeenAt: progress.lastSeenAt } : {}),
+  ...(progress.nextSeeingAt !== undefined ? { nextSeeingAt: progress.nextSeeingAt } : {}),
+  ...(progress.interval !== undefined ? { interval: progress.interval } : {}),
+});
+
+// Keep the full target key and effect cancellation together: the key rejects stored results for superseded
+// sessions, while cancellation prevents their still-pending reads from publishing after identity changes.
+const verificationKey = (deck: RemoteDeck, sessionId: string, cardId: string): string =>
+  [deck.uid, deck.id, sessionId, cardId].join("\u0000");
+
+const belongsToDeckPersistence = (card: Card, deck: Deck): boolean =>
+  card.deckId === deck.id && (deck.localMode ? !("uid" in card) : "uid" in card && card.uid === deck.uid);
+
+const resolveRemoteVerificationTarget = (
+  deck: Deck | undefined,
+  session: StudySession | undefined,
+  snapshotState: SnapshotState
+): RemoteVerificationTarget | undefined => {
+  if (deck?.localMode !== false || session?.deckId !== deck.id || snapshotState.status !== "absent") return;
+
+  return {
+    uid: deck.uid,
+    cardId: snapshotState.cardId,
+    key: verificationKey(deck, snapshotState.session.sessionId, snapshotState.cardId),
+  };
+};
+
+const resolveRemoteStudyState = (
+  deck: RemoteDeck,
+  snapshotState: AbsentSnapshotState,
+  verification: RemoteVerification | undefined
+): StudySessionState => {
+  if (verification === undefined) return { status: "verifying" };
+  if (verification.status === "missing") return { status: "unavailable", reason: "remote-missing" };
+  if (verification.status === "tombstoned") return { status: "unavailable", reason: "remote-tombstoned" };
+  if (verification.status === "error") return { status: "verification-error" };
+  if (verification.read.card.deckId !== deck.id) return { status: "invalid" };
+
+  return {
+    status: "studying",
+    session: snapshotState.session,
+    card: combineCardRead(verification.read),
+  };
+};
+
+const resolvePageState = ({
+  deck,
+  session,
+  snapshotState,
+  localCardsHydrated,
+  verification,
+}: PageStateInputs): StudySessionState => {
+  if (
+    deck === undefined ||
+    (session !== undefined && session.deckId !== deck.id) ||
+    snapshotState.status === "invalid"
+  ) {
+    return { status: "invalid" };
+  }
+  if (snapshotState.status === "studying") {
+    return { status: "studying", session: snapshotState.session, card: snapshotState.card };
+  }
+  if (deck.localMode) {
+    return localCardsHydrated ? { status: "unavailable", reason: "local-missing" } : { status: "verifying" };
+  }
+  return resolveRemoteStudyState(deck, snapshotState, verification);
+};
+
+export const useStudySessionState = (
+  deck: Deck | undefined,
+  cards: readonly Card[],
+  localCardsHydrated: boolean
+): StudySessionState => {
+  const session = useStudySession(deck?.id ?? "");
+  const scopedCards = deck === undefined ? [] : cards.filter((card) => belongsToDeckPersistence(card, deck));
+  const snapshotState = resolveStudySession(session, scopedCards);
+  const [verification, setVerification] = React.useState<VerificationState>();
+
+  const target = resolveRemoteVerificationTarget(deck, session, snapshotState);
+  const targetUid = target?.uid;
+  const targetCardId = target?.cardId;
+  const currentVerificationKey = target?.key;
+  const currentVerification =
+    verification !== undefined && verification.key === currentVerificationKey ? verification.result : undefined;
 
   React.useEffect(() => {
-    if (sessionState.status === "studying") {
-      touchStudySession(deckId);
-      return;
-    }
-    if (sessionState.status === "preparing") return;
+    if (targetUid === undefined || targetCardId === undefined || currentVerificationKey === undefined) return;
 
-    // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
-    removeStudySession(deckId);
-  }, [deckId, sessionState.status]);
+    let current = true;
+    void fetchRemoteCardRead(targetUid, targetCardId).then(
+      (result) => {
+        if (current) setVerification({ key: currentVerificationKey, result });
+      },
+      () => {
+        if (current) setVerification({ key: currentVerificationKey, result: { status: "error" } });
+      }
+    );
+    return () => {
+      current = false;
+    };
+  }, [currentVerificationKey, targetCardId, targetUid]);
 
-  return sessionState;
+  const state = resolvePageState({
+    deck,
+    session,
+    snapshotState,
+    localCardsHydrated,
+    verification: currentVerification,
+  });
+
+  const studyingDeckId = state.status === "studying" ? state.session.deckId : undefined;
+  const studyingSessionId = state.status === "studying" ? state.session.sessionId : undefined;
+
+  React.useEffect(() => {
+    if (studyingDeckId !== undefined) touchStudySession(studyingDeckId);
+  }, [studyingDeckId, studyingSessionId]);
+
+  const invalidSession = state.status === "invalid" && deck !== undefined ? session : undefined;
+  React.useEffect(() => {
+    if (invalidSession === undefined) return;
+
+    removeStudySessionIfCurrent(invalidSession);
+  }, [invalidSession]);
+
+  return state;
 };

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -2,7 +2,7 @@ import { useAuthUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
-import { editStudyProgress } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 import { getStudySession, moveStudySession, planStudySessionSwipe, removeStudySession } from "@/entities/study-session";
 
 import * as React from "react";
@@ -17,7 +17,21 @@ export interface SwipeState {
   swipeFeedback?: SwipeDirection;
 }
 
-export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: () => void): SwipeState => {
+const persistStudyProgress = (
+  uid: string,
+  progress: StudyProgressEdit,
+  verifiedRemoteCardId: Card["id"] | undefined
+): Promise<void> =>
+  verifiedRemoteCardId === progress.cardId
+    ? editStudyProgress(uid, progress, { persistence: "remote", cardId: verifiedRemoteCardId })
+    : editStudyProgress(uid, progress);
+
+export const useSwipe = (
+  deckId: DeckId,
+  cards: readonly Card[],
+  onCardChanged: () => void,
+  verifiedRemoteCardId?: Card["id"]
+): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
   const feedback = useSwipeFeedback(preferences.appearance.showSwipeFeedback);
@@ -38,7 +52,8 @@ export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: 
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saved = await editStudyProgress(uid, swipePlan.progress).then(
+    const saveProgress = persistStudyProgress(uid, swipePlan.progress, verifiedRemoteCardId);
+    const saved = await saveProgress.then(
       () => true,
       () => false
     );

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -2,7 +2,7 @@ import { useAuthUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
-import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressEdit, type StudyProgressTarget } from "@/entities/study-progress";
 import { getStudySession, moveStudySession, planStudySessionSwipe, removeStudySession } from "@/entities/study-session";
 
 import * as React from "react";
@@ -20,17 +20,14 @@ export interface SwipeState {
 const persistStudyProgress = (
   uid: string,
   progress: StudyProgressEdit,
-  verifiedRemoteCardId: Card["id"] | undefined
-): Promise<void> =>
-  verifiedRemoteCardId === progress.cardId
-    ? editStudyProgress(uid, progress, { persistence: "remote", cardId: verifiedRemoteCardId })
-    : editStudyProgress(uid, progress);
+  target: StudyProgressTarget | undefined
+): Promise<void> => editStudyProgress(uid, progress, target);
 
 export const useSwipe = (
   deckId: DeckId,
   cards: readonly Card[],
   onCardChanged: () => void,
-  verifiedRemoteCardId?: Card["id"]
+  target?: StudyProgressTarget
 ): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
@@ -52,7 +49,7 @@ export const useSwipe = (
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saveProgress = persistStudyProgress(uid, swipePlan.progress, verifiedRemoteCardId);
+    const saveProgress = persistStudyProgress(uid, swipePlan.progress, target);
     const saved = await saveProgress.then(
       () => true,
       () => false

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -23,11 +23,20 @@ const persistStudyProgress = (
   target: StudyProgressTarget | undefined
 ): Promise<void> => editStudyProgress(uid, progress, target);
 
+export interface StudyCompletion {
+  cardCount: number;
+}
+
+interface UseSwipeOptions {
+  onCardChanged: () => void;
+  onCompleted: (completion: StudyCompletion) => void;
+  target: StudyProgressTarget | undefined;
+}
+
 export const useSwipe = (
   deckId: DeckId,
   cards: readonly Card[],
-  onCardChanged: () => void,
-  target?: StudyProgressTarget
+  { onCardChanged, onCompleted, target }: UseSwipeOptions
 ): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
@@ -47,6 +56,11 @@ export const useSwipe = (
       return;
     }
 
+    // Completion is derived from the pre-write snapshot because a successful boundary move removes the session.
+    const completesSession =
+      swipePlan.effect === "next" && swipePlan.session.currentIndex === swipePlan.session.cardOrderIds.length - 1;
+    const cardCount = swipePlan.session.cardOrderIds.length;
+
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
     const saveProgress = persistStudyProgress(uid, swipePlan.progress, target);
@@ -60,6 +74,10 @@ export const useSwipe = (
     if (!moveStudySession(swipePlan.session, swipePlan.effect)) return;
 
     feedback.showSwipe(direction);
+    if (completesSession) {
+      onCompleted({ cardCount });
+      return;
+    }
     if (preferences.appearance.hideBodyWhenCardChanged) onCardChanged();
   };
 

--- a/src/pages/study-session/ui/StudyCompletion.spec.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.spec.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { StudyCompletion } from "./StudyCompletion";
+
+describe("StudyCompletion", () => {
+  it("shows the completed Card count and reports the return action", () => {
+    const onClickBack = vi.fn();
+    render(<StudyCompletion cardCount={1} onClickBack={onClickBack} />);
+
+    expect(screen.getByRole("heading", { name: "Study complete" })).toHaveFocus();
+    expect(screen.getByText("You studied 1 card.")).toBeVisible();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
+    expect(onClickBack).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pages/study-session/ui/StudyCompletion.stories.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { withPageLayout } from "@/storybook/PageLayoutDecorator";
+
+import { StudyCompletion } from "./StudyCompletion";
+
+const meta = {
+  title: "Pages/Study Session/StudyCompletion",
+  component: StudyCompletion,
+  decorators: [withPageLayout],
+  args: {
+    cardCount: 12,
+    onClickBack: () => undefined,
+  },
+} satisfies Meta<typeof StudyCompletion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SingleCard: Story = {
+  args: { cardCount: 1 },
+};

--- a/src/pages/study-session/ui/StudyCompletion.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef, type FC } from "react";
+
+import { Button } from "@/shared/ui/button";
+
+export interface StudyCompletionProps {
+  cardCount: number;
+  onClickBack: () => void;
+}
+
+const cardsLabel = (count: number) => `${String(count)} ${count === 1 ? "card" : "cards"}`;
+
+export const StudyCompletion: FC<StudyCompletionProps> = ({ cardCount, onClickBack }) => {
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    // The swipe control disappears asynchronously, so focus the result to make the transition perceivable.
+    titleRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      aria-labelledby="study-completion-title"
+      className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-6 text-center text-ink shadow-surface"
+    >
+      <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Session complete</p>
+      <h1 ref={titleRef} id="study-completion-title" tabIndex={-1} className="mt-1 text-display font-bold">
+        Study complete
+      </h1>
+      <p className="mt-3 text-body text-ink-muted">You studied {cardsLabel(cardCount)}.</p>
+      <Button className="mt-6" variant="primary" size="lg" onClick={onClickBack}>
+        Back to deck list
+      </Button>
+    </section>
+  );
+};

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -151,7 +152,8 @@ describe("StudySession", () => {
     expect(onClickLeft).not.toHaveBeenCalled();
   });
 
-  it("keeps the back action visible and opens the remaining study actions", () => {
+  it("keeps the back action visible and opens the remaining study actions", async () => {
+    const user = userEvent.setup();
     const onBack = vi.fn();
     const onToggleCardDetails = vi.fn();
     const onToggleSwipeControls = vi.fn();
@@ -171,6 +173,7 @@ describe("StudySession", () => {
     const openActions = screen.getByRole("button", { name: "Open study actions" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
@@ -180,17 +183,24 @@ describe("StudySession", () => {
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const detailsToggle = screen.getByRole("button", { name: "Card details" });
+    const help = screen.getByRole("button", { name: "Open study help" });
     const actions = screen.getByRole("group", { name: "Study actions" });
     expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
+    expect(help).toBeVisible();
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
     expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
     expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
+    expect(actions).toContainElement(help);
     expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
+
+    closeActions.focus();
+    await user.tab();
+    expect(help).toHaveFocus();
 
     fireEvent.click(back);
     fireEvent.click(swipeToggle);
@@ -202,9 +212,10 @@ describe("StudySession", () => {
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
     expect(onToggleCardDetails).toHaveBeenCalledOnce();
 
-    fireEvent.keyDown(closeActions, { key: "Escape" });
+    fireEvent.keyDown(help, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
   });
 
   it("shows and hides all card details from the persisted preference value", () => {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -201,18 +201,6 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
         <AiOutlineLeft aria-hidden="true" className="text-xl" />
       </button>
       <button
-        ref={helpTriggerRef}
-        type="button"
-        aria-label={props.helpTriggerLabel}
-        className={cx(
-          toolbarButtonClass,
-          "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
-        )}
-        onClick={props.onOpenHelp}
-      >
-        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
-      </button>
-      <button
         ref={triggerRef}
         type="button"
         aria-label={props.open ? "Close study actions" : "Open study actions"}
@@ -238,6 +226,19 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
           aria-label="Study actions"
           className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
         >
+          <button
+            ref={helpTriggerRef}
+            type="button"
+            aria-label={props.helpTriggerLabel}
+            className={cx(
+              toolbarButtonClass,
+              "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+            )}
+            onClick={props.onOpenHelp}
+            onKeyDown={closeOnEscape}
+          >
+            <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
+          </button>
           <StudyModeActions
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}
@@ -330,7 +331,7 @@ const BackTextOverlays: React.FC<{
       ) : null}
       {overlay.onClickRight !== undefined ? (
         <BackTextEdgeOverlay
-          // Keep the hit area inside the reserved w-20 while leaving a pointer-free scrollbar gutter.
+          // Leave a pointer-free scrollbar gutter while the hit area floats over the answer.
           className="right-5 w-[calc(5rem-1.25rem)]"
           ariaLabel="Swipe right"
           onClick={overlay.onClickRight}
@@ -351,14 +352,8 @@ const CardContent: React.FC<{
     return (
       <>
         <BackTextOverlays overlay={backTextOverlay} />
-        <div
-          className={cx(
-            "flex min-h-full w-full",
-            // Reserve w-20 per edge; the right reservation includes its pointer-free scrollbar gutter.
-            backTextOverlay?.onClickLeft !== undefined && "pl-20",
-            backTextOverlay?.onClickRight !== undefined && "pr-20"
-          )}
-        >
+        {/* Edge actions float above the full-width answer so enabling them never changes the Card layout. */}
+        <div data-study-answer-content="" className="flex min-h-full w-full">
           {backTextSlot}
         </div>
       </>

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -169,7 +169,8 @@ describe("StudySessionPage", () => {
     expect(screen.queryByText("Back two")).not.toBeInTheDocument();
     expect(mocks.editStudyProgress).toHaveBeenCalledExactlyOnceWith(
       "user-id",
-      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 })
+      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 }),
+      { persistence: "local", cardId: "first-card" }
     );
     expect(getStudySession(deckId)?.currentIndex).toBe(1);
   });

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -404,7 +404,7 @@ describe("StudySessionPage", () => {
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
-  it("shows loading feedback while active session cards are unavailable", async () => {
+  it("shows unavailable feedback without redirecting when a local target is authoritatively missing", async () => {
     await deleteCard("", firstCard);
     await deleteCard("", secondCard);
     clearStudySessions();
@@ -412,7 +412,9 @@ describe("StudySessionPage", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: "Loading…" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "The current study card is unavailable." })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Deck list destination" })).not.toBeInTheDocument();
+    expect(getStudySession(deckId)).toBeDefined();
   });
 
   it("returns to the deck list when no active session exists", async () => {

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -2,13 +2,13 @@ import type { Preferences } from "@/entities/preference";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 import { deleteCard, mutateCards } from "@/entities/card";
 import { createDeck } from "@/entities/deck";
-import { clearStudySessions, getStudySession, startStudy } from "@/entities/study-session";
+import { clearStudySessions, getStudySession, setStudySessionIndex, startStudy } from "@/entities/study-session";
 import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -50,6 +50,18 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { StudySessionPage } from "./StudySessionPage";
 
+const DeckListDestination = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <h1>Deck list destination</h1>
+      <button type="button" onClick={() => void navigate(-1)}>
+        Browser back
+      </button>
+    </>
+  );
+};
+
 describe("StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
@@ -71,15 +83,18 @@ describe("StudySessionPage", () => {
     score: 1,
     numberOfSeen: 4,
   });
-  const renderPage = (path = `/deck/${deckId}/study`) =>
-    render(
-      <MemoryRouter initialEntries={[path]}>
+  const renderPage = (path = `/deck/${deckId}/study`, previousPath?: string) => {
+    const initialEntries = previousPath === undefined ? [path] : [previousPath, path];
+    return render(
+      <MemoryRouter initialEntries={initialEntries} initialIndex={initialEntries.length - 1}>
         <Routes>
-          <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/" element={<DeckListDestination />} />
+          <Route path="/previous" element={<h1>Previous destination</h1>} />
           <Route path="/deck/:id/study" element={<StudySessionPage />} />
         </Routes>
       </MemoryRouter>
     );
+  };
   const openStudyActions = () => {
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
     return screen.getByRole("group", { name: "Study actions" });
@@ -215,6 +230,8 @@ describe("StudySessionPage", () => {
     renderPage();
     const sessionBeforeHelp = getStudySession(deckId);
 
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
+    openStudyActions();
     const trigger = screen.getByRole("button", { name: "Open study help" });
     fireEvent.click(trigger);
     expect(trigger).not.toHaveFocus();
@@ -249,6 +266,7 @@ describe("StudySessionPage", () => {
     document.documentElement.lang = "ja-JP";
     renderPage();
 
+    openStudyActions();
     fireEvent.click(screen.getByRole("button", { name: "学習ヘルプを開く" }));
 
     expect(screen.getByRole("dialog", { name: "学習画面の操作" })).toHaveTextContent(
@@ -264,6 +282,7 @@ describe("StudySessionPage", () => {
 
     try {
       renderPage();
+      openStudyActions();
       fireEvent.click(screen.getByRole("button", { name: "Open study help" }));
 
       act(() => vi.advanceTimersByTime(1000));
@@ -291,6 +310,28 @@ describe("StudySessionPage", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
     expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
     expect(mocks.removeStudySession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the completion screen on the Study route and disables Study shortcuts", async () => {
+    setStudySessionIndex(deckId, 1);
+    renderPage(`/deck/${deckId}/study`, "/previous");
+
+    fireEvent.click(screen.getByRole("button", { name: "Swipe up" }));
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Study complete" })).toBeVisible();
+    expect(screen.getByText("You studied 2 cards.")).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 1, name: "Deck list destination" })).not.toBeInTheDocument();
+    expect(getStudySession(deckId)).toBeUndefined();
+
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Browser back" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Previous destination" })).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 1, name: "Study complete" })).not.toBeInTheDocument();
   });
 
   it("keeps study actions available while the Header stays hidden", () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -47,8 +47,14 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
   if (state == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
 
   if (state.status !== "studying") {
-    return state.status === "preparing" ? (
-      <RouteFeedback title="Loading…" tone="loading" />
+    if (state.status === "verifying") {
+      return <RouteFeedback title="Verifying study session…" tone="loading" />;
+    }
+    if (state.status === "verification-error") {
+      return <RouteFeedback title="Could not verify the study session." tone="error" />;
+    }
+    return state.status === "unavailable" ? (
+      <RouteFeedback title="The current study card is unavailable." tone="not-found" />
     ) : (
       <RouteFeedback title="Study session unavailable." tone="not-found" />
     );

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -10,6 +10,7 @@ import { AppLayout } from "@/widgets/app-layout";
 
 import { type StudyState, useStudy } from "../model/useStudy";
 import { CardOverlay } from "./CardOverlay";
+import { StudyCompletion } from "./StudyCompletion";
 import { StudySession } from "./StudySession";
 
 type StudyShortcutAction =
@@ -156,6 +157,19 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
     if (study?.status !== "invalid") return;
     void navigate(routes.deckList.to(), { replace: true });
   }, [navigate, study?.status]);
+
+  if (study?.status === "completed") {
+    return (
+      <AppLayout showHeader>
+        <StudyCompletion
+          cardCount={study.completion.cardCount}
+          onClickBack={() => {
+            void navigate(routes.deckList.to(), { replace: true });
+          }}
+        />
+      </AppLayout>
+    );
+  }
 
   return renderStudyScreen(study, goBack);
 };

--- a/test/e2e/creation.spec.ts
+++ b/test/e2e/creation.spec.ts
@@ -1,0 +1,103 @@
+import {
+  allowExpectedFirestoreWriteFailure,
+  documentId,
+  expect,
+  failNextFirestoreWrite,
+  listDocuments,
+  readLocalData,
+  test,
+} from "./fixtures";
+
+test("DECK-11 creates one empty local-only Deck without a remote duplicate", async ({ fixture, page, namespace }) => {
+  const name = `${namespace.caseId} local deck`;
+  const category = "typescript";
+  await fixture.apply(page);
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Create deck" }).click();
+  await page.getByRole("textbox", { name: "Name" }).fill(name);
+  await page.getByRole("combobox").selectOption(category);
+  const localOnly = page.getByRole("checkbox", { name: "Local only" });
+  await localOnly.locator("xpath=parent::label").click();
+  await expect(localOnly).toBeChecked();
+  await page.getByRole("button", { name: "Create deck" }).click();
+  await expect(page).toHaveURL(/\/deck\/(?!new$)[^/]+$/);
+  const deckId = new URL(page.url()).pathname.split("/").at(-1);
+  if (deckId === undefined) throw new Error("Created local-only Deck ID is missing");
+  await expect(page.getByText("0 cards")).toBeVisible();
+
+  await page.goto("/");
+  await page.reload();
+
+  const deckArticle = page.getByRole("button", { name: `View ${name}` }).locator("xpath=ancestor::article[1]");
+  await expect(deckArticle).toContainText(category);
+  const local = await readLocalData(page);
+  const localDecks = local.decks.filter(
+    (deck: { id?: string; name?: string }) => deck.id === deckId && deck.name === name
+  );
+  expect(localDecks).toHaveLength(1);
+  expect(localDecks[0]).toEqual(expect.objectContaining({ id: deckId, name, category, localMode: true }));
+  expect(local.cards.filter((card: { deckId?: string }) => card.deckId === deckId)).toEqual([]);
+  expect(
+    (await listDocuments("deck")).filter(
+      (document) =>
+        (document.fields.name as { stringValue?: string } | undefined)?.stringValue === name ||
+        documentId(document) === deckId
+    )
+  ).toEqual([]);
+});
+
+test("CARD-15 retries a failed remote Card create with the same ID and no duplicate", async ({
+  fixture,
+  page,
+  browserErrors,
+  namespace,
+}) => {
+  const deck = fixture.deck();
+  const frontText = `${namespace.caseId} retry front`;
+  const backText = `${namespace.caseId} retry back`;
+  await fixture.apply(page);
+  await page.goto(`/deck/${deck.id}`);
+  await page.getByRole("button", { name: "Add card" }).click();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/card/new$`));
+
+  let attemptedCardId: string | undefined;
+  page.on("request", (request) => {
+    if (!request.url().includes("google.firestore.v1.Firestore/Write/channel")) return;
+    const body = decodeURIComponent((request.postData() ?? "").replaceAll("+", "%20"));
+    attemptedCardId ??= /\/documents\/card\/([a-zA-Z0-9-]+)/.exec(body)?.[1];
+  });
+  const fault = await failNextFirestoreWrite(page, { collection: "card" });
+  allowExpectedFirestoreWriteFailure(browserErrors);
+  await page.getByRole("textbox", { name: "Front text" }).fill(frontText);
+  await page.getByRole("textbox", { name: "Back text" }).fill(backText);
+  await page.getByRole("button", { name: "Create card" }).click();
+  await expect(page.getByText("Unable to create this card. Try again.")).toBeVisible();
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
+  await fault.dispose();
+  expect(attemptedCardId).toBeDefined();
+
+  await expect(page.getByRole("textbox", { name: "Front text" })).toHaveValue(frontText);
+  await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue(backText);
+  await page.getByRole("button", { name: "Create card" }).click();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));
+  await page.reload();
+
+  await expect(page.getByRole("button", { name: `View ${frontText}` })).toBeVisible();
+  const created = (await listDocuments("card")).filter(
+    ({ fields }) =>
+      fields.deckId?.stringValue === deck.id &&
+      fields.uid?.stringValue === deck.uid &&
+      fields.frontText?.stringValue === frontText
+  );
+  expect(created).toHaveLength(1);
+  const [createdCard] = created;
+  if (createdCard === undefined) throw new Error("Created remote Card was not found");
+  expect(documentId(createdCard)).toBe(attemptedCardId);
+  expect(createdCard.fields.backText?.stringValue).toBe(backText);
+  expect(createdCard.fields.uniqueKey?.stringValue).toBe(attemptedCardId);
+  expect((await readLocalData(page)).cards).not.toEqual(
+    expect.arrayContaining([expect.objectContaining({ frontText })])
+  );
+});

--- a/test/e2e/e2e-contract-reporter.ts
+++ b/test/e2e/e2e-contract-reporter.ts
@@ -1,13 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
 import type { FullConfig, FullResult, Reporter, Suite } from "@playwright/test/reporter";
 
-import { validateE2EContract } from "./yaml-fixture";
+import { requireE2ECaseId, validateE2EContract } from "./yaml-fixture";
+
+const readReadmeCaseIds = (): string[] => {
+  const markdown = readFileSync(path.join(process.cwd(), "docs/e2e/README.md"), "utf8");
+  return [...markdown.matchAll(/^\| ([A-Z]+-[0-9]{2}) \|/gmu)].map((match) => {
+    const caseId = match[1];
+    if (caseId === undefined) throw new Error(`Could not parse an E2E case ID from README row: ${match[0]}`);
+    return caseId;
+  });
+};
+
+const validateReadmeIndex = (testTitles: readonly string[]): void => {
+  // The fixture contract already proves detailed specifications match tests; this closes the remaining
+  // README index gap.
+  const testCaseIds = testTitles.map(requireE2ECaseId);
+  const indexedCaseIds = readReadmeCaseIds();
+  const indexedCounts = new Map<string, number>();
+  for (const caseId of indexedCaseIds) {
+    indexedCounts.set(caseId, (indexedCounts.get(caseId) ?? 0) + 1);
+  }
+
+  const testCaseIdSet = new Set(testCaseIds);
+  const indexedCaseIdSet = new Set(indexedCaseIds);
+  const missing = [...testCaseIdSet]
+    .filter((caseId) => !indexedCaseIdSet.has(caseId))
+    .sort((left, right) => left.localeCompare(right));
+  const duplicates = [...indexedCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([caseId, count]) => `${caseId} (${String(count)})`)
+    .sort((left, right) => left.localeCompare(right));
+  const unexpected = [...indexedCaseIdSet]
+    .filter((caseId) => !testCaseIdSet.has(caseId))
+    .sort((left, right) => left.localeCompare(right));
+  const problems = [
+    ...(missing.length === 0 ? [] : [`missing README case IDs: ${missing.join(", ")}`]),
+    ...(duplicates.length === 0 ? [] : [`duplicate README case IDs: ${duplicates.join(", ")}`]),
+    ...(unexpected.length === 0 ? [] : [`unexpected README case IDs: ${unexpected.join(", ")}`]),
+  ];
+  if (problems.length > 0) throw new Error(`Invalid E2E README index: ${problems.join("; ")}`);
+};
 
 class E2EContractReporter implements Reporter {
   private contractStatus: FullResult["status"] = "passed";
 
   onBegin(_config: FullConfig, suite: Suite) {
     try {
-      validateE2EContract(suite.allTests().map(({ title }) => title));
+      const testTitles = suite.allTests().map(({ title }) => title);
+      validateE2EContract(testTitles);
+      validateReadmeIndex(testTitles);
     } catch (error) {
       this.contractStatus = "failed";
       const message = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -9,6 +9,7 @@ import {
 } from "@playwright/test";
 
 import {
+  type FixtureAbsentCard,
   type FixtureCard,
   type FixtureCategory,
   type FixtureDeck,
@@ -23,6 +24,7 @@ import {
 } from "./yaml-fixture";
 
 export type {
+  FixtureAbsentCard,
   FixtureCard,
   FixtureCategory,
   FixtureDeck,
@@ -377,6 +379,7 @@ export interface E2EFixture {
   user: (logicalUid?: string) => FixtureUser;
   deck: (logicalId?: string) => FixtureDeck;
   card: (logicalId?: string) => FixtureCard;
+  absentCard: (logicalId?: string) => FixtureAbsentCard;
   session: (logicalDeckId?: string) => FixtureStudySession;
   uid: (logicalUid: string) => string;
   id: (logicalId: string) => string;
@@ -502,6 +505,7 @@ function createE2EFixture(
     user: (logicalUid) => requireLogicalValue(namespaced.users, "auth user", logicalUid),
     deck: (logicalId) => requireLogicalValue(namespaced.decks, "Deck", logicalId),
     card: (logicalId) => requireLogicalValue(namespaced.cards, "Card", logicalId),
+    absentCard: (logicalId) => requireLogicalValue(namespaced.absentCards, "absent Card", logicalId),
     session: (logicalDeckId) => requireLogicalValue(namespaced.sessions, "Study session", logicalDeckId),
     uid: namespaced.uid,
     id: namespaced.id,
@@ -556,6 +560,27 @@ export const setDocument = async (collection: FirestoreCollection, id: string, d
     body: JSON.stringify({ fields }),
   });
   if (!response.ok) throw new Error(`Firestore seed failed: ${response.status} ${await response.text()}`);
+};
+
+/** Creates a target-specific permission failure without disrupting the Card collection subscription. */
+export const seedForeignOwnedCard = async (id: string): Promise<void> => {
+  const uid = `e2e-foreign-${randomUUID()}`;
+  const deckId = `${id}-foreign-deck`;
+  await setDocument("deck", deckId, { id: deckId, uid, name: "Foreign E2E Deck", isPublic: false });
+  await setDocument("card", id, {
+    id,
+    uid,
+    deckId,
+    frontText: "Foreign E2E Card",
+    backText: "Foreign E2E Card",
+    tags: [],
+    uniqueKey: id,
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+    score: 0,
+    numberOfSeen: 0,
+  });
 };
 
 export const getDocument = async (

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -286,7 +286,7 @@ export const seedConfig = async (page: Page, overrides: E2EConfigOverrides = {})
     // Seed only the first app document so reload assertions observe mutations made by the application.
     if (!window.location.origin.startsWith("http")) return;
     if (window.sessionStorage.getItem("tango-e2e-config-seeded") !== null) return;
-    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 2 }));
+    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 1 }));
     window.sessionStorage.setItem("tango-e2e-config-seeded", "true");
   }, config);
 };

--- a/test/e2e/review-schedule.spec.ts
+++ b/test/e2e/review-schedule.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "./fixtures";
+import { readSession } from "./study-helpers";
+
+test("SETTINGS-03 applies review scheduling to the next study session", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const dueCard = fixture.card("card-due");
+  const futureCard = fixture.card("card-future");
+  const unscheduledCard = fixture.card("card-unscheduled");
+  await fixture.apply(page);
+  await page.goto("/settings");
+
+  const respectReviewSchedule = page.getByRole("checkbox", { name: "Respect review schedule" });
+  await expect(respectReviewSchedule).not.toBeChecked();
+  await respectReviewSchedule.locator("xpath=parent::label").click();
+  await expect(respectReviewSchedule).toBeChecked();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => JSON.parse(localStorage.getItem("tango-config") ?? "{}").state?.preferences?.study?.useCardInterval
+      )
+    )
+    .toBe(true);
+
+  await page.reload();
+  await expect(respectReviewSchedule).toBeChecked();
+  await page.goto(`/deck/${deck.id}/start`);
+  await page.getByRole("button", { name: "Start 2 cards" }).click();
+
+  const session = await readSession(page, deck.id);
+  expect(session?.cardOrderIds).toHaveLength(2);
+  expect(session?.cardOrderIds).toEqual(expect.arrayContaining([dueCard.id, unscheduledCard.id]));
+  expect(session?.cardOrderIds).not.toContain(futureCard.id);
+});

--- a/test/e2e/study-back-text.spec.ts
+++ b/test/e2e/study-back-text.spec.ts
@@ -141,7 +141,7 @@ test("SWIPE-21 runs the mapped right overlay action once and shows the next Card
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex + 1);
 });
 
-test("SWIPE-22 selects edge answer text beside overlays on a narrow viewport", async ({ fixture, page }) => {
+test("SWIPE-22 keeps the full answer width beneath overlays on a narrow viewport", async ({ fixture, page }) => {
   await page.setViewportSize({ width: 320, height: 568 });
   const deck = fixture.deck();
   const session = fixture.session();
@@ -149,28 +149,33 @@ test("SWIPE-22 selects edge answer text beside overlays on a narrow viewport", a
   await fixture.apply(page);
 
   await page.goto(`/deck/${deck.id}/study`);
-  await revealAnswer(page, currentCard.frontText);
+  const answerRegion = await revealAnswer(page, currentCard.frontText);
+  const answerContent = page.locator("[data-study-answer-content]");
+  const backTextSurface = answerContent.locator(":scope > *").first();
   const leftOverlayButton = page.getByRole("button", { name: "Swipe left" });
   const rightOverlayButton = page.getByRole("button", { name: "Swipe right" });
   const answerText = page.getByText(currentCard.backText, { exact: true });
-  const leftOverlay = await leftOverlayButton.boundingBox();
-  const rightOverlay = await rightOverlayButton.boundingBox();
-  const answerTextBounds = await answerText.boundingBox();
-  if (leftOverlay == null || rightOverlay == null || answerTextBounds == null) {
-    throw new Error("Expected visible answer text and back text overlays");
+  const answerRegionBounds = await answerRegion.boundingBox();
+  const backTextSurfaceBounds = await backTextSurface.boundingBox();
+  const leftOverlayBounds = await leftOverlayButton.boundingBox();
+  const rightOverlayBounds = await rightOverlayButton.boundingBox();
+  if (
+    answerRegionBounds == null ||
+    backTextSurfaceBounds == null ||
+    leftOverlayBounds == null ||
+    rightOverlayBounds == null
+  ) {
+    throw new Error("Expected visible answer region, back text, and overlays");
   }
 
-  expect(answerTextBounds.x).toBeGreaterThanOrEqual(leftOverlay.x + leftOverlay.width);
-  expect(answerTextBounds.x + answerTextBounds.width).toBeLessThanOrEqual(rightOverlay.x);
-
-  await selectBackText(page, currentCard.backText);
+  expect(backTextSurfaceBounds.x).toBe(answerRegionBounds.x);
+  expect(backTextSurfaceBounds.width).toBe(answerRegionBounds.width);
+  expect(leftOverlayBounds.x + leftOverlayBounds.width).toBeGreaterThan(backTextSurfaceBounds.x);
+  expect(rightOverlayBounds.x).toBeLessThan(backTextSurfaceBounds.x + backTextSurfaceBounds.width);
 
   await expect(answerText).toBeVisible();
   await expect(leftOverlayButton).toBeVisible();
   await expect(rightOverlayButton).toBeVisible();
-  await expect
-    .poll(async () => page.evaluate(() => window.getSelection()?.toString() ?? ""))
-    .toContain(currentCard.backText);
   await expect.poll(() => readProgress(currentCard.id)).toEqual(progressOf(currentCard));
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
 });

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -1,6 +1,14 @@
 import type { Page } from "@playwright/test";
 
-import { allowExpectedFirestoreWriteFailure, expect, failNextFirestoreWrite, readLocalData, test } from "./fixtures";
+import {
+  allowExpectedFirestoreWriteFailure,
+  expect,
+  failNextFirestoreWrite,
+  getDocument,
+  readLocalData,
+  seedForeignOwnedCard,
+  test,
+} from "./fixtures";
 import { progressOf, readProgress, readSession } from "./study-helpers";
 
 const cardAt = <T>(cards: readonly T[], index: number) => {
@@ -381,4 +389,45 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
   await expect(dialog).not.toBeVisible();
   await expect(page.getByRole("button", { name: "Open study help" })).toBeFocused();
   await expect(page.getByRole("button", { name: "Swipe left" })).toHaveCount(0);
+});
+
+test("SWIPE-25 shows unavailable after the server confirms the remote target is missing", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const target = fixture.absentCard();
+  const session = fixture.session();
+  await fixture.apply(page);
+  expect(await getDocument("card", target.id)).toBeUndefined();
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "The current study card is unavailable." })).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+});
+
+test("SWIPE-26 preserves the remote session when target verification fails", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const target = fixture.absentCard();
+  const session = fixture.session();
+  await fixture.apply(page);
+  await seedForeignOwnedCard(target.id);
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "Could not verify the study session." })).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+});
+
+test("SWIPE-27 shows unavailable for an authoritatively missing local target", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "The current study card is unavailable." })).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
 });

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -189,7 +189,7 @@ test("SWIPE-09 restarts an in-progress Deck from a new session", async ({ fixtur
   expect(restarted?.currentIndex).toBe(0);
 });
 
-test("SWIPE-10 finishes the final Card and removes the session", async ({ fixture, page }) => {
+test("SWIPE-10 finishes the final Card and shows the completion screen", async ({ fixture, page }) => {
   const deck = fixture.deck();
   const session = fixture.session();
   const finalCard = fixture.card("card-3");
@@ -197,6 +197,13 @@ test("SWIPE-10 finishes the final Card and removes the session", async ({ fixtur
 
   await page.goto(`/deck/${deck.id}/study`);
   await page.getByRole("button", { name: "Swipe up" }).click();
+
+  await expect(page).toHaveURL(`/deck/${deck.id}/study`);
+  await expect(page.getByRole("heading", { name: "Study complete" })).toBeVisible();
+  await expect(page.getByText(`You studied ${String(session.cardOrderIds.length)} cards.`)).toBeVisible();
+  const backToDeckList = page.getByRole("button", { name: "Back to deck list" });
+  await expect(backToDeckList).toBeVisible();
+  await backToDeckList.click();
 
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole("button", { name: `Continue ${deck.name}` })).toHaveCount(0);
@@ -357,6 +364,8 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
 
   await page.goto(`/deck/${deck.id}/study`);
   const progressBeforeHelp = await readProgress(currentCard.id);
+  await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Open study actions" }).click();
   await page.getByRole("button", { name: "Open study help" }).click();
 
   const dialog = page.getByRole("dialog", { name: "Study controls" });

--- a/test/e2e/yaml-fixture.ts
+++ b/test/e2e/yaml-fixture.ts
@@ -56,6 +56,12 @@ export interface FixtureCard {
   interval?: number;
 }
 
+export interface FixtureAbsentCard {
+  id: string;
+  deckId: string;
+  uid?: string;
+}
+
 export interface FixtureStudySession {
   sessionId: string;
   deckId: string;
@@ -97,11 +103,12 @@ export interface FixturePreferences {
 
 export interface FixtureState {
   auth: { users: FixtureUser[] };
-  remote: { decks: FixtureDeck[]; cards: FixtureCard[] };
+  remote: { decks: FixtureDeck[]; cards: FixtureCard[]; absentCards: FixtureAbsentCard[] };
   browser: {
     preferences: FixturePreferences;
     localDecks: FixtureDeck[];
     localCards: FixtureCard[];
+    absentCards: FixtureAbsentCard[];
     studySessions: Record<string, FixtureStudySession>;
   };
 }
@@ -118,6 +125,7 @@ export interface NamespacedFixture {
   users: ReadonlyMap<string, FixtureUser>;
   decks: ReadonlyMap<string, FixtureDeck>;
   cards: ReadonlyMap<string, FixtureCard>;
+  absentCards: ReadonlyMap<string, FixtureAbsentCard>;
   sessions: ReadonlyMap<string, FixtureStudySession>;
   uid: (logicalUid: string) => string;
   id: (logicalId: string) => string;
@@ -236,6 +244,17 @@ const localCardSchema = z.strictObject({
   ...cardStateFields,
 });
 
+const remoteAbsentCardSchema = z.strictObject({
+  id: nonEmptyString,
+  deckId: nonEmptyString,
+  uid: nonEmptyString,
+});
+
+const localAbsentCardSchema = z.strictObject({
+  id: nonEmptyString,
+  deckId: nonEmptyString,
+});
+
 const swipeActionSchema = z.enum([
   "DoNothing",
   "GoBack",
@@ -307,6 +326,7 @@ const fixtureDocumentSchema = z.strictObject({
     .strictObject({
       decks: z.array(remoteDeckSchema).optional(),
       cards: z.array(remoteCardSchema).optional(),
+      absentCards: z.array(remoteAbsentCardSchema).optional(),
     })
     .optional(),
   browser: z
@@ -314,6 +334,7 @@ const fixtureDocumentSchema = z.strictObject({
       preferences: preferencesSchema.optional(),
       localDecks: z.array(localDeckSchema).optional(),
       localCards: z.array(localCardSchema).optional(),
+      absentCards: z.array(localAbsentCardSchema).optional(),
       studySessions: z.record(nonEmptyString, studySessionSchema).optional(),
       sampleDeck: sampleDeckSchema.optional(),
     })
@@ -325,6 +346,8 @@ type RawRemoteDeck = z.infer<typeof remoteDeckSchema>;
 type RawLocalDeck = z.infer<typeof localDeckSchema>;
 type RawRemoteCard = z.infer<typeof remoteCardSchema>;
 type RawLocalCard = z.infer<typeof localCardSchema>;
+type RawRemoteAbsentCard = z.infer<typeof remoteAbsentCardSchema>;
+type RawLocalAbsentCard = z.infer<typeof localAbsentCardSchema>;
 type RawPreferences = z.infer<typeof preferencesSchema>;
 type RawUser = z.infer<typeof userSchema>;
 type RawStudySession = z.infer<typeof studySessionSchema>;
@@ -746,8 +769,10 @@ interface LogicalFixtureCollections {
   users: RawUser[];
   remoteDecks: RawRemoteDeck[];
   remoteCards: RawRemoteCard[];
+  remoteAbsentCards: RawRemoteAbsentCard[];
   localDecks: RawLocalDeck[];
   localCards: RawLocalCard[];
+  localAbsentCards: RawLocalAbsentCard[];
   studySessions: Record<string, RawStudySession>;
   sampleDeck: RawSampleDeck | undefined;
   sampleCards: RawSampleCard[];
@@ -765,8 +790,10 @@ const collectLogicalFixture = (document: FixtureDocument): LogicalFixtureCollect
   } = document;
   const remoteDecks = document.remote?.decks ?? [];
   const remoteCards = document.remote?.cards ?? [];
+  const remoteAbsentCards = document.remote?.absentCards ?? [];
   const localDecks = document.browser?.localDecks ?? [];
   const localCards = document.browser?.localCards ?? [];
+  const localAbsentCards = document.browser?.absentCards ?? [];
   const studySessions = document.browser?.studySessions ?? {};
   const sampleDeck = document.browser?.sampleDeck;
   const sampleCards = parseSampleCards(sampleDeck);
@@ -774,8 +801,10 @@ const collectLogicalFixture = (document: FixtureDocument): LogicalFixtureCollect
     users,
     remoteDecks,
     remoteCards,
+    remoteAbsentCards,
     localDecks,
     localCards,
+    localAbsentCards,
     studySessions,
     sampleDeck,
     sampleCards,
@@ -793,7 +822,12 @@ const validateUniqueLogicalIds = (fixture: LogicalFixtureCollections) => {
     [...fixture.remoteDecks, ...fixture.localDecks, ...sampleDecks].map(({ id: logicalId }) => logicalId),
     "Deck ID"
   );
-  const cardIds = [...fixture.remoteCards, ...fixture.localCards].map(({ id: logicalId }) => logicalId);
+  const cardIds = [
+    ...fixture.remoteCards,
+    ...fixture.remoteAbsentCards,
+    ...fixture.localCards,
+    ...fixture.localAbsentCards,
+  ].map(({ id: logicalId }) => logicalId);
   assertUnique(cardIds.concat(fixture.sampleCardIds), "Card ID");
   assertUnique(
     Object.values(fixture.studySessions).map(({ sessionId }) => sessionId),
@@ -805,8 +839,10 @@ const validateStableApplicationIds = (fixture: LogicalFixtureCollections) => {
   const ordinaryIds = [
     ...fixture.remoteDecks.map(({ id }) => id),
     ...fixture.remoteCards.map(({ id }) => id),
+    ...fixture.remoteAbsentCards.map(({ id }) => id),
     ...fixture.localDecks.map(({ id }) => id),
     ...fixture.localCards.map(({ id }) => id),
+    ...fixture.localAbsentCards.map(({ id }) => id),
     ...Object.values(fixture.studySessions).map(({ sessionId }) => sessionId),
   ];
   const reservedId = ordinaryIds.find(isStableApplicationId);
@@ -823,7 +859,7 @@ const validateRemoteReferences = (fixture: LogicalFixtureCollections) => {
   for (const deck of fixture.remoteDecks) {
     if (!userIds.has(deck.uid)) throw new Error(`Remote Deck ${deck.id} references unknown UID ${deck.uid}`);
   }
-  for (const card of fixture.remoteCards) {
+  for (const card of [...fixture.remoteCards, ...fixture.remoteAbsentCards]) {
     if (!userIds.has(card.uid)) throw new Error(`Remote Card ${card.id} references unknown UID ${card.uid}`);
     const deck = remoteDeckById.get(card.deckId);
     if (deck === undefined) throw new Error(`Remote Card ${card.id} references unknown remote Deck ${card.deckId}`);
@@ -839,7 +875,7 @@ const localDeckIds = (fixture: LogicalFixtureCollections) =>
 
 const validateLocalReferences = (fixture: LogicalFixtureCollections) => {
   const deckIds = localDeckIds(fixture);
-  for (const card of fixture.localCards) {
+  for (const card of [...fixture.localCards, ...fixture.localAbsentCards]) {
     if (!deckIds.has(card.deckId)) {
       throw new Error(`Local Card ${card.id} references unknown local Deck ${card.deckId}`);
     }
@@ -854,7 +890,9 @@ interface SessionCardReference {
 const buildCardLookup = (fixture: LogicalFixtureCollections) => {
   const cards: SessionCardReference[] = [
     ...fixture.remoteCards.map(({ id, deckId }) => ({ id, deckId })),
+    ...fixture.remoteAbsentCards.map(({ id, deckId }) => ({ id, deckId })),
     ...fixture.localCards.map(({ id, deckId }) => ({ id, deckId })),
+    ...fixture.localAbsentCards.map(({ id, deckId }) => ({ id, deckId })),
     ...fixture.sampleCardIds.map((id) => ({ id, deckId: "sample-v1" })),
   ];
   return new Map(cards.map((card) => [card.id, card]));
@@ -888,6 +926,13 @@ const validateStudySessions = (fixture: LogicalFixtureCollections) => {
   const cardById = buildCardLookup(fixture);
   for (const [key, session] of Object.entries(fixture.studySessions)) {
     validateSession(key, session, deckIds, cardById);
+  }
+
+  const referencedCardIds = new Set(Object.values(fixture.studySessions).flatMap(({ cardOrderIds }) => cardOrderIds));
+  for (const absentCard of [...fixture.remoteAbsentCards, ...fixture.localAbsentCards]) {
+    if (!referencedCardIds.has(absentCard.id)) {
+      throw new Error(`Absent Card ${absentCard.id} must be referenced by a Study session`);
+    }
   }
 };
 
@@ -978,11 +1023,30 @@ const normalizeRemoteCards = (
     normalizeCard(card, identifiers.idFor(card.id), identifiers.idFor(card.deckId), identifiers.uidFor(card.uid)),
   ]);
 
+const normalizeRemoteAbsentCards = (
+  cards: readonly RawRemoteAbsentCard[],
+  identifiers: FixtureIdentifierMappers
+): NormalizedCollection<FixtureAbsentCard> =>
+  buildNormalizedCollection(cards, (card) => [
+    card.id,
+    {
+      id: identifiers.idFor(card.id),
+      deckId: identifiers.idFor(card.deckId),
+      uid: identifiers.uidFor(card.uid),
+    },
+  ]);
+
 const normalizeLocalCards = (
   cards: readonly RawLocalCard[],
   idFor: FixtureIdentifierMappers["idFor"]
 ): NormalizedCollection<FixtureCard> =>
   buildNormalizedCollection(cards, (card) => [card.id, normalizeCard(card, idFor(card.id), idFor(card.deckId))]);
+
+const normalizeLocalAbsentCards = (
+  cards: readonly RawLocalAbsentCard[],
+  idFor: FixtureIdentifierMappers["idFor"]
+): NormalizedCollection<FixtureAbsentCard> =>
+  buildNormalizedCollection(cards, (card) => [card.id, { id: idFor(card.id), deckId: idFor(card.deckId) }]);
 
 const normalizeSampleDeck = (
   sampleDeck: RawSampleDeck | undefined,
@@ -1033,12 +1097,15 @@ const normalizeSessions = (
   };
 };
 
-const validateRuntimeIds = (
-  users: NormalizedCollection<FixtureUser>,
-  decks: NormalizedCollection<FixtureDeck>,
-  cards: NormalizedCollection<FixtureCard>,
-  sessions: NormalizedSessions
-) => {
+interface RuntimeFixtureCollections {
+  users: NormalizedCollection<FixtureUser>;
+  decks: NormalizedCollection<FixtureDeck>;
+  cards: NormalizedCollection<FixtureCard>;
+  absentCards: NormalizedCollection<FixtureAbsentCard>;
+  sessions: NormalizedSessions;
+}
+
+const validateRuntimeIds = ({ users, decks, cards, absentCards, sessions }: RuntimeFixtureCollections) => {
   assertUnique(
     users.values.map(({ uid: runtimeUid }) => runtimeUid),
     "runtime auth UID"
@@ -1048,7 +1115,7 @@ const validateRuntimeIds = (
     "runtime Deck ID"
   );
   assertUnique(
-    cards.values.map(({ id: runtimeId }) => runtimeId),
+    [...cards.values, ...absentCards.values].map(({ id: runtimeId }) => runtimeId),
     "runtime Card ID"
   );
   assertUnique(
@@ -1077,8 +1144,11 @@ export const namespaceFixture = (
     normalizeLocalCards(logical.localCards, identifiers.idFor),
     normalizeSampleCards(logical.sampleDeck, logical.sampleCards, identifiers.idFor)
   );
+  const remoteAbsentCards = normalizeRemoteAbsentCards(logical.remoteAbsentCards, identifiers);
+  const localAbsentCards = normalizeLocalAbsentCards(logical.localAbsentCards, identifiers.idFor);
+  const absentCards = mergeNormalizedCollections(remoteAbsentCards, localAbsentCards);
   const sessions = normalizeSessions(logical.studySessions, identifiers.idFor);
-  validateRuntimeIds(users, decks, cards, sessions);
+  validateRuntimeIds({ users, decks, cards, absentCards, sessions });
 
   const remoteDeckCount = logical.remoteDecks.length;
   const remoteCardCount = logical.remoteCards.length;
@@ -1089,17 +1159,20 @@ export const namespaceFixture = (
       remote: {
         decks: decks.values.slice(0, remoteDeckCount),
         cards: cards.values.slice(0, remoteCardCount),
+        absentCards: remoteAbsentCards.values,
       },
       browser: {
         preferences: normalizePreferences(document.browser?.preferences),
         localDecks: decks.values.slice(remoteDeckCount),
         localCards: cards.values.slice(remoteCardCount),
+        absentCards: localAbsentCards.values,
         studySessions: sessions.byDeckId,
       },
     },
     users: users.lookup,
     decks: decks.lookup,
     cards: cards.lookup,
+    absentCards: absentCards.lookup,
     sessions: sessions.lookup,
     uid: identifiers.uidFor,
     id: identifiers.idFor,

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -111,9 +111,8 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     await deleteDeck("uid", d.id);
 
     await expect(getDoc(doc(db, "deck", d.id))).rejects.toMatchObject({ code: "permission-denied" });
-    await Promise.all(
-      cards.map((card) => expect(getDoc(doc(db, "card", card.id))).rejects.toMatchObject({ code: "permission-denied" }))
-    );
+    const deletedCardSnapshots = await Promise.all(cards.map((card) => getDoc(doc(db, "card", card.id))));
+    expect(deletedCardSnapshots.every((snapshot) => !snapshot.exists())).toBe(true);
   });
 
   it("moves a local Deck and its Cards to Firestore when local mode is disabled", async () => {

--- a/test/integration/firestore/rules.spec.ts
+++ b/test/integration/firestore/rules.spec.ts
@@ -4,7 +4,7 @@
  * "should create a deck", "should update a deck".
  */
 
-import { it, describe, beforeEach, beforeAll, afterAll } from "vitest";
+import { it, describe, beforeEach, beforeAll, afterAll, expect } from "vitest";
 import * as fs from "node:fs";
 import {
   assertFails,
@@ -85,6 +85,11 @@ describe("firestore/rule", () => {
         await assertSucceeds(getDoc(doc(db, "card", id)));
       });
 
+      it("should confirm that a card is missing", async () => {
+        const snapshot = await assertSucceeds(getDoc(doc(db, "card", uuid())));
+        expect(snapshot.exists()).toBe(false);
+      });
+
       it("should create a card", async () => {
         const [deckId, id] = [uuid(), uuid()];
         await createData("deck", deckId, { uid: "uid" });
@@ -149,6 +154,11 @@ describe("firestore/rule", () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertFails(getDoc(doc(db, "card", id)));
+      });
+
+      it("should let an authenticated non-owner confirm that a card is missing", async () => {
+        const snapshot = await assertSucceeds(getDoc(doc(db, "card", uuid())));
+        expect(snapshot.exists()).toBe(false);
       });
 
       it("should read a public card", async () => {
@@ -220,6 +230,10 @@ describe("firestore/rule", () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertFails(getDoc(doc(db, "card", id)));
+      });
+
+      it("should not confirm missing cards without authentication", async () => {
+        await assertFails(getDoc(doc(db, "card", uuid())));
       });
 
       it("should read a public card", async () => {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,8 +8,16 @@ import "@/test/initializeTestFirestore";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, fetchCardReads, mutateCards, subscribeCards } from "@/entities/card";
+import {
+  deleteCard,
+  editCard,
+  fetchCardReads,
+  fetchRemoteCardRead,
+  mutateCards,
+  subscribeCards,
+} from "@/entities/card";
 import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
+import { deleteCard as deleteRemoteCard } from "@/entities/card/api/firestore";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture, createRemoteDeckInput } from "@/test/factories";
@@ -49,6 +57,19 @@ describe("Query realtime subscriptions", () => {
       card: expect.objectContaining({ id: card.id, frontText: "Fetched Card" }),
       progress: expect.objectContaining({ cardId: card.id, score: 2, numberOfSeen: 3 }),
     });
+  });
+
+  it("confirms missing and tombstoned Card documents through a single server read", async () => {
+    const uid = "uid";
+    const deck = createDeckFixture({ id: crypto.randomUUID(), uid });
+    const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid });
+    await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
+
+    await expect(fetchRemoteCardRead(uid, crypto.randomUUID())).resolves.toEqual({ status: "missing" });
+
+    await mutateCards(uid, [{ kind: "create", card }]);
+    await deleteRemoteCard(uid, card);
+    await expect(fetchRemoteCardRead(uid, card.id)).resolves.toEqual({ status: "tombstoned" });
   });
 
   it("delivers initial, update, and delete snapshots without a cursor", async () => {


### PR DESCRIPTION
## Related issue

Fixes #947

Parent roadmap: #208

## Summary

- classify Study sessions without using Card collection length as a readiness signal
- verify absent remote targets with a single-document server read while preserving recoverable sessions
- add strict absent Card fixtures and SWIPE-25 through SWIPE-27 coverage

## Testing

- mise run check
- mise run e2e
- reviewer rounds: 3; final findings: none