### PR TITLE
feat(#952): Add study completion screen

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -133,7 +133,7 @@
 | SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](./study.md#swipe-07) |
 | SWIPE-08 | write | [学習画面から戻った後に同じ位置から Continue できる](./study.md#swipe-08) |
 | SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](./study.md#swipe-09) |
-| SWIPE-10 | write | [最後の Card を完了して session を終了できる](./study.md#swipe-10) |
+| SWIPE-10 | write | [最後の Card を完了して completion screen を表示できる](./study.md#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](./study.md#swipe-11) |
 | SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](./study.md#swipe-12) |
 | SWIPE-13 | write | [remote Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-13) |

--- a/docs/e2e/fixture/study-session-last.yaml
+++ b/docs/e2e/fixture/study-session-last.yaml
@@ -1,4 +1,4 @@
-extends: study-session-start.yaml
+extends: study-session-middle.yaml
 browser:
   studySessions:
     deck-1:

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -16,7 +16,7 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-07 | read | [filter に一致する Card がない場合は session を開始できない](#swipe-07) |
 | SWIPE-08 | write | [学習画面から戻った後に同じ位置から Continue できる](#swipe-08) |
 | SWIPE-09 | write | [Restart で新しい session を先頭から開始できる](#swipe-09) |
-| SWIPE-10 | write | [最後の Card を完了して session を終了できる](#swipe-10) |
+| SWIPE-10 | write | [最後の Card を完了して completion screen を表示できる](#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
 | SWIPE-12 | write | [学習結果の保存失敗後に同じ Card から再試行できる](#swipe-12) |
 | SWIPE-13 | write | [remote Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-13) |
@@ -209,7 +209,7 @@ Then:
 
 <a id="swipe-10"></a>
 
-### SWIPE-10 最後の Card を完了して session を終了できる
+### SWIPE-10 最後の Card を完了して completion screen を表示できる
 
 カテゴリ: `write`
 
@@ -226,7 +226,9 @@ Then:
 
 - 最後の Card の学習結果が保存される。
 - 対象 Deck の学習 session が削除される。
-- Deck 一覧へ戻り、対象 Deck に Continue action が表示されない。
+- Study completion screen に完了 message と学習した Card 数が表示される。
+- Deck 一覧へ automatic redirect せず、Deck 一覧へ戻る action が利用できる。
+- Deck 一覧へ戻った後、対象 Deck に Continue action が表示されない。
 - browser error が発生しない。
 
 <a id="swipe-11"></a>

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -57,9 +57,15 @@ vi.mock("@/entities/study-session", async (importOriginal) => {
 
 import { useStudy as useStudyState } from "./useStudy";
 
-const useStudy = (routeDeckId: string) => {
+const useAnyStudy = (routeDeckId: string) => {
   const study = useStudyState(routeDeckId);
   if (study == null) throw new Error("Expected the test Deck to exist");
+  return study;
+};
+
+const useStudy = (routeDeckId: string) => {
+  const study = useAnyStudy(routeDeckId);
+  if (study.status === "completed") throw new Error("Expected an active Study state");
   return study;
 };
 
@@ -214,6 +220,17 @@ describe("useStudy", () => {
     expect(result.current).not.toHaveProperty("swipeFeedback");
   });
 
+  it("does not complete the final Card when persistence fails", async () => {
+    setStudySessionIndex(deckId, 1);
+    mocks.editStudyProgress.mockRejectedValueOnce(new Error("write failed"));
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await actAsync(() => result.current.swipeRight());
+
+    expect(result.current.status).toBe("studying");
+    expect(getStudySession(deckId)?.currentIndex).toBe(1);
+  });
+
   it("blocks a second swipe while the first write is unresolved", async () => {
     let finishWrite: () => void = () => undefined;
     mocks.editStudyProgress.mockReturnValueOnce(
@@ -253,6 +270,29 @@ describe("useStudy", () => {
     expect(result.current).not.toHaveProperty("swipeFeedback");
   });
 
+  it("does not complete a final Card when the active session is replaced during the write", async () => {
+    clearStudySessions();
+    startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    mocks.cards = cards.slice(0, 1);
+    let finishWrite: () => void = () => undefined;
+    mocks.editStudyProgress.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishWrite = resolve;
+      })
+    );
+    const { result } = renderHook(() => useStudy(deckId));
+
+    const swipe = result.current.swipeRight();
+    act(() => startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    await actAsync(async () => {
+      finishWrite();
+      await swipe;
+    });
+
+    expect(result.current.status).toBe("studying");
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
   it("advances after a timestamp-only session touch during the write", async () => {
     vi.spyOn(Date, "now").mockReturnValue(946_684_800_000);
     let finishWrite: () => void = () => undefined;
@@ -287,15 +327,26 @@ describe("useStudy", () => {
     expect(getStudySession(deckId)).toBeUndefined();
   });
 
-  it("removes the session after the final card is persisted", async () => {
-    clearStudySessions();
-    startStudy(deckId, cards.slice(0, 1), { shuffled: false, maxNumberOfCardsToLearn: 0 });
-    mocks.cards = cards.slice(0, 1);
+  it("does not complete when previous crosses the first Card boundary", async () => {
+    mocks.preferences = createPreferences({ cardSwipeLeft: "GoToPrevCard" });
     const { result } = renderHook(() => useStudy(deckId));
 
-    await actAsync(() => result.current.swipeRight());
+    await actAsync(() => result.current.swipeLeft());
+
+    expect(result.current.status).toBe("invalid");
+    expect(getStudySession(deckId)).toBeUndefined();
+  });
+
+  it("completes after the final Card is persisted and preserves the session Card count", async () => {
+    setStudySessionIndex(deckId, 1);
+    const { result } = renderHook(() => useAnyStudy(deckId));
+
+    if (result.current.status !== "studying") throw new Error("Expected an active Study state");
+    const { swipeRight } = result.current;
+    await actAsync(swipeRight);
 
     expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
     expect(getStudySession(deckId)).toBeUndefined();
+    expect(result.current).toEqual({ status: "completed", completion: { cardCount: 2 } });
   });
 });

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -13,13 +13,14 @@ import { setStudySessionIndex } from "@/entities/study-session";
 import { useAutoPlay } from "./useAutoPlay";
 import { buildStudyHelpContent } from "./studyHelp";
 import { useStudySessionState } from "./useStudySessionState";
-import { useSwipe } from "./useSwipe";
+import { type StudyCompletion, useSwipe } from "./useSwipe";
 
 export const useStudy = (deckId: string) => {
   const cards = useCards();
   const deck = useDeck(deckId);
   const preferences = usePreferences();
   const sessionState = useStudySessionState(deckId, cards);
+  const [completion, setCompletion] = React.useState<StudyCompletion>();
   const [showBackText, setShowBackText] = React.useState(false);
   const [helpOpen, setHelpOpen] = React.useState(false);
   const hideBackText = () => setShowBackText(false);
@@ -30,7 +31,7 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipe = useSwipe(deckId, cards, hideBackText);
+  const swipe = useSwipe(deckId, cards, hideBackText, setCompletion);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;
@@ -60,6 +61,7 @@ export const useStudy = (deckId: string) => {
   };
 
   if (deck == null) return;
+  if (completion != null) return { status: "completed" as const, completion };
   if (sessionState.status !== "studying") return { ...controls, status: sessionState.status };
 
   const category = getCategory(deck.category, sessionState.card.tags);

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -17,7 +17,16 @@ export interface SwipeState {
   swipeFeedback?: SwipeDirection;
 }
 
-export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: () => void): SwipeState => {
+export interface StudyCompletion {
+  cardCount: number;
+}
+
+export const useSwipe = (
+  deckId: DeckId,
+  cards: readonly Card[],
+  onCardChanged: () => void,
+  onCompleted: (completion: StudyCompletion) => void
+): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
   const feedback = useSwipeFeedback(preferences.appearance.showSwipeFeedback);
@@ -36,6 +45,11 @@ export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: 
       return;
     }
 
+    // Completion is derived from the pre-write snapshot because a successful boundary move removes the session.
+    const completesSession =
+      swipePlan.effect === "next" && swipePlan.session.currentIndex === swipePlan.session.cardOrderIds.length - 1;
+    const cardCount = swipePlan.session.cardOrderIds.length;
+
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
     const saved = await editStudyProgress(uid, swipePlan.progress).then(
@@ -48,6 +62,10 @@ export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: 
     if (!moveStudySession(swipePlan.session, swipePlan.effect)) return;
 
     feedback.showSwipe(direction);
+    if (completesSession) {
+      onCompleted({ cardCount });
+      return;
+    }
     if (preferences.appearance.hideBodyWhenCardChanged) onCardChanged();
   };
 

--- a/src/pages/study-session/ui/StudyCompletion.spec.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.spec.tsx
@@ -9,9 +9,9 @@ describe("StudyCompletion", () => {
     const onClickBack = vi.fn();
     render(<StudyCompletion cardCount={1} onClickBack={onClickBack} />);
 
-    expect(screen.getByRole("heading", { name: "Study complete" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Study complete" })).toHaveFocus();
     expect(screen.getByText("You studied 1 card.")).toBeVisible();
-    expect(screen.getByRole("status")).toHaveFocus();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
     expect(onClickBack).toHaveBeenCalledOnce();

--- a/src/pages/study-session/ui/StudyCompletion.spec.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.spec.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { StudyCompletion } from "./StudyCompletion";
+
+describe("StudyCompletion", () => {
+  it("shows the completed Card count and reports the return action", () => {
+    const onClickBack = vi.fn();
+    render(<StudyCompletion cardCount={1} onClickBack={onClickBack} />);
+
+    expect(screen.getByRole("heading", { name: "Study complete" })).toBeVisible();
+    expect(screen.getByText("You studied 1 card.")).toBeVisible();
+    expect(screen.getByRole("status")).toHaveFocus();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
+    expect(onClickBack).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pages/study-session/ui/StudyCompletion.stories.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { withPageLayout } from "@/storybook/PageLayoutDecorator";
+
+import { StudyCompletion } from "./StudyCompletion";
+
+const meta = {
+  title: "Pages/Study Session/StudyCompletion",
+  component: StudyCompletion,
+  decorators: [withPageLayout],
+  args: {
+    cardCount: 12,
+    onClickBack: () => undefined,
+  },
+} satisfies Meta<typeof StudyCompletion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SingleCard: Story = {
+  args: { cardCount: 1 },
+};

--- a/src/pages/study-session/ui/StudyCompletion.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.tsx
@@ -10,23 +10,20 @@ export interface StudyCompletionProps {
 const cardsLabel = (count: number) => `${String(count)} ${count === 1 ? "card" : "cards"}`;
 
 export const StudyCompletion: FC<StudyCompletionProps> = ({ cardCount, onClickBack }) => {
-  const completionRef = useRef<HTMLElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
     // The swipe control disappears asynchronously, so focus the result to make the transition perceivable.
-    completionRef.current?.focus();
+    titleRef.current?.focus();
   }, []);
 
   return (
     <section
-      ref={completionRef}
-      role="status"
-      tabIndex={-1}
       aria-labelledby="study-completion-title"
       className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-6 text-center text-ink shadow-surface"
     >
       <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Session complete</p>
-      <h1 id="study-completion-title" className="mt-1 text-display font-bold">
+      <h1 ref={titleRef} id="study-completion-title" tabIndex={-1} className="mt-1 text-display font-bold">
         Study complete
       </h1>
       <p className="mt-3 text-body text-ink-muted">You studied {cardsLabel(cardCount)}.</p>

--- a/src/pages/study-session/ui/StudyCompletion.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef, type FC } from "react";
+
+import { Button } from "@/shared/ui/button";
+
+export interface StudyCompletionProps {
+  cardCount: number;
+  onClickBack: () => void;
+}
+
+const cardsLabel = (count: number) => `${String(count)} ${count === 1 ? "card" : "cards"}`;
+
+export const StudyCompletion: FC<StudyCompletionProps> = ({ cardCount, onClickBack }) => {
+  const completionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    // The swipe control disappears asynchronously, so focus the result to make the transition perceivable.
+    completionRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      ref={completionRef}
+      role="status"
+      tabIndex={-1}
+      aria-labelledby="study-completion-title"
+      className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-6 text-center text-ink shadow-surface"
+    >
+      <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Session complete</p>
+      <h1 id="study-completion-title" className="mt-1 text-display font-bold">
+        Study complete
+      </h1>
+      <p className="mt-3 text-body text-ink-muted">You studied {cardsLabel(cardCount)}.</p>
+      <Button className="mt-6" variant="primary" size="lg" onClick={onClickBack}>
+        Back to deck list
+      </Button>
+    </section>
+  );
+};

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -8,7 +8,7 @@ import "@testing-library/jest-dom/vitest";
 
 import { deleteCard, mutateCards } from "@/entities/card";
 import { createDeck } from "@/entities/deck";
-import { clearStudySessions, getStudySession, startStudy } from "@/entities/study-session";
+import { clearStudySessions, getStudySession, setStudySessionIndex, startStudy } from "@/entities/study-session";
 import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
@@ -290,6 +290,21 @@ describe("StudySessionPage", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
     expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
     expect(mocks.removeStudySession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the completion screen on the Study route and disables Study shortcuts", async () => {
+    setStudySessionIndex(deckId, 1);
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Swipe up" }));
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Study complete" })).toBeVisible();
+    expect(screen.getByText("You studied 2 cards.")).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 1, name: "Deck list destination" })).not.toBeInTheDocument();
+    expect(getStudySession(deckId)).toBeUndefined();
+
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
   });
 
   it("keeps study actions available while the Header stays hidden", () => {

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Preferences } from "@/entities/preference";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -50,6 +50,18 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { StudySessionPage } from "./StudySessionPage";
 
+const DeckListDestination = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <h1>Deck list destination</h1>
+      <button type="button" onClick={() => void navigate(-1)}>
+        Browser back
+      </button>
+    </>
+  );
+};
+
 describe("StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
@@ -71,15 +83,18 @@ describe("StudySessionPage", () => {
     score: 1,
     numberOfSeen: 4,
   });
-  const renderPage = (path = `/deck/${deckId}/study`) =>
-    render(
-      <MemoryRouter initialEntries={[path]}>
+  const renderPage = (path = `/deck/${deckId}/study`, previousPath?: string) => {
+    const initialEntries = previousPath === undefined ? [path] : [previousPath, path];
+    return render(
+      <MemoryRouter initialEntries={initialEntries} initialIndex={initialEntries.length - 1}>
         <Routes>
-          <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/" element={<DeckListDestination />} />
+          <Route path="/previous" element={<h1>Previous destination</h1>} />
           <Route path="/deck/:id/study" element={<StudySessionPage />} />
         </Routes>
       </MemoryRouter>
     );
+  };
   const openStudyActions = () => {
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
     return screen.getByRole("group", { name: "Study actions" });
@@ -294,7 +309,7 @@ describe("StudySessionPage", () => {
 
   it("keeps the completion screen on the Study route and disables Study shortcuts", async () => {
     setStudySessionIndex(deckId, 1);
-    renderPage();
+    renderPage(`/deck/${deckId}/study`, "/previous");
 
     fireEvent.click(screen.getByRole("button", { name: "Swipe up" }));
 
@@ -305,6 +320,13 @@ describe("StudySessionPage", () => {
 
     fireEvent.keyDown(window, { key: "ArrowUp" });
     expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Browser back" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Previous destination" })).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 1, name: "Study complete" })).not.toBeInTheDocument();
   });
 
   it("keeps study actions available while the Header stays hidden", () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -10,6 +10,7 @@ import { AppLayout } from "@/widgets/app-layout";
 
 import { type StudyState, useStudy } from "../model/useStudy";
 import { CardOverlay } from "./CardOverlay";
+import { StudyCompletion } from "./StudyCompletion";
 import { StudySession } from "./StudySession";
 
 type StudyShortcutAction =
@@ -150,6 +151,19 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
     if (study?.status !== "invalid") return;
     void navigate(routes.deckList.to(), { replace: true });
   }, [navigate, study?.status]);
+
+  if (study?.status === "completed") {
+    return (
+      <AppLayout showHeader>
+        <StudyCompletion
+          cardCount={study.completion.cardCount}
+          onClickBack={() => {
+            void navigate(routes.deckList.to());
+          }}
+        />
+      </AppLayout>
+    );
+  }
 
   return renderStudyScreen(study, goBack);
 };

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -158,7 +158,7 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
         <StudyCompletion
           cardCount={study.completion.cardCount}
           onClickBack={() => {
-            void navigate(routes.deckList.to());
+            void navigate(routes.deckList.to(), { replace: true });
           }}
         />
       </AppLayout>

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -181,7 +181,7 @@ test("SWIPE-09 restarts an in-progress Deck from a new session", async ({ fixtur
   expect(restarted?.currentIndex).toBe(0);
 });
 
-test("SWIPE-10 finishes the final Card and removes the session", async ({ fixture, page }) => {
+test("SWIPE-10 finishes the final Card and shows the completion screen", async ({ fixture, page }) => {
   const deck = fixture.deck();
   const session = fixture.session();
   const finalCard = fixture.card("card-3");
@@ -189,6 +189,13 @@ test("SWIPE-10 finishes the final Card and removes the session", async ({ fixtur
 
   await page.goto(`/deck/${deck.id}/study`);
   await page.getByRole("button", { name: "Swipe up" }).click();
+
+  await expect(page).toHaveURL(`/deck/${deck.id}/study`);
+  await expect(page.getByRole("heading", { name: "Study complete" })).toBeVisible();
+  await expect(page.getByText(`You studied ${String(session.cardOrderIds.length)} cards.`)).toBeVisible();
+  const backToDeckList = page.getByRole("button", { name: "Back to deck list" });
+  await expect(backToDeckList).toBeVisible();
+  await backToDeckList.click();
 
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole("button", { name: `Continue ${deck.name}` })).toHaveCount(0);


### PR DESCRIPTION
## Related issue

Fixes #952

## Summary

- Keep the user on the Study route after completing the final Card and show a completion summary.
- Complete only after progress persistence and StudySession advancement both succeed.
- Add accessible completion UI, Page/model coverage, and update the SWIPE-10 E2E contract.

## Testing

- mise run check
- npm run e2e -- --grep SWIPE-10