### PR TITLE
[No issue] Extend E2E acceptance coverage

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -75,7 +75,8 @@
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
 | SETTINGS-01 | write | [Dark mode を自動保存して reload 後も反映できる](./settings.md#settings-01) |
-| SETTINGS-02 | write | [Maximum cards 設定を次の学習 session に反映できる](./settings.md#settings-02) |
+| SETTINGS-02 | write | [Maximum cards 設定を学習開始画面に反映できる](./settings.md#settings-02) |
+| SETTINGS-03 | batch | [Respect review schedule を次の学習 session に反映できる](./settings.md#settings-03) |
 
 ### Import
 
@@ -103,6 +104,7 @@
 | DECK-08 | read | [Deck の Card を CSV で export できる](./deck.md#deck-08) |
 | DECK-09 | write | [空の remote Deck を作成して reload 後も確認できる](./deck.md#deck-09) |
 | DECK-10 | write | [remote Deck の作成失敗後に重複なく再試行できる](./deck.md#deck-10) |
+| DECK-11 | write | [空の local-only Deck を作成して reload 後も確認できる](./creation.md#deck-11) |
 
 ### Card
 
@@ -120,6 +122,9 @@
 | CARD-10 | write | [score と tag の filter を保存して Card 一覧へ反映できる](./card.md#card-10) |
 | CARD-11 | read | [Card view を直接開ける](./card.md#card-11) |
 | CARD-12 | read | [存在しない Card から復帰できる](./card.md#card-12) |
+| CARD-13 | write | [remote Deck に Card を作成できる](./card.md#card-13) |
+| CARD-14 | write | [local-only Deck に Card を作成できる](./card.md#card-14) |
+| CARD-15 | write | [remote Card の作成失敗後に重複なく再試行できる](./creation.md#card-15) |
 
 ### Study
 

--- a/docs/e2e/creation.md
+++ b/docs/e2e/creation.md
@@ -1,0 +1,62 @@
+# Creation E2E テスト仕様書
+
+## 目的
+
+Deck / Card の作成が保存先の境界を守り、失敗後の再試行でも同じ identity を維持して重複しないことを確認する。
+
+## テストケース
+
+| ID | カテゴリ | テストケース |
+| --- | --- | --- |
+| DECK-11 | write | [空の local-only Deck を作成して reload 後も確認できる](#deck-11) |
+| CARD-15 | write | [remote Card の作成失敗後に重複なく再試行できる](#card-15) |
+
+<a id="deck-11"></a>
+
+### DECK-11 空の local-only Deck を作成して reload 後も確認できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`empty`](./fixture/empty.yaml)
+- ユーザーとして認証されている。
+- 作成対象の Deck は現在の UID の remote data と local-only data のどちらにも存在しない。
+
+When:
+
+- Deck の作成画面で name と category を入力し、Local only を有効にして保存した後、Deck 一覧を reload する。
+
+Then:
+
+- 作成した空の Deck が reload 後も Deck 一覧に表示される。
+- 作成した Deck は browser storage に一つだけ存在する。
+- remote data に同じ Deck が存在しない。
+- 対象 Deck に Card が存在しない。
+- browser error が発生しない。
+
+<a id="card-15"></a>
+
+### CARD-15 remote Card の作成失敗後に重複なく再試行できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`remote-deck-with-cards`](./fixture/remote-deck-with-cards.yaml)
+- 認証済みユーザーが所有する remote Deck が存在する。
+- remote Card の最初の作成要求が失敗している。
+- 作成失敗が画面内で処理され、入力内容と作成対象の Card ID が維持されている。
+- 次の作成要求は成功できる。
+
+When:
+
+- 入力内容を変更せずに同じ Card の作成を再試行し、Card 一覧を reload する。
+
+Then:
+
+- 最初の要求と再試行で同じ Card ID が使用される。
+- 作成した Card が対象 Deck の remote data に一つだけ存在する。
+- Card の front text、back text、deck ID、owner、unique key が最初の作成要求から維持されている。
+- browser storage に同じ Card の local-only duplicate が存在しない。
+- 最初の作成失敗に伴う未処理の browser error が発生しない。

--- a/docs/e2e/fixture/study-review-schedule.yaml
+++ b/docs/e2e/fixture/study-review-schedule.yaml
@@ -1,0 +1,23 @@
+extends: remote-deck-with-cards.yaml
+remote:
+  cards:
+    - id: card-due
+      deckId: deck-1
+      uid: user-1
+      frontText: due card
+      backText: due answer
+      uniqueKey: due-card
+      nextSeeingAt: "2000-01-01T00:00:00.000Z"
+    - id: card-future
+      deckId: deck-1
+      uid: user-1
+      frontText: future card
+      backText: future answer
+      uniqueKey: future-card
+      nextSeeingAt: "2999-01-01T00:00:00.000Z"
+    - id: card-unscheduled
+      deckId: deck-1
+      uid: user-1
+      frontText: unscheduled card
+      backText: unscheduled answer
+      uniqueKey: unscheduled-card

--- a/docs/e2e/settings.md
+++ b/docs/e2e/settings.md
@@ -2,14 +2,15 @@
 
 ## 目的
 
-Settings の自動保存が reload を越えて維持され、保存した学習設定が次の学習 session に反映されることを確認する。
+Settings の自動保存が reload を越えて維持され、保存した学習設定が学習開始画面や次の学習 session に反映されることを確認する。
 
 ## テストケース
 
 | ID | カテゴリ | テストケース |
 | --- | --- | --- |
 | SETTINGS-01 | write | [Dark mode を自動保存して reload 後も反映できる](#settings-01) |
-| SETTINGS-02 | write | [Maximum cards 設定を次の学習 session に反映できる](#settings-02) |
+| SETTINGS-02 | write | [Maximum cards 設定を学習開始画面に反映できる](#settings-02) |
+| SETTINGS-03 | batch | [Respect review schedule を次の学習 session に反映できる](#settings-03) |
 
 <a id="settings-01"></a>
 
@@ -34,7 +35,7 @@ Then:
 
 <a id="settings-02"></a>
 
-### SETTINGS-02 Maximum cards 設定を次の学習 session に反映できる
+### SETTINGS-02 Maximum cards 設定を学習開始画面に反映できる
 
 カテゴリ: `write`
 
@@ -50,6 +51,31 @@ When:
 
 Then:
 
-- 学習開始画面に表示される session の Card 数が変更後の上限と一致する。
+- 学習開始画面に表示される対象 Card 数が変更後の上限と一致する。
 - start action に変更後の上限と同じ Card 数が表示される。
+- browser error が発生しない。
+
+<a id="settings-03"></a>
+
+### SETTINGS-03 Respect review schedule を次の学習 session に反映できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`study-review-schedule`](./fixture/study-review-schedule.yaml)
+- 認証済みユーザーが所有する Deck に、過去または将来の next seeing time を持つ Card と、next seeing time を持たない Card が存在する。
+- `Respect review schedule` は無効である。
+- 対象 Deck に進行中の学習 session が存在しない。
+
+When:
+
+- Settings 画面で `Respect review schedule` を有効にし、自動保存後にページを reload する。
+- 対象 Deck の学習開始画面から session を開始する。
+
+Then:
+
+- `Respect review schedule` が reload 後も有効である。
+- 過去の next seeing time を持つ Card と、next seeing time を持たない Card が session に含まれる。
+- 将来の next seeing time を持つ Card は session に含まれない。
 - browser error が発生しない。

--- a/test/e2e/creation.spec.ts
+++ b/test/e2e/creation.spec.ts
@@ -1,0 +1,103 @@
+import {
+  allowExpectedFirestoreWriteFailure,
+  documentId,
+  expect,
+  failNextFirestoreWrite,
+  listDocuments,
+  readLocalData,
+  test,
+} from "./fixtures";
+
+test("DECK-11 creates one empty local-only Deck without a remote duplicate", async ({ fixture, page, namespace }) => {
+  const name = `${namespace.caseId} local deck`;
+  const category = "typescript";
+  await fixture.apply(page);
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Create deck" }).click();
+  await page.getByRole("textbox", { name: "Name" }).fill(name);
+  await page.getByRole("combobox").selectOption(category);
+  const localOnly = page.getByRole("checkbox", { name: "Local only" });
+  await localOnly.locator("xpath=parent::label").click();
+  await expect(localOnly).toBeChecked();
+  await page.getByRole("button", { name: "Create deck" }).click();
+  await expect(page).toHaveURL(/\/deck\/(?!new$)[^/]+$/);
+  const deckId = new URL(page.url()).pathname.split("/").at(-1);
+  if (deckId === undefined) throw new Error("Created local-only Deck ID is missing");
+  await expect(page.getByText("0 cards")).toBeVisible();
+
+  await page.goto("/");
+  await page.reload();
+
+  const deckArticle = page.getByRole("button", { name: `View ${name}` }).locator("xpath=ancestor::article[1]");
+  await expect(deckArticle).toContainText(category);
+  const local = await readLocalData(page);
+  const localDecks = local.decks.filter(
+    (deck: { id?: string; name?: string }) => deck.id === deckId && deck.name === name
+  );
+  expect(localDecks).toHaveLength(1);
+  expect(localDecks[0]).toEqual(expect.objectContaining({ id: deckId, name, category, localMode: true }));
+  expect(local.cards.filter((card: { deckId?: string }) => card.deckId === deckId)).toEqual([]);
+  expect(
+    (await listDocuments("deck")).filter(
+      (document) =>
+        (document.fields.name as { stringValue?: string } | undefined)?.stringValue === name ||
+        documentId(document) === deckId
+    )
+  ).toEqual([]);
+});
+
+test("CARD-15 retries a failed remote Card create with the same ID and no duplicate", async ({
+  fixture,
+  page,
+  browserErrors,
+  namespace,
+}) => {
+  const deck = fixture.deck();
+  const frontText = `${namespace.caseId} retry front`;
+  const backText = `${namespace.caseId} retry back`;
+  await fixture.apply(page);
+  await page.goto(`/deck/${deck.id}`);
+  await page.getByRole("button", { name: "Add card" }).click();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/card/new$`));
+
+  let attemptedCardId: string | undefined;
+  page.on("request", (request) => {
+    if (!request.url().includes("google.firestore.v1.Firestore/Write/channel")) return;
+    const body = decodeURIComponent((request.postData() ?? "").replaceAll("+", "%20"));
+    attemptedCardId ??= /\/documents\/card\/([a-zA-Z0-9-]+)/.exec(body)?.[1];
+  });
+  const fault = await failNextFirestoreWrite(page, { collection: "card" });
+  allowExpectedFirestoreWriteFailure(browserErrors);
+  await page.getByRole("textbox", { name: "Front text" }).fill(frontText);
+  await page.getByRole("textbox", { name: "Back text" }).fill(backText);
+  await page.getByRole("button", { name: "Create card" }).click();
+  await expect(page.getByText("Unable to create this card. Try again.")).toBeVisible();
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
+  await fault.dispose();
+  expect(attemptedCardId).toBeDefined();
+
+  await expect(page.getByRole("textbox", { name: "Front text" })).toHaveValue(frontText);
+  await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue(backText);
+  await page.getByRole("button", { name: "Create card" }).click();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));
+  await page.reload();
+
+  await expect(page.getByRole("button", { name: `View ${frontText}` })).toBeVisible();
+  const created = (await listDocuments("card")).filter(
+    ({ fields }) =>
+      fields.deckId?.stringValue === deck.id &&
+      fields.uid?.stringValue === deck.uid &&
+      fields.frontText?.stringValue === frontText
+  );
+  expect(created).toHaveLength(1);
+  const [createdCard] = created;
+  if (createdCard === undefined) throw new Error("Created remote Card was not found");
+  expect(documentId(createdCard)).toBe(attemptedCardId);
+  expect(createdCard.fields.backText?.stringValue).toBe(backText);
+  expect(createdCard.fields.uniqueKey?.stringValue).toBe(attemptedCardId);
+  expect((await readLocalData(page)).cards).not.toEqual(
+    expect.arrayContaining([expect.objectContaining({ frontText })])
+  );
+});

--- a/test/e2e/e2e-contract-reporter.ts
+++ b/test/e2e/e2e-contract-reporter.ts
@@ -1,13 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
 import type { FullConfig, FullResult, Reporter, Suite } from "@playwright/test/reporter";
 
-import { validateE2EContract } from "./yaml-fixture";
+import { requireE2ECaseId, validateE2EContract } from "./yaml-fixture";
+
+const readReadmeCaseIds = (): string[] => {
+  const markdown = readFileSync(path.join(process.cwd(), "docs/e2e/README.md"), "utf8");
+  return [...markdown.matchAll(/^\| ([A-Z]+-[0-9]{2}) \|/gmu)].map((match) => {
+    const caseId = match[1];
+    if (caseId === undefined) throw new Error(`Could not parse an E2E case ID from README row: ${match[0]}`);
+    return caseId;
+  });
+};
+
+const validateReadmeIndex = (testTitles: readonly string[]): void => {
+  // The fixture contract already proves detailed specifications match tests; this closes the remaining
+  // README index gap.
+  const testCaseIds = testTitles.map(requireE2ECaseId);
+  const indexedCaseIds = readReadmeCaseIds();
+  const indexedCounts = new Map<string, number>();
+  for (const caseId of indexedCaseIds) {
+    indexedCounts.set(caseId, (indexedCounts.get(caseId) ?? 0) + 1);
+  }
+
+  const testCaseIdSet = new Set(testCaseIds);
+  const indexedCaseIdSet = new Set(indexedCaseIds);
+  const missing = [...testCaseIdSet]
+    .filter((caseId) => !indexedCaseIdSet.has(caseId))
+    .sort((left, right) => left.localeCompare(right));
+  const duplicates = [...indexedCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([caseId, count]) => `${caseId} (${String(count)})`)
+    .sort((left, right) => left.localeCompare(right));
+  const unexpected = [...indexedCaseIdSet]
+    .filter((caseId) => !testCaseIdSet.has(caseId))
+    .sort((left, right) => left.localeCompare(right));
+  const problems = [
+    ...(missing.length === 0 ? [] : [`missing README case IDs: ${missing.join(", ")}`]),
+    ...(duplicates.length === 0 ? [] : [`duplicate README case IDs: ${duplicates.join(", ")}`]),
+    ...(unexpected.length === 0 ? [] : [`unexpected README case IDs: ${unexpected.join(", ")}`]),
+  ];
+  if (problems.length > 0) throw new Error(`Invalid E2E README index: ${problems.join("; ")}`);
+};
 
 class E2EContractReporter implements Reporter {
   private contractStatus: FullResult["status"] = "passed";
 
   onBegin(_config: FullConfig, suite: Suite) {
     try {
-      validateE2EContract(suite.allTests().map(({ title }) => title));
+      const testTitles = suite.allTests().map(({ title }) => title);
+      validateE2EContract(testTitles);
+      validateReadmeIndex(testTitles);
     } catch (error) {
       this.contractStatus = "failed";
       const message = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/test/e2e/review-schedule.spec.ts
+++ b/test/e2e/review-schedule.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "./fixtures";
+import { readSession } from "./study-helpers";
+
+test("SETTINGS-03 applies review scheduling to the next study session", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const dueCard = fixture.card("card-due");
+  const futureCard = fixture.card("card-future");
+  const unscheduledCard = fixture.card("card-unscheduled");
+  await fixture.apply(page);
+  await page.goto("/settings");
+
+  const respectReviewSchedule = page.getByRole("checkbox", { name: "Respect review schedule" });
+  await expect(respectReviewSchedule).not.toBeChecked();
+  await respectReviewSchedule.locator("xpath=parent::label").click();
+  await expect(respectReviewSchedule).toBeChecked();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => JSON.parse(localStorage.getItem("tango-config") ?? "{}").state?.preferences?.study?.useCardInterval
+      )
+    )
+    .toBe(true);
+
+  await page.reload();
+  await expect(respectReviewSchedule).toBeChecked();
+  await page.goto(`/deck/${deck.id}/start`);
+  await page.getByRole("button", { name: "Start 2 cards" }).click();
+
+  const session = await readSession(page, deck.id);
+  expect(session?.cardOrderIds).toHaveLength(2);
+  expect(session?.cardOrderIds).toEqual(expect.arrayContaining([dueCard.id, unscheduledCard.id]));
+  expect(session?.cardOrderIds).not.toContain(futureCard.id);
+});


### PR DESCRIPTION
## Related issue

None

## Summary

- add E2E coverage for review scheduling, local-only Deck creation, and remote Card creation retries
- restore `CARD-13` and `CARD-14` in the E2E README index and clarify the `SETTINGS-02` scope
- validate that every Playwright E2E case ID appears exactly once in the README index

## Verification

- GitHub Actions `Test` workflow: passed
  - Code quality
  - Build
  - Unit coverage
  - Firestore integration
  - Storybook
  - Sample
  - E2E
- GitHub Actions `Audit` workflow: passed
