### PR TITLE
[No issue] Hide header while viewing card back text

### DIFF
--- a/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
@@ -108,6 +108,7 @@ describe("CardListPage interactions", () => {
   it("builds the list presentation and coordinates filter, view, and edit interactions", async () => {
     renderCardList();
 
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     expect(screen.getByText("score -2–4 · 2 tags")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Remove typescript filter" }));
     expect(screen.queryByRole("button", { name: "Remove typescript filter" })).not.toBeInTheDocument();
@@ -115,8 +116,10 @@ describe("CardListPage interactions", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "View Front" }));
     expect(screen.getByText("Back")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Close card" }));
     expect(screen.queryByText("Back")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
 
     await userEvent.click(screen.getByRole("button", { name: "Open actions for Front" }));
     await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -27,7 +27,7 @@ const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
   });
 
   return (
-    <AppLayout showHeader>
+    <AppLayout showHeader={state.answer == null}>
       <Feedback tone="error">{state.mutationError == null ? null : "Unable to save changes. Try again."}</Feedback>
       <Feedback tone="success">{state.successMessage}</Feedback>
       {state.deletionTarget != null ? (


### PR DESCRIPTION
## Related issue

None

## Summary

- Hide the application header while a card back text overlay is open from the card list.
- Restore the header after closing the overlay.
- Cover the header visibility transitions with an interaction test.

## Testing

- mise run check