### PR TITLE
chore(#396): Align latest protected update conflicts

### DIFF
--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -71,27 +71,6 @@ describe("preferences store", () => {
     });
   });
 
-  it.each(["system", "en", "ja"] as const)(
-    "updates and persists the %s language without resetting other preferences",
-    (language) => {
-      const storage = useMemoryStorage();
-      preferencesStore.getState().updatePreferences({ appearance: { darkMode: true } });
-
-      preferencesStore.getState().updatePreferences({ language });
-
-      const expectedPreferences = {
-        ...defaultPreferences,
-        language,
-        appearance: { ...defaultPreferences.appearance, darkMode: true },
-      };
-      expect(preferencesStore.getState().preferences).toEqual(expectedPreferences);
-      expect(JSON.parse(storage.getItem("tango-config") ?? "{}")).toEqual({
-        state: { preferences: expectedPreferences },
-        version: 2,
-      });
-    }
-  );
-
   it("validates numeric ranges during updates", () => {
     const store = preferencesStore;
 
@@ -150,51 +129,33 @@ describe("preferences store", () => {
           },
         },
       },
-      version: 2,
+      version: 1,
     });
   });
 
-  it("hydrates persisted preferences", async () => {
+  it("hydrates version 1 preferences with defaults for additive fields", async () => {
+    const { showBackTextSwipeOverlays: _showBackTextSwipeOverlays, ...controlsBeforeSwipeOverlays } =
+      defaultPreferences.controls;
     const persistedPreferences = {
       ...defaultPreferences,
       loadSample: false,
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
+      controls: { ...controlsBeforeSwipeOverlays, showSwipeButtonList: false },
     };
     useMemoryStorage({
-      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 2 }),
-    });
-
-    await preferencesStore.persist.rehydrate();
-
-    expect(preferencesStore.getState().preferences).toEqual(persistedPreferences);
-  });
-
-  it("recovers a missing language in an older version 2 snapshot without resetting other preferences", async () => {
-    const { language: _language, ...persistedPreferences } = {
-      ...defaultPreferences,
-      loadSample: false,
-      appearance: { ...defaultPreferences.appearance, darkMode: true },
-      study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
-    };
-    useMemoryStorage({
-      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 2 }),
+      "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 1 }),
     });
 
     await preferencesStore.persist.rehydrate();
 
     expect(preferencesStore.getState().preferences).toEqual({
       ...persistedPreferences,
-      language: "system",
+      controls: { ...persistedPreferences.controls, showBackTextSwipeOverlays: false },
     });
   });
 
-  it("discards version 1 preferences after the persisted shape changes", async () => {
-    const {
-      showCardDetails: _showCardDetails,
-      showBackTextSwipeOverlays: _showBackTextSwipeOverlays,
-      ...legacyControls
-    } = defaultPreferences.controls;
+  it("discards version 2 preferences without migration", async () => {
     useMemoryStorage({
       "tango-config": JSON.stringify({
         state: {
@@ -203,10 +164,10 @@ describe("preferences store", () => {
             loadSample: false,
             appearance: { ...defaultPreferences.appearance, darkMode: true },
             study: { ...defaultPreferences.study, cardInterval: 15, selectedTags: ["legacy"] },
-            controls: { ...legacyControls, showSwipeButtonList: false },
+            controls: { ...defaultPreferences.controls, showSwipeButtonList: false },
           },
         },
-        version: 1,
+        version: 2,
       }),
     });
 
@@ -223,8 +184,8 @@ describe("preferences store", () => {
 
   it.each([
     ["malformed JSON", "not-json"],
-    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 2 })],
-    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 2 })],
+    ["schema mismatch", JSON.stringify({ state: { preferences: "invalid" }, version: 1 })],
+    ["incompatible envelope", JSON.stringify({ state: { config: { darkMode: true } }, version: 1 })],
   ])("uses current defaults for %s", async (_case, persistedValue) => {
     useMemoryStorage({ "tango-config": persistedValue });
 

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/firebase", () => ({ auth: {} }));
@@ -151,7 +152,8 @@ describe("StudySession", () => {
     expect(onClickLeft).not.toHaveBeenCalled();
   });
 
-  it("keeps the back action visible and opens the remaining study actions", () => {
+  it("keeps the back action visible and opens the remaining study actions", async () => {
+    const user = userEvent.setup();
     const onBack = vi.fn();
     const onToggleCardDetails = vi.fn();
     const onToggleSwipeControls = vi.fn();
@@ -171,6 +173,7 @@ describe("StudySession", () => {
     const openActions = screen.getByRole("button", { name: "Open study actions" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
@@ -180,17 +183,24 @@ describe("StudySession", () => {
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const detailsToggle = screen.getByRole("button", { name: "Card details" });
+    const help = screen.getByRole("button", { name: "Open study help" });
     const actions = screen.getByRole("group", { name: "Study actions" });
     expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
+    expect(help).toBeVisible();
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
     expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
     expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
+    expect(actions).toContainElement(help);
     expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
+
+    closeActions.focus();
+    await user.tab();
+    expect(help).toHaveFocus();
 
     fireEvent.click(back);
     fireEvent.click(swipeToggle);
@@ -202,9 +212,10 @@ describe("StudySession", () => {
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
     expect(onToggleCardDetails).toHaveBeenCalledOnce();
 
-    fireEvent.keyDown(closeActions, { key: "Escape" });
+    fireEvent.keyDown(help, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
   });
 
   it("shows and hides all card details from the persisted preference value", () => {


### PR DESCRIPTION
## Related issue

Part of #396

## Summary

- align the two new conflict hunks introduced by the latest `main`
- preserve the upstream Preferences version reset and study-help behavior during the protected update
- restore the language-specific preference coverage after GitHub records `main` ancestry

## Verification

- both files exactly match current `origin/main`
- clean `git merge-tree` simulation against current `origin/main`

This is the second intermediate ruleset-compliance step for #1344 because `main` advanced during the first protected update.