### PR TITLE
[No issue] Float study back text overlays

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -152,7 +152,7 @@
 | SWIPE-19 | read | [長い裏面 text を scroll しても Card の状態を維持できる](./study-back-text.md#swipe-19) |
 | SWIPE-20 | write | [左 overlay から設定済み action を実行できる](./study-back-text.md#swipe-20) |
 | SWIPE-21 | write | [右 overlay から設定済み action を実行できる](./study-back-text.md#swipe-21) |
-| SWIPE-22 | read | [狭い画面で overlay と重ならずに端の裏面 text を選択できる](./study-back-text.md#swipe-22) |
+| SWIPE-22 | read | [狭い画面でも overlay の下で裏面を全幅表示できる](./study-back-text.md#swipe-22) |
 | SWIPE-23 | read | [overlay 上から長い裏面 text を scroll できる](./study-back-text.md#swipe-23) |
 
 ### Persistence

--- a/docs/e2e/study-back-text.md
+++ b/docs/e2e/study-back-text.md
@@ -160,7 +160,7 @@ Then:
 
 <a id="swipe-22"></a>
 
-### SWIPE-22 狭い画面で overlay と重ならずに端の裏面 text を選択できる
+### SWIPE-22 狭い画面でも overlay の下で裏面を全幅表示できる
 
 カテゴリ: `read`
 
@@ -173,13 +173,13 @@ Given:
 
 When:
 
-- 現在の Card を裏面へ切り替え、左端から始まる back text を primary mouse button の drag で選択する。
+- 現在の Card を裏面へ切り替える。
 
 Then:
 
-- back text の表示領域が左右 overlay と重ならない。
-- 選択範囲に対象 Card の back text が含まれる。
-- 対象 Card の back text と左右 overlay が引き続き表示される。
+- back text の表示領域が answer region と同じ幅を維持する。
+- 左右 overlay が back text の上に浮いた状態で表示される。
+- 対象 Card の back text が表示される。
 - Card の学習結果と session の位置が変更されない。
 - browser error が発生しない。
 

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -331,7 +331,7 @@ const BackTextOverlays: React.FC<{
       ) : null}
       {overlay.onClickRight !== undefined ? (
         <BackTextEdgeOverlay
-          // Keep the hit area inside the reserved w-20 while leaving a pointer-free scrollbar gutter.
+          // Leave a pointer-free scrollbar gutter while the hit area floats over the answer.
           className="right-5 w-[calc(5rem-1.25rem)]"
           ariaLabel="Swipe right"
           onClick={overlay.onClickRight}
@@ -352,14 +352,8 @@ const CardContent: React.FC<{
     return (
       <>
         <BackTextOverlays overlay={backTextOverlay} />
-        <div
-          className={cx(
-            "flex min-h-full w-full",
-            // Reserve w-20 per edge; the right reservation includes its pointer-free scrollbar gutter.
-            backTextOverlay?.onClickLeft !== undefined && "pl-20",
-            backTextOverlay?.onClickRight !== undefined && "pr-20"
-          )}
-        >
+        {/* Edge actions float above the full-width answer so enabling them never changes the Card layout. */}
+        <div data-study-answer-content="" className="flex min-h-full w-full">
           {backTextSlot}
         </div>
       </>

--- a/test/e2e/study-back-text.spec.ts
+++ b/test/e2e/study-back-text.spec.ts
@@ -141,7 +141,7 @@ test("SWIPE-21 runs the mapped right overlay action once and shows the next Card
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex + 1);
 });
 
-test("SWIPE-22 selects edge answer text beside overlays on a narrow viewport", async ({ fixture, page }) => {
+test("SWIPE-22 keeps the full answer width beneath overlays on a narrow viewport", async ({ fixture, page }) => {
   await page.setViewportSize({ width: 320, height: 568 });
   const deck = fixture.deck();
   const session = fixture.session();
@@ -149,28 +149,33 @@ test("SWIPE-22 selects edge answer text beside overlays on a narrow viewport", a
   await fixture.apply(page);
 
   await page.goto(`/deck/${deck.id}/study`);
-  await revealAnswer(page, currentCard.frontText);
+  const answerRegion = await revealAnswer(page, currentCard.frontText);
+  const answerContent = page.locator("[data-study-answer-content]");
+  const backTextSurface = answerContent.locator(":scope > *").first();
   const leftOverlayButton = page.getByRole("button", { name: "Swipe left" });
   const rightOverlayButton = page.getByRole("button", { name: "Swipe right" });
   const answerText = page.getByText(currentCard.backText, { exact: true });
-  const leftOverlay = await leftOverlayButton.boundingBox();
-  const rightOverlay = await rightOverlayButton.boundingBox();
-  const answerTextBounds = await answerText.boundingBox();
-  if (leftOverlay == null || rightOverlay == null || answerTextBounds == null) {
-    throw new Error("Expected visible answer text and back text overlays");
+  const answerRegionBounds = await answerRegion.boundingBox();
+  const backTextSurfaceBounds = await backTextSurface.boundingBox();
+  const leftOverlayBounds = await leftOverlayButton.boundingBox();
+  const rightOverlayBounds = await rightOverlayButton.boundingBox();
+  if (
+    answerRegionBounds == null ||
+    backTextSurfaceBounds == null ||
+    leftOverlayBounds == null ||
+    rightOverlayBounds == null
+  ) {
+    throw new Error("Expected visible answer region, back text, and overlays");
   }
 
-  expect(answerTextBounds.x).toBeGreaterThanOrEqual(leftOverlay.x + leftOverlay.width);
-  expect(answerTextBounds.x + answerTextBounds.width).toBeLessThanOrEqual(rightOverlay.x);
-
-  await selectBackText(page, currentCard.backText);
+  expect(backTextSurfaceBounds.x).toBe(answerRegionBounds.x);
+  expect(backTextSurfaceBounds.width).toBe(answerRegionBounds.width);
+  expect(leftOverlayBounds.x + leftOverlayBounds.width).toBeGreaterThan(backTextSurfaceBounds.x);
+  expect(rightOverlayBounds.x).toBeLessThan(backTextSurfaceBounds.x + backTextSurfaceBounds.width);
 
   await expect(answerText).toBeVisible();
   await expect(leftOverlayButton).toBeVisible();
   await expect(rightOverlayButton).toBeVisible();
-  await expect
-    .poll(async () => page.evaluate(() => window.getSelection()?.toString() ?? ""))
-    .toContain(currentCard.backText);
   await expect.poll(() => readProgress(currentCard.id)).toEqual(progressOf(currentCard));
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
 });


### PR DESCRIPTION
## Related issue
None

## Summary
- Float the back-text swipe overlays above the full-width Card answer.
- Preserve edge actions, scrollbar gutter, and wheel/touch scrolling behavior.
- Update SWIPE-22 coverage and its E2E contract for the floating layout.

## Testing
- mise run e2e (64 passed)
- mise run check (112 test files, 589 tests passed)