### PR TITLE
chore(#396): Apply final conflict resolution

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,4 +19,9 @@
 
 - The product is under active development. Do not preserve backward compatibility for store state unless explicitly requested.
 - Breaking changes to store state shape and behavior are allowed. Prefer the simplest current design over compatibility layers.
-- In particular, do not add migrations or retain legacy state formats for Zustand `persist`. Invalidate or discard incompatible persisted state instead.
+- Do not add migrations or retain legacy Zustand `persist` formats unless explicitly requested.
+- Keep the Preferences persist version at 1 unless a dedicated task explicitly changes it.
+- Do not bump a persist version solely because an additive field was introduced.
+- Additive fields that the current schema can safely default must remain compatible with the current version.
+- If existing state must be invalidated, document the reason and impact in a dedicated Issue.
+- Invalidate or discard persisted state that is genuinely incompatible with the current schema.

--- a/src/entities/preference/model/schema.ts
+++ b/src/entities/preference/model/schema.ts
@@ -96,7 +96,7 @@ export const controlPreferencesSchema = z
 export const preferencesSchema = z
   .object({
     loadSample: z.boolean().catch(DEFAULT_LOAD_SAMPLE),
-    // Storage version 2 predates this field, so recover it locally without discarding the rest of the snapshot.
+    // Language is additive within persistence version 1, so recover it without discarding the rest of the snapshot.
     language: languagePreferenceSchema.catch(DEFAULT_LANGUAGE),
     appearance: appearancePreferencesSchema,
     study: studyPreferencesSchema,

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -71,6 +71,27 @@ describe("preferences store", () => {
     });
   });
 
+  it.each(["system", "en", "ja"] as const)(
+    "updates and persists the %s language without resetting other preferences",
+    (language) => {
+      const storage = useMemoryStorage();
+      preferencesStore.getState().updatePreferences({ appearance: { darkMode: true } });
+
+      preferencesStore.getState().updatePreferences({ language });
+
+      const expectedPreferences = {
+        ...defaultPreferences,
+        language,
+        appearance: { ...defaultPreferences.appearance, darkMode: true },
+      };
+      expect(preferencesStore.getState().preferences).toEqual(expectedPreferences);
+      expect(JSON.parse(storage.getItem("tango-config") ?? "{}")).toEqual({
+        state: { preferences: expectedPreferences },
+        version: 1,
+      });
+    }
+  );
+
   it("validates numeric ranges during updates", () => {
     const store = preferencesStore;
 
@@ -134,10 +155,13 @@ describe("preferences store", () => {
   });
 
   it("hydrates version 1 preferences with defaults for additive fields", async () => {
-    const { showBackTextSwipeOverlays: _showBackTextSwipeOverlays, ...controlsBeforeSwipeOverlays } =
-      defaultPreferences.controls;
+    const {
+      language: _language,
+      controls: { showBackTextSwipeOverlays: _showBackTextSwipeOverlays, ...controlsBeforeSwipeOverlays },
+      ...preferencesBeforeAdditiveFields
+    } = defaultPreferences;
     const persistedPreferences = {
-      ...defaultPreferences,
+      ...preferencesBeforeAdditiveFields,
       loadSample: false,
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
@@ -151,6 +175,7 @@ describe("preferences store", () => {
 
     expect(preferencesStore.getState().preferences).toEqual({
       ...persistedPreferences,
+      language: "system",
       controls: { ...persistedPreferences.controls, showBackTextSwipeOverlays: false },
     });
   });

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -7,8 +7,8 @@ import { preferencesSchema } from "./schema";
 import type { Preferences } from "./types";
 
 const PREFERENCES_STORAGE_KEY = "tango-config";
-// No migration is registered: changing this version deliberately invalidates older state shapes.
-const PREFERENCES_STORAGE_VERSION = 2;
+// Keep this stable for safely defaultable additions; a dedicated task must justify invalidating existing preferences.
+const PREFERENCES_STORAGE_VERSION = 1;
 
 /** @internal Partial updates for each top-level preference field. */
 export type PartialPreferences = {

--- a/src/features/deck-filter/model/useDeckFilterState.spec.tsx
+++ b/src/features/deck-filter/model/useDeckFilterState.spec.tsx
@@ -272,7 +272,6 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     renderFilter();
 
-    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
     expect(screen.getByRole("checkbox", { name: "Match all selected tags" })).toBeChecked();
@@ -295,7 +294,6 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     view = renderFilter();
 
-    expect(screen.getByText("−2 to 2")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("2");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("-2");
 
@@ -304,7 +302,7 @@ describe("DeckFilterForm with useDeckFilterState", () => {
     view.unmount();
     renderFilter();
 
-    expect(screen.getByText("Any score")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });

--- a/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
+++ b/src/features/deck-filter/ui/DeckFilterForm.spec.tsx
@@ -38,7 +38,6 @@ describe("DeckFilterForm", () => {
     const maximum = within(scoreRegion).getByRole("combobox", { name: "Maximum score" });
     const minimum = within(scoreRegion).getByRole("combobox", { name: "Minimum score" });
 
-    expect(within(scoreRegion).getByText("−2 to 4")).toBeInTheDocument();
     expect(maximum).toHaveValue("4");
     expect(minimum).toHaveValue("-2");
 
@@ -54,7 +53,8 @@ describe("DeckFilterForm", () => {
 
   it("shows unrestricted limits", () => {
     render(<DeckFilterForm {...createProps()} scoreMax={null} scoreMin={null} />);
-    expect(screen.getByText("Any score")).toBeInTheDocument();
+    const scoreRegion = screen.getByRole("region", { name: "Score range" });
+    expect(within(scoreRegion).queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Maximum score" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveValue("");
   });

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen, within } from "@testing-library/react";
+import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -32,14 +33,13 @@ describe("ScoreRange", () => {
     expect(numericOptionValues(maximum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
     expect(minimum).toHaveAccessibleDescription("Include cards at or above this score.");
     expect(maximum).toHaveAccessibleDescription("Include cards at or below this score.");
-    expect(screen.getByText("Any score")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Clear limits" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
-  it("reports native selections and summarizes two-sided and one-sided limits", async () => {
+  it("reports native selections", async () => {
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
-    const view = render(
+    render(
       <ScoreRange
         maximum={4}
         minimum={-2}
@@ -49,33 +49,10 @@ describe("ScoreRange", () => {
       />
     );
 
-    expect(screen.getByText("−2 to 4")).toBeInTheDocument();
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "-1");
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "3");
     expect(onMinimumChange).toHaveBeenCalledWith(-1);
     expect(onMaximumChange).toHaveBeenCalledWith(3);
-
-    view.rerender(
-      <ScoreRange
-        maximum={null}
-        minimum={-2}
-        onClear={vi.fn()}
-        onMaximumChange={onMaximumChange}
-        onMinimumChange={onMinimumChange}
-      />
-    );
-    expect(screen.getByText("−2 and above")).toBeInTheDocument();
-
-    view.rerender(
-      <ScoreRange
-        maximum={4}
-        minimum={null}
-        onClear={vi.fn()}
-        onMaximumChange={onMaximumChange}
-        onMinimumChange={onMinimumChange}
-      />
-    );
-    expect(screen.getByText("4 and below")).toBeInTheDocument();
   });
 
   it("preserves saved scores outside the standard integer choices", () => {
@@ -96,7 +73,6 @@ describe("ScoreRange", () => {
     expect(maximum).toHaveValue("14.25");
     expect(within(minimum).getByRole("option", { name: "−12.5" })).toBeInTheDocument();
     expect(within(maximum).getByRole("option", { name: "14.25" })).toBeInTheDocument();
-    expect(screen.getByText("−12.5 to 14.25")).toBeInTheDocument();
   });
 
   it("limits new choices to a valid range while retaining the active choices", () => {
@@ -130,6 +106,33 @@ describe("ScoreRange", () => {
     expect(onClear).toHaveBeenCalledOnce();
     expect(onMinimumChange).not.toHaveBeenCalled();
     expect(onMaximumChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps focus in the range controls and announces when limits are cleared", async () => {
+    const ControlledScoreRange = () => {
+      const [maximum, setMaximum] = useState<number | null>(4);
+      const [minimum, setMinimum] = useState<number | null>(-2);
+
+      return (
+        <ScoreRange
+          maximum={maximum}
+          minimum={minimum}
+          onClear={() => {
+            setMaximum(null);
+            setMinimum(null);
+          }}
+          onMaximumChange={setMaximum}
+          onMinimumChange={setMinimum}
+        />
+      );
+    };
+
+    render(<ControlledScoreRange />);
+    await userEvent.click(screen.getByRole("button", { name: "Clear limits" }));
+
+    expect(screen.getByRole("combobox", { name: "Minimum score" })).toHaveFocus();
+    expect(screen.getByRole("status")).toHaveTextContent("No score limits.");
+    expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
   it("shows an invalid saved range without mutating it and allows both recovery paths", async () => {

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -2,7 +2,7 @@
  * @file Defines the deck filter's score range presentation component.
  */
 
-import { useId } from "react";
+import { useId, useRef } from "react";
 import type * as React from "react";
 
 import { Button } from "@/shared/ui/button";
@@ -37,11 +37,11 @@ interface ScoreSelectProps {
 
 const displayScore = (value: number): string => String(value).replace("-", "−");
 
-const scoreRangeLabel = (minimum: number | null, maximum: number | null): string => {
-  if (minimum != null && maximum != null) return `${displayScore(minimum)} to ${displayScore(maximum)}`;
-  if (minimum != null) return `${displayScore(minimum)} and above`;
-  if (maximum != null) return `${displayScore(maximum)} and below`;
-  return "Any score";
+const scoreRangeStatus = (minimum: number | null, maximum: number | null): string => {
+  if (minimum != null && maximum != null) return `Score range: ${displayScore(minimum)} to ${displayScore(maximum)}.`;
+  if (minimum != null) return `Minimum score: ${displayScore(minimum)}. No maximum score.`;
+  if (maximum != null) return `Maximum score: ${displayScore(maximum)}. No minimum score.`;
+  return "No score limits.";
 };
 
 const scoreOptions = (
@@ -60,14 +60,18 @@ const scoreOptions = (
     .sort((left, right) => left - right);
 };
 
-const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
-  <div className="rounded-control bg-surface-muted p-3">
-    <label htmlFor={props.id} className="text-body font-medium text-ink">
+const ScoreSelect = ({
+  ref: selectRef,
+  ...props
+}: ScoreSelectProps & { ref?: React.RefObject<HTMLSelectElement | null> }) => (
+  <div className="min-w-0">
+    <label htmlFor={props.id} className="text-caption font-medium text-ink-muted">
       {props.label}
     </label>
     <Select
+      ref={selectRef}
       id={props.id}
-      className="mt-2"
+      className="mt-1"
       value={props.value == null ? NO_LIMIT_VALUE : String(props.value)}
       aria-label={`${props.label} score`}
       aria-describedby={props.describedBy}
@@ -80,7 +84,7 @@ const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
         props.onChange(event.currentTarget.value === NO_LIMIT_VALUE ? null : Number(event.currentTarget.value))
       }
     />
-    <p id={`${props.id}-description`} className="mt-1 text-caption text-ink-muted">
+    <p id={`${props.id}-description`} className="sr-only">
       {props.description}
     </p>
   </div>
@@ -91,6 +95,7 @@ const ScoreSelect: React.FC<ScoreSelectProps> = (props) => (
  */
 export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
   const idPrefix = useId();
+  const minimumSelectRef = useRef<HTMLSelectElement>(null);
   const headingId = `${idPrefix}-score-heading`;
   const minimumId = `${idPrefix}-minimum-score`;
   const maximumId = `${idPrefix}-maximum-score`;
@@ -104,33 +109,30 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
   return (
     <section
       aria-labelledby={headingId}
-      className="space-y-4 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
+      className="space-y-3 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
     >
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 id={headingId} className="text-title font-semibold text-ink">
-            Score range
-          </h2>
-          <p className="mt-1 text-caption text-ink-muted">Limit cards by their current score.</p>
-        </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <span
-            aria-live="polite"
-            className="rounded-control bg-surface-muted px-2 py-1 text-caption font-bold text-accent-primary"
-          >
-            {scoreRangeLabel(props.minimum, props.maximum)}
-          </span>
-          <Button
-            variant="quiet"
-            size="sm"
-            label="Clear limits"
-            disabled={props.minimum == null && props.maximum == null}
-            onClick={props.onClear}
-          />
-        </div>
+      <header className="flex items-center justify-between gap-3">
+        <h2 id={headingId} className="text-title font-semibold text-ink">
+          Score range
+        </h2>
+        <Button
+          variant="quiet"
+          size="sm"
+          className="border-0 text-accent-primary"
+          hidden={props.minimum == null && props.maximum == null}
+          onClick={() => {
+            props.onClear();
+            // The clear action hides its own button on the next render, so keyboard focus must move
+            // to a stable control before that render commits.
+            minimumSelectRef.current?.focus();
+          }}
+        >
+          Clear <span className="sr-only">limits</span>
+        </Button>
       </header>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2 sm:gap-3">
         <ScoreSelect
+          ref={minimumSelectRef}
           id={minimumId}
           label="Minimum"
           value={props.minimum}
@@ -140,6 +142,9 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           description="Include cards at or above this score."
           onChange={props.onMinimumChange}
         />
+        <span aria-hidden="true" className="flex min-h-touch items-center text-caption text-ink-muted">
+          to
+        </span>
         <ScoreSelect
           id={maximumId}
           label="Maximum"
@@ -151,6 +156,9 @@ export const ScoreRange: React.FC<ScoreRangeProps> = (props) => {
           onChange={props.onMaximumChange}
         />
       </div>
+      <p role="status" aria-live="polite" className="sr-only">
+        {scoreRangeStatus(props.minimum, props.maximum)}
+      </p>
       {invalid ? (
         <p id={warningId} role="alert" className="rounded-control border border-danger p-3 text-caption text-danger">
           Minimum score must not be greater than maximum score.

--- a/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
@@ -108,6 +108,7 @@ describe("CardListPage interactions", () => {
   it("builds the list presentation and coordinates filter, view, and edit interactions", async () => {
     renderCardList();
 
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
     expect(screen.getByText("score -2–4 · 2 tags")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Remove typescript filter" }));
     expect(screen.queryByRole("button", { name: "Remove typescript filter" })).not.toBeInTheDocument();
@@ -115,8 +116,10 @@ describe("CardListPage interactions", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "View Front" }));
     expect(screen.getByText("Back")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "tango" })).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Close card" }));
     expect(screen.queryByText("Back")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "tango" })).toBeVisible();
 
     await userEvent.click(screen.getByRole("button", { name: "Open actions for Front" }));
     await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -27,7 +27,7 @@ const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
   });
 
   return (
-    <AppLayout showHeader>
+    <AppLayout showHeader={state.answer == null}>
       <Feedback tone="error">{state.mutationError == null ? null : "Unable to save changes. Try again."}</Feedback>
       <Feedback tone="success">{state.successMessage}</Feedback>
       {state.deletionTarget != null ? (

--- a/src/pages/settings/ui/SettingsForm.spec.tsx
+++ b/src/pages/settings/ui/SettingsForm.spec.tsx
@@ -50,6 +50,8 @@ describe("SettingsForm", () => {
     expect(playback).toBeChecked();
     expect(backTextSwipeOverlays).not.toBeChecked();
     expect(cardDetails).toBeChecked();
+    expect(language).toHaveValue("system");
+    expect(language).toHaveDisplayValue("System");
     expect(screen.getByText("Display left and right study actions while viewing an answer")).toBeInTheDocument();
     expect(maximumCards).toHaveValue("24");
 
@@ -105,6 +107,7 @@ describe("SettingsForm", () => {
 
     expect(screen.getByRole("heading", { level: 1, name: "設定" })).toBeVisible();
     expect(screen.getByRole("combobox", { name: "言語" })).toHaveDisplayValue("System");
+    expect(screen.getByRole("checkbox", { name: "裏面のスワイプ操作を表示" })).toBeVisible();
     expect(screen.getByRole("checkbox", { name: "ダークモード" })).toBeVisible();
     expect(screen.getByRole("slider", { name: "最大カード数" })).toHaveAttribute("aria-valuetext", "24枚");
     expect(screen.getByRole("slider", { name: "自動再生の間隔" })).toHaveAttribute("aria-valuetext", "7秒");

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -101,8 +101,8 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
           </SettingsRow>
           <SettingsRow
             inputId={inputIds.showBackTextSwipeOverlays}
-            label="Show back text swipe overlays"
-            description="Display left and right study actions while viewing an answer"
+            label={t("settings.appearance.showBackTextSwipeOverlays.label")}
+            description={t("settings.appearance.showBackTextSwipeOverlays.help")}
           >
             <Switch
               {...props.form.register("controls.showBackTextSwipeOverlays")}

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -201,18 +201,6 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
         <AiOutlineLeft aria-hidden="true" className="text-xl" />
       </button>
       <button
-        ref={helpTriggerRef}
-        type="button"
-        aria-label={props.helpTriggerLabel}
-        className={cx(
-          toolbarButtonClass,
-          "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
-        )}
-        onClick={props.onOpenHelp}
-      >
-        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
-      </button>
-      <button
         ref={triggerRef}
         type="button"
         aria-label={props.open ? "Close study actions" : "Open study actions"}
@@ -238,6 +226,19 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
           aria-label="Study actions"
           className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
         >
+          <button
+            ref={helpTriggerRef}
+            type="button"
+            aria-label={props.helpTriggerLabel}
+            className={cx(
+              toolbarButtonClass,
+              "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+            )}
+            onClick={props.onOpenHelp}
+            onKeyDown={closeOnEscape}
+          >
+            <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
+          </button>
           <StudyModeActions
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -214,6 +214,8 @@ describe("StudySessionPage", () => {
     renderPage();
     const sessionBeforeHelp = getStudySession(deckId);
 
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
+    openStudyActions();
     const trigger = screen.getByRole("button", { name: "Open study help" });
     fireEvent.click(trigger);
     expect(trigger).not.toHaveFocus();
@@ -248,6 +250,7 @@ describe("StudySessionPage", () => {
     document.documentElement.lang = "ja-JP";
     renderPage();
 
+    openStudyActions();
     fireEvent.click(screen.getByRole("button", { name: "学習ヘルプを開く" }));
 
     expect(screen.getByRole("dialog", { name: "学習画面の操作" })).toHaveTextContent(
@@ -263,6 +266,7 @@ describe("StudySessionPage", () => {
 
     try {
       renderPage();
+      openStudyActions();
       fireEvent.click(screen.getByRole("button", { name: "Open study help" }));
 
       act(() => vi.advanceTimersByTime(1000));

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -287,7 +287,7 @@ export const seedConfig = async (page: Page, overrides: E2EConfigOverrides = {})
     // Seed only the first app document so reload assertions observe mutations made by the application.
     if (!window.location.origin.startsWith("http")) return;
     if (window.sessionStorage.getItem("tango-e2e-config-seeded") !== null) return;
-    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 2 }));
+    window.localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: value }, version: 1 }));
     window.sessionStorage.setItem("tango-e2e-config-seeded", "true");
   }, config);
 };

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -349,6 +349,8 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
 
   await page.goto(`/deck/${deck.id}/study`);
   const progressBeforeHelp = await readProgress(currentCard.id);
+  await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Open study actions" }).click();
   await page.getByRole("button", { name: "Open study help" }).click();
 
   const dialog = page.getByRole("dialog", { name: "Study controls" });


### PR DESCRIPTION
## Summary

- replace the temporary conflict-neutralizing tree with the reviewed #396 localization on current main
- preserve Preferences persistence version 1 and additive language hydration
- carry forward the latest upstream score-range, study-help, and Card List fixes

## Testing

- mise run check (113 test files, 605 tests)
- npm run test:storybook (61 test files, 382 tests)
- focused post-rebase unit tests (34 tests)

## Review

- mandatory review round 2: no P0, P1, or P2 findings