### PR TITLE
fix(#952): Address study completion review feedback

### DIFF
--- a/src/pages/study-session/ui/StudyCompletion.spec.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.spec.tsx
@@ -9,9 +9,9 @@ describe("StudyCompletion", () => {
     const onClickBack = vi.fn();
     render(<StudyCompletion cardCount={1} onClickBack={onClickBack} />);
 
-    expect(screen.getByRole("heading", { name: "Study complete" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Study complete" })).toHaveFocus();
     expect(screen.getByText("You studied 1 card.")).toBeVisible();
-    expect(screen.getByRole("status")).toHaveFocus();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
     expect(onClickBack).toHaveBeenCalledOnce();

--- a/src/pages/study-session/ui/StudyCompletion.tsx
+++ b/src/pages/study-session/ui/StudyCompletion.tsx
@@ -10,23 +10,20 @@ export interface StudyCompletionProps {
 const cardsLabel = (count: number) => `${String(count)} ${count === 1 ? "card" : "cards"}`;
 
 export const StudyCompletion: FC<StudyCompletionProps> = ({ cardCount, onClickBack }) => {
-  const completionRef = useRef<HTMLElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
     // The swipe control disappears asynchronously, so focus the result to make the transition perceivable.
-    completionRef.current?.focus();
+    titleRef.current?.focus();
   }, []);
 
   return (
     <section
-      ref={completionRef}
-      role="status"
-      tabIndex={-1}
       aria-labelledby="study-completion-title"
       className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-6 text-center text-ink shadow-surface"
     >
       <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Session complete</p>
-      <h1 id="study-completion-title" className="mt-1 text-display font-bold">
+      <h1 ref={titleRef} id="study-completion-title" tabIndex={-1} className="mt-1 text-display font-bold">
         Study complete
       </h1>
       <p className="mt-3 text-body text-ink-muted">You studied {cardsLabel(cardCount)}.</p>

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -2,7 +2,7 @@ import type { Preferences } from "@/entities/preference";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -50,6 +50,18 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { StudySessionPage } from "./StudySessionPage";
 
+const DeckListDestination = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <h1>Deck list destination</h1>
+      <button type="button" onClick={() => void navigate(-1)}>
+        Browser back
+      </button>
+    </>
+  );
+};
+
 describe("StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
@@ -71,15 +83,18 @@ describe("StudySessionPage", () => {
     score: 1,
     numberOfSeen: 4,
   });
-  const renderPage = (path = `/deck/${deckId}/study`) =>
-    render(
-      <MemoryRouter initialEntries={[path]}>
+  const renderPage = (path = `/deck/${deckId}/study`, previousPath?: string) => {
+    const initialEntries = previousPath === undefined ? [path] : [previousPath, path];
+    return render(
+      <MemoryRouter initialEntries={initialEntries} initialIndex={initialEntries.length - 1}>
         <Routes>
-          <Route path="/" element={<h1>Deck list destination</h1>} />
+          <Route path="/" element={<DeckListDestination />} />
+          <Route path="/previous" element={<h1>Previous destination</h1>} />
           <Route path="/deck/:id/study" element={<StudySessionPage />} />
         </Routes>
       </MemoryRouter>
     );
+  };
   const openStudyActions = () => {
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
     return screen.getByRole("group", { name: "Study actions" });
@@ -294,7 +309,7 @@ describe("StudySessionPage", () => {
 
   it("keeps the completion screen on the Study route and disables Study shortcuts", async () => {
     setStudySessionIndex(deckId, 1);
-    renderPage();
+    renderPage(`/deck/${deckId}/study`, "/previous");
 
     fireEvent.click(screen.getByRole("button", { name: "Swipe up" }));
 
@@ -305,6 +320,13 @@ describe("StudySessionPage", () => {
 
     fireEvent.keyDown(window, { key: "ArrowUp" });
     expect(mocks.editStudyProgress).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to deck list" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Browser back" }));
+    expect(screen.getByRole("heading", { level: 1, name: "Previous destination" })).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 1, name: "Study complete" })).not.toBeInTheDocument();
   });
 
   it("keeps study actions available while the Header stays hidden", () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -158,7 +158,7 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
         <StudyCompletion
           cardCount={study.completion.cardCount}
           onClickBack={() => {
-            void navigate(routes.deckList.to());
+            void navigate(routes.deckList.to(), { replace: true });
           }}
         />
       </AppLayout>


### PR DESCRIPTION
## Related issue

Fixes #952

## Summary

- Focus the completion heading instead of a live status region.
- Replace the terminal Study history entry when returning to the deck list.
- Verify browser Back reaches the route preceding the Study session.

## Testing

- mise run check
- npm run test:unit -- src/pages/study-session/ui/StudyCompletion.spec.tsx src/pages/study-session/ui/StudySessionPage.spec.tsx