### PR TITLE
fix(#947): Address Study persistence review comments

### DIFF
--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -64,10 +64,20 @@ describe("StudyProgress mutations", () => {
     expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
   });
 
-  it("rejects a verified remote identity for another Card", async () => {
+  it("writes progress for a resolved local Card despite an ambiguous global lookup", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "local", score: 2 }, { persistence: "local", cardId: "local" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({ id: "local", score: 2 });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a resolved persistence identity for another Card", async () => {
     await expect(
       editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "other-card" })
-    ).rejects.toThrow("Verified Card identity does not match progress");
+    ).rejects.toThrow("Resolved Card identity does not match progress");
 
     expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
   });

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,19 +1,25 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { studyProgressEditSchema } from "../model/schema";
-import type { RemoteStudyProgressTarget, StudyProgressEdit } from "../model/types";
+import type { StudyProgressEdit, StudyProgressTarget } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
 export const editStudyProgress = async (
   uid: string,
   progress: StudyProgressEdit,
-  verifiedTarget?: RemoteStudyProgressTarget
+  target?: StudyProgressTarget
 ): Promise<void> => {
   const edit = studyProgressEditSchema.parse(progress);
-  if (verifiedTarget !== undefined) {
-    if (verifiedTarget.cardId !== edit.cardId) throw new Error("Verified Card identity does not match progress");
-    await editRemoteStudyProgress(uid, edit);
+  if (target !== undefined) {
+    if (target.cardId !== edit.cardId) throw new Error("Resolved Card identity does not match progress");
+    if (target.persistence === "remote") {
+      await editRemoteStudyProgress(uid, edit);
+      return;
+    }
+
+    const { cardId: id, ...fields } = edit;
+    editLocalCardStudyProgress(omitUndefined({ id, ...fields }));
     return;
   }
 

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,2 +1,2 @@
 export { editStudyProgress } from "./api/mutations";
-export type { StudyProgressEdit } from "./model/types";
+export type { StudyProgressEdit, StudyProgressTarget } from "./model/types";

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -29,11 +29,8 @@ export interface StudyProgressDocumentFields {
 /** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
-/** Server-verified remote identity that permits a write before the Card subscription publishes its snapshot. */
-export interface RemoteStudyProgressTarget {
-  persistence: "remote";
-  cardId: CardId;
-}
+/** Persistence identity already resolved by the consuming model, independent of ambiguous same-ID store entries. */
+export type StudyProgressTarget = { persistence: "local"; cardId: CardId } | { persistence: "remote"; cardId: CardId };
 
 /** Learning outcome derived from one study interaction. */
 export type StudyRating = "mastered" | "not-mastered" | "unrated";

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -13,7 +13,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
-import { createDeck, createLocalDeck, createPreferences } from "@/test/factories";
+import { createDeck, createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
@@ -129,7 +129,10 @@ describe("useStudy", () => {
 
     await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-2" } }));
     expect(result.current).toMatchObject({ showBackText: false, swipeFeedback: "cardSwipeRight" });
-    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
   });
 
   it("reports unavailable after the server confirms a missing remote target", async () => {
@@ -157,10 +160,27 @@ describe("useStudy", () => {
     expect(getStudySession(deckId)).toBeDefined();
   });
 
-  it("uses an active server result while the Card subscription catches up", async () => {
+  it("writes the displayed local Card while a same-ID remote copy overlaps migration", async () => {
+    const localCard = createLocalCard({ id: "card-1", deckId, frontText: "local card" });
+    mocks.deck = createLocalDeck({ id: deckId });
+    mocks.cards = [cards[0] as Card, localCard];
+    clearStudySessions();
+    startStudy(deckId, [localCard], { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current).toMatchObject({ status: "studying", card: { frontText: "local card" } });
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "local",
+      cardId: "card-1",
+    });
+  });
+
+  it("writes the verified remote Card while a same-ID local copy overlaps subscription catch-up", async () => {
     const [currentCard] = cards;
     if (currentCard == null || !("uid" in currentCard)) throw new Error("Expected a remote Card");
-    mocks.cards = [];
+    mocks.cards = [createLocalCard({ id: currentCard.id, deckId, frontText: "same-ID local copy" })];
     mocks.fetchRemoteCardRead.mockResolvedValue({
       status: "active",
       read: {

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -31,17 +31,16 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipeCards =
-    sessionState.status === "studying" && !cards.some(({ id }) => id === sessionState.card.id)
-      ? [...cards, sessionState.card]
-      : cards;
-  const verifiedRemoteCardId =
-    sessionState.status === "studying" &&
-    "uid" in sessionState.card &&
-    !cards.some(({ id }) => id === sessionState.card.id)
-      ? sessionState.card.id
+  // Use the exact displayed Card because local-to-remote migration can temporarily leave both persistence modes
+  // with the same ID; swipe planning and writes must follow the Deck-scoped Card selected above.
+  const swipeCards = sessionState.status === "studying" ? [sessionState.card] : [];
+  const persistenceTarget =
+    sessionState.status === "studying"
+      ? "uid" in sessionState.card
+        ? { persistence: "remote" as const, cardId: sessionState.card.id }
+        : { persistence: "local" as const, cardId: sessionState.card.id }
       : undefined;
-  const swipe = useSwipe(deckId, swipeCards, hideBackText, verifiedRemoteCardId);
+  const swipe = useSwipe(deckId, swipeCards, hideBackText, persistenceTarget);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -2,7 +2,7 @@ import { useAuthUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
-import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressEdit, type StudyProgressTarget } from "@/entities/study-progress";
 import { getStudySession, moveStudySession, planStudySessionSwipe, removeStudySession } from "@/entities/study-session";
 
 import * as React from "react";
@@ -20,17 +20,14 @@ export interface SwipeState {
 const persistStudyProgress = (
   uid: string,
   progress: StudyProgressEdit,
-  verifiedRemoteCardId: Card["id"] | undefined
-): Promise<void> =>
-  verifiedRemoteCardId === progress.cardId
-    ? editStudyProgress(uid, progress, { persistence: "remote", cardId: verifiedRemoteCardId })
-    : editStudyProgress(uid, progress);
+  target: StudyProgressTarget | undefined
+): Promise<void> => editStudyProgress(uid, progress, target);
 
 export const useSwipe = (
   deckId: DeckId,
   cards: readonly Card[],
   onCardChanged: () => void,
-  verifiedRemoteCardId?: Card["id"]
+  target?: StudyProgressTarget
 ): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
@@ -52,7 +49,7 @@ export const useSwipe = (
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saveProgress = persistStudyProgress(uid, swipePlan.progress, verifiedRemoteCardId);
+    const saveProgress = persistStudyProgress(uid, swipePlan.progress, target);
     const saved = await saveProgress.then(
       () => true,
       () => false

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -169,7 +169,8 @@ describe("StudySessionPage", () => {
     expect(screen.queryByText("Back two")).not.toBeInTheDocument();
     expect(mocks.editStudyProgress).toHaveBeenCalledExactlyOnceWith(
       "user-id",
-      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 })
+      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 }),
+      { persistence: "local", cardId: "first-card" }
     );
     expect(getStudySession(deckId)?.currentIndex).toBe(1);
   });

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -111,9 +111,8 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     await deleteDeck("uid", d.id);
 
     await expect(getDoc(doc(db, "deck", d.id))).rejects.toMatchObject({ code: "permission-denied" });
-    await Promise.all(
-      cards.map((card) => expect(getDoc(doc(db, "card", card.id))).rejects.toMatchObject({ code: "permission-denied" }))
-    );
+    const deletedCardSnapshots = await Promise.all(cards.map((card) => getDoc(doc(db, "card", card.id))));
+    expect(deletedCardSnapshots.every((snapshot) => !snapshot.exists())).toBe(true);
   });
 
   it("moves a local Deck and its Cards to Firestore when local mode is disabled", async () => {


### PR DESCRIPTION
## Summary

- route Study progress through the exact displayed Card's local or remote persistence identity
- cover same-ID local/remote overlap in both directions
- align the Firestore deletion integration assertion with the missing-document read contract

## Validation

- focused unit tests: 52 passed
- focused Firestore integration tests: 5 passed
- `mise run check`: 113 files, 601 tests passed
- `mise run e2e`: 67 passed
- mandatory reviewer round 2: no findings

Follow-up for #1351.