### PR TITLE
fix(#947): Verify missing Study session cards

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -141,6 +141,9 @@
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](./study.md#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](./study.md#swipe-24) |
+| SWIPE-25 | read | [remote target Card の欠損を確認して unavailable と表示できる](./study.md#swipe-25) |
+| SWIPE-26 | read | [remote target Card の確認失敗時に session を維持できる](./study.md#swipe-26) |
+| SWIPE-27 | read | [local target Card の欠損を unavailable と表示できる](./study.md#swipe-27) |
 
 ### Study Back Text
 

--- a/docs/e2e/fixture/study-session-local-absent.yaml
+++ b/docs/e2e/fixture/study-session-local-absent.yaml
@@ -1,0 +1,11 @@
+extends: local-deck-with-cards.yaml
+browser:
+  absentCards:
+    - id: missing-card
+      deckId: deck-1
+  studySessions:
+    deck-1:
+      sessionId: session-1
+      deckId: deck-1
+      cardOrderIds: [missing-card]
+      currentIndex: 0

--- a/docs/e2e/fixture/study-session-remote-absent.yaml
+++ b/docs/e2e/fixture/study-session-remote-absent.yaml
@@ -1,0 +1,11 @@
+extends: study-session-start.yaml
+remote:
+  absentCards:
+    - id: missing-card
+      uid: user-1
+      deckId: deck-1
+browser:
+  studySessions:
+    deck-1:
+      cardOrderIds: [missing-card]
+      currentIndex: 0

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -24,6 +24,9 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](#swipe-24) |
+| SWIPE-25 | read | [remote target Card の欠損を確認して unavailable と表示できる](#swipe-25) |
+| SWIPE-26 | read | [remote target Card の確認失敗時に session を維持できる](#swipe-26) |
+| SWIPE-27 | read | [local target Card の欠損を unavailable と表示できる](#swipe-27) |
 
 <a id="swipe-02"></a>
 
@@ -395,4 +398,70 @@ Then:
 - 非表示の操作ボタンは現在の設定と一致する説明で表示される。
 - dialog 内のキー入力で Card、学習結果、session の位置が変更されない。
 - focus が dialog 内に維持され、閉じた後は Help trigger へ戻る。
+- browser error が発生しない。
+
+<a id="swipe-25"></a>
+
+### SWIPE-25 remote target Card の欠損を確認して unavailable と表示できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-remote-absent`](./fixture/study-session-remote-absent.yaml)
+- 認証済みユーザーが所有する remote Deck に、物理 document が存在しない Card を参照する session が存在する。
+
+When:
+
+- 対象の学習画面を開く。
+
+Then:
+
+- target Card が server で missing と確認された後、現在の Card が利用できないことが表示される。
+- Deck 一覧へ自動 redirect されない。
+- recovery UI が追加されるまで active session は維持される。
+- browser error が発生しない。
+
+<a id="swipe-26"></a>
+
+### SWIPE-26 remote target Card の確認失敗時に session を維持できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-remote-absent`](./fixture/study-session-remote-absent.yaml)
+- 認証済みユーザーが所有する remote Deck に、target Card の server verification が permission error になる session が存在する。
+
+When:
+
+- 対象の学習画面を開く。
+
+Then:
+
+- target Card を確認できなかったことが表示される。
+- missing または unavailable として扱われず、Deck 一覧へ自動 redirect されない。
+- active session と現在位置が維持される。
+- browser error が発生しない。
+
+<a id="swipe-27"></a>
+
+### SWIPE-27 local target Card の欠損を unavailable と表示できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-local-absent`](./fixture/study-session-local-absent.yaml)
+- browser storage の local-only Deck に、永続 Card が存在しない target を参照する session が存在する。
+
+When:
+
+- 対象の学習画面を開く。
+
+Then:
+
+- local Card hydration 完了後、現在の Card が利用できないことが表示される。
+- remote verification を待たず、Deck 一覧へ自動 redirect されない。
+- recovery UI が追加されるまで active session は維持される。
 - browser error が発生しない。

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,10 @@ service cloud.firestore {
       function belongsToDeck() {
         return getDeck(request.resource.data.deckId).data.uid == request.auth.uid
       }
-      allow read: if isOwner() || isPublic();
+      // Authenticated single-document verification must distinguish an absent target from a forbidden existing Card.
+      allow get: if (request.auth != null && !exists(/databases/$(database)/documents/card/$(cardId))) ||
+                    isOwner() || isPublic();
+      allow list: if isOwner() || isPublic();
       allow create: if isValid() && belongsToDeck();
       allow update: if isValidOwner() && belongsToDeck();
       allow delete: if isOwner();

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -9,7 +9,17 @@ import type {
   RemoteCardRead,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  onSnapshot,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 
 import { mapStudyProgressDocument, type StudyProgress } from "@/entities/study-progress/@x/card";
 import { db } from "@/shared/firebase";
@@ -27,6 +37,12 @@ export interface CardRead {
   card: RemoteCardRead;
   progress: StudyProgress;
 }
+
+/** Server-confirmed physical state for one remote Card document. */
+export type RemoteCardReadResult =
+  | { status: "active"; read: CardRead }
+  | { status: "missing" }
+  | { status: "tombstoned" };
 
 /** Maps one physical Card document into independent Card and StudyProgress read models. */
 const mapCardRead = (id: CardId, value: unknown): CardRead => {
@@ -81,6 +97,16 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
 export const fetchCardReads = async (uid: string): Promise<CardRead[]> => {
   const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return mapActiveCardReads(snapshot.docs);
+};
+
+/** Reads one Card from the server without treating a collection snapshot miss as deletion. */
+export const fetchRemoteCardRead = async (uid: string, cardId: CardId): Promise<RemoteCardReadResult> => {
+  const snapshot = await getDocFromServer(doc(db, CARD_COLLECTION, cardId));
+  if (!snapshot.exists()) return { status: "missing" };
+
+  const read = mapCardRead(cardId, snapshot.data());
+  if (read.card.uid !== uid) throw new Error("Card owner does not match the authenticated user");
+  return read.card.deletedAt === null ? { status: "active", read } : { status: "tombstoned" };
 };
 
 /** Writes a new physical Card document with synchronized creation and update timestamps. */

--- a/src/entities/card/api/remote-read.spec.ts
+++ b/src/entities/card/api/remote-read.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn((...parts: unknown[]) => parts),
+  getDocFromServer: vi.fn(),
+  getDocsFromServer: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  doc: mocks.doc,
+  getDocFromServer: mocks.getDocFromServer,
+  getDocsFromServer: mocks.getDocsFromServer,
+  onSnapshot: vi.fn(),
+  query: mocks.query,
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  where: vi.fn(),
+}));
+vi.mock("@/shared/firebase", () => ({ db: "db" }));
+
+import { fetchRemoteCardRead } from "./firestore";
+
+const cardDocument = (overrides: Record<string, unknown> = {}) => ({
+  frontText: "Front",
+  backText: "Back",
+  tags: [],
+  uniqueKey: "key-card",
+  deckId: "deck-a",
+  uid: "uid-a",
+  createdAt: 1,
+  updatedAt: 2,
+  deletedAt: null,
+  score: 3,
+  numberOfSeen: 4,
+  ...overrides,
+});
+
+const resolveDocument = (value: unknown) => {
+  mocks.getDocFromServer.mockResolvedValue({ exists: () => true, data: () => value });
+};
+
+describe("single remote Card read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns one separated active Card read without querying the collection", async () => {
+    resolveDocument(cardDocument({ lastSeenAt: 5 }));
+
+    await expect(fetchRemoteCardRead("uid-a", "card-a")).resolves.toEqual({
+      status: "active",
+      read: {
+        card: expect.objectContaining({ id: "card-a", deckId: "deck-a", uid: "uid-a" }),
+        progress: expect.objectContaining({ cardId: "card-a", score: 3, numberOfSeen: 4, lastSeenAt: 5 }),
+      },
+    });
+    expect(mocks.doc).toHaveBeenCalledWith("db", "card", "card-a");
+    expect(mocks.getDocsFromServer).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes a missing document from a tombstone", async () => {
+    mocks.getDocFromServer.mockResolvedValueOnce({ exists: () => false });
+    await expect(fetchRemoteCardRead("uid-a", "missing")).resolves.toEqual({ status: "missing" });
+
+    resolveDocument(cardDocument({ deletedAt: 3 }));
+    await expect(fetchRemoteCardRead("uid-a", "deleted")).resolves.toEqual({ status: "tombstoned" });
+  });
+
+  it("rejects owner mismatches and malformed physical documents", async () => {
+    resolveDocument(cardDocument({ uid: "uid-b" }));
+    await expect(fetchRemoteCardRead("uid-a", "foreign")).rejects.toThrow("owner does not match");
+
+    resolveDocument(cardDocument({ tags: [42] }));
+    await expect(fetchRemoteCardRead("uid-a", "invalid")).rejects.toThrow('Invalid Firestore card document "invalid"');
+  });
+});

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,11 +1,11 @@
 export { subscribeCards } from "./api/firestore";
 /** @public Separated read operations for the cross-Entity Card document boundary. */
-export { fetchCardReads, subscribeCardReads } from "./api/firestore";
+export { fetchCardReads, fetchRemoteCardRead, subscribeCardReads } from "./api/firestore";
 /** @public Separated read contract for the cross-Entity Card document boundary. */
-export type { CardRead } from "./api/firestore";
+export type { CardRead, RemoteCardReadResult } from "./api/firestore";
 export { generateCardId } from "./api/id";
 export { createCard, deleteCard, editCard, mutateCards } from "./api/mutations";
-export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
+export { useCard, useCards, useCardsByDeckId, useLocalCardsHydrated } from "./model/hooks";
 export { cardContentSchema } from "./model/schema";
 export { clearRemoteCards } from "./model/store";
 export type {

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -1,8 +1,18 @@
+import * as React from "react";
 import { useStore } from "zustand";
 
 import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
 import { cardStore } from "./store";
 import type { Card, CardId } from "./types";
+
+const subscribeLocalCardsHydration = (onStoreChange: () => void): (() => void) => {
+  const stopHydrating = cardStore.persist.onHydrate(onStoreChange);
+  const stopHydrated = cardStore.persist.onFinishHydration(onStoreChange);
+  return () => {
+    stopHydrating();
+    stopHydrated();
+  };
+};
 
 // Reads remote and local Cards as one ordered collection.
 export const useCards = (): Card[] => {
@@ -16,6 +26,10 @@ export const useCard = (id: CardId | undefined): Card | undefined =>
     cardStore,
     (state) => state.remoteCards.find((card) => card.id === id) ?? state.localCards.find((card) => card.id === id)
   );
+
+// Local absence becomes authoritative only after persisted Cards have finished hydrating.
+export const useLocalCardsHydrated = (): boolean =>
+  React.useSyncExternalStore(subscribeLocalCardsHydration, cardStore.persist.hasHydrated, () => false);
 
 // Reads the Cards and available tags owned by one Deck.
 export const useCardsByDeckId = (deckId: string): { cards: Card[]; tags: string[] } => {

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -53,6 +53,25 @@ describe("StudyProgress mutations", () => {
     expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
   });
 
+  it("writes progress for a verified remote Card before the Card store catches up", async () => {
+    await editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "remote" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editRemoteStudyProgress).toHaveBeenCalledExactlyOnceWith("user", {
+      cardId: "remote",
+      score: 2,
+    });
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a verified remote identity for another Card", async () => {
+    await expect(
+      editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "other-card" })
+    ).rejects.toThrow("Verified Card identity does not match progress");
+
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
   it("rejects progress for an unknown Card", async () => {
     await expect(editStudyProgress("user", { cardId: "missing", score: 2 })).rejects.toThrow(
       'Card "missing" was not found'

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -64,10 +64,20 @@ describe("StudyProgress mutations", () => {
     expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
   });
 
-  it("rejects a verified remote identity for another Card", async () => {
+  it("writes progress for a resolved local Card despite an ambiguous global lookup", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "local", score: 2 }, { persistence: "local", cardId: "local" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({ id: "local", score: 2 });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a resolved persistence identity for another Card", async () => {
     await expect(
       editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "other-card" })
-    ).rejects.toThrow("Verified Card identity does not match progress");
+    ).rejects.toThrow("Resolved Card identity does not match progress");
 
     expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
   });

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,19 +1,25 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { studyProgressEditSchema } from "../model/schema";
-import type { RemoteStudyProgressTarget, StudyProgressEdit } from "../model/types";
+import type { StudyProgressEdit, StudyProgressTarget } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
 export const editStudyProgress = async (
   uid: string,
   progress: StudyProgressEdit,
-  verifiedTarget?: RemoteStudyProgressTarget
+  target?: StudyProgressTarget
 ): Promise<void> => {
   const edit = studyProgressEditSchema.parse(progress);
-  if (verifiedTarget !== undefined) {
-    if (verifiedTarget.cardId !== edit.cardId) throw new Error("Verified Card identity does not match progress");
-    await editRemoteStudyProgress(uid, edit);
+  if (target !== undefined) {
+    if (target.cardId !== edit.cardId) throw new Error("Resolved Card identity does not match progress");
+    if (target.persistence === "remote") {
+      await editRemoteStudyProgress(uid, edit);
+      return;
+    }
+
+    const { cardId: id, ...fields } = edit;
+    editLocalCardStudyProgress(omitUndefined({ id, ...fields }));
     return;
   }
 

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,12 +1,22 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { studyProgressEditSchema } from "../model/schema";
-import type { StudyProgressEdit } from "../model/types";
+import type { RemoteStudyProgressTarget, StudyProgressEdit } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
-export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
+export const editStudyProgress = async (
+  uid: string,
+  progress: StudyProgressEdit,
+  verifiedTarget?: RemoteStudyProgressTarget
+): Promise<void> => {
   const edit = studyProgressEditSchema.parse(progress);
+  if (verifiedTarget !== undefined) {
+    if (verifiedTarget.cardId !== edit.cardId) throw new Error("Verified Card identity does not match progress");
+    await editRemoteStudyProgress(uid, edit);
+    return;
+  }
+
   const card = findCardById(edit.cardId);
   if (card === undefined) throw new Error(`Card "${edit.cardId}" was not found`);
 

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,1 +1,2 @@
 export { editStudyProgress } from "./api/mutations";
+export type { StudyProgressEdit } from "./model/types";

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,2 +1,2 @@
 export { editStudyProgress } from "./api/mutations";
-export type { StudyProgressEdit } from "./model/types";
+export type { StudyProgressEdit, StudyProgressTarget } from "./model/types";

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -29,6 +29,12 @@ export interface StudyProgressDocumentFields {
 /** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
+/** Server-verified remote identity that permits a write before the Card subscription publishes its snapshot. */
+export interface RemoteStudyProgressTarget {
+  persistence: "remote";
+  cardId: CardId;
+}
+
 /** Learning outcome derived from one study interaction. */
 export type StudyRating = "mastered" | "not-mastered" | "unrated";
 

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -29,11 +29,8 @@ export interface StudyProgressDocumentFields {
 /** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
-/** Server-verified remote identity that permits a write before the Card subscription publishes its snapshot. */
-export interface RemoteStudyProgressTarget {
-  persistence: "remote";
-  cardId: CardId;
-}
+/** Persistence identity already resolved by the consuming model, independent of ambiguous same-ID store entries. */
+export type StudyProgressTarget = { persistence: "local"; cardId: CardId } | { persistence: "remote"; cardId: CardId };
 
 /** Learning outcome derived from one study interaction. */
 export type StudyRating = "mastered" | "not-mastered" | "unrated";

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -13,6 +13,7 @@ export {
   getStudySession,
   moveStudySession,
   removeStudySession,
+  removeStudySessionIfCurrent,
   setStudySessionIndex,
   startStudy,
   touchStudySession,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -85,14 +85,15 @@ describe("resolveStudySession", () => {
     });
   });
 
-  it("waits while Cards have not loaded", () => {
-    expect(resolveStudySession(session, [])).toEqual({ status: "preparing" });
+  it("reports target absence without inferring whether the snapshot has loaded", () => {
+    expect(resolveStudySession(session, [])).toEqual({ status: "absent", session, cardId: "card-2" });
+    expect(resolveStudySession(session, cards)).toEqual({ status: "absent", session, cardId: "card-2" });
   });
 
-  it("rejects a missing session, empty position, or absent loaded Card", () => {
+  it("rejects a missing session or empty position", () => {
     expect(resolveStudySession(undefined, cards)).toEqual({ status: "invalid" });
-    expect(resolveStudySession({ ...session, cardOrderIds: [] }, [])).toEqual({ status: "invalid" });
-    expect(resolveStudySession(session, cards)).toEqual({ status: "invalid" });
+    const emptySession = { ...session, cardOrderIds: [] };
+    expect(resolveStudySession(emptySession, [])).toEqual({ status: "invalid", session: emptySession });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -103,7 +103,7 @@ export const selectStudyCards = <TCard extends StudyCardSelectionCard>(
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
-// Resolves whether an active session can study now, is waiting for Cards, or is invalid.
+// Reports snapshot absence without guessing whether an external read has completed.
 export const resolveStudySession = <Card extends StudySessionCard>(
   session: StudySession | undefined,
   cards: readonly Card[]
@@ -111,13 +111,12 @@ export const resolveStudySession = <Card extends StudySessionCard>(
   if (session == null) return { status: "invalid" };
 
   const cardId = getCurrentStudySessionCardId(session);
-  if (cardId == null) return { status: "invalid" };
+  if (cardId == null) return { status: "invalid", session };
 
   const card = cards.find(({ id }) => id === cardId);
   if (card != null) return { status: "studying", session, card };
 
-  // An empty collection can still be an in-flight read; loaded Cards prove that the persisted Card is absent.
-  return { status: cards.length === 0 ? "preparing" : "invalid" };
+  return { status: "absent", session, cardId };
 };
 
 // Collapses control actions into the movement, exit, or no-op effects understood by a study session.

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -11,6 +11,7 @@ import {
   getStudySession,
   moveStudySession,
   removeStudySession,
+  removeStudySessionIfCurrent,
   setStudySessionIndex,
   startStudy,
   studySessionStore,
@@ -179,6 +180,21 @@ describe("study store", () => {
     expect(store.getState().sessionsByDeckId).toEqual({
       "deck-2": expect.objectContaining({ deckId: "deck-2" }),
     });
+  });
+
+  it("removes only the session identity and position that were verified", () => {
+    startSession("deck-1", ["card-1", "card-2"]);
+    const verified = getStudySession("deck-1");
+    if (verified == null) throw new Error("Expected an active study session");
+
+    setStudySessionIndex("deck-1", 1);
+    expect(removeStudySessionIfCurrent(verified)).toBe(false);
+    expect(getStudySession("deck-1")?.currentIndex).toBe(1);
+
+    const current = getStudySession("deck-1");
+    if (current == null) throw new Error("Expected an active study session");
+    expect(removeStudySessionIfCurrent(current)).toBe(true);
+    expect(getStudySession("deck-1")).toBeUndefined();
   });
 
   it("clears both memory and persisted storage", () => {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -140,6 +140,18 @@ export const removeStudySession = (deckId: DeckId): void => {
   });
 };
 
+// Destructive recovery must not remove a session that changed after the invalid state was observed.
+export const removeStudySessionIfCurrent = (previous: StudySession): boolean => {
+  let removed = false;
+  studySessionStore.setState((state) => {
+    const current = state.sessionsByDeckId[previous.deckId];
+    if (!isStudySessionPositionUnchanged(previous, current)) return;
+    delete state.sessionsByDeckId[previous.deckId];
+    removed = true;
+  });
+  return removed;
+};
+
 // Clears every live and persisted study session.
 export const clearStudySessions = (): void => {
   // Publish the empty state before durable cleanup so auth changes cannot expose the previous user's sessions.

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -50,7 +50,8 @@ export type StudySessionSwipePlan =
 /** Minimal Card identity needed to resolve a study session position. */
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
 
-/** Resolution of an active study session against the currently loaded Cards. */
+/** Resolution of an active study session against one provided Card snapshot. */
 export type ResolvedStudySession<Card extends StudySessionCard> =
-  | { status: "preparing" | "invalid" }
+  | { status: "invalid"; session?: StudySession }
+  | { status: "absent"; session: StudySession; cardId: StudySession["cardOrderIds"][number] }
   | { status: "studying"; session: StudySession; card: Card };

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -13,7 +13,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
-import { createDeck, createLocalDeck, createPreferences } from "@/test/factories";
+import { createDeck, createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
@@ -129,7 +129,10 @@ describe("useStudy", () => {
 
     await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-2" } }));
     expect(result.current).toMatchObject({ showBackText: false, swipeFeedback: "cardSwipeRight" });
-    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
   });
 
   it("reports unavailable after the server confirms a missing remote target", async () => {
@@ -157,10 +160,27 @@ describe("useStudy", () => {
     expect(getStudySession(deckId)).toBeDefined();
   });
 
-  it("uses an active server result while the Card subscription catches up", async () => {
+  it("writes the displayed local Card while a same-ID remote copy overlaps migration", async () => {
+    const localCard = createLocalCard({ id: "card-1", deckId, frontText: "local card" });
+    mocks.deck = createLocalDeck({ id: deckId });
+    mocks.cards = [cards[0] as Card, localCard];
+    clearStudySessions();
+    startStudy(deckId, [localCard], { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current).toMatchObject({ status: "studying", card: { frontText: "local card" } });
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "local",
+      cardId: "card-1",
+    });
+  });
+
+  it("writes the verified remote Card while a same-ID local copy overlaps subscription catch-up", async () => {
     const [currentCard] = cards;
     if (currentCard == null || !("uid" in currentCard)) throw new Error("Expected a remote Card");
-    mocks.cards = [];
+    mocks.cards = [createLocalCard({ id: currentCard.id, deckId, frontText: "same-ID local copy" })];
     mocks.fetchRemoteCardRead.mockResolvedValue({
       status: "active",
       read: {

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -13,13 +13,15 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
-import { createDeck, createPreferences } from "@/test/factories";
+import { createDeck, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
   cards: [] as Card[],
   deck: undefined as Deck | undefined,
   editStudyProgress: vi.fn(),
+  fetchRemoteCardRead: vi.fn(),
+  localCardsHydrated: true,
   touchStudySession: vi.fn(),
 }));
 
@@ -34,7 +36,9 @@ vi.mock("@/entities/preference", async (importOriginal) => ({
 }));
 vi.mock("@/entities/card", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/card")>()),
+  fetchRemoteCardRead: mocks.fetchRemoteCardRead,
   useCards: () => mocks.cards,
+  useLocalCardsHydrated: () => mocks.localCardsHydrated,
 }));
 vi.mock("@/entities/deck", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/deck")>()),
@@ -86,8 +90,10 @@ describe("useStudy", () => {
     localStorage.clear();
     vi.clearAllMocks();
     mocks.editStudyProgress.mockResolvedValue(undefined);
+    mocks.fetchRemoteCardRead.mockReset();
+    mocks.localCardsHydrated = true;
     mocks.cards = cards;
-    mocks.deck = createDeck({ id: deckId, category: "raw" });
+    mocks.deck = createDeck({ id: deckId, uid: "user-1", category: "raw" });
     mocks.preferences = createPreferences({
       cardInterval: 1,
       defaultAutoPlay: false,
@@ -126,10 +132,114 @@ describe("useStudy", () => {
     expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
   });
 
-  it("reports preparing while the session card is not available", () => {
+  it("reports unavailable after the server confirms a missing remote target", async () => {
     mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
     const { result } = renderHook(() => useStudy(deckId));
-    expect(result.current.status).toBe("preparing");
+    expect(result.current.status).toBe("verifying");
+
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("waits for local hydration before treating a missing Card as authoritative", () => {
+    mocks.cards = [];
+    mocks.deck = createLocalDeck({ id: deckId });
+    mocks.localCardsHydrated = false;
+    const { result, rerender } = renderHook(() => useStudy(deckId));
+    expect(result.current.status).toBe("verifying");
+
+    mocks.localCardsHydrated = true;
+    rerender();
+
+    expect(result.current.status).toBe("unavailable");
+    expect(mocks.fetchRemoteCardRead).not.toHaveBeenCalled();
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("uses an active server result while the Card subscription catches up", async () => {
+    const [currentCard] = cards;
+    if (currentCard == null || !("uid" in currentCard)) throw new Error("Expected a remote Card");
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({
+      status: "active",
+      read: {
+        card: {
+          id: currentCard.id,
+          deckId: currentCard.deckId,
+          uid: currentCard.uid,
+          frontText: currentCard.frontText,
+          backText: currentCard.backText,
+          tags: currentCard.tags,
+          uniqueKey: currentCard.uniqueKey,
+          createdAt: currentCard.createdAt,
+          updatedAt: currentCard.updatedAt,
+          deletedAt: currentCard.deletedAt,
+        },
+        progress: {
+          cardId: currentCard.id,
+          score: currentCard.score,
+          numberOfSeen: currentCard.numberOfSeen,
+          lastSeenAt: currentCard.lastSeenAt,
+        },
+      },
+    });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-1" } }));
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
+    expect(getStudySession(deckId)?.currentIndex).toBe(1);
+  });
+
+  it("preserves the session when remote target verification fails", async () => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockRejectedValue(new Error("network failure"));
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await waitFor(() => expect(result.current.status).toBe("verification-error"));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("does not treat another Deck's loaded Cards as proof that the target is missing", async () => {
+    const otherCard = { ...cards[0], id: "other-card", deckId: "other-deck" } as Card;
+    mocks.cards = [otherCard];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current.status).toBe("verifying");
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("ignores a verification result after the session target is replaced", async () => {
+    let resolveOldVerification: (result: { status: "missing" }) => void = () => undefined;
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockImplementation((_uid: string, cardId: string) => {
+      if (cardId === "card-1") {
+        return new Promise((resolve) => {
+          resolveOldVerification = resolve;
+        });
+      }
+      return new Promise(() => undefined);
+    });
+    const { result } = renderHook(() => useStudy(deckId));
+    const previousSessionId = getStudySession(deckId)?.sessionId;
+
+    act(() => startStudy(deckId, cards.slice(1), { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    await waitFor(() => expect(mocks.fetchRemoteCardRead).toHaveBeenCalledWith("user-1", "card-2"));
+    await actAsync(async () => {
+      resolveOldVerification({ status: "missing" });
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe("verifying");
+    expect(getStudySession(deckId)?.sessionId).not.toBe(previousSessionId);
+    expect(getStudySession(deckId)?.cardOrderIds).toEqual(["card-2"]);
   });
 
   it("reports persisted control visibility and playback availability", () => {

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useCards } from "@/entities/card";
+import { useCards, useLocalCardsHydrated } from "@/entities/card";
 import { getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
 import {
   toggleShowCardDetails,
@@ -17,9 +17,10 @@ import { useSwipe } from "./useSwipe";
 
 export const useStudy = (deckId: string) => {
   const cards = useCards();
+  const localCardsHydrated = useLocalCardsHydrated();
   const deck = useDeck(deckId);
   const preferences = usePreferences();
-  const sessionState = useStudySessionState(deckId, cards);
+  const sessionState = useStudySessionState(deck, cards, localCardsHydrated);
   const [showBackText, setShowBackText] = React.useState(false);
   const [helpOpen, setHelpOpen] = React.useState(false);
   const hideBackText = () => setShowBackText(false);
@@ -30,7 +31,17 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipe = useSwipe(deckId, cards, hideBackText);
+  const swipeCards =
+    sessionState.status === "studying" && !cards.some(({ id }) => id === sessionState.card.id)
+      ? [...cards, sessionState.card]
+      : cards;
+  const verifiedRemoteCardId =
+    sessionState.status === "studying" &&
+    "uid" in sessionState.card &&
+    !cards.some(({ id }) => id === sessionState.card.id)
+      ? sessionState.card.id
+      : undefined;
+  const swipe = useSwipe(deckId, swipeCards, hideBackText, verifiedRemoteCardId);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -31,17 +31,16 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipeCards =
-    sessionState.status === "studying" && !cards.some(({ id }) => id === sessionState.card.id)
-      ? [...cards, sessionState.card]
-      : cards;
-  const verifiedRemoteCardId =
-    sessionState.status === "studying" &&
-    "uid" in sessionState.card &&
-    !cards.some(({ id }) => id === sessionState.card.id)
-      ? sessionState.card.id
+  // Use the exact displayed Card because local-to-remote migration can temporarily leave both persistence modes
+  // with the same ID; swipe planning and writes must follow the Deck-scoped Card selected above.
+  const swipeCards = sessionState.status === "studying" ? [sessionState.card] : [];
+  const persistenceTarget =
+    sessionState.status === "studying"
+      ? "uid" in sessionState.card
+        ? { persistence: "remote" as const, cardId: sessionState.card.id }
+        : { persistence: "local" as const, cardId: sessionState.card.id }
       : undefined;
-  const swipe = useSwipe(deckId, swipeCards, hideBackText, verifiedRemoteCardId);
+  const swipe = useSwipe(deckId, swipeCards, hideBackText, persistenceTarget);
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;

--- a/src/pages/study-session/model/useStudySessionState.ts
+++ b/src/pages/study-session/model/useStudySessionState.ts
@@ -1,25 +1,174 @@
-import type { Card } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
-import { removeStudySession, resolveStudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+import { type Card, type CardRead, fetchRemoteCardRead, type RemoteCardReadResult } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import {
+  removeStudySessionIfCurrent,
+  resolveStudySession,
+  type StudySession,
+  touchStudySession,
+  useStudySession,
+} from "@/entities/study-session";
 
 import * as React from "react";
 
-export type StudySessionState = ReturnType<typeof resolveStudySession<Card>>;
+type RemoteVerification = RemoteCardReadResult | { status: "error" };
 
-export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
-  const session = useStudySession(deckId);
-  const sessionState = resolveStudySession(session, cards);
+interface VerificationState {
+  key: string;
+  result: RemoteVerification;
+}
+
+type RemoteDeck = Extract<Deck, { localMode: false }>;
+type SnapshotState = ReturnType<typeof resolveStudySession<Card>>;
+type AbsentSnapshotState = Extract<SnapshotState, { status: "absent" }>;
+
+interface RemoteVerificationTarget {
+  uid: string;
+  cardId: string;
+  key: string;
+}
+
+interface PageStateInputs {
+  deck: Deck | undefined;
+  session: StudySession | undefined;
+  snapshotState: SnapshotState;
+  localCardsHydrated: boolean;
+  verification: RemoteVerification | undefined;
+}
+
+export type StudySessionState =
+  | { status: "verifying" }
+  | { status: "unavailable"; reason: "local-missing" | "remote-missing" | "remote-tombstoned" }
+  | { status: "verification-error" }
+  | { status: "invalid" }
+  | { status: "studying"; session: StudySession; card: Card };
+
+const combineCardRead = ({ card, progress }: CardRead): Card => ({
+  ...card,
+  score: progress.score,
+  numberOfSeen: progress.numberOfSeen,
+  ...(progress.lastSeenAt !== undefined ? { lastSeenAt: progress.lastSeenAt } : {}),
+  ...(progress.nextSeeingAt !== undefined ? { nextSeeingAt: progress.nextSeeingAt } : {}),
+  ...(progress.interval !== undefined ? { interval: progress.interval } : {}),
+});
+
+// Keep the full target key and effect cancellation together: the key rejects stored results for superseded
+// sessions, while cancellation prevents their still-pending reads from publishing after identity changes.
+const verificationKey = (deck: RemoteDeck, sessionId: string, cardId: string): string =>
+  [deck.uid, deck.id, sessionId, cardId].join("\u0000");
+
+const belongsToDeckPersistence = (card: Card, deck: Deck): boolean =>
+  card.deckId === deck.id && (deck.localMode ? !("uid" in card) : "uid" in card && card.uid === deck.uid);
+
+const resolveRemoteVerificationTarget = (
+  deck: Deck | undefined,
+  session: StudySession | undefined,
+  snapshotState: SnapshotState
+): RemoteVerificationTarget | undefined => {
+  if (deck?.localMode !== false || session?.deckId !== deck.id || snapshotState.status !== "absent") return;
+
+  return {
+    uid: deck.uid,
+    cardId: snapshotState.cardId,
+    key: verificationKey(deck, snapshotState.session.sessionId, snapshotState.cardId),
+  };
+};
+
+const resolveRemoteStudyState = (
+  deck: RemoteDeck,
+  snapshotState: AbsentSnapshotState,
+  verification: RemoteVerification | undefined
+): StudySessionState => {
+  if (verification === undefined) return { status: "verifying" };
+  if (verification.status === "missing") return { status: "unavailable", reason: "remote-missing" };
+  if (verification.status === "tombstoned") return { status: "unavailable", reason: "remote-tombstoned" };
+  if (verification.status === "error") return { status: "verification-error" };
+  if (verification.read.card.deckId !== deck.id) return { status: "invalid" };
+
+  return {
+    status: "studying",
+    session: snapshotState.session,
+    card: combineCardRead(verification.read),
+  };
+};
+
+const resolvePageState = ({
+  deck,
+  session,
+  snapshotState,
+  localCardsHydrated,
+  verification,
+}: PageStateInputs): StudySessionState => {
+  if (
+    deck === undefined ||
+    (session !== undefined && session.deckId !== deck.id) ||
+    snapshotState.status === "invalid"
+  ) {
+    return { status: "invalid" };
+  }
+  if (snapshotState.status === "studying") {
+    return { status: "studying", session: snapshotState.session, card: snapshotState.card };
+  }
+  if (deck.localMode) {
+    return localCardsHydrated ? { status: "unavailable", reason: "local-missing" } : { status: "verifying" };
+  }
+  return resolveRemoteStudyState(deck, snapshotState, verification);
+};
+
+export const useStudySessionState = (
+  deck: Deck | undefined,
+  cards: readonly Card[],
+  localCardsHydrated: boolean
+): StudySessionState => {
+  const session = useStudySession(deck?.id ?? "");
+  const scopedCards = deck === undefined ? [] : cards.filter((card) => belongsToDeckPersistence(card, deck));
+  const snapshotState = resolveStudySession(session, scopedCards);
+  const [verification, setVerification] = React.useState<VerificationState>();
+
+  const target = resolveRemoteVerificationTarget(deck, session, snapshotState);
+  const targetUid = target?.uid;
+  const targetCardId = target?.cardId;
+  const currentVerificationKey = target?.key;
+  const currentVerification =
+    verification !== undefined && verification.key === currentVerificationKey ? verification.result : undefined;
 
   React.useEffect(() => {
-    if (sessionState.status === "studying") {
-      touchStudySession(deckId);
-      return;
-    }
-    if (sessionState.status === "preparing") return;
+    if (targetUid === undefined || targetCardId === undefined || currentVerificationKey === undefined) return;
 
-    // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
-    removeStudySession(deckId);
-  }, [deckId, sessionState.status]);
+    let current = true;
+    void fetchRemoteCardRead(targetUid, targetCardId).then(
+      (result) => {
+        if (current) setVerification({ key: currentVerificationKey, result });
+      },
+      () => {
+        if (current) setVerification({ key: currentVerificationKey, result: { status: "error" } });
+      }
+    );
+    return () => {
+      current = false;
+    };
+  }, [currentVerificationKey, targetCardId, targetUid]);
 
-  return sessionState;
+  const state = resolvePageState({
+    deck,
+    session,
+    snapshotState,
+    localCardsHydrated,
+    verification: currentVerification,
+  });
+
+  const studyingDeckId = state.status === "studying" ? state.session.deckId : undefined;
+  const studyingSessionId = state.status === "studying" ? state.session.sessionId : undefined;
+
+  React.useEffect(() => {
+    if (studyingDeckId !== undefined) touchStudySession(studyingDeckId);
+  }, [studyingDeckId, studyingSessionId]);
+
+  const invalidSession = state.status === "invalid" && deck !== undefined ? session : undefined;
+  React.useEffect(() => {
+    if (invalidSession === undefined) return;
+
+    removeStudySessionIfCurrent(invalidSession);
+  }, [invalidSession]);
+
+  return state;
 };

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -2,7 +2,7 @@ import { useAuthUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
-import { editStudyProgress } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
 import { getStudySession, moveStudySession, planStudySessionSwipe, removeStudySession } from "@/entities/study-session";
 
 import * as React from "react";
@@ -17,7 +17,21 @@ export interface SwipeState {
   swipeFeedback?: SwipeDirection;
 }
 
-export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: () => void): SwipeState => {
+const persistStudyProgress = (
+  uid: string,
+  progress: StudyProgressEdit,
+  verifiedRemoteCardId: Card["id"] | undefined
+): Promise<void> =>
+  verifiedRemoteCardId === progress.cardId
+    ? editStudyProgress(uid, progress, { persistence: "remote", cardId: verifiedRemoteCardId })
+    : editStudyProgress(uid, progress);
+
+export const useSwipe = (
+  deckId: DeckId,
+  cards: readonly Card[],
+  onCardChanged: () => void,
+  verifiedRemoteCardId?: Card["id"]
+): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
   const feedback = useSwipeFeedback(preferences.appearance.showSwipeFeedback);
@@ -38,7 +52,8 @@ export const useSwipe = (deckId: DeckId, cards: readonly Card[], onCardChanged: 
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saved = await editStudyProgress(uid, swipePlan.progress).then(
+    const saveProgress = persistStudyProgress(uid, swipePlan.progress, verifiedRemoteCardId);
+    const saved = await saveProgress.then(
       () => true,
       () => false
     );

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -2,7 +2,7 @@ import { useAuthUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
-import { editStudyProgress, type StudyProgressEdit } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressEdit, type StudyProgressTarget } from "@/entities/study-progress";
 import { getStudySession, moveStudySession, planStudySessionSwipe, removeStudySession } from "@/entities/study-session";
 
 import * as React from "react";
@@ -20,17 +20,14 @@ export interface SwipeState {
 const persistStudyProgress = (
   uid: string,
   progress: StudyProgressEdit,
-  verifiedRemoteCardId: Card["id"] | undefined
-): Promise<void> =>
-  verifiedRemoteCardId === progress.cardId
-    ? editStudyProgress(uid, progress, { persistence: "remote", cardId: verifiedRemoteCardId })
-    : editStudyProgress(uid, progress);
+  target: StudyProgressTarget | undefined
+): Promise<void> => editStudyProgress(uid, progress, target);
 
 export const useSwipe = (
   deckId: DeckId,
   cards: readonly Card[],
   onCardChanged: () => void,
-  verifiedRemoteCardId?: Card["id"]
+  target?: StudyProgressTarget
 ): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
@@ -52,7 +49,7 @@ export const useSwipe = (
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saveProgress = persistStudyProgress(uid, swipePlan.progress, verifiedRemoteCardId);
+    const saveProgress = persistStudyProgress(uid, swipePlan.progress, target);
     const saved = await saveProgress.then(
       () => true,
       () => false

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -169,7 +169,8 @@ describe("StudySessionPage", () => {
     expect(screen.queryByText("Back two")).not.toBeInTheDocument();
     expect(mocks.editStudyProgress).toHaveBeenCalledExactlyOnceWith(
       "user-id",
-      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 })
+      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 }),
+      { persistence: "local", cardId: "first-card" }
     );
     expect(getStudySession(deckId)?.currentIndex).toBe(1);
   });

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -404,7 +404,7 @@ describe("StudySessionPage", () => {
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
-  it("shows loading feedback while active session cards are unavailable", async () => {
+  it("shows unavailable feedback without redirecting when a local target is authoritatively missing", async () => {
     await deleteCard("", firstCard);
     await deleteCard("", secondCard);
     clearStudySessions();
@@ -412,7 +412,9 @@ describe("StudySessionPage", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: "Loading…" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "The current study card is unavailable." })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Deck list destination" })).not.toBeInTheDocument();
+    expect(getStudySession(deckId)).toBeDefined();
   });
 
   it("returns to the deck list when no active session exists", async () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -47,8 +47,14 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
   if (state == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
 
   if (state.status !== "studying") {
-    return state.status === "preparing" ? (
-      <RouteFeedback title="Loading…" tone="loading" />
+    if (state.status === "verifying") {
+      return <RouteFeedback title="Verifying study session…" tone="loading" />;
+    }
+    if (state.status === "verification-error") {
+      return <RouteFeedback title="Could not verify the study session." tone="error" />;
+    }
+    return state.status === "unavailable" ? (
+      <RouteFeedback title="The current study card is unavailable." tone="not-found" />
     ) : (
       <RouteFeedback title="Study session unavailable." tone="not-found" />
     );

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -9,6 +9,7 @@ import {
 } from "@playwright/test";
 
 import {
+  type FixtureAbsentCard,
   type FixtureCard,
   type FixtureCategory,
   type FixtureDeck,
@@ -23,6 +24,7 @@ import {
 } from "./yaml-fixture";
 
 export type {
+  FixtureAbsentCard,
   FixtureCard,
   FixtureCategory,
   FixtureDeck,
@@ -377,6 +379,7 @@ export interface E2EFixture {
   user: (logicalUid?: string) => FixtureUser;
   deck: (logicalId?: string) => FixtureDeck;
   card: (logicalId?: string) => FixtureCard;
+  absentCard: (logicalId?: string) => FixtureAbsentCard;
   session: (logicalDeckId?: string) => FixtureStudySession;
   uid: (logicalUid: string) => string;
   id: (logicalId: string) => string;
@@ -502,6 +505,7 @@ function createE2EFixture(
     user: (logicalUid) => requireLogicalValue(namespaced.users, "auth user", logicalUid),
     deck: (logicalId) => requireLogicalValue(namespaced.decks, "Deck", logicalId),
     card: (logicalId) => requireLogicalValue(namespaced.cards, "Card", logicalId),
+    absentCard: (logicalId) => requireLogicalValue(namespaced.absentCards, "absent Card", logicalId),
     session: (logicalDeckId) => requireLogicalValue(namespaced.sessions, "Study session", logicalDeckId),
     uid: namespaced.uid,
     id: namespaced.id,
@@ -556,6 +560,27 @@ export const setDocument = async (collection: FirestoreCollection, id: string, d
     body: JSON.stringify({ fields }),
   });
   if (!response.ok) throw new Error(`Firestore seed failed: ${response.status} ${await response.text()}`);
+};
+
+/** Creates a target-specific permission failure without disrupting the Card collection subscription. */
+export const seedForeignOwnedCard = async (id: string): Promise<void> => {
+  const uid = `e2e-foreign-${randomUUID()}`;
+  const deckId = `${id}-foreign-deck`;
+  await setDocument("deck", deckId, { id: deckId, uid, name: "Foreign E2E Deck", isPublic: false });
+  await setDocument("card", id, {
+    id,
+    uid,
+    deckId,
+    frontText: "Foreign E2E Card",
+    backText: "Foreign E2E Card",
+    tags: [],
+    uniqueKey: id,
+    createdAt: 0,
+    updatedAt: 0,
+    deletedAt: null,
+    score: 0,
+    numberOfSeen: 0,
+  });
 };
 
 export const getDocument = async (

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -1,6 +1,14 @@
 import type { Page } from "@playwright/test";
 
-import { allowExpectedFirestoreWriteFailure, expect, failNextFirestoreWrite, readLocalData, test } from "./fixtures";
+import {
+  allowExpectedFirestoreWriteFailure,
+  expect,
+  failNextFirestoreWrite,
+  getDocument,
+  readLocalData,
+  seedForeignOwnedCard,
+  test,
+} from "./fixtures";
 import { progressOf, readProgress, readSession } from "./study-helpers";
 
 const cardAt = <T>(cards: readonly T[], index: number) => {
@@ -381,4 +389,45 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
   await expect(dialog).not.toBeVisible();
   await expect(page.getByRole("button", { name: "Open study help" })).toBeFocused();
   await expect(page.getByRole("button", { name: "Swipe left" })).toHaveCount(0);
+});
+
+test("SWIPE-25 shows unavailable after the server confirms the remote target is missing", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const target = fixture.absentCard();
+  const session = fixture.session();
+  await fixture.apply(page);
+  expect(await getDocument("card", target.id)).toBeUndefined();
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "The current study card is unavailable." })).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+});
+
+test("SWIPE-26 preserves the remote session when target verification fails", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const target = fixture.absentCard();
+  const session = fixture.session();
+  await fixture.apply(page);
+  await seedForeignOwnedCard(target.id);
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "Could not verify the study session." })).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+});
+
+test("SWIPE-27 shows unavailable for an authoritatively missing local target", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "The current study card is unavailable." })).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
 });

--- a/test/e2e/yaml-fixture.ts
+++ b/test/e2e/yaml-fixture.ts
@@ -56,6 +56,12 @@ export interface FixtureCard {
   interval?: number;
 }
 
+export interface FixtureAbsentCard {
+  id: string;
+  deckId: string;
+  uid?: string;
+}
+
 export interface FixtureStudySession {
   sessionId: string;
   deckId: string;
@@ -97,11 +103,12 @@ export interface FixturePreferences {
 
 export interface FixtureState {
   auth: { users: FixtureUser[] };
-  remote: { decks: FixtureDeck[]; cards: FixtureCard[] };
+  remote: { decks: FixtureDeck[]; cards: FixtureCard[]; absentCards: FixtureAbsentCard[] };
   browser: {
     preferences: FixturePreferences;
     localDecks: FixtureDeck[];
     localCards: FixtureCard[];
+    absentCards: FixtureAbsentCard[];
     studySessions: Record<string, FixtureStudySession>;
   };
 }
@@ -118,6 +125,7 @@ export interface NamespacedFixture {
   users: ReadonlyMap<string, FixtureUser>;
   decks: ReadonlyMap<string, FixtureDeck>;
   cards: ReadonlyMap<string, FixtureCard>;
+  absentCards: ReadonlyMap<string, FixtureAbsentCard>;
   sessions: ReadonlyMap<string, FixtureStudySession>;
   uid: (logicalUid: string) => string;
   id: (logicalId: string) => string;
@@ -236,6 +244,17 @@ const localCardSchema = z.strictObject({
   ...cardStateFields,
 });
 
+const remoteAbsentCardSchema = z.strictObject({
+  id: nonEmptyString,
+  deckId: nonEmptyString,
+  uid: nonEmptyString,
+});
+
+const localAbsentCardSchema = z.strictObject({
+  id: nonEmptyString,
+  deckId: nonEmptyString,
+});
+
 const swipeActionSchema = z.enum([
   "DoNothing",
   "GoBack",
@@ -307,6 +326,7 @@ const fixtureDocumentSchema = z.strictObject({
     .strictObject({
       decks: z.array(remoteDeckSchema).optional(),
       cards: z.array(remoteCardSchema).optional(),
+      absentCards: z.array(remoteAbsentCardSchema).optional(),
     })
     .optional(),
   browser: z
@@ -314,6 +334,7 @@ const fixtureDocumentSchema = z.strictObject({
       preferences: preferencesSchema.optional(),
       localDecks: z.array(localDeckSchema).optional(),
       localCards: z.array(localCardSchema).optional(),
+      absentCards: z.array(localAbsentCardSchema).optional(),
       studySessions: z.record(nonEmptyString, studySessionSchema).optional(),
       sampleDeck: sampleDeckSchema.optional(),
     })
@@ -325,6 +346,8 @@ type RawRemoteDeck = z.infer<typeof remoteDeckSchema>;
 type RawLocalDeck = z.infer<typeof localDeckSchema>;
 type RawRemoteCard = z.infer<typeof remoteCardSchema>;
 type RawLocalCard = z.infer<typeof localCardSchema>;
+type RawRemoteAbsentCard = z.infer<typeof remoteAbsentCardSchema>;
+type RawLocalAbsentCard = z.infer<typeof localAbsentCardSchema>;
 type RawPreferences = z.infer<typeof preferencesSchema>;
 type RawUser = z.infer<typeof userSchema>;
 type RawStudySession = z.infer<typeof studySessionSchema>;
@@ -746,8 +769,10 @@ interface LogicalFixtureCollections {
   users: RawUser[];
   remoteDecks: RawRemoteDeck[];
   remoteCards: RawRemoteCard[];
+  remoteAbsentCards: RawRemoteAbsentCard[];
   localDecks: RawLocalDeck[];
   localCards: RawLocalCard[];
+  localAbsentCards: RawLocalAbsentCard[];
   studySessions: Record<string, RawStudySession>;
   sampleDeck: RawSampleDeck | undefined;
   sampleCards: RawSampleCard[];
@@ -765,8 +790,10 @@ const collectLogicalFixture = (document: FixtureDocument): LogicalFixtureCollect
   } = document;
   const remoteDecks = document.remote?.decks ?? [];
   const remoteCards = document.remote?.cards ?? [];
+  const remoteAbsentCards = document.remote?.absentCards ?? [];
   const localDecks = document.browser?.localDecks ?? [];
   const localCards = document.browser?.localCards ?? [];
+  const localAbsentCards = document.browser?.absentCards ?? [];
   const studySessions = document.browser?.studySessions ?? {};
   const sampleDeck = document.browser?.sampleDeck;
   const sampleCards = parseSampleCards(sampleDeck);
@@ -774,8 +801,10 @@ const collectLogicalFixture = (document: FixtureDocument): LogicalFixtureCollect
     users,
     remoteDecks,
     remoteCards,
+    remoteAbsentCards,
     localDecks,
     localCards,
+    localAbsentCards,
     studySessions,
     sampleDeck,
     sampleCards,
@@ -793,7 +822,12 @@ const validateUniqueLogicalIds = (fixture: LogicalFixtureCollections) => {
     [...fixture.remoteDecks, ...fixture.localDecks, ...sampleDecks].map(({ id: logicalId }) => logicalId),
     "Deck ID"
   );
-  const cardIds = [...fixture.remoteCards, ...fixture.localCards].map(({ id: logicalId }) => logicalId);
+  const cardIds = [
+    ...fixture.remoteCards,
+    ...fixture.remoteAbsentCards,
+    ...fixture.localCards,
+    ...fixture.localAbsentCards,
+  ].map(({ id: logicalId }) => logicalId);
   assertUnique(cardIds.concat(fixture.sampleCardIds), "Card ID");
   assertUnique(
     Object.values(fixture.studySessions).map(({ sessionId }) => sessionId),
@@ -805,8 +839,10 @@ const validateStableApplicationIds = (fixture: LogicalFixtureCollections) => {
   const ordinaryIds = [
     ...fixture.remoteDecks.map(({ id }) => id),
     ...fixture.remoteCards.map(({ id }) => id),
+    ...fixture.remoteAbsentCards.map(({ id }) => id),
     ...fixture.localDecks.map(({ id }) => id),
     ...fixture.localCards.map(({ id }) => id),
+    ...fixture.localAbsentCards.map(({ id }) => id),
     ...Object.values(fixture.studySessions).map(({ sessionId }) => sessionId),
   ];
   const reservedId = ordinaryIds.find(isStableApplicationId);
@@ -823,7 +859,7 @@ const validateRemoteReferences = (fixture: LogicalFixtureCollections) => {
   for (const deck of fixture.remoteDecks) {
     if (!userIds.has(deck.uid)) throw new Error(`Remote Deck ${deck.id} references unknown UID ${deck.uid}`);
   }
-  for (const card of fixture.remoteCards) {
+  for (const card of [...fixture.remoteCards, ...fixture.remoteAbsentCards]) {
     if (!userIds.has(card.uid)) throw new Error(`Remote Card ${card.id} references unknown UID ${card.uid}`);
     const deck = remoteDeckById.get(card.deckId);
     if (deck === undefined) throw new Error(`Remote Card ${card.id} references unknown remote Deck ${card.deckId}`);
@@ -839,7 +875,7 @@ const localDeckIds = (fixture: LogicalFixtureCollections) =>
 
 const validateLocalReferences = (fixture: LogicalFixtureCollections) => {
   const deckIds = localDeckIds(fixture);
-  for (const card of fixture.localCards) {
+  for (const card of [...fixture.localCards, ...fixture.localAbsentCards]) {
     if (!deckIds.has(card.deckId)) {
       throw new Error(`Local Card ${card.id} references unknown local Deck ${card.deckId}`);
     }
@@ -854,7 +890,9 @@ interface SessionCardReference {
 const buildCardLookup = (fixture: LogicalFixtureCollections) => {
   const cards: SessionCardReference[] = [
     ...fixture.remoteCards.map(({ id, deckId }) => ({ id, deckId })),
+    ...fixture.remoteAbsentCards.map(({ id, deckId }) => ({ id, deckId })),
     ...fixture.localCards.map(({ id, deckId }) => ({ id, deckId })),
+    ...fixture.localAbsentCards.map(({ id, deckId }) => ({ id, deckId })),
     ...fixture.sampleCardIds.map((id) => ({ id, deckId: "sample-v1" })),
   ];
   return new Map(cards.map((card) => [card.id, card]));
@@ -888,6 +926,13 @@ const validateStudySessions = (fixture: LogicalFixtureCollections) => {
   const cardById = buildCardLookup(fixture);
   for (const [key, session] of Object.entries(fixture.studySessions)) {
     validateSession(key, session, deckIds, cardById);
+  }
+
+  const referencedCardIds = new Set(Object.values(fixture.studySessions).flatMap(({ cardOrderIds }) => cardOrderIds));
+  for (const absentCard of [...fixture.remoteAbsentCards, ...fixture.localAbsentCards]) {
+    if (!referencedCardIds.has(absentCard.id)) {
+      throw new Error(`Absent Card ${absentCard.id} must be referenced by a Study session`);
+    }
   }
 };
 
@@ -978,11 +1023,30 @@ const normalizeRemoteCards = (
     normalizeCard(card, identifiers.idFor(card.id), identifiers.idFor(card.deckId), identifiers.uidFor(card.uid)),
   ]);
 
+const normalizeRemoteAbsentCards = (
+  cards: readonly RawRemoteAbsentCard[],
+  identifiers: FixtureIdentifierMappers
+): NormalizedCollection<FixtureAbsentCard> =>
+  buildNormalizedCollection(cards, (card) => [
+    card.id,
+    {
+      id: identifiers.idFor(card.id),
+      deckId: identifiers.idFor(card.deckId),
+      uid: identifiers.uidFor(card.uid),
+    },
+  ]);
+
 const normalizeLocalCards = (
   cards: readonly RawLocalCard[],
   idFor: FixtureIdentifierMappers["idFor"]
 ): NormalizedCollection<FixtureCard> =>
   buildNormalizedCollection(cards, (card) => [card.id, normalizeCard(card, idFor(card.id), idFor(card.deckId))]);
+
+const normalizeLocalAbsentCards = (
+  cards: readonly RawLocalAbsentCard[],
+  idFor: FixtureIdentifierMappers["idFor"]
+): NormalizedCollection<FixtureAbsentCard> =>
+  buildNormalizedCollection(cards, (card) => [card.id, { id: idFor(card.id), deckId: idFor(card.deckId) }]);
 
 const normalizeSampleDeck = (
   sampleDeck: RawSampleDeck | undefined,
@@ -1033,12 +1097,15 @@ const normalizeSessions = (
   };
 };
 
-const validateRuntimeIds = (
-  users: NormalizedCollection<FixtureUser>,
-  decks: NormalizedCollection<FixtureDeck>,
-  cards: NormalizedCollection<FixtureCard>,
-  sessions: NormalizedSessions
-) => {
+interface RuntimeFixtureCollections {
+  users: NormalizedCollection<FixtureUser>;
+  decks: NormalizedCollection<FixtureDeck>;
+  cards: NormalizedCollection<FixtureCard>;
+  absentCards: NormalizedCollection<FixtureAbsentCard>;
+  sessions: NormalizedSessions;
+}
+
+const validateRuntimeIds = ({ users, decks, cards, absentCards, sessions }: RuntimeFixtureCollections) => {
   assertUnique(
     users.values.map(({ uid: runtimeUid }) => runtimeUid),
     "runtime auth UID"
@@ -1048,7 +1115,7 @@ const validateRuntimeIds = (
     "runtime Deck ID"
   );
   assertUnique(
-    cards.values.map(({ id: runtimeId }) => runtimeId),
+    [...cards.values, ...absentCards.values].map(({ id: runtimeId }) => runtimeId),
     "runtime Card ID"
   );
   assertUnique(
@@ -1077,8 +1144,11 @@ export const namespaceFixture = (
     normalizeLocalCards(logical.localCards, identifiers.idFor),
     normalizeSampleCards(logical.sampleDeck, logical.sampleCards, identifiers.idFor)
   );
+  const remoteAbsentCards = normalizeRemoteAbsentCards(logical.remoteAbsentCards, identifiers);
+  const localAbsentCards = normalizeLocalAbsentCards(logical.localAbsentCards, identifiers.idFor);
+  const absentCards = mergeNormalizedCollections(remoteAbsentCards, localAbsentCards);
   const sessions = normalizeSessions(logical.studySessions, identifiers.idFor);
-  validateRuntimeIds(users, decks, cards, sessions);
+  validateRuntimeIds({ users, decks, cards, absentCards, sessions });
 
   const remoteDeckCount = logical.remoteDecks.length;
   const remoteCardCount = logical.remoteCards.length;
@@ -1089,17 +1159,20 @@ export const namespaceFixture = (
       remote: {
         decks: decks.values.slice(0, remoteDeckCount),
         cards: cards.values.slice(0, remoteCardCount),
+        absentCards: remoteAbsentCards.values,
       },
       browser: {
         preferences: normalizePreferences(document.browser?.preferences),
         localDecks: decks.values.slice(remoteDeckCount),
         localCards: cards.values.slice(remoteCardCount),
+        absentCards: localAbsentCards.values,
         studySessions: sessions.byDeckId,
       },
     },
     users: users.lookup,
     decks: decks.lookup,
     cards: cards.lookup,
+    absentCards: absentCards.lookup,
     sessions: sessions.lookup,
     uid: identifiers.uidFor,
     id: identifiers.idFor,

--- a/test/integration/firestore/deck.spec.ts
+++ b/test/integration/firestore/deck.spec.ts
@@ -111,9 +111,8 @@ describe.concurrent("firestore/deck", { retry: 3 }, () => {
     await deleteDeck("uid", d.id);
 
     await expect(getDoc(doc(db, "deck", d.id))).rejects.toMatchObject({ code: "permission-denied" });
-    await Promise.all(
-      cards.map((card) => expect(getDoc(doc(db, "card", card.id))).rejects.toMatchObject({ code: "permission-denied" }))
-    );
+    const deletedCardSnapshots = await Promise.all(cards.map((card) => getDoc(doc(db, "card", card.id))));
+    expect(deletedCardSnapshots.every((snapshot) => !snapshot.exists())).toBe(true);
   });
 
   it("moves a local Deck and its Cards to Firestore when local mode is disabled", async () => {

--- a/test/integration/firestore/rules.spec.ts
+++ b/test/integration/firestore/rules.spec.ts
@@ -4,7 +4,7 @@
  * "should create a deck", "should update a deck".
  */
 
-import { it, describe, beforeEach, beforeAll, afterAll } from "vitest";
+import { it, describe, beforeEach, beforeAll, afterAll, expect } from "vitest";
 import * as fs from "node:fs";
 import {
   assertFails,
@@ -85,6 +85,11 @@ describe("firestore/rule", () => {
         await assertSucceeds(getDoc(doc(db, "card", id)));
       });
 
+      it("should confirm that a card is missing", async () => {
+        const snapshot = await assertSucceeds(getDoc(doc(db, "card", uuid())));
+        expect(snapshot.exists()).toBe(false);
+      });
+
       it("should create a card", async () => {
         const [deckId, id] = [uuid(), uuid()];
         await createData("deck", deckId, { uid: "uid" });
@@ -149,6 +154,11 @@ describe("firestore/rule", () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertFails(getDoc(doc(db, "card", id)));
+      });
+
+      it("should let an authenticated non-owner confirm that a card is missing", async () => {
+        const snapshot = await assertSucceeds(getDoc(doc(db, "card", uuid())));
+        expect(snapshot.exists()).toBe(false);
       });
 
       it("should read a public card", async () => {
@@ -220,6 +230,10 @@ describe("firestore/rule", () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertFails(getDoc(doc(db, "card", id)));
+      });
+
+      it("should not confirm missing cards without authentication", async () => {
+        await assertFails(getDoc(doc(db, "card", uuid())));
       });
 
       it("should read a public card", async () => {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,8 +8,16 @@ import "@/test/initializeTestFirestore";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, fetchCardReads, mutateCards, subscribeCards } from "@/entities/card";
+import {
+  deleteCard,
+  editCard,
+  fetchCardReads,
+  fetchRemoteCardRead,
+  mutateCards,
+  subscribeCards,
+} from "@/entities/card";
 import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
+import { deleteCard as deleteRemoteCard } from "@/entities/card/api/firestore";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture, createRemoteDeckInput } from "@/test/factories";
@@ -49,6 +57,19 @@ describe("Query realtime subscriptions", () => {
       card: expect.objectContaining({ id: card.id, frontText: "Fetched Card" }),
       progress: expect.objectContaining({ cardId: card.id, score: 2, numberOfSeen: 3 }),
     });
+  });
+
+  it("confirms missing and tombstoned Card documents through a single server read", async () => {
+    const uid = "uid";
+    const deck = createDeckFixture({ id: crypto.randomUUID(), uid });
+    const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid });
+    await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
+
+    await expect(fetchRemoteCardRead(uid, crypto.randomUUID())).resolves.toEqual({ status: "missing" });
+
+    await mutateCards(uid, [{ kind: "create", card }]);
+    await deleteRemoteCard(uid, card);
+    await expect(fetchRemoteCardRead(uid, card.id)).resolves.toEqual({ status: "tombstoned" });
   });
 
   it("delivers initial, update, and delete snapshots without a cursor", async () => {


### PR DESCRIPTION
## Related issue

Fixes #947

Parent roadmap: #208

Supersedes #1351 after addressing its review comments and syncing with the latest `main`.

## Summary

- classify Study sessions without using Card collection length as a readiness signal
- verify absent remote targets with a single-document server read while preserving recoverable sessions
- route progress through the exact displayed Card's explicit local or remote persistence identity
- add strict absent Card fixtures and SWIPE-25 through SWIPE-27 coverage
- preserve the Study completion flow added by #952

## Testing

- focused Study unit tests: 57 passed
- focused Firestore integration tests: 5 passed
- `mise run check`: 114 files, 607 tests passed
- `mise run e2e`: 70 passed
- reviewer rounds: 3; final findings: none