### PR TITLE
fix(#396): Synchronize Storybook document language

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,8 +8,10 @@ import { INITIAL_VIEWPORTS } from "./support/storybookViewports";
 import "../src/app/styles/index.css";
 
 const withI18n: Decorator = (Story, context) => {
-  // Every story starts from English unless it explicitly demonstrates another locale.
-  void appI18n.changeLanguage(context.parameters.locale === "ja" ? "ja" : "en");
+  // Keep visible copy and document metadata deterministic unless a story explicitly demonstrates Japanese.
+  const language = context.parameters.locale === "ja" ? "ja" : "en";
+  document.documentElement.lang = language;
+  void appI18n.changeLanguage(language);
   return createElement(I18nextProvider, { i18n: appI18n }, createElement(Story));
 };
 

--- a/src/pages/settings/ui/SettingsForm.stories.tsx
+++ b/src/pages/settings/ui/SettingsForm.stories.tsx
@@ -46,6 +46,7 @@ export const Default: Story = {};
 export const Japanese: Story = {
   parameters: { locale: "ja" },
   play: async ({ canvas }) => {
+    await expect(document.documentElement).toHaveAttribute("lang", "ja");
     await expect(canvas.getByRole("heading", { level: 1, name: "設定" })).toBeVisible();
     await expect(canvas.getByRole("combobox", { name: "言語" })).toHaveDisplayValue("System");
   },


### PR DESCRIPTION
## Related issue

Related to #396

## Summary

- keep Storybook document language metadata synchronized with the configured story locale
- assert Japanese stories expose `lang="ja"` on the document element

## Testing

- `npm run test:storybook -- src/pages/settings/ui/SettingsForm.stories.tsx`
- `npm run test:storybook`
- `mise run check`