### PR TITLE
fix(#406): Address navigation guard review feedback

### DIFF
--- a/src/pages/card-form/model/useCardForm.ts
+++ b/src/pages/card-form/model/useCardForm.ts
@@ -5,16 +5,28 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
 import { useAuthUid } from "@/entities/auth";
-import { cardContentSchema, editCard, useCard } from "@/entities/card";
+import { type Card, cardContentSchema, editCard, useCard } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 
 const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
 export type CardFormValues = z.infer<typeof cardFormSchema>;
 
+const getCardFormValues = (card: Card): CardFormValues => ({
+  frontText: card.frontText,
+  backText: card.backText,
+  tags: [...card.tags],
+});
+
+const areCardFormValuesEqual = (left: CardFormValues, right: CardFormValues): boolean =>
+  left.frontText === right.frontText &&
+  left.backText === right.backText &&
+  left.tags.length === right.tags.length &&
+  left.tags.every((tag, index) => tag === right.tags[index]);
+
 interface UseCardFormOptions {
   cardId: string;
-  onSaved: () => void;
+  onSaved: (deckId: Card["deckId"]) => void;
 }
 
 export const useCardForm = ({ cardId, onSaved }: UseCardFormOptions) => {
@@ -22,32 +34,50 @@ export const useCardForm = ({ cardId, onSaved }: UseCardFormOptions) => {
   const card = useCard(cardId);
   const isMounted = useMountedGuard();
   const [saveError, setSaveError] = React.useState<unknown>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [failedBaseline, setFailedBaseline] = React.useState<CardFormValues | null>(null);
   const form = useForm<CardFormValues>({
-    ...(card && {
-      values: {
-        frontText: card.frontText,
-        backText: card.backText,
-        tags: card.tags,
-      },
-    }),
+    ...(card && { values: getCardFormValues(card) }),
     // Firestore can roll an optimistic snapshot back after a rejected write; that refresh must not erase the retry payload.
     resetOptions: { keepDirtyValues: true },
     resolver: zodResolver(cardFormSchema),
   });
-
   if (card == null) return;
 
   const submit = form.handleSubmit(async (values) => {
+    const submittedInput = form.getValues();
+    // A failed attempt keeps its pre-optimistic baseline for retries that start before Firestore rolls back.
+    const retryBaseline = failedBaseline ?? getCardFormValues(card);
+    setIsSaving(true);
     setSaveError(null);
     try {
       await editCard(uid, { id: card.id, ...values });
-      // A Card write may finish after the user discards the form; do not navigate from that stale Page.
-      if (isMounted()) onSaved();
+      if (isMounted()) {
+        const savedBaseline = { ...values, tags: [...values.tags] };
+        setFailedBaseline(null);
+        if (areCardFormValuesEqual(form.getValues(), submittedInput)) {
+          onSaved(card.deckId);
+        } else {
+          // A successful write may finish after another edit; preserve that edit against the payload just saved.
+          form.reset(savedBaseline, { keepValues: true });
+        }
+      }
     } catch (error) {
-      if (isMounted()) setSaveError(error);
+      if (isMounted()) {
+        // Optimistic snapshots may replace RHF's baseline while pending; restore it without erasing the retry payload.
+        form.reset(retryBaseline, { keepValues: true });
+        setFailedBaseline(retryBaseline);
+        setSaveError(error);
+      }
+    } finally {
+      if (isMounted()) setIsSaving(false);
     }
   });
   const onFormSubmit = (event?: Parameters<typeof submit>[0]) => {
+    if (isSaving) {
+      event?.preventDefault();
+      return;
+    }
     void submit(event);
   };
 
@@ -63,6 +93,7 @@ export const useCardForm = ({ cardId, onSaved }: UseCardFormOptions) => {
     categories: CATEGORY,
     form,
     isDirty: form.formState.isDirty,
+    isSaving,
     onSubmit: onFormSubmit,
     saveError,
   };

--- a/src/pages/card-form/ui/CardEditor.spec.tsx
+++ b/src/pages/card-form/ui/CardEditor.spec.tsx
@@ -52,6 +52,7 @@ const CardEditorHarness = (props: { cardId: string; onCancel: () => void; onSave
       cardInfo={editor.cardInfo}
       categories={editor.categories}
       form={editor.form}
+      isSaving={editor.isSaving}
       onCancel={props.onCancel}
       onSubmit={editor.onSubmit}
       saveError={editor.saveError}

--- a/src/pages/card-form/ui/CardEditor.stories.tsx
+++ b/src/pages/card-form/ui/CardEditor.stories.tsx
@@ -29,8 +29,7 @@ const CardEditorStory = ({ card, isSaving, validationError, saveError, onCancel 
       form.setError("frontText", { message: "Front text is required." });
       form.setError("backText", { message: "Back text is required." });
     }
-    if (isSaving) void form.handleSubmit(() => new Promise(() => undefined))();
-  }, [form, isSaving, validationError]);
+  }, [form, validationError]);
 
   return (
     <CardEditor
@@ -42,6 +41,7 @@ const CardEditorStory = ({ card, isSaving, validationError, saveError, onCancel 
       }}
       categories={CATEGORY}
       form={form}
+      isSaving={isSaving}
       onCancel={onCancel}
       onSubmit={form.handleSubmit(() => undefined)}
       saveError={saveError}

--- a/src/pages/card-form/ui/CardEditor.tsx
+++ b/src/pages/card-form/ui/CardEditor.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 import { AiOutlineArrowLeft } from "react-icons/ai";
-import { type UseFormReturn, useFormState } from "react-hook-form";
+import type { UseFormReturn } from "react-hook-form";
 
 import type { CardId } from "@/entities/card";
 import { CardFields, type CardFormFields } from "@/features/card-form";
@@ -12,6 +12,7 @@ export interface CardEditorProps {
   cardInfo: { uniqueKey: string; id: CardId; createdAt?: number; lastSeenAt?: number };
   categories: readonly string[];
   form: UseFormReturn<CardFormFields>;
+  isSaving: boolean;
   onCancel: () => void;
   onSubmit: React.SubmitEventHandler<HTMLFormElement>;
   saveError?: unknown;
@@ -23,66 +24,63 @@ export const CardEditor: React.FC<CardEditorProps> = ({
   cardInfo,
   categories,
   form,
+  isSaving,
   onCancel,
   onSubmit,
   saveError,
-}) => {
-  const formState = useFormState({ control: form.control });
-
-  return (
-    <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
-      <header className="mb-section-gap">
-        <button
-          type="button"
-          className="mb-4 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
-          onClick={onCancel}
-        >
-          <AiOutlineArrowLeft aria-hidden="true" />
-          Back to cards
-        </button>
-        <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Card editor</p>
-        <h1 className="mt-1 break-words text-display font-bold text-ink">Edit card</h1>
-        <p className="mt-2 text-body text-ink-muted">Update the prompt, answer, and organization for this card.</p>
-      </header>
-      <Feedback tone="error">{saveError == null ? null : "Unable to save changes. Try again."}</Feedback>
-      <Form onSubmit={onSubmit}>
-        <CardFields categories={categories} form={form} />
-        <details className="rounded-surface border border-border bg-surface-muted p-4">
-          <summary className="flex min-h-touch cursor-pointer items-center font-semibold text-ink">
-            Card information
-          </summary>
-          <dl className="mt-4 grid gap-3 text-caption">
-            <div className="min-w-0">
-              <dt className="font-medium text-ink-muted">Unique key</dt>
-              <dd className="break-all text-ink">{cardInfo.uniqueKey}</dd>
+}) => (
+  <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
+    <header className="mb-section-gap">
+      <button
+        type="button"
+        className="mb-4 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
+        onClick={onCancel}
+      >
+        <AiOutlineArrowLeft aria-hidden="true" />
+        Back to cards
+      </button>
+      <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">Card editor</p>
+      <h1 className="mt-1 break-words text-display font-bold text-ink">Edit card</h1>
+      <p className="mt-2 text-body text-ink-muted">Update the prompt, answer, and organization for this card.</p>
+    </header>
+    <Feedback tone="error">{saveError == null ? null : "Unable to save changes. Try again."}</Feedback>
+    <Form onSubmit={onSubmit}>
+      <CardFields categories={categories} form={form} />
+      <details className="rounded-surface border border-border bg-surface-muted p-4">
+        <summary className="flex min-h-touch cursor-pointer items-center font-semibold text-ink">
+          Card information
+        </summary>
+        <dl className="mt-4 grid gap-3 text-caption">
+          <div className="min-w-0">
+            <dt className="font-medium text-ink-muted">Unique key</dt>
+            <dd className="break-all text-ink">{cardInfo.uniqueKey}</dd>
+          </div>
+          <div className="min-w-0">
+            <dt className="font-medium text-ink-muted">ID</dt>
+            <dd className="break-all text-ink">{cardInfo.id}</dd>
+          </div>
+          {cardInfo.createdAt !== undefined && (
+            <div>
+              <dt className="font-medium text-ink-muted">Created</dt>
+              <dd className="text-ink">{formatDate(cardInfo.createdAt)}</dd>
             </div>
-            <div className="min-w-0">
-              <dt className="font-medium text-ink-muted">ID</dt>
-              <dd className="break-all text-ink">{cardInfo.id}</dd>
+          )}
+          {cardInfo.lastSeenAt !== undefined && (
+            <div>
+              <dt className="font-medium text-ink-muted">Last seen</dt>
+              <dd className="text-ink">{formatDate(cardInfo.lastSeenAt)}</dd>
             </div>
-            {cardInfo.createdAt !== undefined && (
-              <div>
-                <dt className="font-medium text-ink-muted">Created</dt>
-                <dd className="text-ink">{formatDate(cardInfo.createdAt)}</dd>
-              </div>
-            )}
-            {cardInfo.lastSeenAt !== undefined && (
-              <div>
-                <dt className="font-medium text-ink-muted">Last seen</dt>
-                <dd className="text-ink">{formatDate(cardInfo.lastSeenAt)}</dd>
-              </div>
-            )}
-          </dl>
-        </details>
-        <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">
-          <Button variant="quiet" type="button" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button variant="primary" type="submit" disabled={formState.isSubmitting}>
-            {formState.isSubmitting ? <span>Saving…</span> : <span>Save changes</span>}
-          </Button>
-        </div>
-      </Form>
-    </section>
-  );
-};
+          )}
+        </dl>
+      </details>
+      <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">
+        <Button variant="quiet" type="button" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit" disabled={isSaving}>
+          {isSaving ? <span>Saving…</span> : <span>Save changes</span>}
+        </Button>
+      </div>
+    </Form>
+  </section>
+);

--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -1,3 +1,4 @@
+import type { Card } from "@/entities/card";
 import type { Preferences } from "@/entities/preference";
 
 import { render, screen } from "@testing-library/react";
@@ -9,11 +10,14 @@ import "@testing-library/jest-dom/vitest";
 import { mutateCards } from "@/entities/card";
 import { createDeck } from "@/entities/deck";
 import { actAsync } from "@/test/act";
-import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
+import { createCard as createRemoteCard, createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as unknown as Preferences,
   setDarkMode: vi.fn(),
+  beforeCardWrite: undefined as (() => Promise<void>) | undefined,
+  skipCardWrite: false,
+  remoteCard: undefined as Card | undefined,
 }));
 
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
@@ -21,6 +25,21 @@ vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
 }));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...actual,
+    useCard(id: Parameters<typeof actual.useCard>[0]) {
+      const storedCard = actual.useCard(id);
+      return mocks.remoteCard?.id === id ? mocks.remoteCard : storedCard;
+    },
+    editCard: async (...args: Parameters<typeof actual.editCard>) => {
+      await mocks.beforeCardWrite?.();
+      if (mocks.skipCardWrite) return;
+      return actual.editCard(...args);
+    },
+  };
+});
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { CardFormPage } from "./CardFormPage";
@@ -33,16 +52,20 @@ describe("CardFormPage", () => {
       [
         { path: "/previous", element: <h1>Previous page</h1> },
         { path: "/", element: <h1>Deck list</h1> },
+        { path: "/deck/:id", element: <h1>Card list</h1> },
         { path: "/card/:id/edit", element: <CardFormPage /> },
       ],
       { initialEntries: ["/previous", path], initialIndex: 1 }
     );
-    return render(<RouterProvider router={router} />);
+    return Object.assign(render(<RouterProvider router={router} />), { router });
   };
 
   beforeEach(async () => {
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
     mocks.setDarkMode.mockReset();
+    mocks.beforeCardWrite = undefined;
+    mocks.skipCardWrite = false;
+    mocks.remoteCard = undefined;
     await createDeck("", createLocalDeck({ id: deckId }));
     await mutateCards("", [
       {
@@ -78,13 +101,16 @@ describe("CardFormPage", () => {
     expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Delayed back");
   });
 
-  it("returns to the previous page after saving", async () => {
-    renderPage();
+  it("replaces the editor with its Card list after saving", async () => {
+    const view = renderPage();
 
     await userEvent.clear(screen.getByRole("textbox", { name: "Front text" }));
     await userEvent.type(screen.getByRole("textbox", { name: "Front text" }), "Saved front");
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
+    expect(await screen.findByRole("heading", { level: 1, name: "Card list" })).toBeVisible();
+    expect(view.router.state.location.pathname).toBe(`/deck/${deckId}`);
+    await actAsync(async () => view.router.navigate(-1));
     expect(await screen.findByRole("heading", { level: 1, name: "Previous page" })).toBeVisible();
   });
 
@@ -107,6 +133,115 @@ describe("CardFormPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Keep editing" }));
 
     expect(frontText).toHaveValue("Unsaved front");
+  });
+
+  it("keeps a remote Card protected and non-submittable across a pending optimistic snapshot", async () => {
+    let rejectWrite: (error: Error) => void = () => undefined;
+    mocks.beforeCardWrite = () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectWrite = reject;
+      });
+    mocks.skipCardWrite = true;
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Front text", backText: "Back text" });
+    const view = renderPage();
+    const frontText = screen.getByRole("textbox", { name: "Front text" });
+    await userEvent.clear(frontText);
+    await userEvent.type(frontText, "Retry front");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Retry front", backText: "Back text" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+
+    await actAsync(async () => rejectWrite(new Error("write failed")));
+    expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Front text", backText: "Back text" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    expect(frontText).toHaveValue("Retry front");
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+  });
+
+  it("keeps the confirmed Card baseline when a retry fails before the delayed rollback", async () => {
+    const rejectWrites: Array<(error: Error) => void> = [];
+    const rejectWrite = (index: number) => {
+      const reject = rejectWrites[index];
+      if (reject === undefined) throw new Error(`missing write ${index}`);
+      reject(new Error("write failed"));
+    };
+    mocks.beforeCardWrite = () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectWrites.push(reject);
+      });
+    mocks.skipCardWrite = true;
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Front text", backText: "Back text" });
+    const view = renderPage();
+    const frontText = screen.getByRole("textbox", { name: "Front text" });
+    await userEvent.clear(frontText);
+    await userEvent.type(frontText, "Retry front");
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Retry front", backText: "Back text" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    await actAsync(async () => {
+      rejectWrite(0);
+      await Promise.resolve();
+    });
+    expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    await actAsync(async () => {
+      rejectWrite(1);
+      await Promise.resolve();
+    });
+    expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
+
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Front text", backText: "Back text" });
+    view.rerender(<RouterProvider router={view.router} />);
+    expect(frontText).toHaveValue("Retry front");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+  });
+
+  it("keeps edits made after a remote Card submission when that submission succeeds", async () => {
+    let resolveWrite: () => void = () => undefined;
+    mocks.beforeCardWrite = () =>
+      new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+    mocks.skipCardWrite = true;
+    mocks.remoteCard = createRemoteCard({ id: cardId, deckId, frontText: "Front text", backText: "Back text" });
+    const view = renderPage();
+    const frontText = screen.getByRole("textbox", { name: "Front text" });
+    await userEvent.clear(frontText);
+    await userEvent.type(frontText, "Submitted front");
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    mocks.remoteCard = createRemoteCard({
+      id: cardId,
+      deckId,
+      frontText: "Submitted front",
+      backText: "Back text",
+    });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    await userEvent.clear(frontText);
+    await userEvent.type(frontText, "Later front");
+    await actAsync(async () => resolveWrite());
+
+    expect(await screen.findByRole("button", { name: "Save changes" })).toBeEnabled();
+    expect(screen.getByRole("heading", { level: 1, name: "Edit card" })).toBeVisible();
+    expect(frontText).toHaveValue("Later front");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
   });
 
   it("navigates with both recovery actions when the card is unavailable", async () => {

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { useNavigationGuard } from "@/shared/router";
+import { routes, useNavigationGuard } from "@/shared/router";
 import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
@@ -10,9 +10,18 @@ import { CardEditor } from "./CardEditor";
 
 const CardFormContent: React.FC<{ cardId: string }> = ({ cardId }) => {
   const navigate = useNavigate();
-  const goBack = () => void navigate(-1);
-  const editor = useCardForm({ cardId, onSaved: () => guard.allowNavigation(goBack) });
-  const guard = useNavigationGuard(editor?.isDirty ?? false);
+  const goBack = () => navigate(-1);
+  const cancel = () => void goBack();
+  const editor = useCardForm({
+    cardId,
+    onSaved: (deckId) => {
+      const cardListPath = routes.cardList.to(deckId);
+      void guard.allowNavigation({ historyAction: "REPLACE", to: cardListPath }, () =>
+        navigate(cardListPath, { replace: true })
+      );
+    },
+  });
+  const guard = useNavigationGuard(editor != null && (editor.isDirty || editor.isSaving));
 
   if (editor == null) {
     return (
@@ -27,7 +36,8 @@ const CardFormContent: React.FC<{ cardId: string }> = ({ cardId }) => {
         cardInfo={editor.cardInfo}
         categories={editor.categories}
         form={editor.form}
-        onCancel={goBack}
+        isSaving={editor.isSaving}
+        onCancel={cancel}
         onSubmit={editor.onSubmit}
         saveError={editor.saveError}
       />

--- a/src/pages/deck-create/ui/DeckCreatePage.tsx
+++ b/src/pages/deck-create/ui/DeckCreatePage.tsx
@@ -10,7 +10,12 @@ import { DeckCreateView } from "./DeckCreateView";
 export const DeckCreatePage: React.FC = () => {
   const navigate = useNavigate();
   const state = useDeckCreateForm({
-    onCreated: (deckId) => guard.allowNavigation(() => void navigate(routes.cardList.to(deckId), { replace: true })),
+    onCreated: (deckId) => {
+      const cardListPath = routes.cardList.to(deckId);
+      void guard.allowNavigation({ historyAction: "REPLACE", to: cardListPath }, () =>
+        navigate(cardListPath, { replace: true })
+      );
+    },
   });
   const guard = useNavigationGuard(state.isDirty);
 

--- a/src/pages/deck-form/model/useDeckForm.ts
+++ b/src/pages/deck-form/model/useDeckForm.ts
@@ -25,6 +25,13 @@ const getDeckEditInput = (deck: Deck, values: DeckFormValues): Parameters<typeof
   url: values.url ?? null,
 });
 
+const areDeckFormValuesEqual = (left: DeckFormValues, right: DeckFormValues): boolean =>
+  left.name === right.name &&
+  left.category === right.category &&
+  left.url === right.url &&
+  left.convertToBr === right.convertToBr &&
+  left.localMode === right.localMode;
+
 interface UseDeckFormOptions {
   deckId: string;
   onSaved: () => void;
@@ -35,26 +42,50 @@ export const useDeckForm = ({ deckId, onSaved }: UseDeckFormOptions) => {
   const deck = useDeck(deckId);
   const isMounted = useMountedGuard();
   const [saveError, setSaveError] = React.useState<unknown>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [failedBaseline, setFailedBaseline] = React.useState<DeckFormValues | null>(null);
   const form = useForm<DeckFormValues>({
     ...(deck && { values: getDeckFormValues(deck) }),
     // Subscription refreshes may update clean fields, but must not erase the user's retry payload.
     resetOptions: { keepDirtyValues: true },
     resolver: zodResolver(deckFormSchema),
   });
-
   if (deck == null) return;
 
   const submit = form.handleSubmit(async (values) => {
+    const submittedInput = form.getValues();
+    // A failed attempt keeps its pre-optimistic baseline for retries that start before Firestore rolls back.
+    const retryBaseline = failedBaseline ?? getDeckFormValues(deck);
+    setIsSaving(true);
     setSaveError(null);
     try {
       await editDeck(uid, getDeckEditInput(deck, values));
-      // A Deck write may finish after the user leaves this Page; prevent that stale completion from navigating them.
-      if (isMounted()) onSaved();
+      if (isMounted()) {
+        const savedBaseline = { ...values };
+        setFailedBaseline(null);
+        if (areDeckFormValuesEqual(form.getValues(), submittedInput)) {
+          onSaved();
+        } else {
+          // A successful write may finish after another edit; preserve that edit against the payload just saved.
+          form.reset(savedBaseline, { keepValues: true });
+        }
+      }
     } catch (error) {
-      if (isMounted()) setSaveError(error);
+      if (isMounted()) {
+        // Optimistic snapshots may replace RHF's baseline while pending; restore it without erasing the retry payload.
+        form.reset(retryBaseline, { keepValues: true });
+        setFailedBaseline(retryBaseline);
+        setSaveError(error);
+      }
+    } finally {
+      if (isMounted()) setIsSaving(false);
     }
   });
   const onFormSubmit = (event?: Parameters<typeof submit>[0]) => {
+    if (isSaving) {
+      event?.preventDefault();
+      return;
+    }
     void submit(event);
   };
 
@@ -71,6 +102,7 @@ export const useDeckForm = ({ deckId, onSaved }: UseDeckFormOptions) => {
     form,
     isDirty: form.formState.isDirty,
     isLocalOnly: deck.localMode,
+    isSaving,
     onSubmit: onFormSubmit,
     saveError,
   };

--- a/src/pages/deck-form/ui/DeckEditor.spec.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.spec.tsx
@@ -53,6 +53,7 @@ const DeckEditorHarness = (props: { deckId: string; onCancel: () => void; onSave
       deckName={editor.deckName}
       form={editor.form}
       isLocalOnly={editor.isLocalOnly}
+      isSaving={editor.isSaving}
       onCancel={props.onCancel}
       onDelete={() => undefined}
       onSubmit={editor.onSubmit}

--- a/src/pages/deck-form/ui/DeckEditor.stories.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.stories.tsx
@@ -35,8 +35,7 @@ const DeckEditorStory = ({ deck, isSaving, validationError, saveError, onCancel,
       form.setError("name", { message: "Deck name is required." });
       form.setError("url", { message: "Enter a valid URL." });
     }
-    if (isSaving) void form.handleSubmit(() => new Promise(() => undefined))();
-  }, [form, isSaving, validationError]);
+  }, [form, validationError]);
 
   return (
     <DeckEditor
@@ -45,6 +44,7 @@ const DeckEditorStory = ({ deck, isSaving, validationError, saveError, onCancel,
       deckName={deck.name}
       form={form}
       isLocalOnly={deck.localMode}
+      isSaving={isSaving}
       onCancel={onCancel}
       onDelete={onDelete}
       onSubmit={form.handleSubmit(() => undefined)}

--- a/src/pages/deck-form/ui/DeckEditor.tsx
+++ b/src/pages/deck-form/ui/DeckEditor.tsx
@@ -15,6 +15,7 @@ export interface DeckEditorProps {
   deckInfo: { id: DeckId; createdAt: number; updatedAt: number };
   form: UseFormReturn<DeckFormValues>;
   isLocalOnly: boolean;
+  isSaving: boolean;
   onCancel: () => void;
   saveError?: unknown;
   onDelete: () => void;
@@ -27,6 +28,7 @@ export const DeckEditor: React.FC<DeckEditorProps> = ({
   deckName,
   form,
   isLocalOnly,
+  isSaving,
   onCancel,
   onDelete,
   onSubmit,
@@ -52,6 +54,7 @@ export const DeckEditor: React.FC<DeckEditorProps> = ({
       deckInfo={deckInfo}
       form={form}
       isLocalOnly={isLocalOnly}
+      isSaving={isSaving}
       onCancel={onCancel}
       onSubmit={onSubmit}
     />

--- a/src/pages/deck-form/ui/DeckForm.stories.tsx
+++ b/src/pages/deck-form/ui/DeckForm.stories.tsx
@@ -33,8 +33,7 @@ const DeckFormStory = ({ deck, isSaving, validationError, onCancel }: DeckFormSt
       form.setError("name", { message: "Deck name is required." });
       form.setError("url", { message: "Enter a valid URL." });
     }
-    if (isSaving) void form.handleSubmit(() => new Promise(() => undefined))();
-  }, [form, isSaving, validationError]);
+  }, [form, validationError]);
 
   return (
     <DeckForm
@@ -42,6 +41,7 @@ const DeckFormStory = ({ deck, isSaving, validationError, onCancel }: DeckFormSt
       deckInfo={{ id: deck.id, createdAt: deck.createdAt, updatedAt: deck.updatedAt }}
       form={form}
       isLocalOnly={deck.localMode}
+      isSaving={isSaving}
       onCancel={onCancel}
       onSubmit={form.handleSubmit(() => undefined)}
     />

--- a/src/pages/deck-form/ui/DeckForm.tsx
+++ b/src/pages/deck-form/ui/DeckForm.tsx
@@ -19,6 +19,7 @@ export interface DeckFormProps {
   };
   form: UseFormReturn<DeckFormValues>;
   isLocalOnly: boolean;
+  isSaving: boolean;
   onCancel: () => void;
   onSubmit: React.SubmitEventHandler<HTMLFormElement>;
 }
@@ -137,8 +138,8 @@ export const DeckForm: React.FC<DeckFormProps> = (props) => {
         <Button variant="quiet" type="button" onClick={props.onCancel}>
           Cancel
         </Button>
-        <Button variant="primary" type="submit" disabled={formState.isSubmitting}>
-          {formState.isSubmitting ? "Saving…" : "Save changes"}
+        <Button variant="primary" type="submit" disabled={props.isSaving}>
+          {props.isSaving ? "Saving…" : "Save changes"}
         </Button>
       </div>
     </Form>

--- a/src/pages/deck-form/ui/DeckFormPage.spec.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.spec.tsx
@@ -1,3 +1,4 @@
+import type { Deck } from "@/entities/deck";
 import type { Preferences } from "@/entities/preference";
 
 import { render, screen, within } from "@testing-library/react";
@@ -8,11 +9,14 @@ import "@testing-library/jest-dom/vitest";
 
 import { createDeck } from "@/entities/deck";
 import { actAsync } from "@/test/act";
-import { createLocalDeck, createPreferences } from "@/test/factories";
+import { createDeck as createRemoteDeck, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as unknown as Preferences,
   setDarkMode: vi.fn(),
+  beforeDeckWrite: undefined as (() => Promise<void>) | undefined,
+  skipDeckWrite: false,
+  remoteDeck: undefined as Deck | undefined,
 }));
 
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
@@ -20,6 +24,21 @@ vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
 }));
+vi.mock("@/entities/deck", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/entities/deck")>();
+  return {
+    ...actual,
+    useDeck(id: Parameters<typeof actual.useDeck>[0]) {
+      const storedDeck = actual.useDeck(id);
+      return mocks.remoteDeck?.id === id ? mocks.remoteDeck : storedDeck;
+    },
+    editDeck: async (...args: Parameters<typeof actual.editDeck>) => {
+      await mocks.beforeDeckWrite?.();
+      if (mocks.skipDeckWrite) return;
+      return actual.editDeck(...args);
+    },
+  };
+});
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { DeckFormPage } from "./DeckFormPage";
@@ -41,6 +60,9 @@ describe("DeckFormPage", () => {
   beforeEach(async () => {
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
     mocks.setDarkMode.mockReset();
+    mocks.beforeDeckWrite = undefined;
+    mocks.skipDeckWrite = false;
+    mocks.remoteDeck = undefined;
     await createDeck("", createLocalDeck({ id: deckId, name: "Deck name", category: "", convertToBr: false }));
   });
 
@@ -122,6 +144,110 @@ describe("DeckFormPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Keep editing" }));
 
     expect(name).toHaveValue("Unsaved deck");
+  });
+
+  it("keeps a remote Deck protected and non-submittable across a pending optimistic snapshot", async () => {
+    let rejectWrite: (error: Error) => void = () => undefined;
+    mocks.beforeDeckWrite = () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectWrite = reject;
+      });
+    mocks.skipDeckWrite = true;
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Deck name" });
+    const view = renderPage();
+    const name = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(name);
+    await userEvent.type(name, "Retry deck");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Retry deck" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+
+    await actAsync(async () => rejectWrite(new Error("write failed")));
+    expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Deck name" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    expect(name).toHaveValue("Retry deck");
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+  });
+
+  it("keeps the confirmed Deck baseline when a retry fails before the delayed rollback", async () => {
+    const rejectWrites: Array<(error: Error) => void> = [];
+    const rejectWrite = (index: number) => {
+      const reject = rejectWrites[index];
+      if (reject === undefined) throw new Error(`missing write ${index}`);
+      reject(new Error("write failed"));
+    };
+    mocks.beforeDeckWrite = () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectWrites.push(reject);
+      });
+    mocks.skipDeckWrite = true;
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Deck name" });
+    const view = renderPage();
+    const name = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(name);
+    await userEvent.type(name, "Retry deck");
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Retry deck" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    await actAsync(async () => {
+      rejectWrite(0);
+      await Promise.resolve();
+    });
+    expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    await actAsync(async () => {
+      rejectWrite(1);
+      await Promise.resolve();
+    });
+    expect(await screen.findByText("Unable to save changes. Try again.")).toBeVisible();
+
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Deck name" });
+    view.rerender(<RouterProvider router={view.router} />);
+    expect(name).toHaveValue("Retry deck");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+  });
+
+  it("keeps edits made after a remote Deck submission when that submission succeeds", async () => {
+    let resolveWrite: () => void = () => undefined;
+    mocks.beforeDeckWrite = () =>
+      new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+    mocks.skipDeckWrite = true;
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Deck name" });
+    const view = renderPage();
+    const name = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(name);
+    await userEvent.type(name, "Submitted deck");
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toBeDisabled();
+    mocks.remoteDeck = createRemoteDeck({ id: deckId, name: "Submitted deck" });
+    view.rerender(<RouterProvider router={view.router} />);
+
+    await userEvent.clear(name);
+    await userEvent.type(name, "Later deck");
+    await actAsync(async () => resolveWrite());
+
+    expect(await screen.findByRole("button", { name: "Save changes" })).toBeEnabled();
+    expect(screen.getByRole("heading", { level: 1, name: "Submitted deck" })).toBeVisible();
+    expect(name).toHaveValue("Later deck");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
   });
 
   it("shows navigation confirmation above an open deletion dialog", async () => {

--- a/src/pages/deck-form/ui/DeckFormPage.tsx
+++ b/src/pages/deck-form/ui/DeckFormPage.tsx
@@ -11,10 +11,17 @@ import { DeckEditor } from "./DeckEditor";
 
 const DeckFormContent: React.FC<{ deckId: string }> = ({ deckId }) => {
   const navigate = useNavigate();
-  const goToList = () => void navigate(routes.deckList.to(), { replace: true });
-  const editor = useDeckForm({ deckId, onSaved: () => guard.allowNavigation(goToList) });
-  const guard = useNavigationGuard(editor?.isDirty ?? false);
-  const deletion = useDeckDeletion({ onDeleted: () => guard.allowNavigation(goToList) });
+  const deckListPath = routes.deckList.to();
+  const goToList = () => navigate(deckListPath, { replace: true });
+  const cancel = () => void goToList();
+  const editor = useDeckForm({
+    deckId,
+    onSaved: () => void guard.allowNavigation({ historyAction: "REPLACE", to: deckListPath }, goToList),
+  });
+  const guard = useNavigationGuard(editor != null && (editor.isDirty || editor.isSaving));
+  const deletion = useDeckDeletion({
+    onDeleted: () => void guard.allowNavigation({ historyAction: "REPLACE", to: deckListPath }, goToList),
+  });
 
   if (editor == null) {
     return (
@@ -34,7 +41,8 @@ const DeckFormContent: React.FC<{ deckId: string }> = ({ deckId }) => {
         deckName={editor.deckName}
         form={editor.form}
         isLocalOnly={editor.isLocalOnly}
-        onCancel={goToList}
+        isSaving={editor.isSaving}
+        onCancel={cancel}
         saveError={editor.saveError}
         onDelete={() => deletion.request(editor.deckInfo.id)}
         onSubmit={editor.onSubmit}

--- a/src/shared/router/navigationGuard.spec.tsx
+++ b/src/shared/router/navigationGuard.spec.tsx
@@ -21,11 +21,29 @@ const GuardedRoute = () => {
         Reset
       </button>
       <Link to="/next">Leave</Link>
-      <button type="button" onClick={() => guard.allowNavigation(() => void navigate("/next"))}>
+      <button
+        type="button"
+        onClick={() => void guard.allowNavigation({ historyAction: "PUSH", to: "/next" }, () => navigate("/next"))}
+      >
         Save successfully
       </button>
-      <button type="button" onClick={() => guard.allowNavigation(() => undefined)}>
-        No-op success
+      <button
+        type="button"
+        onClick={() => {
+          void guard.allowNavigation({ historyAction: "PUSH", to: "/next" }, () => undefined);
+          void navigate("/unrelated");
+        }}
+      >
+        No-op then unrelated
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void guard.allowNavigation({ historyAction: "PUSH", to: "/next" }, () => new Promise(() => undefined));
+          void navigate(-1);
+        }}
+      >
+        Pending save then Back
       </button>
       {guard.element}
     </>
@@ -36,9 +54,11 @@ const renderGuard = () => {
   const router = createMemoryRouter(
     [
       { path: "/form", element: <GuardedRoute /> },
+      { path: "/previous", element: <h1>Previous page</h1> },
       { path: "/next", element: <h1>Next page</h1> },
+      { path: "/unrelated", element: <h1>Unrelated page</h1> },
     ],
-    { initialEntries: ["/form"] }
+    { initialEntries: ["/previous", "/form"], initialIndex: 1 }
   );
   return render(<RouterProvider router={router} />);
 };
@@ -73,13 +93,22 @@ describe("useNavigationGuard", () => {
     expect(await screen.findByRole("heading", { name: "Next page" })).toBeVisible();
   });
 
-  it("does not retain a bypass after a no-op navigation", async () => {
+  it("clears a synchronous no-op before a same-turn unrelated navigation", async () => {
     renderGuard();
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    await userEvent.click(screen.getByRole("button", { name: "No-op success" }));
-    await userEvent.click(screen.getByRole("link", { name: "Leave" }));
+    await userEvent.click(screen.getByRole("button", { name: "No-op then unrelated" }));
 
     expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Unrelated page" })).not.toBeInTheDocument();
+  });
+
+  it("does not spend a pending save bypass on an unrelated Back navigation", async () => {
+    renderGuard();
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await userEvent.click(screen.getByRole("button", { name: "Pending save then Back" }));
+
+    expect(screen.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Previous page" })).not.toBeInTheDocument();
   });
 
   it("requests browser-native confirmation only while dirty", async () => {

--- a/src/shared/router/navigationGuard.tsx
+++ b/src/shared/router/navigationGuard.tsx
@@ -1,7 +1,20 @@
 import * as React from "react";
-import { useBeforeUnload, useBlocker } from "react-router-dom";
+import { NavigationType, useBeforeUnload, useBlocker } from "react-router-dom";
 
 import { NavigationGuardDialog } from "../ui/navigation-guard-dialog";
+
+type AllowedNavigationIntent = { historyAction: "PUSH" | "REPLACE"; to: string };
+
+const getLocationPath = (location: { pathname: string; search: string; hash: string }): string =>
+  `${location.pathname}${location.search}${location.hash}`;
+
+const matchesHistoryAction = (
+  intendedAction: AllowedNavigationIntent["historyAction"],
+  actualAction: NavigationType
+): boolean => {
+  if (intendedAction === "PUSH") return actualAction === NavigationType.Push;
+  return actualAction === NavigationType.Replace;
+};
 
 const BeforeUnloadGuard = () => {
   useBeforeUnload(
@@ -17,23 +30,41 @@ const BeforeUnloadGuard = () => {
 };
 
 export const useNavigationGuard = (isDirty: boolean) => {
-  const bypassNextNavigation = React.useRef<boolean>(false);
-  const blocker = useBlocker(() => {
-    // biome-ignore lint/suspicious/noUnnecessaryConditions: Imperative success navigation sets this ref synchronously.
-    if (bypassNextNavigation.current) {
-      bypassNextNavigation.current = false;
+  const allowedNavigation = React.useRef<{
+    intent: AllowedNavigationIntent;
+    token: symbol;
+  } | null>(null);
+  const blocker = useBlocker(({ historyAction, nextLocation }) => {
+    const pending = allowedNavigation.current;
+    const matchesIntent =
+      // biome-ignore lint/suspicious/noUnnecessaryConditions: Imperative navigation arms this ref outside render.
+      pending != null &&
+      matchesHistoryAction(pending.intent.historyAction, historyAction) &&
+      pending.intent.to === getLocationPath(nextLocation);
+    if (matchesIntent) {
+      allowedNavigation.current = null;
       return false;
     }
     return isDirty;
   });
 
-  const allowNavigation = (navigate: () => void) => {
-    bypassNextNavigation.current = true;
+  const allowNavigation = (intent: AllowedNavigationIntent, navigate: () => void | Promise<void>) => {
+    const navigationToken = Symbol("allowed-navigation");
+    allowedNavigation.current = { intent, token: navigationToken };
+    const clearAllowedNavigation = () => {
+      if (allowedNavigation.current?.token === navigationToken) allowedNavigation.current = null;
+    };
     try {
-      navigate();
-    } finally {
-      // A no-op or failed navigation must not let a later unrelated navigation escape the guard.
-      bypassNextNavigation.current = false;
+      const result = navigate();
+      if (result === undefined) {
+        // Synchronous no-ops must not expose even a microtask-sized bypass window.
+        clearAllowedNavigation();
+        return;
+      }
+      return result.finally(clearAllowedNavigation);
+    } catch (error) {
+      clearAllowedNavigation();
+      throw error;
     }
   };
 


### PR DESCRIPTION
## Summary

- keep unsaved-change protection active independently of React Hook Form submission state
- preserve retry payloads and confirmed baselines across optimistic write failures
- bind successful navigation to exact targets and replace Card editors with their owning Card list
- preserve edits made while a save is pending

## Testing

- `mise run check` (113 files, 607 tests)
- `mise run e2e` (65 passed)
- mandatory reviewer: no P0, P1, or P2 findings