### PR TITLE
[No issue] Simplify study session filters

### DIFF
--- a/src/features/deck-filter/index.ts
+++ b/src/features/deck-filter/index.ts
@@ -1,2 +1,3 @@
 export { DeckFilterForm } from "./ui/DeckFilterForm";
+export { ScoreRange } from "./ui/ScoreRange";
 export { useDeckFilterState } from "./model/useDeckFilterState";

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -17,7 +17,7 @@ const numericOptionValues = (select: HTMLElement): string[] =>
     .filter(Boolean);
 
 describe("ScoreRange", () => {
-  it("offers No limit and scores from −10 through 10 with accessible labels", () => {
+  it("shows a dash for an unrestricted boundary and explains its meaning accessibly", () => {
     render(
       <ScoreRange maximum={null} minimum={null} onClear={vi.fn()} onMaximumChange={vi.fn()} onMinimumChange={vi.fn()} />
     );
@@ -27,12 +27,12 @@ describe("ScoreRange", () => {
 
     expect(minimum).toHaveValue("");
     expect(maximum).toHaveValue("");
-    expect(within(minimum).getByRole("option", { name: "No limit" })).toHaveValue("");
-    expect(within(maximum).getByRole("option", { name: "No limit" })).toHaveValue("");
+    expect(within(minimum).getByRole("option", { name: "-" })).toHaveValue("");
+    expect(within(maximum).getByRole("option", { name: "-" })).toHaveValue("");
     expect(numericOptionValues(minimum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
     expect(numericOptionValues(maximum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
-    expect(minimum).toHaveAccessibleDescription("Include cards at or above this score.");
-    expect(maximum).toHaveAccessibleDescription("Include cards at or below this score.");
+    expect(minimum).toHaveAccessibleDescription("No minimum score. Include cards at or above this score.");
+    expect(maximum).toHaveAccessibleDescription("No maximum score. Include cards at or below this score.");
     expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 

--- a/src/features/deck-filter/ui/ScoreRange.spec.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.spec.tsx
@@ -31,12 +31,12 @@ describe("ScoreRange", () => {
     expect(within(maximum).getByRole("option", { name: "-" })).toHaveValue("");
     expect(numericOptionValues(minimum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
     expect(numericOptionValues(maximum)).toEqual(Array.from({ length: 21 }, (_, index) => String(index - 10)));
-    expect(minimum).toHaveAccessibleDescription("No minimum score. Include cards at or above this score.");
-    expect(maximum).toHaveAccessibleDescription("No maximum score. Include cards at or below this score.");
+    expect(minimum).toHaveAccessibleDescription("A dash means no minimum score. Include cards at or above this score.");
+    expect(maximum).toHaveAccessibleDescription("A dash means no maximum score. Include cards at or below this score.");
     expect(screen.queryByRole("button", { name: "Clear limits" })).not.toBeInTheDocument();
   });
 
-  it("reports native selections", async () => {
+  it("explains the dash while numeric boundaries are selected and reports native selections", async () => {
     const onMinimumChange = vi.fn();
     const onMaximumChange = vi.fn();
     render(
@@ -49,8 +49,13 @@ describe("ScoreRange", () => {
       />
     );
 
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Minimum score" }), "-1");
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Maximum score" }), "3");
+    const minimum = screen.getByRole("combobox", { name: "Minimum score" });
+    const maximum = screen.getByRole("combobox", { name: "Maximum score" });
+    expect(minimum).toHaveAccessibleDescription("A dash means no minimum score. Include cards at or above this score.");
+    expect(maximum).toHaveAccessibleDescription("A dash means no maximum score. Include cards at or below this score.");
+
+    await userEvent.selectOptions(minimum, "-1");
+    await userEvent.selectOptions(maximum, "3");
     expect(onMinimumChange).toHaveBeenCalledWith(-1);
     expect(onMaximumChange).toHaveBeenCalledWith(3);
   });

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -86,8 +86,7 @@ const ScoreSelect = ({
       }
     />
     <p id={`${props.id}-description`} className="sr-only">
-      {props.value == null ? `No ${props.label.toLowerCase()} score. ` : ""}
-      {props.description}
+      A dash means no {props.label.toLowerCase()} score. {props.description}
     </p>
   </div>
 );

--- a/src/features/deck-filter/ui/ScoreRange.tsx
+++ b/src/features/deck-filter/ui/ScoreRange.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/shared/ui/button";
 import { Select } from "@/shared/ui/forms";
 
 const NO_LIMIT_VALUE = "";
+const NO_LIMIT_LABEL = "-";
 const MINIMUM_STANDARD_SCORE = -10;
 const MAXIMUM_STANDARD_SCORE = 10;
 const STANDARD_SCORES = Array.from(
@@ -77,7 +78,7 @@ const ScoreSelect = ({
       aria-describedby={props.describedBy}
       aria-invalid={props.invalid || undefined}
       options={[
-        { label: "No limit", value: NO_LIMIT_VALUE },
+        { label: NO_LIMIT_LABEL, value: NO_LIMIT_VALUE },
         ...props.scores.map((score) => ({ label: displayScore(score), value: String(score) })),
       ]}
       onChange={(event) =>
@@ -85,6 +86,7 @@ const ScoreSelect = ({
       }
     />
     <p id={`${props.id}-description`} className="sr-only">
+      {props.value == null ? `No ${props.label.toLowerCase()} score. ` : ""}
       {props.description}
     </p>
   </div>

--- a/src/pages/study-session-start/ui/StudySessionFilters.stories.tsx
+++ b/src/pages/study-session-start/ui/StudySessionFilters.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { fn } from "storybook/test";
+
+import { StudySessionFilters } from "./StudySessionFilters";
+
+type StudySessionFiltersProps = React.ComponentProps<typeof StudySessionFilters>;
+
+const tags = Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`);
+
+const InteractiveStudySessionFilters: React.FC<StudySessionFiltersProps> = (props) => {
+  const [scoreMax, setScoreMax] = React.useState(props.scoreMax);
+  const [scoreMin, setScoreMin] = React.useState(props.scoreMin);
+  const [selectedTags, setSelectedTags] = React.useState(props.selectedTags);
+  const [tagAndFilter, setTagAndFilter] = React.useState(props.tagAndFilter);
+
+  return (
+    <StudySessionFilters
+      {...props}
+      scoreMax={scoreMax}
+      scoreMin={scoreMin}
+      selectedTags={selectedTags}
+      tagAndFilter={tagAndFilter}
+      clearScoreRange={() => {
+        props.clearScoreRange();
+        setScoreMax(null);
+        setScoreMin(null);
+      }}
+      setScoreMax={(value) => {
+        props.setScoreMax(value);
+        setScoreMax(value);
+      }}
+      setScoreMin={(value) => {
+        props.setScoreMin(value);
+        setScoreMin(value);
+      }}
+      setSelectedTags={(value) => {
+        props.setSelectedTags(value);
+        setSelectedTags(value);
+      }}
+      setTagAndFilter={(value) => {
+        props.setTagAndFilter(value);
+        setTagAndFilter(value);
+      }}
+    />
+  );
+};
+
+const meta = {
+  title: "Pages/Study Session Start/StudySessionFilters",
+  component: StudySessionFilters,
+  tags: ["autodocs"],
+  args: {
+    scoreMax: 1,
+    scoreMin: -1,
+    selectedTags: ["tag-12", "tag-3"],
+    tagAndFilter: false,
+    tags,
+    clearScoreRange: fn(),
+    setScoreMax: fn(),
+    setScoreMin: fn(),
+    setSelectedTags: fn(),
+    setTagAndFilter: fn(),
+  },
+  render: (args) => <InteractiveStudySessionFilters {...args} />,
+} satisfies Meta<typeof StudySessionFilters>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoFilters: Story = {
+  args: { scoreMax: null, scoreMin: null, selectedTags: [] },
+};
+
+export const ManyTags: Story = {
+  args: {
+    tags: Array.from({ length: 100 }, (_, index) => `tag-${String(index + 1)}`),
+    selectedTags: Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`),
+    tagAndFilter: true,
+  },
+};
+
+export const Mobile320: Story = {
+  globals: { viewport: { value: "iphone5", isRotated: false } },
+};
+
+export const Dark: Story = {
+  globals: { theme: "dark" },
+};

--- a/src/pages/study-session-start/ui/StudySessionFilters.tsx
+++ b/src/pages/study-session-start/ui/StudySessionFilters.tsx
@@ -1,0 +1,37 @@
+import type * as React from "react";
+
+import { ScoreRange } from "@/features/deck-filter";
+
+import { StudySessionTagFilter } from "./StudySessionTagFilter";
+
+interface StudySessionFiltersProps {
+  scoreMax: number | null;
+  scoreMin: number | null;
+  selectedTags: string[];
+  tagAndFilter: boolean;
+  tags: string[];
+  clearScoreRange: () => void;
+  setScoreMax: (value: number | null) => void;
+  setScoreMin: (value: number | null) => void;
+  setSelectedTags: (value: string[]) => void;
+  setTagAndFilter: (value: boolean) => void;
+}
+
+export const StudySessionFilters: React.FC<StudySessionFiltersProps> = (props) => (
+  <div className="w-full space-y-4 text-ink">
+    <ScoreRange
+      maximum={props.scoreMax}
+      minimum={props.scoreMin}
+      onClear={props.clearScoreRange}
+      onMaximumChange={props.setScoreMax}
+      onMinimumChange={props.setScoreMin}
+    />
+    <StudySessionTagFilter
+      tags={props.tags}
+      selectedTags={props.selectedTags}
+      matchAll={props.tagAndFilter}
+      onSelectedTagsChange={props.setSelectedTags}
+      onMatchAllChange={props.setTagAndFilter}
+    />
+  </div>
+);

--- a/src/pages/study-session-start/ui/StudySessionStart.stories.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStart.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { fn } from "storybook/test";
 
-import { withPageLayout } from "@/storybook/PageLayoutDecorator";
-import { DeckFilterForm } from "@/features/deck-filter";
 import * as fixture from "@/storybook/fixture";
+import { withPageLayout } from "@/storybook/PageLayoutDecorator";
 
+import { StudySessionFilters } from "./StudySessionFilters";
 import { StudySessionStart } from "./StudySessionStart";
 
 const Filters: React.FC<{
@@ -19,7 +19,7 @@ const Filters: React.FC<{
   const [tagAndFilter, setTagAndFilter] = React.useState(props.initialTagAndFilter);
 
   return (
-    <DeckFilterForm
+    <StudySessionFilters
       scoreMax={scoreMax}
       scoreMin={scoreMin}
       tags={[...props.tags]}

--- a/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.spec.tsx
@@ -15,12 +15,13 @@ const mocks = vi.hoisted(() => ({
   preferences: null as unknown as Preferences,
   deck: null as Deck | null,
   cards: [] as Card[],
+  tags: [] as string[],
   setDarkMode: vi.fn(),
   editDeck: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@/entities/card", () => ({
-  useCardsByDeckId: () => ({ cards: mocks.cards, tags: [] }),
+  useCardsByDeckId: () => ({ cards: mocks.cards, tags: mocks.tags }),
 }));
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
 vi.mock("@/entities/deck", () => ({
@@ -67,6 +68,7 @@ describe("StudySessionStartPage", () => {
     mocks.preferences = createPreferences({ appearance: { darkMode: false }, study: { maxNumberOfCardsToLearn: 1 } });
     mocks.deck = createDeck({ id: deckId, name: "Japanese vocabulary" });
     mocks.cards = [createCard({ id: cardId, deckId })];
+    mocks.tags = [];
     vi.clearAllMocks();
   });
 
@@ -108,6 +110,17 @@ describe("StudySessionStartPage", () => {
     expect(screen.getByRole("button", { name: "Start 1 card" })).toBeVisible();
     expect(screen.getByText("1 card matches your filters.")).toBeVisible();
     expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deckId, scoreMin: 1 });
+  });
+
+  it("reveals additional tags and persists a newly selected tag", async () => {
+    mocks.tags = Array.from({ length: 12 }, (_, index) => `tag-${index + 1}`);
+    renderPage();
+
+    expect(screen.queryByRole("checkbox", { name: "tag-12" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Show 4 more tags" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "tag-12" }));
+
+    expect(mocks.editDeck).toHaveBeenCalledWith("user-id", { id: deckId, selectedTags: ["tag-12"] });
   });
 
   it("creates a study session before navigating to it", async () => {

--- a/src/pages/study-session-start/ui/StudySessionStartPage.tsx
+++ b/src/pages/study-session-start/ui/StudySessionStartPage.tsx
@@ -4,12 +4,13 @@ import { useKey } from "react-use";
 
 import type { Deck } from "@/entities/deck";
 import { useDeck } from "@/entities/deck";
-import { DeckFilterForm, useDeckFilterState } from "@/features/deck-filter";
+import { useDeckFilterState } from "@/features/deck-filter";
 import { routes } from "@/shared/router";
 import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
 import { useStudySessionStartState } from "../model/useStudySessionStartState";
+import { StudySessionFilters } from "./StudySessionFilters";
 import { StudySessionStart } from "./StudySessionStart";
 
 // The Enter shortcut listens at the window level, so interactive controls must own the event.
@@ -44,7 +45,7 @@ const AvailableStudySessionStartPage: React.FC<{ deck: Deck }> = ({ deck }) => {
         maxNumberOfCardsToLearn={state.maxNumberOfCardsToLearn}
         cardsLength={state.cardsLength}
         onClickStart={start}
-        filterSlot={<DeckFilterForm {...filter} tags={state.tags} />}
+        filterSlot={<StudySessionFilters {...filter} tags={state.tags} />}
       />
     </AppLayout>
   );

--- a/src/pages/study-session-start/ui/StudySessionTagFilter.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionTagFilter.spec.tsx
@@ -1,0 +1,200 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import type * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { StudySessionTagFilter } from "./StudySessionTagFilter";
+
+const tagNames = () => screen.getAllByRole<HTMLInputElement>("checkbox").map((checkbox) => checkbox.value);
+
+const ControlledTagFilter: React.FC<{ tags: string[]; initialSelectedTags?: string[] }> = ({
+  tags,
+  initialSelectedTags = [],
+}) => {
+  const [selectedTags, setSelectedTags] = useState(initialSelectedTags);
+
+  return (
+    <StudySessionTagFilter
+      tags={tags}
+      selectedTags={selectedTags}
+      matchAll={false}
+      onSelectedTagsChange={setSelectedTags}
+      onMatchAllChange={vi.fn()}
+    />
+  );
+};
+
+describe("StudySessionTagFilter", () => {
+  it("reports tag, clear, and explicit match-mode changes with a deduplicated selection count", async () => {
+    const user = userEvent.setup();
+    const onSelectedTagsChange = vi.fn();
+    const onMatchAllChange = vi.fn();
+    const filter = (matchAll: boolean) => (
+      <StudySessionTagFilter
+        tags={["one", "two"]}
+        selectedTags={["one", "one"]}
+        matchAll={matchAll}
+        onSelectedTagsChange={onSelectedTagsChange}
+        onMatchAllChange={onMatchAllChange}
+      />
+    );
+    const view = render(filter(false));
+
+    const region = screen.getByRole("region", { name: "Tags" });
+    expect(within(region).getByText("1 selected")).toBeVisible();
+    expect(within(region).getByRole("group", { name: "Match" })).toBeVisible();
+    expect(within(region).getByRole("radio", { name: "Any" })).toBeChecked();
+    expect(within(region).getByRole("radio", { name: "All" })).not.toBeChecked();
+    expect(within(region).getByRole("button", { name: "Clear" })).toBeEnabled();
+
+    await user.click(within(region).getByRole("checkbox", { name: "two" }));
+    await user.click(within(region).getByRole("checkbox", { name: "one" }));
+    await user.click(within(region).getByRole("radio", { name: "All" }));
+    view.rerender(filter(true));
+    await user.click(within(region).getByRole("radio", { name: "Any" }));
+    await user.click(within(region).getByRole("button", { name: "Clear" }));
+
+    expect(onSelectedTagsChange).toHaveBeenNthCalledWith(1, ["one", "two"]);
+    expect(onSelectedTagsChange).toHaveBeenNthCalledWith(2, []);
+    expect(onSelectedTagsChange).toHaveBeenNthCalledWith(3, []);
+    expect(onMatchAllChange).toHaveBeenNthCalledWith(1, true);
+    expect(onMatchAllChange).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("keeps selected and stale tags first while progressively disclosing unselected tags", async () => {
+    const user = userEvent.setup();
+    const tags = [
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+      "six",
+      "seven",
+      "eight",
+      "nine",
+      "ten",
+      "eleven",
+      "twelve",
+      "two",
+    ];
+    render(<ControlledTagFilter tags={tags} initialSelectedTags={["stale", "four", "stale"]} />);
+
+    expect(tagNames()).toEqual(["stale", "four", "one", "two", "three", "five", "six", "seven", "eight", "nine"]);
+    const showMore = screen.getByRole("button", { name: "Show 3 more tags" });
+    expect(showMore).toHaveAttribute("aria-expanded", "false");
+    expect(showMore).toHaveAttribute("aria-controls");
+
+    await user.click(showMore);
+    expect(screen.getByRole("button", { name: "Show fewer tags" })).toHaveAttribute("aria-expanded", "true");
+    expect(tagNames()).toEqual([
+      "stale",
+      "four",
+      "one",
+      "two",
+      "three",
+      "five",
+      "six",
+      "seven",
+      "eight",
+      "nine",
+      "ten",
+      "eleven",
+      "twelve",
+    ]);
+
+    await user.click(screen.getByRole("checkbox", { name: "twelve" }));
+    expect(tagNames().slice(0, 3)).toEqual(["stale", "four", "twelve"]);
+    await user.click(screen.getByRole("button", { name: "Show fewer tags" }));
+
+    expect(screen.getByRole("checkbox", { name: "twelve" })).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: "twelve" })).toBeChecked();
+    expect(screen.queryByRole("checkbox", { name: "ten" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "eleven" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show 2 more tags" })).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("moves focus to a remaining tag when deselection removes a collapsed chip", async () => {
+    const user = userEvent.setup();
+    const tags = Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`);
+    render(<ControlledTagFilter tags={tags} initialSelectedTags={["tag-12"]} />);
+
+    screen.getByRole("checkbox", { name: "tag-12" }).focus();
+    await user.keyboard(" ");
+
+    expect(screen.queryByRole("checkbox", { name: "tag-12" })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "tag-1" })).toHaveFocus();
+  });
+
+  it("moves focus to the match controls when the last stale selected tag disappears", async () => {
+    const user = userEvent.setup();
+    render(<ControlledTagFilter tags={[]} initialSelectedTags={["stale"]} />);
+
+    screen.getByRole("checkbox", { name: "stale" }).focus();
+    await user.keyboard(" ");
+
+    expect(screen.queryByRole("checkbox", { name: "stale" })).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Any" })).toHaveFocus();
+  });
+
+  it("moves focus before Clear disables itself", async () => {
+    const user = userEvent.setup();
+    render(<ControlledTagFilter tags={["one"]} initialSelectedTags={["one"]} />);
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "Any" })).toHaveFocus();
+  });
+
+  it("omits disclosure when there are no more than eight unselected tags", () => {
+    render(
+      <StudySessionTagFilter
+        tags={Array.from({ length: 8 }, (_, index) => `tag-${String(index + 1)}`)}
+        selectedTags={[]}
+        matchAll={false}
+        onSelectedTagsChange={vi.fn()}
+        onMatchAllChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("No filter")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(8);
+    expect(screen.queryByRole("button", { name: /Show/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a simple empty state when no tags are available", () => {
+    render(
+      <StudySessionTagFilter
+        tags={[]}
+        selectedTags={[]}
+        matchAll={true}
+        onSelectedTagsChange={vi.fn()}
+        onMatchAllChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("No tags available.")).toBeVisible();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Show/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "All" })).toBeChecked();
+  });
+
+  it("keeps a long tag available through its native checkbox", () => {
+    const longTag = "averylongunbrokentag".repeat(12);
+    render(
+      <StudySessionTagFilter
+        tags={[longTag]}
+        selectedTags={[]}
+        matchAll={false}
+        onSelectedTagsChange={vi.fn()}
+        onMatchAllChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("checkbox", { name: longTag })).toBeVisible();
+  });
+});

--- a/src/pages/study-session-start/ui/StudySessionTagFilter.spec.tsx
+++ b/src/pages/study-session-start/ui/StudySessionTagFilter.spec.tsx
@@ -116,6 +116,30 @@ describe("StudySessionTagFilter", () => {
     expect(screen.getByRole("button", { name: "Show 2 more tags" })).toHaveAttribute("aria-expanded", "false");
   });
 
+  it("moves keyboard focus through newly revealed tags and keeps it on the disclosure when collapsing", async () => {
+    const user = userEvent.setup();
+    const tags = Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`);
+    render(<ControlledTagFilter tags={tags} />);
+
+    const showMore = screen.getByRole("button", { name: "Show 4 more tags" });
+    showMore.focus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("checkbox", { name: "tag-9" })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole("checkbox", { name: "tag-10" })).toHaveFocus();
+    await user.tab();
+    await user.tab();
+    await user.tab();
+
+    const showFewer = screen.getByRole("button", { name: "Show fewer tags" });
+    expect(showFewer).toHaveFocus();
+    await user.keyboard(" ");
+
+    expect(screen.getByRole("button", { name: "Show 4 more tags" })).toHaveFocus();
+    expect(screen.queryByRole("checkbox", { name: "tag-9" })).not.toBeInTheDocument();
+  });
+
   it("moves focus to a remaining tag when deselection removes a collapsed chip", async () => {
     const user = userEvent.setup();
     const tags = Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`);
@@ -181,6 +205,25 @@ describe("StudySessionTagFilter", () => {
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Show/ })).not.toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "All" })).toBeChecked();
+  });
+
+  it("bounds a large all-selected tag list while keeping every selection available", () => {
+    const tags = Array.from({ length: 120 }, (_, index) => `tag-${String(index + 1)}`);
+    render(
+      <StudySessionTagFilter
+        tags={tags}
+        selectedTags={tags}
+        matchAll={false}
+        onSelectedTagsChange={vi.fn()}
+        onMatchAllChange={vi.fn()}
+      />
+    );
+
+    const tagChoices = screen.getByRole("group", { name: "Tag choices" });
+    expect(within(tagChoices).getAllByRole("checkbox")).toHaveLength(120);
+    expect(tagChoices).toHaveClass("max-h-64", "overflow-y-auto");
+    expect(screen.getByText("120 selected")).toBeVisible();
+    expect(screen.queryByRole("button", { name: /Show/ })).not.toBeInTheDocument();
   });
 
   it("keeps a long tag available through its native checkbox", () => {

--- a/src/pages/study-session-start/ui/StudySessionTagFilter.stories.tsx
+++ b/src/pages/study-session-start/ui/StudySessionTagFilter.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { expect, fn } from "storybook/test";
+
+import { StudySessionTagFilter } from "./StudySessionTagFilter";
+
+type StudySessionTagFilterProps = React.ComponentProps<typeof StudySessionTagFilter>;
+
+const tags = Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`);
+
+const InteractiveStudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (props) => {
+  const [matchAll, setMatchAll] = React.useState(props.matchAll);
+  const [selectedTags, setSelectedTags] = React.useState(props.selectedTags);
+
+  return (
+    <StudySessionTagFilter
+      {...props}
+      matchAll={matchAll}
+      selectedTags={selectedTags}
+      onMatchAllChange={(value) => {
+        props.onMatchAllChange(value);
+        setMatchAll(value);
+      }}
+      onSelectedTagsChange={(value) => {
+        props.onSelectedTagsChange(value);
+        setSelectedTags(value);
+      }}
+    />
+  );
+};
+
+const meta = {
+  title: "Pages/Study Session Start/StudySessionTagFilter",
+  component: StudySessionTagFilter,
+  tags: ["autodocs"],
+  args: {
+    tags,
+    selectedTags: [],
+    matchAll: false,
+    onSelectedTagsChange: fn(),
+    onMatchAllChange: fn(),
+  },
+  render: (args) => <InteractiveStudySessionTagFilter {...args} />,
+} satisfies Meta<typeof StudySessionTagFilter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {};
+
+export const Expanded: Story = {
+  play: async ({ canvas, userEvent }) => {
+    const disclosure = canvas.getByRole("button", { name: "Show 4 more tags" });
+    await userEvent.click(disclosure);
+
+    await expect(canvas.getAllByRole("checkbox")).toHaveLength(12);
+    await expect(canvas.getByRole("button", { name: "Show fewer tags" })).toHaveAttribute("aria-expanded", "true");
+  },
+};
+
+export const Selected: Story = {
+  args: { selectedTags: ["tag-12", "tag-3"], matchAll: true },
+};
+
+export const Empty: Story = {
+  args: { tags: [] },
+};
+
+export const LongTag: Story = {
+  args: { tags: ["averylongunbrokentag".repeat(12)] },
+};
+
+export const Mobile320: Story = {
+  args: { selectedTags: ["tag-12", "tag-3"] },
+  globals: { viewport: { value: "iphone5", isRotated: false } },
+};
+
+export const Dark: Story = {
+  args: { selectedTags: ["tag-12", "tag-3"] },
+  globals: { theme: "dark" },
+};

--- a/src/pages/study-session-start/ui/StudySessionTagFilter.stories.tsx
+++ b/src/pages/study-session-start/ui/StudySessionTagFilter.stories.tsx
@@ -7,6 +7,7 @@ import { StudySessionTagFilter } from "./StudySessionTagFilter";
 type StudySessionTagFilterProps = React.ComponentProps<typeof StudySessionTagFilter>;
 
 const tags = Array.from({ length: 12 }, (_, index) => `tag-${String(index + 1)}`);
+const manyTags = Array.from({ length: 120 }, (_, index) => `tag-${String(index + 1)}`);
 
 const InteractiveStudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (props) => {
   const [matchAll, setMatchAll] = React.useState(props.matchAll);
@@ -60,6 +61,10 @@ export const Expanded: Story = {
 
 export const Selected: Story = {
   args: { selectedTags: ["tag-12", "tag-3"], matchAll: true },
+};
+
+export const AllSelectedManyTags: Story = {
+  args: { tags: manyTags, selectedTags: manyTags, matchAll: true },
 };
 
 export const Empty: Story = {

--- a/src/pages/study-session-start/ui/StudySessionTagFilter.tsx
+++ b/src/pages/study-session-start/ui/StudySessionTagFilter.tsx
@@ -1,0 +1,160 @@
+import { useId, useRef, useState } from "react";
+import type * as React from "react";
+
+import { Button } from "@/shared/ui/button";
+import { TagList } from "@/shared/ui/content";
+import { Tag } from "@/shared/ui/forms";
+
+const COLLAPSED_UNSELECTED_TAG_LIMIT = 8;
+
+const uniqueInOrder = (values: readonly string[]): string[] => [...new Set(values)];
+
+export interface StudySessionTagFilterProps {
+  tags: string[];
+  selectedTags: string[];
+  matchAll: boolean;
+  onSelectedTagsChange: (tags: string[]) => void;
+  onMatchAllChange: (matchAll: boolean) => void;
+}
+
+export const StudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (props) => {
+  const idPrefix = useId();
+  const [expanded, setExpanded] = useState(false);
+  const matchAnyRef = useRef<HTMLInputElement>(null);
+  const tagRefs = useRef(new Map<string, HTMLInputElement>());
+  const headingId = `${idPrefix}-study-session-tags-heading`;
+  const tagListId = `${idPrefix}-study-session-tags-list`;
+  const tagInputName = `${idPrefix}-study-session-tags`;
+  const radioGroupName = `${idPrefix}-study-session-tag-match`;
+  const selectedTags = uniqueInOrder(props.selectedTags);
+  const selectedTagSet = new Set(selectedTags);
+  const unselectedTags = uniqueInOrder(props.tags).filter((tag) => !selectedTagSet.has(tag));
+  const hiddenTagCount = Math.max(0, unselectedTags.length - COLLAPSED_UNSELECTED_TAG_LIMIT);
+  const visibleUnselectedTags = expanded ? unselectedTags : unselectedTags.slice(0, COLLAPSED_UNSELECTED_TAG_LIMIT);
+  // Persisted selections remain visible even when a tag disappeared from the current Card set, so
+  // the user can still understand and remove that filter.
+  const visibleTags = [...selectedTags, ...visibleUnselectedTags];
+  const status = selectedTags.length === 0 ? "No filter" : `${String(selectedTags.length)} selected`;
+
+  const toggleTag = (tag: string) => {
+    if (!selectedTagSet.has(tag)) {
+      props.onSelectedTagsChange([...selectedTags, tag]);
+      return;
+    }
+
+    const nextSelectedTags = selectedTags.filter((selectedTag) => selectedTag !== tag);
+    const nextSelectedTagSet = new Set(nextSelectedTags);
+    const nextUnselectedTags = uniqueInOrder(props.tags).filter(
+      (availableTag) => !nextSelectedTagSet.has(availableTag)
+    );
+    const nextVisibleTags = expanded
+      ? [...nextSelectedTags, ...nextUnselectedTags]
+      : [...nextSelectedTags, ...nextUnselectedTags.slice(0, COLLAPSED_UNSELECTED_TAG_LIMIT)];
+
+    if (!nextVisibleTags.includes(tag)) {
+      // A controlled update can remove the activated chip from the collapsed list. Move focus
+      // first so keyboard users land on a predictable control instead of the document body.
+      const nextFocusableTag = nextVisibleTags.find((visibleTag) => tagRefs.current.has(visibleTag));
+      (nextFocusableTag === undefined ? matchAnyRef.current : tagRefs.current.get(nextFocusableTag))?.focus();
+    }
+
+    props.onSelectedTagsChange(nextSelectedTags);
+  };
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="min-w-0 space-y-4 rounded-surface border border-border bg-surface p-4 shadow-surface md:p-5"
+    >
+      <header className="flex min-w-0 items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h2 id={headingId} className="text-title font-semibold text-ink">
+            Tags
+          </h2>
+          <p aria-live="polite" className="text-caption text-ink-muted">
+            {status}
+          </p>
+        </div>
+        <Button
+          variant="quiet"
+          size="sm"
+          className="shrink-0 border-0 text-accent-primary"
+          disabled={selectedTags.length === 0}
+          onClick={() => {
+            // Clearing disables this button, so focus a control that remains operable first.
+            matchAnyRef.current?.focus();
+            props.onSelectedTagsChange([]);
+          }}
+        >
+          Clear
+        </Button>
+      </header>
+
+      <fieldset>
+        <legend className="text-caption font-semibold text-ink">Match</legend>
+        <div className="mt-2 flex flex-wrap gap-x-5 gap-y-2">
+          <label className="flex min-h-touch cursor-pointer items-center gap-2 text-body text-ink">
+            <input
+              ref={matchAnyRef}
+              type="radio"
+              name={radioGroupName}
+              value="any"
+              checked={!props.matchAll}
+              className="size-4 accent-accent-primary"
+              onChange={() => props.onMatchAllChange(false)}
+            />
+            Any
+          </label>
+          <label className="flex min-h-touch cursor-pointer items-center gap-2 text-body text-ink">
+            <input
+              type="radio"
+              name={radioGroupName}
+              value="all"
+              checked={props.matchAll}
+              className="size-4 accent-accent-primary"
+              onChange={() => props.onMatchAllChange(true)}
+            />
+            All
+          </label>
+        </div>
+      </fieldset>
+
+      <div id={tagListId}>
+        {visibleTags.length === 0 ? (
+          <p className="text-caption text-ink-muted">No tags available.</p>
+        ) : (
+          <TagList>
+            {visibleTags.map((tag) => (
+              <Tag
+                key={tag}
+                ref={(element) => {
+                  if (element === null) tagRefs.current.delete(tag);
+                  else tagRefs.current.set(tag, element);
+                }}
+                small
+                wrap
+                label={tag}
+                name={tagInputName}
+                value={tag}
+                checked={selectedTagSet.has(tag)}
+                onChange={() => toggleTag(tag)}
+              />
+            ))}
+          </TagList>
+        )}
+      </div>
+
+      {hiddenTagCount > 0 ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-controls={tagListId}
+          className="min-h-touch rounded-control px-1 text-caption font-semibold text-accent-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded ? "Show fewer tags" : `Show ${String(hiddenTagCount)} more tags`}
+        </button>
+      ) : null}
+    </section>
+  );
+};

--- a/src/pages/study-session-start/ui/StudySessionTagFilter.tsx
+++ b/src/pages/study-session-start/ui/StudySessionTagFilter.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type * as React from "react";
 
 import { Button } from "@/shared/ui/button";
@@ -22,6 +22,7 @@ export const StudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (prop
   const [expanded, setExpanded] = useState(false);
   const matchAnyRef = useRef<HTMLInputElement>(null);
   const tagRefs = useRef(new Map<string, HTMLInputElement>());
+  const pendingExpandedTagFocusRef = useRef<string | null>(null);
   const headingId = `${idPrefix}-study-session-tags-heading`;
   const tagListId = `${idPrefix}-study-session-tags-list`;
   const tagInputName = `${idPrefix}-study-session-tags`;
@@ -35,6 +36,13 @@ export const StudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (prop
   // the user can still understand and remove that filter.
   const visibleTags = [...selectedTags, ...visibleUnselectedTags];
   const status = selectedTags.length === 0 ? "No filter" : `${String(selectedTags.length)} selected`;
+
+  useEffect(() => {
+    if (!expanded || pendingExpandedTagFocusRef.current === null) return;
+
+    tagRefs.current.get(pendingExpandedTagFocusRef.current)?.focus();
+    pendingExpandedTagFocusRef.current = null;
+  }, [expanded]);
 
   const toggleTag = (tag: string) => {
     if (!selectedTagSet.has(tag)) {
@@ -119,7 +127,11 @@ export const StudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (prop
         </div>
       </fieldset>
 
-      <div id={tagListId}>
+      <fieldset
+        id={tagListId}
+        aria-label="Tag choices"
+        className={visibleTags.length > 30 ? "max-h-64 overflow-y-auto" : undefined}
+      >
         {visibleTags.length === 0 ? (
           <p className="text-caption text-ink-muted">No tags available.</p>
         ) : (
@@ -142,7 +154,7 @@ export const StudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (prop
             ))}
           </TagList>
         )}
-      </div>
+      </fieldset>
 
       {hiddenTagCount > 0 ? (
         <button
@@ -150,7 +162,14 @@ export const StudySessionTagFilter: React.FC<StudySessionTagFilterProps> = (prop
           aria-expanded={expanded}
           aria-controls={tagListId}
           className="min-h-touch rounded-control px-1 text-caption font-semibold text-accent-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-          onClick={() => setExpanded((current) => !current)}
+          onClick={(event) => {
+            if (!expanded && event.detail === 0) {
+              // Keyboard activation inserts the revealed tags before this button. Move focus to
+              // the first new tag so forward Tab reaches the newly available choices.
+              pendingExpandedTagFocusRef.current = unselectedTags[COLLAPSED_UNSELECTED_TAG_LIMIT] ?? null;
+            }
+            setExpanded((current) => !current);
+          }}
         >
           {expanded ? "Show fewer tags" : `Show ${String(hiddenTagCount)} more tags`}
         </button>


### PR DESCRIPTION
## Related issue

None

## Summary

- Simplify Study Start tag filtering with explicit Any/All matching and Clear-only actions.
- Keep selected tags visible first, show eight unselected tags initially, and progressively disclose the rest.
- Display unrestricted score boundaries as a dash while preserving accessible no-limit descriptions.
- Preserve keyboard focus when selected or newly revealed tags move in the collapsed list.
- Bound large persisted tag selections in a vertical scroll region.

## Testing

- mise run check (116 test files, 641 tests)
- Storybook tests for StudySessionTagFilter, StudySessionFilters, and StudySessionStart (21 tests)
- Manual Storybook QA at desktop and 320px widths
