### PR TITLE
[No issue] Add configurable study help shortcut

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -151,6 +151,7 @@
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](./study.md#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](./study.md#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](./study.md#swipe-24) |
+| SWIPE-25 | write | [Help button の表示設定を reload 後も維持できる](./study.md#swipe-25) |
 
 ### Study Back Text
 

--- a/docs/e2e/study.md
+++ b/docs/e2e/study.md
@@ -24,6 +24,7 @@ Deck の学習画面で、Card の表示、学習結果の保存、session の�
 | SWIPE-16 | write | [local-only Deck で primary mouse の上方向 drag により次の Card へ進める](#swipe-16) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](#swipe-24) |
+| SWIPE-25 | write | [Help button の表示設定を reload 後も維持できる](#swipe-25) |
 
 <a id="swipe-02"></a>
 
@@ -397,4 +398,28 @@ Then:
 - 非表示の操作ボタンは現在の設定と一致する説明で表示される。
 - dialog 内のキー入力で Card、学習結果、session の位置が変更されない。
 - focus が dialog 内に維持され、閉じた後は Help trigger へ戻る。
+- browser error が発生しない。
+
+<a id="swipe-25"></a>
+
+### SWIPE-25 Help button の表示設定を reload 後も維持できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`study-session-help`](./fixture/study-session-help.yaml)
+- 認証済みユーザーが所有する Deck に進行中の学習 session が存在する。
+- Help button の表示設定は既定値の ON である。
+
+When:
+
+- 学習画面の Study actions から Help button の表示を OFF にする。
+- 学習画面を reload する。
+
+Then:
+
+- Help button は既定で省略ボタンの左側に表示される。
+- 表示を OFF にすると Help button は非表示になる。
+- reload 後も Help button の表示設定は OFF のまま維持される。
 - browser error が発生しない。

--- a/src/entities/preference/index.ts
+++ b/src/entities/preference/index.ts
@@ -8,6 +8,7 @@ export type {
 export {
   setDarkMode,
   toggleShowCardDetails,
+  toggleShowHelp,
   toggleShowPlaybackControls,
   toggleShowSwipeButtonList,
   updatePreferences,

--- a/src/entities/preference/model/schema.ts
+++ b/src/entities/preference/model/schema.ts
@@ -22,6 +22,7 @@ const DEFAULT_STUDY = {
 };
 
 const DEFAULT_CONTROLS = {
+  showHelp: true,
   showSwipeButtonList: true,
   showPlaybackControls: true,
   showCardDetails: true,
@@ -81,6 +82,7 @@ const studyPreferencesSchema = z
 
 export const controlPreferencesSchema = z
   .object({
+    showHelp: z.boolean().catch(DEFAULT_CONTROLS.showHelp),
     showSwipeButtonList: z.boolean().catch(DEFAULT_CONTROLS.showSwipeButtonList),
     showPlaybackControls: z.boolean().catch(DEFAULT_CONTROLS.showPlaybackControls),
     showCardDetails: z.boolean().catch(DEFAULT_CONTROLS.showCardDetails),

--- a/src/entities/preference/model/store.spec.ts
+++ b/src/entities/preference/model/store.spec.ts
@@ -6,6 +6,7 @@ import {
   preferencesStore,
   setDarkMode,
   toggleShowCardDetails,
+  toggleShowHelp,
   toggleShowPlaybackControls,
   toggleShowSwipeButtonList,
   updatePreferences,
@@ -41,6 +42,10 @@ describe("preferences store", () => {
 
   it("keeps back text swipe overlays off by default", () => {
     expect(defaultPreferences.controls.showBackTextSwipeOverlays).toBe(false);
+  });
+
+  it("shows the study Help shortcut by default", () => {
+    expect(defaultPreferences.controls.showHelp).toBe(true);
   });
 
   it("updates each preference group without resetting other settings", () => {
@@ -113,6 +118,7 @@ describe("preferences store", () => {
     toggleShowSwipeButtonList();
     toggleShowPlaybackControls();
     toggleShowCardDetails();
+    toggleShowHelp();
 
     expect(preferencesStore.getState().preferences).toEqual({
       ...defaultPreferences,
@@ -124,6 +130,7 @@ describe("preferences store", () => {
         showSwipeButtonList: false,
         showPlaybackControls: false,
         showCardDetails: false,
+        showHelp: false,
       },
     });
   });
@@ -157,7 +164,11 @@ describe("preferences store", () => {
   it("hydrates version 1 preferences with defaults for additive fields", async () => {
     const {
       language: _language,
-      controls: { showBackTextSwipeOverlays: _showBackTextSwipeOverlays, ...controlsBeforeSwipeOverlays },
+      controls: {
+        showHelp: _showHelp,
+        showBackTextSwipeOverlays: _showBackTextSwipeOverlays,
+        ...controlsBeforeAdditiveFields
+      },
       ...preferencesBeforeAdditiveFields
     } = defaultPreferences;
     const persistedPreferences = {
@@ -165,7 +176,7 @@ describe("preferences store", () => {
       loadSample: false,
       appearance: { ...defaultPreferences.appearance, darkMode: true },
       study: { ...defaultPreferences.study, selectedTags: ["typescript"] },
-      controls: { ...controlsBeforeSwipeOverlays, showSwipeButtonList: false },
+      controls: { ...controlsBeforeAdditiveFields, showSwipeButtonList: false },
     };
     useMemoryStorage({
       "tango-config": JSON.stringify({ state: { preferences: persistedPreferences }, version: 1 }),
@@ -176,7 +187,7 @@ describe("preferences store", () => {
     expect(preferencesStore.getState().preferences).toEqual({
       ...persistedPreferences,
       language: "system",
-      controls: { ...persistedPreferences.controls, showBackTextSwipeOverlays: false },
+      controls: { ...persistedPreferences.controls, showHelp: true, showBackTextSwipeOverlays: false },
     });
   });
 

--- a/src/entities/preference/model/store.ts
+++ b/src/entities/preference/model/store.ts
@@ -89,6 +89,12 @@ export const replacePreferences = (input: PartialPreferences): void => {
 // Sets the appearance color mode preference explicitly.
 export const setDarkMode = (darkMode: boolean): void => updatePreferences({ appearance: { darkMode } });
 
+// Toggles whether the study Help shortcut is shown.
+export const toggleShowHelp = (): void => {
+  const { showHelp } = preferencesStore.getState().preferences.controls;
+  updatePreferences({ controls: { showHelp: !showHelp } });
+};
+
 // Toggles whether study swipe controls are shown.
 export const toggleShowSwipeButtonList = (): void => {
   const { showSwipeButtonList } = preferencesStore.getState().preferences.controls;

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -4,6 +4,7 @@ import { useCards } from "@/entities/card";
 import { getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
 import {
   toggleShowCardDetails,
+  toggleShowHelp,
   toggleShowPlaybackControls,
   toggleShowSwipeButtonList,
   usePreferences,
@@ -41,10 +42,12 @@ export const useStudy = (deckId: string) => {
     ...swipe,
     toggleBackText: () => setShowBackText((visible) => !visible),
     toggleAutoPlay,
+    toggleShowHelp,
     toggleShowCardDetails,
     toggleShowPlaybackControls,
     toggleSwipeButtonList: toggleShowSwipeButtonList,
     showBackText,
+    showHelp: preferences.controls.showHelp,
     playbackControlsAvailable: preferences.study.cardInterval > 0,
     showCardDetails: preferences.controls.showCardDetails,
     showPlaybackControls: preferences.controls.showPlaybackControls,

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -10,12 +10,14 @@ import { StudySession } from "./StudySession";
 const playbackUnavailableDescription = "Playback controls unavailable because the card interval is set to 0";
 
 const toolbarProps = () => ({
+  showHelp: true,
   showCardDetails: true,
   showSwipeControls: true,
   showPlaybackControls: true,
   playbackControlsAvailable: true,
   onBack: vi.fn(),
   onToggleCardDetails: vi.fn(),
+  onToggleHelp: vi.fn(),
   onToggleSwipeControls: vi.fn(),
   onTogglePlaybackControls: vi.fn(),
   help: {
@@ -173,7 +175,7 @@ describe("StudySession", () => {
     const openActions = screen.getByRole("button", { name: "Open study actions" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
@@ -183,18 +185,22 @@ describe("StudySession", () => {
     const swipeToggle = screen.getByRole("button", { name: "Swipe controls" });
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const detailsToggle = screen.getByRole("button", { name: "Card details" });
+    const helpToggle = screen.getByRole("button", { name: "Help button" });
     const help = screen.getByRole("button", { name: "Open study help" });
     const actions = screen.getByRole("group", { name: "Study actions" });
     expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
     expect(help).toBeVisible();
+    expect(helpToggle).toHaveAttribute("aria-pressed", "true");
+    expect(helpToggle).toHaveAttribute("title", "Hide help button");
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
     expect(playbackToggle).toHaveAttribute("aria-pressed", "true");
     expect(detailsToggle).toHaveAttribute("aria-pressed", "true");
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
-    expect(actions).toContainElement(help);
+    expect(actions).toContainElement(helpToggle);
+    expect(actions).not.toContainElement(help);
     expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
@@ -215,7 +221,23 @@ describe("StudySession", () => {
     fireEvent.keyDown(help, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
+  });
+
+  it("hides the Help shortcut while keeping its Header toggle available", () => {
+    const onToggleHelp = vi.fn();
+    render(
+      <StudySession {...toolbarProps()} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
+    );
+
     expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
+
+    const helpToggle = screen.getByRole("button", { name: "Help button" });
+    expect(helpToggle).toHaveAttribute("aria-pressed", "false");
+    expect(helpToggle).toHaveAttribute("title", "Show help button");
+    fireEvent.click(helpToggle);
+    expect(onToggleHelp).toHaveBeenCalledOnce();
   });
 
   it("shows and hides all card details from the persisted preference value", () => {

--- a/src/pages/study-session/ui/StudySession.stories.tsx
+++ b/src/pages/study-session/ui/StudySession.stories.tsx
@@ -25,9 +25,11 @@ const meta = {
   args: {
     onBack: fn(),
     onToggleCardDetails: fn(),
+    onToggleHelp: fn(),
     onToggleSwipeControls: fn(),
     onTogglePlaybackControls: fn(),
     showSwipeControls: true,
+    showHelp: true,
     showPlaybackControls: true,
     showCardDetails: true,
     playbackControlsAvailable: true,
@@ -182,6 +184,22 @@ export const AutoPlay: Story = {
 export const Mobile: Story = {
   globals: { viewport: { value: "iphonex", isRotated: false } },
   play: centeredFrontTextPlay,
+};
+
+export const Mobile320ActionsOpen: Story = {
+  globals: { viewport: { value: "iphone5", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Open study actions" }));
+
+    const backBounds = canvas.getByRole("button", { name: "Back to deck list" }).getBoundingClientRect();
+    const actionsBounds = canvas.getByRole("group", { name: "Study actions" }).getBoundingClientRect();
+    const cardOverlay = canvasElement.querySelector<HTMLElement>("[data-study-card-overlay]");
+    await expect(cardOverlay).not.toBeNull();
+    await expect(actionsBounds.top).toBeGreaterThanOrEqual(backBounds.bottom);
+    await expect(actionsBounds.right).toBeLessThanOrEqual(canvasElement.getBoundingClientRect().right);
+    if (cardOverlay !== null) await expect(cardOverlay).not.toBeVisible();
+  },
 };
 
 export const MobileSafeArea: Story = {

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -54,6 +54,7 @@ const answerSurfaceProps = {
 
 export interface StudySessionProps {
   showBackText?: boolean;
+  showHelp: boolean;
   showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
@@ -81,6 +82,7 @@ export interface StudySessionProps {
   onSwipeDown?: () => void;
   onBack: () => void;
   onToggleCardDetails: () => void;
+  onToggleHelp: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
 }
@@ -89,18 +91,21 @@ const toolbarButtonClass =
   "pointer-events-auto inline-flex size-touch shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
 interface StudyModeActionsProps {
+  showHelp: boolean;
   showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
   playbackDescriptionId: string;
   onEscape: React.KeyboardEventHandler<HTMLButtonElement>;
+  onToggleHelp: () => void;
   onToggleCardDetails: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
 }
 
 const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
+  const helpTitle = props.showHelp ? "Hide help button" : "Show help button";
   const swipeTitle = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
   const playbackTitle = props.playbackControlsAvailable
     ? props.showPlaybackControls
@@ -111,6 +116,17 @@ const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
 
   return (
     <div className="flex items-center gap-1">
+      <button
+        type="button"
+        aria-label="Help button"
+        aria-pressed={props.showHelp}
+        title={helpTitle}
+        className={cx(toolbarButtonClass, props.showHelp && "bg-surface-muted text-accent-primary")}
+        onClick={props.onToggleHelp}
+        onKeyDown={props.onEscape}
+      >
+        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
+      </button>
       <button
         type="button"
         aria-label="Swipe controls"
@@ -161,12 +177,14 @@ const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
 interface StudyToolbarProps {
   ref?: React.RefObject<HTMLButtonElement | null>;
   open: boolean;
+  showHelp: boolean;
   showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
   helpTriggerLabel: string;
   onOpenHelp: () => void;
+  onToggleHelp: () => void;
   onToggleOpen: () => void;
   onToggleCardDetails: () => void;
   onBack: () => void;
@@ -219,33 +237,43 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
           <AiOutlineEllipsis aria-hidden="true" className="text-xl" />
         )}
       </button>
+      {props.showHelp ? (
+        <button
+          ref={helpTriggerRef}
+          type="button"
+          aria-label={props.helpTriggerLabel}
+          className={cx(
+            toolbarButtonClass,
+            "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+          )}
+          onClick={props.onOpenHelp}
+          onKeyDown={closeOnEscape}
+        >
+          <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
+        </button>
+      ) : null}
       {props.open ? (
-        // The overlay stays out of document flow so opening it cannot move the centered prompt.
+        // Four actions cannot share a 320px row with Back and the two right-side triggers. Below 360px,
+        // keep them on a second row and hide metadata there so both interactive surfaces remain unobstructed.
         <fieldset
           id={actionsId}
           aria-label="Study actions"
-          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
+          className={cx(
+            "pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 max-[359px]:absolute max-[359px]:inset-x-0 max-[359px]:top-[calc(var(--spacing-touch)+0.25rem)] max-[359px]:pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]",
+            props.showHelp
+              ? "pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
+              : "pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)]"
+          )}
         >
-          <button
-            ref={helpTriggerRef}
-            type="button"
-            aria-label={props.helpTriggerLabel}
-            className={cx(
-              toolbarButtonClass,
-              "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
-            )}
-            onClick={props.onOpenHelp}
-            onKeyDown={closeOnEscape}
-          >
-            <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
-          </button>
           <StudyModeActions
+            showHelp={props.showHelp}
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}
             showPlaybackControls={props.showPlaybackControls}
             playbackControlsAvailable={props.playbackControlsAvailable}
             playbackDescriptionId={playbackDescriptionId}
             onEscape={closeOnEscape}
+            onToggleHelp={props.onToggleHelp}
             onToggleCardDetails={props.onToggleCardDetails}
             onToggleSwipeControls={props.onToggleSwipeControls}
             onTogglePlaybackControls={props.onTogglePlaybackControls}
@@ -343,11 +371,19 @@ const BackTextOverlays: React.FC<{
 
 const CardContent: React.FC<{
   showBackText: boolean | undefined;
+  hideCardOverlayOnNarrowScreen: boolean;
   backTextSlot: React.ReactNode | undefined;
   frontTextSlot: React.ReactNode | undefined;
   cardOverlaySlot: React.ReactNode | undefined;
   backTextOverlay: StudySessionProps["backTextOverlay"];
-}> = ({ showBackText, backTextSlot, frontTextSlot, cardOverlaySlot, backTextOverlay }) => {
+}> = ({
+  showBackText,
+  hideCardOverlayOnNarrowScreen,
+  backTextSlot,
+  frontTextSlot,
+  cardOverlaySlot,
+  backTextOverlay,
+}) => {
   if (showBackText && backTextSlot != null) {
     return (
       <>
@@ -364,7 +400,15 @@ const CardContent: React.FC<{
       <div className="relative h-full min-h-0">
         {cardOverlaySlot != null ? (
           // Metadata stays below the toolbar without reserving space in the centered prompt surface.
-          <div className="absolute inset-x-0 top-[var(--study-card-top)] h-touch">{cardOverlaySlot}</div>
+          <div
+            data-study-card-overlay=""
+            className={cx(
+              "absolute inset-x-0 top-[var(--study-card-top)] h-touch",
+              hideCardOverlayOnNarrowScreen && "max-[359px]:hidden"
+            )}
+          >
+            {cardOverlaySlot}
+          </div>
         ) : null}
         {/* Reversed vertical insets optically center the prompt when iPhone safe areas are asymmetric. */}
         <div className="h-full min-h-0 pb-[var(--study-safe-area-top)] pt-[var(--study-safe-area-bottom)]">
@@ -472,12 +516,14 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
         <StudyToolbar
           ref={helpTriggerRef}
           open={studyActionsOpen}
+          showHelp={props.showHelp}
           showCardDetails={props.showCardDetails}
           showSwipeControls={props.showSwipeControls}
           showPlaybackControls={props.showPlaybackControls}
           playbackControlsAvailable={props.playbackControlsAvailable}
           helpTriggerLabel={props.help.triggerLabel}
           onOpenHelp={props.help.onOpen}
+          onToggleHelp={props.onToggleHelp}
           onToggleOpen={() => setStudyActionsOpen((open) => !open)}
           onToggleCardDetails={props.onToggleCardDetails}
           onBack={props.onBack}
@@ -496,6 +542,7 @@ export const StudySession: React.FC<StudySessionProps> = (props) => {
       >
         <CardContent
           showBackText={props.showBackText}
+          hideCardOverlayOnNarrowScreen={studyActionsOpen}
           backTextSlot={props.backTextSlot}
           frontTextSlot={props.frontTextSlot}
           cardOverlaySlot={props.showCardDetails ? props.cardOverlaySlot : undefined}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   setDarkMode: vi.fn(),
   touchStudySession: vi.fn(),
   toggleShowCardDetails: vi.fn(),
+  toggleShowHelp: vi.fn(),
   toggleShowPlaybackControls: vi.fn(),
   toggleShowSwipeButtonList: vi.fn(),
 }));
@@ -27,6 +28,7 @@ vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
   toggleShowCardDetails: mocks.toggleShowCardDetails,
+  toggleShowHelp: mocks.toggleShowHelp,
   toggleShowPlaybackControls: mocks.toggleShowPlaybackControls,
   toggleShowSwipeButtonList: mocks.toggleShowSwipeButtonList,
 }));
@@ -109,6 +111,7 @@ describe("StudySessionPage", () => {
     mocks.setDarkMode.mockReset();
     mocks.touchStudySession.mockReset();
     mocks.toggleShowCardDetails.mockReset();
+    mocks.toggleShowHelp.mockReset();
     mocks.toggleShowPlaybackControls.mockReset();
     mocks.toggleShowSwipeButtonList.mockReset();
     await createDeck("", deck);
@@ -229,8 +232,6 @@ describe("StudySessionPage", () => {
     renderPage();
     const sessionBeforeHelp = getStudySession(deckId);
 
-    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
-    openStudyActions();
     const trigger = screen.getByRole("button", { name: "Open study help" });
     fireEvent.click(trigger);
     expect(trigger).not.toHaveFocus();
@@ -350,10 +351,12 @@ describe("StudySessionPage", () => {
     renderPage();
     openStudyActions();
 
+    fireEvent.click(screen.getByRole("button", { name: "Help button" }));
     fireEvent.click(screen.getByRole("button", { name: "Swipe controls" }));
     fireEvent.click(screen.getByRole("button", { name: "Playback controls" }));
     fireEvent.click(screen.getByRole("button", { name: "Card details" }));
 
+    expect(mocks.toggleShowHelp).toHaveBeenCalledOnce();
     expect(mocks.toggleShowSwipeButtonList).toHaveBeenCalledOnce();
     expect(mocks.toggleShowPlaybackControls).toHaveBeenCalledOnce();
     expect(mocks.toggleShowCardDetails).toHaveBeenCalledOnce();

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -68,9 +68,11 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
       <StudySession
         onBack={onBack}
         onToggleCardDetails={state.toggleShowCardDetails}
+        onToggleHelp={state.toggleShowHelp}
         onToggleSwipeControls={state.toggleSwipeButtonList}
         onTogglePlaybackControls={state.toggleShowPlaybackControls}
         showBackText={state.showBackText}
+        showHelp={state.showHelp}
         showCardDetails={state.showCardDetails}
         showSwipeControls={state.showSwipeButtonList}
         showPlaybackControls={state.showPlaybackControls}

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -255,6 +255,7 @@ export const e2eConfig: E2EConfig = {
     selectedTags: [] as string[],
   },
   controls: {
+    showHelp: true,
     showSwipeButtonList: true,
     showPlaybackControls: true,
     showCardDetails: true,

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -356,8 +356,7 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
 
   await page.goto(`/deck/${deck.id}/study`);
   const progressBeforeHelp = await readProgress(currentCard.id);
-  await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
-  await page.getByRole("button", { name: "Open study actions" }).click();
+  await expect(page.getByRole("button", { name: "Open study help" })).toBeVisible();
   await page.getByRole("button", { name: "Open study help" }).click();
 
   const dialog = page.getByRole("dialog", { name: "Study controls" });
@@ -390,4 +389,30 @@ test("SWIPE-24 shows configured Study controls without changing the active sessi
   await expect(dialog).not.toBeVisible();
   await expect(page.getByRole("button", { name: "Open study help" })).toBeFocused();
   await expect(page.getByRole("button", { name: "Swipe left" })).toHaveCount(0);
+});
+
+test("SWIPE-25 toggles and persists the Study Help button", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+  const help = page.getByRole("button", { name: "Open study help" });
+  const actions = page.getByRole("button", { name: "Open study actions" });
+  await expect(help).toBeVisible();
+  await expect(actions).toBeVisible();
+  const helpBounds = await help.boundingBox();
+  const actionsBounds = await actions.boundingBox();
+  expect(helpBounds).not.toBeNull();
+  expect(actionsBounds).not.toBeNull();
+  if (helpBounds !== null && actionsBounds !== null)
+    expect(helpBounds.x + helpBounds.width).toBeLessThanOrEqual(actionsBounds.x);
+
+  await actions.click();
+  await page.getByRole("button", { name: "Help button" }).click();
+  await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Open study actions" }).click();
+  await expect(page.getByRole("button", { name: "Help button" })).toHaveAttribute("aria-pressed", "false");
 });

--- a/test/e2e/yaml-fixture.ts
+++ b/test/e2e/yaml-fixture.ts
@@ -84,6 +84,7 @@ export interface FixturePreferences {
     selectedTags: string[];
   };
   controls: {
+    showHelp: boolean;
     showSwipeButtonList: boolean;
     showPlaybackControls: boolean;
     showCardDetails: boolean;
@@ -273,6 +274,7 @@ const preferencesSchema = z.strictObject({
     .optional(),
   controls: z
     .strictObject({
+      showHelp: z.boolean().optional(),
       showSwipeButtonList: z.boolean().optional(),
       showPlaybackControls: z.boolean().optional(),
       showCardDetails: z.boolean().optional(),
@@ -636,6 +638,7 @@ const fixturePreferenceDefaults: FixturePreferences = {
     selectedTags: [],
   },
   controls: {
+    showHelp: true,
     showSwipeButtonList: true,
     showPlaybackControls: true,
     showCardDetails: true,

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -115,6 +115,7 @@ export type PreferencesOverrides = {
   keepBackTextViewed?: boolean;
   defaultAutoPlay?: boolean;
   selectedTags?: string[];
+  showHelp?: boolean;
   showSwipeButtonList?: boolean;
   showPlaybackControls?: boolean;
   showCardDetails?: boolean;
@@ -151,6 +152,7 @@ const createControls = (
   controls?: Partial<ControlPreferences>,
   flat?: Partial<PreferencesOverrides>
 ): ControlPreferences => ({
+  showHelp: controls?.showHelp ?? flat?.showHelp ?? true,
   showSwipeButtonList: controls?.showSwipeButtonList ?? flat?.showSwipeButtonList ?? true,
   showPlaybackControls: controls?.showPlaybackControls ?? flat?.showPlaybackControls ?? true,
   showCardDetails: controls?.showCardDetails ?? flat?.showCardDetails ?? true,


### PR DESCRIPTION
## Related issue

None

## Summary

- persist a `showHelp` preference that defaults to enabled
- show the Help shortcut to the left of the study actions button and toggle it from the action menu
- keep the expanded toolbar usable at 320px and cover default visibility and persistence

## Testing

- `mise run check`
- `npm run test:storybook -- src/pages/study-session/ui/StudySession.stories.tsx`