### PR TITLE
[No issue] Fix switch overflow in narrow form rows

### DIFF
--- a/src/pages/deck-form/ui/DeckForm.stories.tsx
+++ b/src/pages/deck-form/ui/DeckForm.stories.tsx
@@ -77,5 +77,13 @@ export const Interaction: Story = {
     await expect(convertLineBreaks).toBeChecked();
   },
 };
-export const Mobile: Story = { ...LongContent, globals: { viewport: { value: "iphonex", isRotated: false } } };
+export const Mobile: Story = {
+  ...LongContent,
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+  play: async ({ canvas }) => {
+    const storageSection = canvas.getByRole("region", { name: "Storage" });
+
+    await expect(storageSection.scrollWidth).toBeLessThanOrEqual(storageSection.clientWidth);
+  },
+};
 export const Dark: Story = { ...LongContent, globals: { theme: "dark" } };

--- a/src/shared/ui/forms/FormItem.tsx
+++ b/src/shared/ui/forms/FormItem.tsx
@@ -39,7 +39,8 @@ export const FormItem: React.FC<{
           {props.label}
         </div>
       )}
-      <div className="min-w-0 flex-1 break-words text-ink-muted md:text-right">{props.text ?? props.children}</div>
+      {/* Reserve the touch target width so controls cannot overflow when the label shrinks the row. */}
+      <div className="min-w-touch flex-1 break-words text-ink-muted md:text-right">{props.text ?? props.children}</div>
     </div>
     {props.extra != null && <Description label={props.extra} />}
     {props.help != null && <Description label={props.help} />}


### PR DESCRIPTION
## Related issue

None.

## Summary

- Reserve the minimum touch-target width for form controls so switches stay inside narrow form rows.
- Add mobile Storybook regression coverage for Storage section overflow.

## Testing

- `npm run test:storybook -- src/pages/deck-form/ui/DeckForm.stories.tsx` (8 tests passed)
- `mise run check` (114 test files, 612 tests passed)
- Verified DeckForm, DeckEditor, and DeckCreateView switch containment at iPhone and desktop viewport sizes in Storybook.