### PR TITLE
ci(#233): add dependency review gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,19 @@ permissions:
   contents: read
 
 jobs:
+  # Non-PR callers intentionally skip this job; the aggregate validates that exact event/result pairing.
+  dependency-review:
+    name: Dependency Review
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
   e2e:
     name: E2E
     uses: ./.github/workflows/e2e.yaml
@@ -101,19 +114,26 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Run after every dependency conclusion and fail closed unless every canonical job succeeded.
+  # Fail closed for canonical results; only Dependency Review may be skipped, and only outside PRs.
   test:
     name: Test
     if: ${{ always() }}
-    needs: [checks, e2e, integration]
+    needs: [checks, dependency-review, e2e, integration]
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         env:
           CHECKS_RESULT: ${{ needs.checks.result }}
+          DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
+          EVENT_NAME: ${{ github.event_name }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
         run: |
           test "$CHECKS_RESULT" = success
           test "$E2E_RESULT" = success
           test "$INTEGRATION_RESULT" = success
+          if [ "$EVENT_NAME" = pull_request ]; then
+            test "$DEPENDENCY_REVIEW_RESULT" = success
+          else
+            test "$DEPENDENCY_REVIEW_RESULT" = skipped
+          fi


### PR DESCRIPTION
## Related issue

Fixes #233

## Summary

- add GitHub's official Dependency Review action, pinned to the immutable v5.0.0 commit SHA
- run Dependency Review only for pull requests with `contents: read`
- fail pull requests that introduce vulnerabilities with `high` or `critical` severity
- require Dependency Review success through the existing aggregate `Test` check
- accept only the expected Dependency Review `skipped` result for reusable or manual non-PR runs

## Validation

- GitHub Actions run `33313976764`: Dependency Review, all existing checks, E2E, Integration, and aggregate `Test` succeeded
- closed negative control PR #1395: an isolated `tmp@0.2.5` runtime dependency triggered high-severity advisory `GHSA-ph9p-34f9-6g65`; Dependency Review and aggregate `Test` failed while every existing check succeeded
- confirmed the active `CI Required` ruleset still requires only the aggregate `Test` context
- parsed the updated workflow as YAML
- exercised the aggregate event/result policy with positive and negative shell cases
- verified the action release tag resolves to the pinned commit SHA

## Review gate

- manual diff review found no P0, P1, or P2 findings
- the repository-required custom `reviewer` subagent is unavailable in this execution environment, so this pull request remains a draft until that review is completed
