### PR TITLE
[No issue] Define unit and integration test traceability rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,15 @@ For every task that changes repository files:
 - Do not add test code for non-application code.
 - Write tests against observable behavior so they remain stable under refactoring.
 - Do not write tests that depend on implementation details.
+
+### Unit and Integration Tests
+
+- Treat `docs/e2e` as the single source of truth for runtime application behavior. Do not create separate unit or integration test specification documents or identifier systems.
+- Every new or modified unit or integration test that verifies runtime application behavior must reference at least one existing E2E test case ID in its outermost `describe` title. If the test has no `describe`, include the ID in the test title.
+- If no existing E2E test case defines the expected behavior, add or update the E2E specification before writing the test.
+- Keep unit tests co-located under `src/**/*.spec.{ts,tsx}` and use them for deterministic rules, state transitions, validation, and module or component behavior without real external services.
+- Keep integration tests under `test/integration/**/*.spec.{ts,tsx}` and use them for contracts across application modules, persistence, stores, or emulators. Do not mock the boundary that the test is intended to verify.
+- For parameterized tests, include one representative row that matches the referenced E2E Given / When / Then. Additional rows may cover boundary values and equivalence classes only when they preserve the same behavior and invariants.
+- Do not derive test cases or expected results solely from implementation branches, private functions, internal state shapes, mock call counts, or coverage gaps.
+- Assert observable results through the public boundary of the tested level.
+- Enforce static constraints such as dependency direction and type correctness with lint or typecheck instead of runtime tests. These checks do not require E2E IDs.


### PR DESCRIPTION
## Related issue

None

## Summary

- Treat `docs/e2e` as the single source of truth for runtime application behavior.
- Require new or modified unit and integration tests to reference an existing E2E test case ID, adding or updating the E2E specification when behavior is missing.
- Allow parameterized boundary-value and equivalence-class cases only when they preserve the referenced E2E behavior and invariants.
- Define the unit and integration test locations, public-boundary assertions, and mocking boundary.
- Keep static constraints in lint or typecheck rather than introducing separate test specification IDs.

## Verification

- Reviewed the `AGENTS.md` diff for consistency with the existing E2E conventions.
- No test command was run because this change only updates repository instructions.
