### PR TITLE
[No issue] Keep the study Help control fixed beside actions

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -150,7 +150,7 @@ describe("StudySession", () => {
     expect(onClickLeft).not.toHaveBeenCalled();
   });
 
-  it("keeps the back action visible and opens the remaining study actions", async () => {
+  it("SWIPE-25 keeps the Help slot fixed while opening the remaining study actions", async () => {
     const user = userEvent.setup();
     const onBack = vi.fn();
     const onToggleCardDetails = vi.fn();
@@ -169,9 +169,10 @@ describe("StudySession", () => {
     );
 
     const openActions = screen.getByRole("button", { name: "Open study actions" });
+    const helpTrigger = screen.getByRole("button", { name: "Open study help" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
+    expect(helpTrigger).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
@@ -182,11 +183,11 @@ describe("StudySession", () => {
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const detailsToggle = screen.getByRole("button", { name: "Card details" });
     const helpToggle = screen.getByRole("button", { name: "Help button" });
-    const help = screen.getByRole("button", { name: "Open study help" });
     const actions = screen.getByRole("group", { name: "Study actions" });
     expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
-    expect(help).toBeVisible();
+    expect(helpToggle).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
     expect(helpToggle).toHaveAttribute("aria-pressed", "true");
     expect(helpToggle).toHaveAttribute("title", "Hide help button");
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
@@ -195,14 +196,13 @@ describe("StudySession", () => {
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
-    expect(actions).toContainElement(helpToggle);
-    expect(actions).not.toContainElement(help);
+    expect(actions).not.toContainElement(helpToggle);
     expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
     closeActions.focus();
     await user.tab();
-    expect(help).toHaveFocus();
+    expect(helpToggle).toHaveFocus();
 
     fireEvent.click(back);
     fireEvent.click(swipeToggle);
@@ -214,13 +214,13 @@ describe("StudySession", () => {
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
     expect(onToggleCardDetails).toHaveBeenCalledOnce();
 
-    fireEvent.keyDown(help, { key: "Escape" });
+    fireEvent.keyDown(helpToggle, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
   });
 
-  it("hides the Help shortcut while keeping its Header toggle available", () => {
+  it("SWIPE-25 restores the fixed Help visibility toggle while actions are open", () => {
     const onToggleHelp = vi.fn();
     render(
       <StudySession {...toolbarProps()} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
@@ -229,7 +229,9 @@ describe("StudySession", () => {
     expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
 
+    const actions = screen.getByRole("group", { name: "Study actions" });
     const helpToggle = screen.getByRole("button", { name: "Help button" });
+    expect(actions).not.toContainElement(helpToggle);
     expect(helpToggle).toHaveAttribute("aria-pressed", "false");
     expect(helpToggle).toHaveAttribute("title", "Show help button");
     fireEvent.click(helpToggle);

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -239,9 +239,7 @@ describe("StudySession", () => {
       "top-0"
     );
 
-    rerender(
-      <StudySession {...props} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
-    );
+    rerender(<StudySession {...props} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />);
 
     const hiddenHelpToggle = screen.getByRole("button", { name: "Help button" });
     expect(hiddenHelpToggle).toBe(helpToggle);

--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -220,21 +220,34 @@ describe("StudySession", () => {
     expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
   });
 
-  it("SWIPE-25 restores the fixed Help visibility toggle while actions are open", () => {
+  it("SWIPE-25 keeps the fixed Help visibility toggle mounted while visibility changes", () => {
     const onToggleHelp = vi.fn();
-    render(
-      <StudySession {...toolbarProps()} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
+    const props = toolbarProps();
+    const { rerender } = render(
+      <StudySession {...props} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
     );
 
-    expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
 
     const actions = screen.getByRole("group", { name: "Study actions" });
     const helpToggle = screen.getByRole("button", { name: "Help button" });
     expect(actions).not.toContainElement(helpToggle);
-    expect(helpToggle).toHaveAttribute("aria-pressed", "false");
-    expect(helpToggle).toHaveAttribute("title", "Show help button");
-    fireEvent.click(helpToggle);
+    expect(helpToggle).toHaveAttribute("aria-pressed", "true");
+    expect(helpToggle).toHaveClass(
+      "absolute",
+      "right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)]",
+      "top-0"
+    );
+
+    rerender(
+      <StudySession {...props} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
+    );
+
+    const hiddenHelpToggle = screen.getByRole("button", { name: "Help button" });
+    expect(hiddenHelpToggle).toBe(helpToggle);
+    expect(hiddenHelpToggle).toHaveAttribute("aria-pressed", "false");
+    expect(hiddenHelpToggle).toHaveAttribute("title", "Show help button");
+    fireEvent.click(hiddenHelpToggle);
     expect(onToggleHelp).toHaveBeenCalledOnce();
   });
 

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -78,21 +78,18 @@ const toolbarButtonClass =
   "pointer-events-auto inline-flex size-touch shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
 interface StudyModeActionsProps {
-  showHelp: boolean;
   showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
   playbackDescriptionId: string;
   onEscape: React.KeyboardEventHandler<HTMLButtonElement>;
-  onToggleHelp: () => void;
   onToggleCardDetails: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
 }
 
 const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
-  const helpTitle = props.showHelp ? "Hide help button" : "Show help button";
   const swipeTitle = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
   const playbackTitle = props.playbackControlsAvailable
     ? props.showPlaybackControls
@@ -103,17 +100,6 @@ const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
 
   return (
     <div className="flex items-center gap-1">
-      <button
-        type="button"
-        aria-label="Help button"
-        aria-pressed={props.showHelp}
-        title={helpTitle}
-        className={cx(toolbarButtonClass, props.showHelp && "bg-surface-muted text-accent-primary")}
-        onClick={props.onToggleHelp}
-        onKeyDown={props.onEscape}
-      >
-        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
-      </button>
       <button
         type="button"
         aria-label="Swipe controls"
@@ -183,6 +169,7 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
   const actionsId = React.useId();
   const playbackDescriptionId = React.useId();
   const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const helpTitle = props.showHelp ? "Hide help button" : "Show help button";
 
   const closeOnEscape: React.KeyboardEventHandler<HTMLButtonElement> = (event) => {
     if (event.key !== "Escape" || !props.open) return;
@@ -224,43 +211,39 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
           <AiOutlineEllipsis aria-hidden="true" className="text-xl" />
         )}
       </button>
-      {props.showHelp ? (
+      {props.open || props.showHelp ? (
+        // The fixed slot opens Help while actions are closed and controls its visibility while they are open.
         <button
-          ref={helpTriggerRef}
+          ref={props.open ? undefined : helpTriggerRef}
           type="button"
-          aria-label={props.helpTriggerLabel}
+          aria-label={props.open ? "Help button" : props.helpTriggerLabel}
+          aria-pressed={props.open ? props.showHelp : undefined}
+          title={props.open ? helpTitle : undefined}
           className={cx(
             toolbarButtonClass,
-            "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+            "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0",
+            props.open && props.showHelp && "bg-surface-muted text-accent-primary"
           )}
-          onClick={props.onOpenHelp}
+          onClick={props.open ? props.onToggleHelp : props.onOpenHelp}
           onKeyDown={closeOnEscape}
         >
           <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
         </button>
       ) : null}
       {props.open ? (
-        // Four actions cannot share a 320px row with Back and the two right-side triggers. Below 360px,
-        // keep them on a second row and hide metadata there so both interactive surfaces remain unobstructed.
+        // Keep the three secondary actions below 360px so the fixed Help and menu slots stay unobstructed.
         <fieldset
           id={actionsId}
           aria-label="Study actions"
-          className={cx(
-            "pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 max-[359px]:absolute max-[359px]:inset-x-0 max-[359px]:top-[calc(var(--spacing-touch)+0.25rem)] max-[359px]:pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]",
-            props.showHelp
-              ? "pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
-              : "pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)]"
-          )}
+          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)] max-[359px]:absolute max-[359px]:inset-x-0 max-[359px]:top-[calc(var(--spacing-touch)+0.25rem)] max-[359px]:pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]"
         >
           <StudyModeActions
-            showHelp={props.showHelp}
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}
             showPlaybackControls={props.showPlaybackControls}
             playbackControlsAvailable={props.playbackControlsAvailable}
             playbackDescriptionId={playbackDescriptionId}
             onEscape={closeOnEscape}
-            onToggleHelp={props.onToggleHelp}
             onToggleCardDetails={props.onToggleCardDetails}
             onToggleSwipeControls={props.onToggleSwipeControls}
             onTogglePlaybackControls={props.onTogglePlaybackControls}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -286,7 +286,6 @@ describe("StudySessionPage", () => {
     document.documentElement.lang = "ja-JP";
     renderPage();
 
-    openStudyActions();
     fireEvent.click(screen.getByRole("button", { name: "学習ヘルプを開く" }));
 
     expect(screen.getByRole("dialog", { name: "学習画面の操作" })).toHaveTextContent(
@@ -302,7 +301,6 @@ describe("StudySessionPage", () => {
 
     try {
       renderPage();
-      openStudyActions();
       fireEvent.click(screen.getByRole("button", { name: "Open study help" }));
 
       act(() => vi.advanceTimersByTime(1000));


### PR DESCRIPTION
## Related issue

None

## Summary

- reuse the fixed question-mark slot as the Help dialog trigger while Study actions are closed and as the Help visibility toggle while they are open
- keep that slot mounted immediately to the left of the Study actions trigger so changing the visibility preference does not move it
- reserve stable toolbar space for the remaining actions and update component/Page coverage for the dual-role control

## Testing

- TypeScript syntax validation for the changed source and test files
- CI checks pending