### PR TITLE
[No issue] Add follow-up E2E contracts

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -41,6 +41,7 @@
 | SETTINGS-03 | batch | [Respect review schedule を次の学習 session に反映できる](./settings.md#settings-03) |
 | SETTINGS-04 | write | [日本語設定を自動保存して reload 後も反映できる](./settings.md#settings-04) |
 | SETTINGS-05 | write | [System 設定で browser locale を解決して reload 後も反映できる](./settings.md#settings-05) |
+| SETTINGS-06 | read | [無効な保存済み設定から現在の既定値へ復旧できる](./settings.md#settings-06) |
 
 ### Import
 
@@ -112,6 +113,7 @@
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](./study-session.md#swipe-17) |
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](./study-controls.md#swipe-24) |
 | SWIPE-25 | write | [Help button の表示設定を reload 後も維持できる](./study-controls.md#swipe-25) |
+| SWIPE-26 | batch | [展開した tag filter を保存して学習 session に適用できる](./study-session.md#swipe-26) |
 
 ### Study Back Text
 
@@ -132,3 +134,4 @@
 | --- | --- | --- |
 | PERSIST-01 | read | [UID ごとに remote data を分離して reload 後も表示できる](./persistence.md#persist-01) |
 | PERSIST-02 | batch | [offline cache の変更を再接続後に remote へ同期できる](./persistence.md#persist-02) |
+| PERSIST-03 | write | [別の open client に remote Card の変更を即時反映できる](./persistence.md#persist-03) |

--- a/docs/e2e/deck-management.md
+++ b/docs/e2e/deck-management.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-Deck の作成・編集・削除が保存先の境界を守り、失敗後の再試行でも identity と関連データの整合性を維持できることを確認する。
+Deck の作成・編集・削除が保存先の境界を守り、失敗後の再試行でも identity と関連データの整合性、および操作対象外の Deck の分離を維持できることを確認する。
 
 ## テストケース
 
@@ -30,12 +30,12 @@ Given:
 
 When:
 
-- 対象 Deck の name と category を変更して保存し、画面を reload して編集画面を再度開く。
+- 対象 Deck の name、category、source URL を変更して保存し、画面を reload して編集画面を再度開く。
 
 Then:
 
 - Deck の更新成功が共通 toast で表示される。
-- 編集画面に変更後の name と category が表示される。
+- 編集画面に変更後の name、category、source URL が表示される。
 - browser error が発生しない。
 
 <a id="deck-03"></a>
@@ -46,9 +46,10 @@ Then:
 
 Given:
 
-- Fixture: [`study-session-middle`](./fixture/study-session-middle.yaml)
+- Fixture: [`multi-study-sessions`](./fixture/multi-study-sessions.yaml)
 - 認証済みユーザーが所有する削除対象の Deck が存在する。
 - 対象 Deck に複数の Card と再開可能な学習 session が存在する。
+- 同じユーザーが、操作対象ではない別の Deck、Card、学習 session を所有している。
 
 When:
 
@@ -60,6 +61,7 @@ Then:
 - Deck 一覧に対象 Deck が表示されない。
 - 対象 Deck と関連するすべての Card が保存先から削除されている。
 - 対象 Deck の学習 session を再開できない。
+- 操作対象ではない Deck、Card、学習 session は維持され、引き続き再開できる。
 - browser error が発生しない。
 
 <a id="deck-04"></a>

--- a/docs/e2e/fixture/study-tag-disclosure.yaml
+++ b/docs/e2e/fixture/study-tag-disclosure.yaml
@@ -1,0 +1,78 @@
+extends: empty.yaml
+remote:
+  decks:
+    - id: deck-1
+      uid: user-1
+      name: Tag Study Deck
+      category: English
+  cards:
+    - id: card-01
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 01
+      backText: answer 01
+      tags: [tag-01]
+      uniqueKey: card-tag-01
+    - id: card-02
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 02
+      backText: answer 02
+      tags: [tag-02]
+      uniqueKey: card-tag-02
+    - id: card-03
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 03
+      backText: answer 03
+      tags: [tag-03]
+      uniqueKey: card-tag-03
+    - id: card-04
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 04
+      backText: answer 04
+      tags: [tag-04]
+      uniqueKey: card-tag-04
+    - id: card-05
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 05
+      backText: answer 05
+      tags: [tag-05]
+      uniqueKey: card-tag-05
+    - id: card-06
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 06
+      backText: answer 06
+      tags: [tag-06]
+      uniqueKey: card-tag-06
+    - id: card-07
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 07
+      backText: answer 07
+      tags: [tag-07]
+      uniqueKey: card-tag-07
+    - id: card-08
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 08
+      backText: answer 08
+      tags: [tag-08]
+      uniqueKey: card-tag-08
+    - id: card-09
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 09
+      backText: answer 09
+      tags: [tag-09]
+      uniqueKey: card-tag-09
+    - id: card-10
+      deckId: deck-1
+      uid: user-1
+      frontText: card tag 10
+      backText: answer 10
+      tags: [tag-10]
+      uniqueKey: card-tag-10

--- a/docs/e2e/persistence.md
+++ b/docs/e2e/persistence.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-remote data が認証 UID ごとに分離され、永続 cache と queued write が network 状態の変化を越えて正しく機能することを確認する。
+remote data が認証 UID ごとに分離され、永続 cache、queued write、realtime subscription が network 状態や複数 client を越えて正しく機能することを確認する。
 
 ## テストケース
 
@@ -10,6 +10,7 @@ remote data が認証 UID ごとに分離され、永続 cache と queued write 
 | --- | --- | --- |
 | PERSIST-01 | read | [UID ごとに remote data を分離して reload 後も表示できる](#persist-01) |
 | PERSIST-02 | batch | [offline cache の変更を再接続後に remote へ同期できる](#persist-02) |
+| PERSIST-03 | write | [別の open client に remote Card の変更を即時反映できる](#persist-03) |
 
 <a id="persist-01"></a>
 
@@ -56,4 +57,28 @@ Then:
 - 編集内容が primary browser の画面に維持される。
 - verification browser context に編集内容が remote data として表示される。
 - queued write による重複した Deck や Card は作成されない。
+- 未処理の browser error が発生しない。
+
+<a id="persist-03"></a>
+
+### PERSIST-03 別の open client に remote Card の変更を即時反映できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`remote-deck-with-cards`](./fixture/remote-deck-with-cards.yaml)
+- 同じ UID で認証した独立した2つの browser context が、同じ remote Card の一覧を開いている。
+- secondary browser context は対象 Card の変更前の front text を表示している。
+
+When:
+
+- primary browser context で対象 Card の front text を変更して保存する。
+- secondary browser context は reload せずに開いたままにする。
+
+Then:
+
+- secondary browser context に変更後の front text が表示される。
+- secondary browser context に変更前の front text が残らない。
+- 対象 Card の ID と unique key は維持され、remote data に重複が作成されない。
 - 未処理の browser error が発生しない。

--- a/docs/e2e/settings.md
+++ b/docs/e2e/settings.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-Settings の自動保存が reload を越えて維持され、保存した学習設定が学習開始画面や次の学習 session に反映され、言語設定がアプリケーションへ反映されることを確認する。
+Settings の自動保存が reload を越えて維持され、保存した学習設定が学習開始画面や次の学習 session に反映され、言語設定と無効な保存済み設定からの復旧がアプリケーションへ反映されることを確認する。
 
 ## テストケース
 
@@ -13,6 +13,7 @@ Settings の自動保存が reload を越えて維持され、保存した学習
 | SETTINGS-03 | batch | [Respect review schedule を次の学習 session に反映できる](#settings-03) |
 | SETTINGS-04 | write | [日本語設定を自動保存して reload 後も反映できる](#settings-04) |
 | SETTINGS-05 | write | [System 設定で browser locale を解決して reload 後も反映できる](#settings-05) |
+| SETTINGS-06 | read | [無効な保存済み設定から現在の既定値へ復旧できる](#settings-06) |
 
 <a id="settings-01"></a>
 
@@ -127,4 +128,27 @@ Then:
 - browser storage の language preference が `system` として保存される。
 - `ja-JP` が有効な locale の `ja` に解決され、`html[lang]` が `ja` になる。
 - reload 後も日本語 UI、language preference、`html[lang]` が維持される。
+- browser error が発生しない。
+
+<a id="settings-06"></a>
+
+### SETTINGS-06 無効な保存済み設定から現在の既定値へ復旧できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`empty`](./fixture/empty.yaml)
+- browser storage の現在の persistence version に、Preferences schema と一致しない snapshot が保存されている。
+
+When:
+
+- Settings 画面を reload する。
+
+Then:
+
+- Settings 画面が表示される。
+- Dark mode は現在の既定値である無効へ復旧する。
+- Maximum cards は現在の既定値である `10` へ復旧する。
+- Language は現在の既定値である `System` へ復旧する。
 - browser error が発生しない。

--- a/docs/e2e/study-session.md
+++ b/docs/e2e/study-session.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-学習 session の開始・再開・再作成・完了・永続化が、filter、学習上限、Deck ごとの分離を維持できることを確認する。
+学習 session の開始・再開・再作成・完了・永続化が、filter の選択と保存、学習上限、Deck ごとの分離を維持できることを確認する。
 
 ## テストケース
 
@@ -15,6 +15,7 @@
 | SWIPE-10 | write | [最後の Card を完了して completion screen を表示できる](#swipe-10) |
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
+| SWIPE-26 | batch | [展開した tag filter を保存して学習 session に適用できる](#swipe-26) |
 
 <a id="swipe-06"></a>
 
@@ -174,4 +175,30 @@ Then:
 - 現在だった Card の mastered 学習結果が browser storage に維持されている。
 - session の位置が次の Card に維持されている。
 - 次の Card の front text が表示され、back text は表示されない。
+- browser error が発生しない。
+
+<a id="swipe-26"></a>
+
+### SWIPE-26 展開した tag filter を保存して学習 session に適用できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`study-tag-disclosure`](./fixture/study-tag-disclosure.yaml)
+- 認証済みユーザーが所有する Deck に、それぞれ異なる tag を持つ 10 枚の Card が存在する。
+- 対象 tag は折りたたまれた最初の 8 件より後にあり、まだ filter に選択されていない。
+- 対象 Deck に進行中の学習 session が存在しない。
+
+When:
+
+- 学習開始画面で追加の tag を展開し、対象 tag を選択する。
+- filter の保存完了後に画面を reload し、学習 session を開始する。
+
+Then:
+
+- reload 後も対象 tag が表示され、選択状態を維持する。
+- 対象 Deck の保存済み tag filter に対象 tag だけが含まれる。
+- session には対象 tag を持つ Card だけが含まれる。
+- 対象 Card の front text が表示される。
 - browser error が発生しない。

--- a/test/e2e/deck.spec.ts
+++ b/test/e2e/deck.spec.ts
@@ -35,16 +35,18 @@ test("DECK-01 navigates from the Deck list to its Card list", async ({ fixture, 
   await expect(page.getByText(card.frontText)).toBeVisible();
 });
 
-test("DECK-02 persists edited name and category across reload", async ({ fixture, page, namespace }) => {
+test("DECK-02 persists edited name, category, and source URL across reload", async ({ fixture, page, namespace }) => {
   const deck = fixture.deck();
   await fixture.apply(page);
   const updatedName = `${namespace.caseId} updated`;
+  const updatedSourceUrl = "https://example.com/updated-deck.csv";
 
   await page.goto("/");
   await page.getByRole("button", { name: `Open actions for ${deck.name}` }).click();
   await page.getByRole("menuitem", { name: "Edit" }).click();
   await page.getByRole("textbox", { name: "Name" }).fill(updatedName);
   await page.getByRole("combobox").selectOption("typescript");
+  await page.getByRole("textbox", { name: "Source URL" }).fill(updatedSourceUrl);
   await page.getByRole("button", { name: "Save changes" }).click();
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole("status").filter({ hasText: `Updated deck “${updatedName}”.` })).toBeVisible();
@@ -54,11 +56,15 @@ test("DECK-02 persists edited name and category across reload", async ({ fixture
 
   await expect(page.getByRole("textbox", { name: "Name" })).toHaveValue(updatedName);
   await expect(page.getByRole("combobox")).toHaveValue("typescript");
+  await expect(page.getByRole("textbox", { name: "Source URL" })).toHaveValue(updatedSourceUrl);
 });
 
-test("DECK-03 deletes a Deck, all Cards, and its resumable session", async ({ fixture, page }) => {
-  const deck = fixture.deck();
-  const { cards } = fixture.state.remote;
+test("DECK-03 deletes one Deck and preserves unrelated Deck data", async ({ fixture, page }) => {
+  const deck = fixture.deck("deck-a");
+  const otherDeck = fixture.deck("deck-b");
+  const cards = fixture.state.remote.cards.filter((card) => card.deckId === deck.id);
+  const otherCards = fixture.state.remote.cards.filter((card) => card.deckId === otherDeck.id);
+  const otherSession = fixture.session("deck-b");
   await fixture.apply(page);
   await page.goto("/");
 
@@ -71,8 +77,15 @@ test("DECK-03 deletes a Deck, all Cards, and its resumable session", async ({ fi
   await expect(page.getByRole("button", { name: `View ${deck.name}` })).toHaveCount(0);
   await expect.poll(() => getDocument("deck", deck.id)).toBeUndefined();
   await Promise.all(cards.map((card) => expect.poll(() => getDocument("card", card.id)).toBeUndefined()));
-  expect((await readLocalData(page)).sessionsByDeckId).not.toHaveProperty(deck.id);
+
+  expect(await getDocument("deck", otherDeck.id)).toBeDefined();
+  expect((await Promise.all(otherCards.map((card) => getDocument("card", card.id)))).every(Boolean)).toBe(true);
+  const sessionsByDeckId = (await readLocalData(page)).sessionsByDeckId;
+  expect(sessionsByDeckId).not.toHaveProperty(deck.id);
+  expect(sessionsByDeckId).toHaveProperty(otherDeck.id, otherSession);
   await expect(page.getByRole("button", { name: `Continue ${deck.name}` })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: `View ${otherDeck.name}` })).toBeVisible();
+  await expect(page.getByRole("button", { name: `Continue ${otherDeck.name}` })).toBeVisible();
 });
 
 test("DECK-04 cancels Deck deletion and preserves all related data", async ({ fixture, page }) => {

--- a/test/e2e/persistence-realtime.spec.ts
+++ b/test/e2e/persistence-realtime.spec.ts
@@ -1,0 +1,58 @@
+import {
+  collectBrowserErrors,
+  documentId,
+  expect,
+  listDocuments,
+  requireDocument,
+  test,
+} from "./fixtures";
+
+test("PERSIST-03 reflects a remote Card edit in another open client without reload", async ({
+  baseURL,
+  browser,
+  fixture,
+  namespace,
+  page,
+}) => {
+  const deck = fixture.deck();
+  const card = fixture.card();
+  const updatedFrontText = `${namespace.caseId} live update`;
+  await fixture.seedRemote();
+  await fixture.seedPage(page);
+
+  const secondaryContext = await browser.newContext();
+  const secondaryErrors = collectBrowserErrors(secondaryContext, baseURL);
+  const secondaryPage = await secondaryContext.newPage();
+  await fixture.seedPage(secondaryPage);
+
+  try {
+    await Promise.all([page.goto(`/deck/${deck.id}`), secondaryPage.goto(`/deck/${deck.id}`)]);
+    await Promise.all([
+      expect(page.getByRole("button", { name: `View ${card.frontText}` })).toBeVisible(),
+      expect(secondaryPage.getByRole("button", { name: `View ${card.frontText}` })).toBeVisible(),
+    ]);
+
+    await page.getByRole("button", { name: `Open actions for ${card.frontText}` }).click();
+    await page.getByRole("menuitem", { name: "Edit" }).click();
+    await page.getByRole("textbox", { name: "Front text" }).fill(updatedFrontText);
+    await page.getByRole("button", { name: "Save changes" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));
+    await expect(secondaryPage.getByRole("button", { name: `View ${updatedFrontText}` })).toBeVisible();
+    await expect(secondaryPage.getByRole("button", { name: `View ${card.frontText}` })).toHaveCount(0);
+    await expect
+      .poll(async () => (await requireDocument("card", card.id)).fields.frontText?.stringValue)
+      .toBe(updatedFrontText);
+
+    const matchingCards = (await listDocuments("card")).filter(
+      ({ fields }) =>
+        fields.uid?.stringValue === card.uid &&
+        fields.deckId?.stringValue === deck.id &&
+        fields.uniqueKey?.stringValue === card.uniqueKey
+    );
+    expect(matchingCards.map(documentId)).toEqual([card.id]);
+    secondaryErrors.assert();
+  } finally {
+    await secondaryContext.close();
+  }
+});

--- a/test/e2e/persistence-realtime.spec.ts
+++ b/test/e2e/persistence-realtime.spec.ts
@@ -1,11 +1,4 @@
-import {
-  collectBrowserErrors,
-  documentId,
-  expect,
-  listDocuments,
-  requireDocument,
-  test,
-} from "./fixtures";
+import { collectBrowserErrors, documentId, expect, listDocuments, requireDocument, test } from "./fixtures";
 
 test("PERSIST-03 reflects a remote Card edit in another open client without reload", async ({
   baseURL,

--- a/test/e2e/settings-recovery.spec.ts
+++ b/test/e2e/settings-recovery.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "./fixtures";
+
+test("SETTINGS-06 recovers current defaults from invalid persisted preferences", async ({ fixture, page }) => {
+  await fixture.apply(page);
+  await page.goto("/settings");
+  await page.evaluate(() => {
+    localStorage.setItem("tango-config", JSON.stringify({ state: { preferences: "invalid" }, version: 1 }));
+  });
+
+  await page.reload();
+
+  await expect(page.getByRole("heading", { level: 1, name: "Settings" })).toBeVisible();
+  await expect(page.getByRole("checkbox", { name: "Dark mode" })).not.toBeChecked();
+  await expect(page.getByRole("slider", { name: "Maximum cards" })).toHaveValue("10");
+  await expect(page.getByRole("combobox", { name: "Language" })).toHaveValue("system");
+});

--- a/test/e2e/study-filter.spec.ts
+++ b/test/e2e/study-filter.spec.ts
@@ -1,0 +1,31 @@
+import { expect, requireDocument, test } from "./fixtures";
+import { readSession } from "./study-helpers";
+
+const readSelectedTags = async (deckId: string): Promise<string[]> =>
+  ((await requireDocument("deck", deckId)).fields.selectedTags?.arrayValue?.values ?? [])
+    .map((value) => value.stringValue)
+    .filter((value): value is string => value !== undefined);
+
+test("SWIPE-26 reveals, persists, and applies an additional Study tag", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const targetCard = fixture.card("card-10");
+  await fixture.apply(page);
+  await page.goto(`/deck/${deck.id}/start`);
+
+  const targetTag = page.getByRole("checkbox", { name: "tag-10", exact: true });
+  await expect(targetTag).toHaveCount(0);
+  await page.getByRole("button", { name: "Show 2 more tags" }).click();
+  await expect(targetTag).toBeVisible();
+  await targetTag.locator("xpath=parent::label").click();
+  await expect(targetTag).toBeChecked();
+  await expect(page.getByRole("button", { name: "Start 1 card" })).toBeEnabled();
+  await expect.poll(() => readSelectedTags(deck.id)).toEqual(["tag-10"]);
+
+  await page.reload();
+  await expect(targetTag).toBeVisible();
+  await expect(targetTag).toBeChecked();
+  await page.getByRole("button", { name: "Start 1 card" }).click();
+
+  await expect(page.getByText(targetCard.frontText, { exact: true })).toBeVisible();
+  await expect.poll(async () => (await readSession(page, deck.id))?.cardOrderIds).toEqual([targetCard.id]);
+});


### PR DESCRIPTION
## Related issue

None

## Summary

- Re-audit current unit and Firestore integration coverage against the documented E2E suite, including the still-open follow-up in #1401.
- Add `PERSIST-03` for propagating a remote Card edit to another open client without reload.
- Add `SETTINGS-06` for recovering current defaults from an invalid persisted Preferences snapshot.
- Add `SWIPE-26` for revealing, persisting, and applying an additional Study tag filter.
- Strengthen `DECK-02` to verify source URL persistence across reload.
- Strengthen `DECK-03` to verify that deleting one Deck preserves an unrelated Deck, its Cards, and its resumable Study session.
- Keep auth failures that require a test-only Firebase mock, input-method combinations, validation equivalence classes, subscription teardown, and asynchronous race contracts at the unit or integration level.

## Verification

- Confirmed the branch is based on the current `main` commit `9f12764a78556fe00b07d3f9f8a60065ae0be04c`.
- Confirmed each new E2E ID has one README index entry, one Given / When / Then specification, one fixture reference, and exactly one Playwright test title.
- Pull-request CI will run formatting, lint, type checking, unit coverage, Firestore integration, Storybook, sample tests, and the complete E2E suite.
