### PR TITLE
[No issue] Link unit tests to E2E cases

### DIFF
--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -45,7 +45,7 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { CardFormPage } from "./CardFormPage";
 
-describe("CardFormPage", () => {
+describe("CARD-03 CARD-09 CARD-12 CARD-17 CardFormPage", () => {
   const deckId = "card-form-deck";
   const cardId = "card-id";
   const renderPage = (path = `/card/${cardId}/edit`) => {

--- a/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
@@ -110,7 +110,7 @@ const getCardArticle = (frontText: string) => {
   return article;
 };
 
-describe("CardListPage interactions", () => {
+describe("CARD-02 CARD-04 CARD-10 CARD-16 CARD-18 CardListPage interactions", () => {
   beforeEach(() => {
     dismissToast();
     vi.clearAllMocks();

--- a/src/pages/card-list/ui/CardListPage.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.spec.tsx
@@ -33,7 +33,7 @@ const NextDeckButton = () => {
   );
 };
 
-describe("CardListPage", () => {
+describe("NAVIGATION-02 DECK-06 CARD-01 CARD-10 CardListPage", () => {
   const deckId = "deck-id";
   const nextDeckId = "next-deck";
   const cardId = "card-id";

--- a/src/pages/deck-list/ui/DeckListPage.spec.tsx
+++ b/src/pages/deck-list/ui/DeckListPage.spec.tsx
@@ -37,7 +37,7 @@ vi.mock("@/shared/files", () => ({ downloadTextFile: mocks.downloadTextFile }));
 
 import { DeckListPage } from "./DeckListPage";
 
-describe("DeckListPage", () => {
+describe("NAVIGATION-02 DECK-01 DECK-03 DECK-04 DECK-05 DECK-08 DeckListPage", () => {
   const activeDeck = createLocalDeck({ id: "active-deck", name: "Active deck" });
   const freshDeck = createLocalDeck({ id: "fresh-deck", name: "Fresh deck" });
   const activeCard = createLocalCard({

--- a/src/shared/router/navigationGuard.spec.tsx
+++ b/src/shared/router/navigationGuard.spec.tsx
@@ -63,7 +63,7 @@ const renderGuard = () => {
   return render(<RouterProvider router={router} />);
 };
 
-describe("useNavigationGuard", () => {
+describe("DECK-12 CARD-17 useNavigationGuard", () => {
   it("allows clean navigation and intentional successful navigation", async () => {
     const view = renderGuard();
     await userEvent.click(screen.getByRole("link", { name: "Leave" }));

--- a/test/e2e/card-resilience.spec.ts
+++ b/test/e2e/card-resilience.spec.ts
@@ -40,7 +40,9 @@ test("CARD-16 retries the same Card deletion after a handled failure", async ({ 
 
   const dialog = await openCardDeleteDialog(page, card.frontText);
   await dialog.getByRole("button", { name: "Delete card" }).click();
-  await expect(dialog.getByRole("alert")).toBeVisible();
+  await expect(
+    dialog.getByText("Unable to delete this card. Check your connection and try again.", { exact: true })
+  ).toBeVisible();
   await expect.poll(fault.wasTriggered).toBe(true);
   await fault.waitForFailure();
   await fault.dispose();
@@ -94,7 +96,7 @@ test("CARD-18 retries the same Card-list score change after a handled failure", 
   allowExpectedFirestoreWriteFailure(browserErrors);
 
   await swipeRight(page, card.frontText);
-  await expect(page.getByText("Unable to save changes. Try again.")).toBeVisible();
+  await expect(page.getByText("Unable to save changes. Try again.", { exact: true })).toBeVisible();
   await expect.poll(fault.wasTriggered).toBe(true);
   await fault.waitForFailure();
   await fault.dispose();
@@ -107,7 +109,7 @@ test("CARD-18 retries the same Card-list score change after a handled failure", 
   await expect
     .poll(async () => (await requireDocument("card", unrelatedCard.id)).fields.score?.integerValue)
     .toBe(String(unrelatedCard.score));
-  await expect(page.getByText("Unable to save changes. Try again.")).toHaveCount(0);
+  await expect(page.getByText("Unable to save changes. Try again.", { exact: true })).toHaveCount(0);
   await page.reload();
   await expectScore(page, card.frontText, expectedScore);
 });


### PR DESCRIPTION
## Related issue

No issue

## Summary

- Link existing unit suites to the documented E2E behavior they verify, following the traceability rules in `AGENTS.md`.
- Add the relevant E2E case IDs to the outermost `describe` titles for Card form, Card list, Deck list, and navigation-guard tests.
- Align the `CARD-16` and `CARD-18` Playwright locators with the shared Toast UI introduced on `main`.
- Keep application behavior unchanged; the E2E adjustment only removes stale and ambiguous selectors.

## Changes

- `CardFormPage.spec.tsx`: `CARD-03`, `CARD-09`, `CARD-12`, `CARD-17`
- `CardListPage.interactions.spec.tsx`: `CARD-02`, `CARD-04`, `CARD-10`, `CARD-16`, `CARD-18`
- `CardListPage.spec.tsx`: `NAVIGATION-02`, `DECK-06`, `CARD-01`, `CARD-10`
- `DeckListPage.spec.tsx`: `NAVIGATION-02`, `DECK-01`, `DECK-03`, `DECK-04`, `DECK-05`, `DECK-08`
- `navigationGuard.spec.tsx`: `DECK-12`, `CARD-17`
- `card-resilience.spec.ts`: assert the deletion error inside its dialog and use exact score-error text so the visual Toast is not confused with its live-region announcement.

## Verification

- `Audit` workflow passed.
- Aggregate `Test` workflow passed.
- Dependency Review, code quality, build, unit coverage, Storybook, Firestore integration, sample tests, and E2E all passed.
- The E2E contract check passed and Playwright completed **78 / 78 tests** successfully.

## Review gate

- The repository-required custom `reviewer` subagent is unavailable in this execution environment, so this PR remains a draft pending that mandatory review.