### PR TITLE
[No issue] Keep Study Help icon anchored beside actions

### DIFF
--- a/src/pages/study-session/ui/StudySession.spec.tsx
+++ b/src/pages/study-session/ui/StudySession.spec.tsx
@@ -61,7 +61,7 @@ const swipeWithMouse = (
   fireEvent.mouseUp(document, { ...end, button });
 };
 
-describe("StudySession", () => {
+describe("SWIPE-24 SWIPE-25 StudySession", () => {
   it("shows only the answer on the back", () => {
     render(
       <StudySession
@@ -153,6 +153,7 @@ describe("StudySession", () => {
   it("keeps the back action visible and opens the remaining study actions", async () => {
     const user = userEvent.setup();
     const onBack = vi.fn();
+    const onToggleHelp = vi.fn();
     const onToggleCardDetails = vi.fn();
     const onToggleSwipeControls = vi.fn();
     const onTogglePlaybackControls = vi.fn();
@@ -160,6 +161,7 @@ describe("StudySession", () => {
       <StudySession
         {...toolbarProps()}
         onBack={onBack}
+        onToggleHelp={onToggleHelp}
         onToggleCardDetails={onToggleCardDetails}
         onToggleSwipeControls={onToggleSwipeControls}
         onTogglePlaybackControls={onTogglePlaybackControls}
@@ -169,9 +171,10 @@ describe("StudySession", () => {
     );
 
     const openActions = screen.getByRole("button", { name: "Open study actions" });
+    const help = screen.getByRole("button", { name: "Open study help" });
     expect(openActions).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
+    expect(help).toBeVisible();
     expect(screen.getByRole("button", { name: "Back to deck list" })).toBeVisible();
 
     fireEvent.click(openActions);
@@ -182,11 +185,11 @@ describe("StudySession", () => {
     const playbackToggle = screen.getByRole("button", { name: "Playback controls" });
     const detailsToggle = screen.getByRole("button", { name: "Card details" });
     const helpToggle = screen.getByRole("button", { name: "Help button" });
-    const help = screen.getByRole("button", { name: "Open study help" });
     const actions = screen.getByRole("group", { name: "Study actions" });
     expect(closeActions).toHaveAttribute("aria-expanded", "true");
     expect(back).toBeVisible();
-    expect(help).toBeVisible();
+    expect(helpToggle).toBe(help);
+    expect(helpToggle).toBeVisible();
     expect(helpToggle).toHaveAttribute("aria-pressed", "true");
     expect(helpToggle).toHaveAttribute("title", "Hide help button");
     expect(swipeToggle).toHaveAttribute("aria-pressed", "true");
@@ -195,41 +198,76 @@ describe("StudySession", () => {
     expect(swipeToggle).toHaveAttribute("title", "Hide swipe controls");
     expect(playbackToggle).toHaveAttribute("title", "Hide playback controls");
     expect(detailsToggle).toHaveAttribute("title", "Hide card details");
-    expect(actions).toContainElement(helpToggle);
-    expect(actions).not.toContainElement(help);
+    expect(actions).not.toContainElement(helpToggle);
     expect(actions).not.toContainElement(back);
     expect(actions).not.toContainElement(screen.getByText("Card metadata"));
 
     closeActions.focus();
     await user.tab();
-    expect(help).toHaveFocus();
+    expect(helpToggle).toHaveFocus();
 
     fireEvent.click(back);
+    fireEvent.click(helpToggle);
     fireEvent.click(swipeToggle);
     fireEvent.click(playbackToggle);
     fireEvent.click(detailsToggle);
 
     expect(onBack).toHaveBeenCalledOnce();
+    expect(onToggleHelp).toHaveBeenCalledOnce();
     expect(onToggleSwipeControls).toHaveBeenCalledOnce();
     expect(onTogglePlaybackControls).toHaveBeenCalledOnce();
     expect(onToggleCardDetails).toHaveBeenCalledOnce();
 
-    fireEvent.keyDown(help, { key: "Escape" });
+    fireEvent.keyDown(helpToggle, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Open study actions" })).toHaveFocus();
     expect(screen.queryByRole("group", { name: "Study actions" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open study help" })).toBeVisible();
   });
 
-  it("hides the Help shortcut while keeping its Header toggle available", () => {
+  it("keeps the Help visibility toggle in the same toolbar slot while Study actions are open", () => {
+    const onToggleHelp = vi.fn();
+    const { rerender } = render(
+      <StudySession {...toolbarProps()} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
+    );
+
+    const help = screen.getByRole("button", { name: "Open study help" });
+    fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
+
+    const helpToggle = screen.getByRole("button", { name: "Help button" });
+    expect(helpToggle).toBe(help);
+    expect(helpToggle).toHaveAttribute("aria-pressed", "true");
+    expect(helpToggle).toHaveAttribute("title", "Hide help button");
+
+    rerender(
+      <StudySession
+        {...toolbarProps()}
+        showHelp={false}
+        onToggleHelp={onToggleHelp}
+        frontTextSlot={<div>Front</div>}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Help button" })).toBe(helpToggle);
+    expect(helpToggle).toBeVisible();
+    expect(helpToggle).toHaveAttribute("aria-pressed", "false");
+    expect(helpToggle).toHaveAttribute("title", "Show help button");
+
+    fireEvent.click(helpToggle);
+    expect(onToggleHelp).toHaveBeenCalledOnce();
+  });
+
+  it("hides the Help shortcut while keeping its toolbar toggle available", () => {
     const onToggleHelp = vi.fn();
     render(
       <StudySession {...toolbarProps()} showHelp={false} onToggleHelp={onToggleHelp} frontTextSlot={<div>Front</div>} />
     );
 
     expect(screen.queryByRole("button", { name: "Open study help" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Help button" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open study actions" }));
 
     const helpToggle = screen.getByRole("button", { name: "Help button" });
+    expect(helpToggle).toBeVisible();
     expect(helpToggle).toHaveAttribute("aria-pressed", "false");
     expect(helpToggle).toHaveAttribute("title", "Show help button");
     fireEvent.click(helpToggle);

--- a/src/pages/study-session/ui/StudySession.tsx
+++ b/src/pages/study-session/ui/StudySession.tsx
@@ -78,21 +78,18 @@ const toolbarButtonClass =
   "pointer-events-auto inline-flex size-touch shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
 interface StudyModeActionsProps {
-  showHelp: boolean;
   showCardDetails: boolean;
   showSwipeControls: boolean;
   showPlaybackControls: boolean;
   playbackControlsAvailable: boolean;
   playbackDescriptionId: string;
   onEscape: React.KeyboardEventHandler<HTMLButtonElement>;
-  onToggleHelp: () => void;
   onToggleCardDetails: () => void;
   onToggleSwipeControls: () => void;
   onTogglePlaybackControls: () => void;
 }
 
 const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
-  const helpTitle = props.showHelp ? "Hide help button" : "Show help button";
   const swipeTitle = props.showSwipeControls ? "Hide swipe controls" : "Show swipe controls";
   const playbackTitle = props.playbackControlsAvailable
     ? props.showPlaybackControls
@@ -103,17 +100,6 @@ const StudyModeActions: React.FC<StudyModeActionsProps> = (props) => {
 
   return (
     <div className="flex items-center gap-1">
-      <button
-        type="button"
-        aria-label="Help button"
-        aria-pressed={props.showHelp}
-        title={helpTitle}
-        className={cx(toolbarButtonClass, props.showHelp && "bg-surface-muted text-accent-primary")}
-        onClick={props.onToggleHelp}
-        onKeyDown={props.onEscape}
-      >
-        <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
-      </button>
       <button
         type="button"
         aria-label="Swipe controls"
@@ -183,6 +169,7 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
   const actionsId = React.useId();
   const playbackDescriptionId = React.useId();
   const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const helpTitle = props.showHelp ? "Hide help button" : "Show help button";
 
   const closeOnEscape: React.KeyboardEventHandler<HTMLButtonElement> = (event) => {
     if (event.key !== "Escape" || !props.open) return;
@@ -224,43 +211,41 @@ const StudyToolbar: React.FC<StudyToolbarProps> = ({ ref: helpTriggerRef, ...pro
           <AiOutlineEllipsis aria-hidden="true" className="text-xl" />
         )}
       </button>
-      {props.showHelp ? (
+      {props.open || props.showHelp ? (
+        // The fixed Help slot opens the dialog while the menu is closed and toggles its own visibility while open.
+        // Keeping one element in one slot prevents the icon from moving or disappearing during that toggle.
         <button
           ref={helpTriggerRef}
           type="button"
-          aria-label={props.helpTriggerLabel}
+          aria-label={props.open ? "Help button" : props.helpTriggerLabel}
+          aria-pressed={props.open ? props.showHelp : undefined}
+          title={props.open ? helpTitle : undefined}
           className={cx(
             toolbarButtonClass,
-            "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0"
+            "absolute right-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)] top-0",
+            props.open && props.showHelp && "bg-surface-muted text-accent-primary"
           )}
-          onClick={props.onOpenHelp}
+          onClick={props.open ? props.onToggleHelp : props.onOpenHelp}
           onKeyDown={closeOnEscape}
         >
           <AiOutlineQuestionCircle aria-hidden="true" className="text-xl" />
         </button>
       ) : null}
       {props.open ? (
-        // Four actions cannot share a 320px row with Back and the two right-side triggers. Below 360px,
+        // Three actions cannot share a 320px row with Back and the two fixed right-side controls. Below 360px,
         // keep them on a second row and hide metadata there so both interactive surfaces remain unobstructed.
         <fieldset
           id={actionsId}
           aria-label="Study actions"
-          className={cx(
-            "pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 max-[359px]:absolute max-[359px]:inset-x-0 max-[359px]:top-[calc(var(--spacing-touch)+0.25rem)] max-[359px]:pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]",
-            props.showHelp
-              ? "pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)]"
-              : "pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)+0.25rem)]"
-          )}
+          className="pointer-events-none m-0 flex h-touch min-w-0 items-center justify-end border-0 p-0 pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right)+var(--spacing-touch)*2+0.5rem)] max-[359px]:absolute max-[359px]:inset-x-0 max-[359px]:top-[calc(var(--spacing-touch)+0.25rem)] max-[359px]:pr-[calc(var(--spacing-shell-gutter)+env(safe-area-inset-right))]"
         >
           <StudyModeActions
-            showHelp={props.showHelp}
             showCardDetails={props.showCardDetails}
             showSwipeControls={props.showSwipeControls}
             showPlaybackControls={props.showPlaybackControls}
             playbackControlsAvailable={props.playbackControlsAvailable}
             playbackDescriptionId={playbackDescriptionId}
             onEscape={closeOnEscape}
-            onToggleHelp={props.onToggleHelp}
             onToggleCardDetails={props.onToggleCardDetails}
             onToggleSwipeControls={props.onToggleSwipeControls}
             onTogglePlaybackControls={props.onTogglePlaybackControls}

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -65,7 +65,7 @@ const DeckListDestination = () => {
   );
 };
 
-describe("StudySessionPage", () => {
+describe("SWIPE-24 SWIPE-25 StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
   const firstCard = createLocalCard({
@@ -286,7 +286,6 @@ describe("StudySessionPage", () => {
     document.documentElement.lang = "ja-JP";
     renderPage();
 
-    openStudyActions();
     fireEvent.click(screen.getByRole("button", { name: "学習ヘルプを開く" }));
 
     expect(screen.getByRole("dialog", { name: "学習画面の操作" })).toHaveTextContent(
@@ -302,7 +301,6 @@ describe("StudySessionPage", () => {
 
     try {
       renderPage();
-      openStudyActions();
       fireEvent.click(screen.getByRole("button", { name: "Open study help" }));
 
       act(() => vi.advanceTimersByTime(1000));


### PR DESCRIPTION
## Summary

- keep one Study Help icon in the fixed slot immediately left of the Study actions button
- open the Help dialog from that icon while Study actions are closed
- switch the same icon to the Help visibility toggle while Study actions are open
- keep the icon mounted in the same position when the visibility preference changes
- update the Study Session component tests for the dual-role behavior and hidden preference state

## Verification

- checked the changed TSX files with the TypeScript parser
- repository CI is expected to run the full project checks
