### PR TITLE
[i18n] 残っている固定UI文言を日本語表示できるようにする

### DIFF
--- a/src/app/i18n/resources.ts
+++ b/src/app/i18n/resources.ts
@@ -9,6 +9,36 @@ export const resources = {
         openAccount: "Open account",
         openSettings: "Open settings",
       },
+      card: {
+        answerAria: "Card answer",
+      },
+      deckImport: {
+        uploadPrompt: "Upload a csv file",
+      },
+      navigationGuard: {
+        title: "Discard unsaved changes?",
+        description: "Your changes will be lost if you leave this page.",
+        keepEditing: "Keep editing",
+        discard: "Discard changes",
+      },
+      destructiveDialog: {
+        cancel: "Cancel",
+        close: "Close",
+      },
+      notFound: {
+        page: "Page not found",
+        goHome: "Go home",
+        goBack: "Go back",
+      },
+      score: {
+        aria: "Score {{score}}, {{cue}}",
+        positive: "positive",
+        negative: "negative",
+        neutral: "neutral",
+      },
+      tag: {
+        removeFilter: "Remove {{label}} filter",
+      },
       settings: {
         title: "Settings",
         autoSave: "Changes are saved automatically",
@@ -95,6 +125,36 @@ export const resources = {
         importDecks: "デッキをインポート",
         openAccount: "アカウントを開く",
         openSettings: "設定を開く",
+      },
+      card: {
+        answerAria: "カードの回答",
+      },
+      deckImport: {
+        uploadPrompt: "CSVファイルをアップロード",
+      },
+      navigationGuard: {
+        title: "未保存の変更を破棄しますか？",
+        description: "このページを離れると変更内容は失われます。",
+        keepEditing: "編集を続ける",
+        discard: "変更を破棄",
+      },
+      destructiveDialog: {
+        cancel: "キャンセル",
+        close: "閉じる",
+      },
+      notFound: {
+        page: "ページが見つかりません",
+        goHome: "ホームへ",
+        goBack: "戻る",
+      },
+      score: {
+        aria: "スコア {{score}}、{{cue}}",
+        positive: "正",
+        negative: "負",
+        neutral: "中立",
+      },
+      tag: {
+        removeFilter: "{{label}}フィルターを削除",
       },
       settings: {
         title: "設定",

--- a/src/entities/card/ui/CardView.tsx
+++ b/src/entities/card/ui/CardView.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react";
+import { useTranslation } from "react-i18next";
 
 import { BackText } from "./BackText";
 
@@ -12,6 +13,7 @@ export interface CardViewProps {
 }
 
 export const CardView: React.FC<CardViewProps> = ({ text, category, code, dark, onClick, variant = "surface" }) => {
+  const { t } = useTranslation();
   const content = (
     <BackText
       text={text}
@@ -26,7 +28,7 @@ export const CardView: React.FC<CardViewProps> = ({ text, category, code, dark, 
 
   return (
     <section
-      aria-label="Card answer"
+      aria-label={t("card.answerAria")}
       className="mx-auto w-full rounded-surface bg-surface-elevated text-ink shadow-surface"
     >
       {content}

--- a/src/pages/not-found/ui/NotFoundPage.tsx
+++ b/src/pages/not-found/ui/NotFoundPage.tsx
@@ -1,5 +1,9 @@
 import type * as React from "react";
+import { useTranslation } from "react-i18next";
 
 import { RouteNotFound } from "@/widgets/route-not-found";
 
-export const NotFoundPage: React.FC = () => <RouteNotFound title="Page not found" />;
+export const NotFoundPage: React.FC = () => {
+  const { t } = useTranslation();
+  return <RouteNotFound title={t("notFound.page")} />;
+};

--- a/src/shared/ui/content/RemovableTag.tsx
+++ b/src/shared/ui/content/RemovableTag.tsx
@@ -5,6 +5,7 @@
  */
 
 import type * as React from "react";
+import { useTranslation } from "react-i18next";
 
 import { TagMarker, tagClassName } from "./tagStyles";
 
@@ -19,21 +20,25 @@ export interface RemovableTagProps {
  * Displays a selected filter as a button and calls onRemove when the user asks to remove that
  * label.
  */
-export const RemovableTag: React.FC<RemovableTagProps> = ({ className, label, onRemove }) => (
-  <button
-    type="button"
-    aria-label={`Remove ${label} filter`}
-    className={tagClassName({
-      interactive: true,
-      selected: true,
-      ...(className !== undefined ? { className } : {}),
-    })}
-    onClick={() => onRemove(label)}
-  >
-    <TagMarker selected />
-    <span className="min-w-0 max-w-full truncate">{label}</span>
-    <span aria-hidden="true" className="ml-2 shrink-0">
-      ×
-    </span>
-  </button>
-);
+export const RemovableTag: React.FC<RemovableTagProps> = ({ className, label, onRemove }) => {
+  const { t } = useTranslation();
+
+  return (
+    <button
+      type="button"
+      aria-label={t("tag.removeFilter", { label })}
+      className={tagClassName({
+        interactive: true,
+        selected: true,
+        ...(className !== undefined ? { className } : {}),
+      })}
+      onClick={() => onRemove(label)}
+    >
+      <TagMarker selected />
+      <span className="min-w-0 max-w-full truncate">{label}</span>
+      <span aria-hidden="true" className="ml-2 shrink-0">
+        ×
+      </span>
+    </button>
+  );
+};

--- a/src/shared/ui/content/Score.tsx
+++ b/src/shared/ui/content/Score.tsx
@@ -6,6 +6,7 @@
 
 import cx from "classnames";
 import type * as React from "react";
+import { useTranslation } from "react-i18next";
 
 const scoreDisplayLimit = 99;
 
@@ -15,6 +16,7 @@ const scoreDisplayLimit = 99;
  * neutral, or negative values.
  */
 export const Score: React.FC<{ score?: number; large?: boolean; className?: string }> = (props) => {
+  const { t } = useTranslation();
   const score = props.score ?? 0;
   const displayScore =
     score > scoreDisplayLimit
@@ -23,11 +25,11 @@ export const Score: React.FC<{ score?: number; large?: boolean; className?: stri
         ? `<-${String(scoreDisplayLimit)}`
         : score;
   const isDisplayBounded = Math.abs(score) > scoreDisplayLimit;
-  const cue = score > 0 ? "positive" : score < 0 ? "negative" : "neutral";
+  const cueKey = score > 0 ? "score.positive" : score < 0 ? "score.negative" : "score.neutral";
   return (
     <div
       role="status"
-      aria-label={`Score ${String(score)}, ${cue}`}
+      aria-label={t("score.aria", { score, cue: t(cueKey) })}
       className={cx(
         "inline-flex justify-center rounded-pill font-semibold text-ink-inverse",
         {

--- a/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
+++ b/src/shared/ui/destructive-action-dialog/DestructiveActionDialog.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 
 import { focusableElementSelector } from "../../lib/focusableElementSelector";
 import { Button } from "../button";
@@ -16,6 +17,7 @@ export interface DestructiveActionDialogProps {
 }
 
 export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (props) => {
+  const { t } = useTranslation();
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const cancelRef = React.useRef<HTMLButtonElement>(null);
   const targetNameRef = React.useRef<HTMLSpanElement>(null);
@@ -138,7 +140,7 @@ export const DestructiveActionDialog: React.FC<DestructiveActionDialogProps> = (
             className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-control border border-border bg-transparent px-4 py-2 font-bold text-ink hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
             onClick={handleCancel}
           >
-            {props.pending ? "Close" : "Cancel"}
+            {props.pending ? t("destructiveDialog.close") : t("destructiveDialog.cancel")}
           </button>
           <Button variant="destructive" loading={Boolean(props.pending)} onClick={handleConfirm}>
             {props.confirmLabel}

--- a/src/shared/ui/forms/Upload.tsx
+++ b/src/shared/ui/forms/Upload.tsx
@@ -7,6 +7,7 @@
 import cx from "classnames";
 import type * as React from "react";
 import { AiOutlineCloudUpload } from "react-icons/ai";
+import { useTranslation } from "react-i18next";
 
 /**
  * Renders the Upload user interface.
@@ -17,35 +18,39 @@ export const Upload: React.FC<{
   disabled?: boolean;
   fileName?: string;
   onChange?: (file: File) => void;
-}> = (props) => (
-  <label
-    className={cx(
-      "flex h-48 max-w-sm rounded-surface border-2 border-border bg-surface text-ink shadow-surface transition-shadow duration-normal ease-calm",
-      props.fileName ? "border-solid shadow-elevated" : "border-dashed",
-      props.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-      props.className
-    )}
-  >
-    <div className="relative flex-1">
-      <div className="absolute flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center">
-        <AiOutlineCloudUpload size={24} className="text-xl text-accent-primary" />
-        <span className="text-base tracking-wide text-ink-muted">Upload a csv file</span>
-        {props.fileName ? <span className="max-w-full truncate font-semibold text-ink">{props.fileName}</span> : null}
-      </div>
-      <input
-        type="file"
-        className="h-full w-full cursor-inherit opacity-0"
-        accept=".csv"
-        disabled={props.disabled}
-        onChange={(e) => {
-          if (e.target.files != null) {
-            const [file] = e.target.files;
-            if (file != null) {
-              props.onChange?.(file);
+}> = (props) => {
+  const { t } = useTranslation();
+
+  return (
+    <label
+      className={cx(
+        "flex h-48 max-w-sm rounded-surface border-2 border-border bg-surface text-ink shadow-surface transition-shadow duration-normal ease-calm",
+        props.fileName ? "border-solid shadow-elevated" : "border-dashed",
+        props.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        props.className
+      )}
+    >
+      <div className="relative flex-1">
+        <div className="absolute flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center">
+          <AiOutlineCloudUpload size={24} className="text-xl text-accent-primary" />
+          <span className="text-base tracking-wide text-ink-muted">{t("deckImport.uploadPrompt")}</span>
+          {props.fileName ? <span className="max-w-full truncate font-semibold text-ink">{props.fileName}</span> : null}
+        </div>
+        <input
+          type="file"
+          className="h-full w-full cursor-inherit opacity-0"
+          accept=".csv"
+          disabled={props.disabled}
+          onChange={(e) => {
+            if (e.target.files != null) {
+              const [file] = e.target.files;
+              if (file != null) {
+                props.onChange?.(file);
+              }
             }
-          }
-        }}
-      />
-    </div>
-  </label>
-);
+          }}
+        />
+      </div>
+    </label>
+  );
+};

--- a/src/shared/ui/navigation-guard-dialog/NavigationGuardDialog.tsx
+++ b/src/shared/ui/navigation-guard-dialog/NavigationGuardDialog.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 
 import { focusableElementSelector } from "../../lib/focusableElementSelector";
 import { Button } from "../button";
@@ -9,6 +10,7 @@ interface NavigationGuardDialogProps {
 }
 
 export const NavigationGuardDialog: React.FC<NavigationGuardDialogProps> = ({ onDiscardChanges, onKeepEditing }) => {
+  const { t } = useTranslation();
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const keepEditingRef = React.useRef<HTMLButtonElement>(null);
   const titleId = React.useId();
@@ -65,10 +67,10 @@ export const NavigationGuardDialog: React.FC<NavigationGuardDialogProps> = ({ on
         onKeyDown={handleKeyDown}
       >
         <h2 id={titleId} className="text-title font-bold">
-          Discard unsaved changes?
+          {t("navigationGuard.title")}
         </h2>
         <p id={descriptionId} className="mt-4 text-body text-ink-muted">
-          Your changes will be lost if you leave this page.
+          {t("navigationGuard.description")}
         </p>
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <button
@@ -77,10 +79,10 @@ export const NavigationGuardDialog: React.FC<NavigationGuardDialogProps> = ({ on
             className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-control border border-border bg-transparent px-4 py-2 font-bold text-ink hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
             onClick={onKeepEditing}
           >
-            Keep editing
+            {t("navigationGuard.keepEditing")}
           </button>
           <Button variant="destructive" onClick={onDiscardChanges}>
-            Discard changes
+            {t("navigationGuard.discard")}
           </Button>
         </div>
       </div>

--- a/src/widgets/route-not-found/ui/RouteNotFound.tsx
+++ b/src/widgets/route-not-found/ui/RouteNotFound.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import type { RouteFeedbackProps } from "@/shared/ui/route-feedback";
@@ -6,13 +7,14 @@ import { routes } from "@/shared/router";
 import { RouteFeedback } from "@/shared/ui/route-feedback";
 
 export const RouteNotFound = (props: Pick<RouteFeedbackProps, "description" | "title">) => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   return (
     <RouteFeedback
       {...props}
       tone="not-found"
-      primaryAction={{ label: "Go home", onClick: () => void navigate(routes.deckList.to()) }}
-      secondaryAction={{ label: "Go back", onClick: () => void navigate(-1) }}
+      primaryAction={{ label: t("notFound.goHome"), onClick: () => void navigate(routes.deckList.to()) }}
+      secondaryAction={{ label: t("notFound.goBack"), onClick: () => void navigate(-1) }}
     />
   );
 };


### PR DESCRIPTION
## 概要

Issue #1402 の固定UI文言ローカライズ対応です。
既存の `i18next` / `react-i18next` と静的 `en` / `ja` resourcesを利用し、代表的なShared UIとNot Found周辺の文言を現在のlocaleへ追随させます。

## 変更内容

- `src/app/i18n/resources.ts` にShared UI向けのsemantic translation keyを追加
- Card回答領域のaccessible nameをローカライズ
- CSVアップロード案内をローカライズ
- 未保存変更のnavigation guard dialogをローカライズ
- destructive dialogのCancel / Closeをローカライズ
- Not Found画面と遷移アクションをローカライズ
- Scoreのaccessible labelと状態表現をローカライズ
- 選択済みタグの削除用accessible nameをローカライズ
- user-createdなCard・Deck・tag値は翻訳せず、必要な箇所だけinterpolationする

## 確認事項

- このセッションではテストを実行していません
- 現在のブランチはcurrent mainより遅れているため、main追従と残りのPage / Feature文言対応は本PR内で継続します

Refs #1402