### PR TITLE
fix(#1409): Preserve Account action Toasts across routes

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -32,6 +32,13 @@
 | ACCOUNT-02 | write | [Google sign-in のエラー表示から再試行できる](./account.md#account-02) |
 | ACCOUNT-03 | batch | [sign-out 後に新しい匿名アカウントへ切り替えられる](./account.md#account-03) |
 | ACCOUNT-04 | read | [認証初期化失敗から Reload で復帰できる](./account.md#account-04) |
+| ACCOUNT-05 | batch | [画面遷移後に失敗した sign-out を再試行できる](./account.md#account-05) |
+| ACCOUNT-06 | write | [Account 画面で sign-in の再実行を重複なく完了できる](./account.md#account-06) |
+| ACCOUNT-07 | batch | [Account 画面で sign-out の再実行を重複なく完了できる](./account.md#account-07) |
+| ACCOUNT-08 | write | [表示済みの sign-in 失敗を画面遷移後も再試行できる](./account.md#account-08) |
+| ACCOUNT-09 | batch | [表示済みの sign-out 失敗を画面遷移後も再試行できる](./account.md#account-09) |
+| ACCOUNT-10 | write | [再試行に失敗した sign-in を新しい Retry で復旧できる](./account.md#account-10) |
+| ACCOUNT-11 | batch | [再試行に失敗した sign-out を新しい Retry で復旧できる](./account.md#account-11) |
 
 ### Settings
 

--- a/docs/e2e/account.md
+++ b/docs/e2e/account.md
@@ -12,6 +12,13 @@
 | ACCOUNT-02 | write | [Google sign-in のエラー表示から再試行できる](#account-02) |
 | ACCOUNT-03 | batch | [sign-out 後に新しい匿名アカウントへ切り替えられる](#account-03) |
 | ACCOUNT-04 | read | [認証初期化失敗から Reload で復帰できる](#account-04) |
+| ACCOUNT-05 | batch | [画面遷移後に失敗した sign-out を再試行できる](#account-05) |
+| ACCOUNT-06 | write | [Account 画面で sign-in の再実行を重複なく完了できる](#account-06) |
+| ACCOUNT-07 | batch | [Account 画面で sign-out の再実行を重複なく完了できる](#account-07) |
+| ACCOUNT-08 | write | [表示済みの sign-in 失敗を画面遷移後も再試行できる](#account-08) |
+| ACCOUNT-09 | batch | [表示済みの sign-out 失敗を画面遷移後も再試行できる](#account-09) |
+| ACCOUNT-10 | write | [再試行に失敗した sign-in を新しい Retry で復旧できる](#account-10) |
+| ACCOUNT-11 | batch | [再試行に失敗した sign-out を新しい Retry で復旧できる](#account-11) |
 
 <a id="account-01"></a>
 
@@ -48,15 +55,19 @@ Given:
 
 - Fixture: [`empty`](./fixture/empty.yaml)
 - 匿名アカウントで Account 画面を開いている。
-- Google sign-in の失敗が共通 toast で処理され、toast に `Retry` が表示されている。
+- Google sign-in の popup を開いている間は処理が完了していない。
+- popup を閉じると Google sign-in が失敗する。
 - 再試行では Google sign-in に成功できる。
 
 When:
 
-- `Retry` を選択して Google sign-in を再試行する。
+- Google sign-in を開始し、popup を開いたまま Account 画面から Deck 一覧へ移動する。
+- popup を閉じ、画面遷移後に表示された `Retry` を選択して Google sign-in を再試行する。
+- Account 画面を再び開く。
 
 Then:
 
+- route replacement 後に失敗 toast と `Retry` が表示される。
 - 再試行後にエラー表示が残らない。
 - sign-in 成功が共通 toast で表示される。
 - Account 画面に Google アカウントとの連携状態が表示される。
@@ -107,3 +118,181 @@ Then:
 
 - 再初期化が完了し、Deck 一覧を利用できる。
 - 未処理の browser error が発生しない。
+
+<a id="account-05"></a>
+
+### ACCOUNT-05 画面遷移後に失敗した sign-out を再試行できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`google-study-session-middle`](./fixture/google-study-session-middle.yaml)
+- Google アカウントに連携したユーザーで Account 画面を開いている。
+- 最初の sign-out は Account 画面から離れた後に失敗し、再試行では成功できる。
+
+When:
+
+- sign-out を開始し、処理中に Account 画面から Deck 一覧へ移動する。
+- 画面遷移後に表示された `Retry` を選択して sign-out を再試行する。
+- Account 画面を再び開く。
+
+Then:
+
+- route replacement 後に失敗 toast と `Retry` が表示される。
+- 再試行後にエラー表示が残らない。
+- sign-out 成功が共通 toast で表示される。
+- Account 画面に新しい匿名アカウントが表示される。
+- browser error が発生しない。
+
+<a id="account-06"></a>
+
+### ACCOUNT-06 Account 画面で sign-in の再実行を重複なく完了できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`empty`](./fixture/empty.yaml)
+- 匿名アカウントで Account 画面を開いている。
+- 最初の Google sign-in と通常ボタンからの再実行は popup を閉じると失敗する。
+- `Retry` からの再実行では Google sign-in に成功できる。
+
+When:
+
+- 最初の失敗 toast が表示された状態で Deck 一覧へ移動し、Account 画面を再び開く。
+- 再表示された通常の sign-in ボタンから再実行する。
+- 次の失敗 toast に表示された `Retry` から再実行する。
+- それぞれの再実行中に Account 画面の sign-in ボタンを確認する。
+
+Then:
+
+- Account 画面を再表示しても、直前の失敗 toast と通常ボタンは同じ認証操作を所有する。
+- 再実行を開始するたびに直前の失敗 toast と `Retry` が取り除かれる。
+- 再実行中は sign-in ボタンが busy かつ無効になり、認証操作を重複実行できない。
+- sign-in 成功が共通 toast で表示される。
+- browser error が発生しない。
+
+<a id="account-07"></a>
+
+### ACCOUNT-07 Account 画面で sign-out の再実行を重複なく完了できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`google-study-session-middle`](./fixture/google-study-session-middle.yaml)
+- Google アカウントに連携したユーザーで Account 画面を開いている。
+- 最初の sign-out と `Retry` からの再実行は失敗し、通常ボタンからの次の再実行は成功できる。
+
+When:
+
+- 最初の失敗 toast が表示された状態で Deck 一覧へ移動し、Account 画面を再び開く。
+- 表示中の `Retry` から sign-out を再実行する。
+- 再実行中に Account 画面の sign-out ボタンを確認する。
+- 再実行の失敗後、通常の sign-out ボタンから再実行する。
+
+Then:
+
+- Account 画面を再表示しても、直前の失敗 toast と通常ボタンは同じ認証操作を所有する。
+- 再実行を開始するたびに直前の失敗 toast と `Retry` が取り除かれる。
+- 再実行中は sign-out ボタンが busy かつ無効になり、認証操作を重複実行できない。
+- sign-out 成功が共通 toast で表示される。
+- Account 画面に新しい匿名アカウントが表示される。
+- browser error が発生しない。
+
+<a id="account-08"></a>
+
+### ACCOUNT-08 表示済みの sign-in 失敗を画面遷移後も再試行できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`empty`](./fixture/empty.yaml)
+- 匿名アカウントで Account 画面を開いている。
+- Google sign-in の失敗 toast と `Retry` が表示されている。
+- 再試行では Google sign-in に成功できる。
+
+When:
+
+- Account 画面から Deck 一覧へ移動する。
+- 表示中の `Retry` を選択して Google sign-in を再試行する。
+
+Then:
+
+- route replacement 後も表示済みの失敗 toast と `Retry` を利用できる。
+- sign-in 成功が共通 toast で表示される。
+- browser error が発生しない。
+
+<a id="account-09"></a>
+
+### ACCOUNT-09 表示済みの sign-out 失敗を画面遷移後も再試行できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`google-study-session-middle`](./fixture/google-study-session-middle.yaml)
+- Google アカウントに連携したユーザーで Account 画面を開いている。
+- sign-out の失敗 toast と `Retry` が表示されている。
+- 再試行では sign-out に成功できる。
+
+When:
+
+- Account 画面から Deck 一覧へ移動する。
+- 表示中の `Retry` を選択して sign-out を再試行する。
+
+Then:
+
+- route replacement 後も表示済みの失敗 toast と `Retry` を利用できる。
+- sign-out 成功が共通 toast で表示される。
+- browser error が発生しない。
+
+<a id="account-10"></a>
+
+### ACCOUNT-10 再試行に失敗した sign-in を新しい Retry で復旧できる
+
+カテゴリ: `write`
+
+Given:
+
+- Fixture: [`empty`](./fixture/empty.yaml)
+- 匿名アカウントで Account 画面を開いている。
+- 最初の Google sign-in と最初の再試行は失敗し、次の再試行は成功できる。
+
+When:
+
+- 最初の失敗 toast に表示された `Retry` から再実行し、popup を閉じる。
+- 再実行の失敗後に表示された新しい `Retry` から再実行する。
+
+Then:
+
+- 最初の `Retry` は自身の失敗 toast だけを閉じる。
+- 再実行に失敗すると、新しい失敗 toast と `Retry` が表示される。
+- 新しい `Retry` から sign-in に成功できる。
+- browser error が発生しない。
+
+<a id="account-11"></a>
+
+### ACCOUNT-11 再試行に失敗した sign-out を新しい Retry で復旧できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`google-study-session-middle`](./fixture/google-study-session-middle.yaml)
+- Google アカウントに連携したユーザーで Account 画面を開いている。
+- 最初の sign-out と最初の再試行は失敗し、次の再試行は成功できる。
+
+When:
+
+- 最初の失敗 toast に表示された `Retry` から再実行する。
+- 再実行の失敗後に表示された新しい `Retry` から再実行する。
+
+Then:
+
+- 最初の `Retry` は自身の失敗 toast だけを閉じる。
+- 再実行に失敗すると、新しい失敗 toast と `Retry` が表示される。
+- 新しい `Retry` から sign-out に成功できる。
+- browser error が発生しない。

--- a/src/pages/account/model/useAccountAction.ts
+++ b/src/pages/account/model/useAccountAction.ts
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 import { dismissToast, showToast, type ToastId } from "@/shared/ui/toast";
 
 interface AccountActionMessages {
@@ -8,52 +7,112 @@ interface AccountActionMessages {
   failure: string;
 }
 
-export const useAccountAction = (action: () => Promise<unknown>, messages: AccountActionMessages) => {
-  const [pending, setPending] = useState(false);
-  const isMounted = useMountedGuard();
-  const errorToastId = useRef<ToastId | undefined>(undefined);
+type ReportPending = (pending: boolean) => void;
 
-  const dismissErrorToast = () => {
-    if (errorToastId.current === undefined) return;
-    dismissToast(errorToastId.current);
-    errorToastId.current = undefined;
+interface FailureToast {
+  active: boolean;
+  id: ToastId;
+}
+
+interface PendingReporter {
+  active: boolean;
+  report: ReportPending;
+}
+
+const createAccountAction = (action: () => Promise<unknown>, messages: AccountActionMessages) => {
+  let currentFailure: FailureToast | undefined;
+  let mountedReporter: PendingReporter | undefined;
+
+  const reportPending = (reporter: PendingReporter | undefined, pending: boolean) => {
+    if (reporter?.active) reporter.report(pending);
   };
 
-  const run = async (): Promise<void> => {
-    dismissErrorToast();
-    setPending(true);
+  const dismissFailure = (failure: FailureToast): boolean => {
+    if (!failure.active) return false;
+    failure.active = false;
+    if (currentFailure === failure) currentFailure = undefined;
+    dismissToast(failure.id);
+    return true;
+  };
+
+  const dismissCurrentFailure = () => {
+    if (currentFailure !== undefined) dismissFailure(currentFailure);
+  };
+
+  const execute = async (reporter: PendingReporter | undefined): Promise<void> => {
+    reportPending(reporter, true);
     try {
       await action();
-      // Auth transitions can temporarily unmount the Account route, but a completed user action still owns its result.
+      dismissCurrentFailure();
       showToast({ message: messages.success, tone: "success" });
     } catch (error) {
-      if (isMounted()) {
-        const toastId = showToast({
-          message: messages.failure,
-          tone: "error",
-          action: {
-            label: "Retry",
-            onClick: () => {
-              dismissToast(toastId);
-              if (errorToastId.current === toastId) errorToastId.current = undefined;
-              void run().catch(() => undefined);
-            },
+      dismissCurrentFailure();
+      let failure!: FailureToast;
+      const toastId = showToast({
+        message: messages.failure,
+        tone: "error",
+        action: {
+          label: "Retry",
+          onClick: () => {
+            if (!dismissFailure(failure)) return;
+            // Retry must survive route replacement, so it repeats only the application-owned command and notification flow.
+            void execute(mountedReporter).catch(() => undefined);
           },
-        });
-        errorToastId.current = toastId;
-      }
+        },
+      });
+      failure = { active: true, id: toastId };
+      currentFailure = failure;
       throw error;
     } finally {
-      if (isMounted()) setPending(false);
+      reportPending(reporter, false);
     }
   };
 
-  useEffect(
-    () => () => {
-      if (errorToastId.current !== undefined) dismissToast(errorToastId.current);
+  return {
+    createReporter: (report: ReportPending): PendingReporter => ({ active: false, report }),
+    mount: (reporter: PendingReporter) => {
+      reporter.active = true;
+      mountedReporter = reporter;
+      return () => {
+        // Route replacement detaches only Page-local pending updates; the failure Toast remains application-owned.
+        reporter.active = false;
+        if (mountedReporter === reporter) mountedReporter = undefined;
+      };
     },
-    []
-  );
+    run: (reporter: PendingReporter) => {
+      dismissCurrentFailure();
+      return execute(reporter);
+    },
+  };
+};
+
+const accountActions = new WeakMap<() => Promise<unknown>, Map<string, ReturnType<typeof createAccountAction>>>();
+
+const getAccountAction = (action: () => Promise<unknown>, messages: AccountActionMessages) => {
+  let actionsByMessage = accountActions.get(action);
+  if (actionsByMessage === undefined) {
+    actionsByMessage = new Map();
+    accountActions.set(action, actionsByMessage);
+  }
+
+  const messageKey = `${messages.success}\u0000${messages.failure}`;
+  const existing = actionsByMessage.get(messageKey);
+  if (existing !== undefined) return existing;
+
+  // Only Toast ownership crosses route mounts; the pending value and every Promise remain local to their Page/command.
+  const accountAction = createAccountAction(action, messages);
+  actionsByMessage.set(messageKey, accountAction);
+  return accountAction;
+};
+
+export const useAccountAction = (action: () => Promise<unknown>, messages: AccountActionMessages) => {
+  const [pending, setPending] = useState(false);
+  const accountAction = getAccountAction(action, messages);
+  const [reporter] = useState(() => accountAction.createReporter(setPending));
+
+  useEffect(() => accountAction.mount(reporter), [accountAction, reporter]);
+
+  const run = (): Promise<void> => accountAction.run(reporter);
 
   return { pending, run };
 };

--- a/src/pages/account/model/useSignIn.spec.tsx
+++ b/src/pages/account/model/useSignIn.spec.tsx
@@ -26,16 +26,26 @@ const deferred = <T,>() => {
   return { promise, reject, resolve };
 };
 
+const getToast = (callIndex: number) => {
+  const toast = vi.mocked(showToast).mock.calls[callIndex]?.[0];
+  if (toast === undefined) throw new Error(`Toast call ${callIndex} was not published`);
+  return toast;
+};
+
 describe("useSignIn", () => {
   beforeEach(() => {
     mocks.loginGoogle.mockReset();
     mocks.loginGoogle.mockResolvedValue(undefined);
     vi.mocked(dismissToast).mockReset();
     vi.mocked(showToast).mockReset();
-    vi.mocked(showToast).mockReturnValue(1);
+    let nextToastId = 0;
+    vi.mocked(showToast).mockImplementation(() => {
+      nextToastId += 1;
+      return nextToastId;
+    });
   });
 
-  it("reports a pending sign-in until the operation completes", async () => {
+  it("ACCOUNT-06 reports a pending sign-in until the operation completes", async () => {
     const request = deferred<void>();
     mocks.loginGoogle.mockReturnValue(request.promise);
     const { result } = renderHook(() => useSignIn());
@@ -56,27 +66,20 @@ describe("useSignIn", () => {
     expect(showToast).toHaveBeenCalledWith({ message: "Signed in.", tone: "success" });
   });
 
-  it("offers a Toast action that dismisses and retries a failed sign-in", async () => {
-    const failure = new Error("Sign-in failed");
+  it("ACCOUNT-06 reports a pending sign-in while Retry runs on the mounted owner", async () => {
     const retry = deferred<void>();
-    mocks.loginGoogle.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
+    mocks.loginGoogle.mockRejectedValueOnce(new Error("Sign-in failed")).mockReturnValueOnce(retry.promise);
     const { result } = renderHook(() => useSignIn());
 
     await actAsync(async () => {
       await expect(result.current.signIn()).rejects.toThrow("Sign-in failed");
     });
-    const failureToast = vi.mocked(showToast).mock.calls[0]?.[0];
-    if (failureToast === undefined) throw new Error("Sign-in failure Toast was not shown");
-    expect(failureToast).toMatchObject({ message: "Unable to sign in.", tone: "error", action: { label: "Retry" } });
 
     act(() => {
-      failureToast.action?.onClick();
+      getToast(0).action?.onClick();
     });
 
-    expect(dismissToast).toHaveBeenCalledWith(1);
-    expect(vi.mocked(dismissToast).mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.loginGoogle.mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY
-    );
+    expect(mocks.loginGoogle).toHaveBeenCalledTimes(2);
     expect(result.current.pending).toBe(true);
 
     await actAsync(async () => {
@@ -88,22 +91,85 @@ describe("useSignIn", () => {
     expect(showToast).toHaveBeenLastCalledWith({ message: "Signed in.", tone: "success" });
   });
 
-  it("dismisses its failed sign-in Toast when its owner unmounts", async () => {
-    const failure = new Error("Sign-in failed");
-    mocks.loginGoogle.mockRejectedValue(failure);
-    const { result: firstResult, unmount } = renderHook(() => useSignIn());
+  it("ACCOUNT-06 invalidates the old Retry when a remounted owner reruns sign-in", async () => {
+    const rerun = deferred<void>();
+    mocks.loginGoogle.mockRejectedValueOnce(new Error("Sign-in failed")).mockReturnValueOnce(rerun.promise);
+    const { result, unmount } = renderHook(() => useSignIn());
 
     await actAsync(async () => {
-      await expect(firstResult.current.signIn()).rejects.toThrow("Sign-in failed");
+      await expect(result.current.signIn()).rejects.toThrow("Sign-in failed");
     });
+    const oldFailureToast = getToast(0);
     unmount();
+    const { result: remountedResult } = renderHook(() => useSignIn());
+    let operation!: Promise<void>;
 
-    expect(dismissToast).toHaveBeenCalledWith(1);
+    act(() => {
+      operation = remountedResult.current.signIn();
+    });
+
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(remountedResult.current.pending).toBe(true);
+
+    act(() => {
+      oldFailureToast.action?.onClick();
+    });
+
+    expect(mocks.loginGoogle).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledTimes(1);
+
+    await actAsync(async () => {
+      rerun.resolve();
+      await operation;
+    });
   });
 
-  it("does not show a failure Toast when sign-in rejects after unmount", async () => {
+  it("ACCOUNT-01 publishes a completed sign-in after its auth transition unmounts the owner", async () => {
     const request = deferred<void>();
     mocks.loginGoogle.mockReturnValue(request.promise);
+    const { result, unmount } = renderHook(() => useSignIn());
+    let operation!: Promise<void>;
+
+    act(() => {
+      operation = result.current.signIn();
+    });
+    unmount();
+    await actAsync(async () => {
+      request.resolve();
+      await operation;
+    });
+
+    expect(showToast).toHaveBeenCalledExactlyOnceWith({ message: "Signed in.", tone: "success" });
+  });
+
+  it("ACCOUNT-08 keeps a failed sign-in Toast when its owner unmounts", async () => {
+    mocks.loginGoogle.mockRejectedValue(new Error("Sign-in failed"));
+    const { result, unmount } = renderHook(() => useSignIn());
+
+    await actAsync(async () => {
+      await expect(result.current.signIn()).rejects.toThrow("Sign-in failed");
+    });
+    expect(getToast(0)).toMatchObject({
+      message: "Unable to sign in.",
+      tone: "error",
+      action: { label: "Retry" },
+    });
+
+    unmount();
+
+    expect(dismissToast).not.toHaveBeenCalled();
+
+    mocks.loginGoogle.mockResolvedValueOnce(undefined);
+    act(() => {
+      getToast(0).action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(2));
+  });
+
+  it("ACCOUNT-02 publishes a late failure and retries it after the owner unmounts", async () => {
+    const request = deferred<void>();
+    const retry = deferred<void>();
+    mocks.loginGoogle.mockReturnValueOnce(request.promise).mockReturnValueOnce(retry.promise);
     const { result, unmount } = renderHook(() => useSignIn());
     let operation!: Promise<void>;
 
@@ -116,6 +182,116 @@ describe("useSignIn", () => {
       await expect(operation).rejects.toThrow("Late sign-in failure");
     });
 
-    expect(showToast).not.toHaveBeenCalled();
+    const failureToast = getToast(0);
+    expect(failureToast).toMatchObject({ message: "Unable to sign in.", tone: "error", action: { label: "Retry" } });
+
+    act(() => {
+      failureToast.action?.onClick();
+    });
+
+    expect(mocks.loginGoogle).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(vi.mocked(dismissToast).mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.loginGoogle.mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY
+    );
+
+    await actAsync(async () => {
+      retry.resolve();
+      await retry.promise;
+    });
+
+    expect(showToast).toHaveBeenLastCalledWith({ message: "Signed in.", tone: "success" });
+  });
+
+  it("ACCOUNT-10 publishes a replacement failure and invalidates the stale Retry", async () => {
+    mocks.loginGoogle
+      .mockRejectedValueOnce(new Error("Sign-in failed"))
+      .mockRejectedValueOnce(new Error("Retry failed"));
+    const { result } = renderHook(() => useSignIn());
+
+    await actAsync(async () => {
+      await expect(result.current.signIn()).rejects.toThrow("Sign-in failed");
+    });
+    const firstFailureToast = getToast(0);
+
+    act(() => {
+      firstFailureToast.action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(2));
+
+    expect(mocks.loginGoogle).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(getToast(1)).toMatchObject({
+      message: "Unable to sign in.",
+      tone: "error",
+      action: { label: "Retry" },
+    });
+    expect(getToast(1).action?.onClick).not.toBe(firstFailureToast.action?.onClick);
+    expect(result.current.pending).toBe(false);
+
+    act(() => {
+      firstFailureToast.action?.onClick();
+    });
+
+    expect(mocks.loginGoogle).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(dismissToast).not.toHaveBeenCalledWith(2);
+
+    mocks.loginGoogle.mockResolvedValueOnce(undefined);
+    act(() => {
+      getToast(1).action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(3));
+  });
+
+  it("ACCOUNT-10 invalidates an earlier failure before an out-of-order failure is published", async () => {
+    const earlierRequest = deferred<void>();
+    const laterRequest = deferred<void>();
+    mocks.loginGoogle.mockReturnValueOnce(earlierRequest.promise).mockReturnValueOnce(laterRequest.promise);
+    const { result: earlierResult, unmount } = renderHook(() => useSignIn());
+    let earlierOperation!: Promise<void>;
+
+    act(() => {
+      earlierOperation = earlierResult.current.signIn();
+    });
+    unmount();
+
+    const { result: laterResult } = renderHook(() => useSignIn());
+    let laterOperation!: Promise<void>;
+
+    act(() => {
+      laterOperation = laterResult.current.signIn();
+    });
+
+    await actAsync(async () => {
+      earlierRequest.reject(new Error("Earlier sign-in failed"));
+      await expect(earlierOperation).rejects.toThrow("Earlier sign-in failed");
+    });
+    const staleFailureToast = getToast(0);
+
+    await actAsync(async () => {
+      laterRequest.reject(new Error("Later sign-in failed"));
+      await expect(laterOperation).rejects.toThrow("Later sign-in failed");
+    });
+
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(vi.mocked(dismissToast).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(showToast).mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY
+    );
+    const currentFailureToast = getToast(1);
+
+    act(() => {
+      staleFailureToast.action?.onClick();
+    });
+
+    expect(mocks.loginGoogle).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(dismissToast).not.toHaveBeenCalledWith(2);
+
+    mocks.loginGoogle.mockResolvedValueOnce(undefined);
+    act(() => {
+      currentFailureToast.action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(3));
   });
 });

--- a/src/pages/account/model/useSignOut.spec.tsx
+++ b/src/pages/account/model/useSignOut.spec.tsx
@@ -26,16 +26,26 @@ const deferred = <T,>() => {
   return { promise, reject, resolve };
 };
 
+const getToast = (callIndex: number) => {
+  const toast = vi.mocked(showToast).mock.calls[callIndex]?.[0];
+  if (toast === undefined) throw new Error(`Toast call ${callIndex} was not published`);
+  return toast;
+};
+
 describe("useSignOut", () => {
   beforeEach(() => {
     mocks.signOutCurrentUser.mockReset();
     mocks.signOutCurrentUser.mockResolvedValue(undefined);
     vi.mocked(dismissToast).mockReset();
     vi.mocked(showToast).mockReset();
-    vi.mocked(showToast).mockReturnValue(1);
+    let nextToastId = 0;
+    vi.mocked(showToast).mockImplementation(() => {
+      nextToastId += 1;
+      return nextToastId;
+    });
   });
 
-  it("reports a pending sign-out until the operation completes", async () => {
+  it("ACCOUNT-07 reports a pending sign-out until the operation completes", async () => {
     const request = deferred<void>();
     mocks.signOutCurrentUser.mockReturnValue(request.promise);
     const { result } = renderHook(() => useSignOut());
@@ -56,24 +66,20 @@ describe("useSignOut", () => {
     expect(showToast).toHaveBeenCalledWith({ message: "Signed out.", tone: "success" });
   });
 
-  it("offers a Toast action that dismisses and retries a failed sign-out", async () => {
-    const failure = new Error("Sign-out failed");
+  it("ACCOUNT-07 reports a pending sign-out while Retry runs on the mounted owner", async () => {
     const retry = deferred<void>();
-    mocks.signOutCurrentUser.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
+    mocks.signOutCurrentUser.mockRejectedValueOnce(new Error("Sign-out failed")).mockReturnValueOnce(retry.promise);
     const { result } = renderHook(() => useSignOut());
 
     await actAsync(async () => {
       await expect(result.current.signOut()).rejects.toThrow("Sign-out failed");
     });
-    const failureToast = vi.mocked(showToast).mock.calls[0]?.[0];
-    if (failureToast === undefined) throw new Error("Sign-out failure Toast was not shown");
-    expect(failureToast).toMatchObject({ message: "Unable to sign out.", tone: "error", action: { label: "Retry" } });
 
     act(() => {
-      failureToast.action?.onClick();
+      getToast(0).action?.onClick();
     });
 
-    expect(dismissToast).toHaveBeenCalledWith(1);
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(2);
     expect(result.current.pending).toBe(true);
 
     await actAsync(async () => {
@@ -85,20 +91,40 @@ describe("useSignOut", () => {
     expect(showToast).toHaveBeenLastCalledWith({ message: "Signed out.", tone: "success" });
   });
 
-  it("dismisses its failed sign-out Toast when its owner unmounts", async () => {
-    const failure = new Error("Sign-out failed");
-    mocks.signOutCurrentUser.mockRejectedValue(failure);
-    const { result: firstResult, unmount } = renderHook(() => useSignOut());
+  it("ACCOUNT-07 invalidates the old Retry when a remounted owner reruns sign-out", async () => {
+    const rerun = deferred<void>();
+    mocks.signOutCurrentUser.mockRejectedValueOnce(new Error("Sign-out failed")).mockReturnValueOnce(rerun.promise);
+    const { result, unmount } = renderHook(() => useSignOut());
 
     await actAsync(async () => {
-      await expect(firstResult.current.signOut()).rejects.toThrow("Sign-out failed");
+      await expect(result.current.signOut()).rejects.toThrow("Sign-out failed");
     });
+    const oldFailureToast = getToast(0);
     unmount();
+    const { result: remountedResult } = renderHook(() => useSignOut());
+    let operation!: Promise<void>;
 
-    expect(dismissToast).toHaveBeenCalledWith(1);
+    act(() => {
+      operation = remountedResult.current.signOut();
+    });
+
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(remountedResult.current.pending).toBe(true);
+
+    act(() => {
+      oldFailureToast.action?.onClick();
+    });
+
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledTimes(1);
+
+    await actAsync(async () => {
+      rerun.resolve();
+      await operation;
+    });
   });
 
-  it("publishes a completed sign-out after its auth transition unmounts the owner", async () => {
+  it("ACCOUNT-03 publishes a completed sign-out after its auth transition unmounts the owner", async () => {
     const request = deferred<void>();
     mocks.signOutCurrentUser.mockReturnValue(request.promise);
     const { result, unmount } = renderHook(() => useSignOut());
@@ -114,5 +140,151 @@ describe("useSignOut", () => {
     });
 
     expect(showToast).toHaveBeenCalledExactlyOnceWith({ message: "Signed out.", tone: "success" });
+  });
+
+  it("ACCOUNT-09 keeps a failed sign-out Toast when its owner unmounts", async () => {
+    mocks.signOutCurrentUser.mockRejectedValue(new Error("Sign-out failed"));
+    const { result, unmount } = renderHook(() => useSignOut());
+
+    await actAsync(async () => {
+      await expect(result.current.signOut()).rejects.toThrow("Sign-out failed");
+    });
+    expect(getToast(0)).toMatchObject({
+      message: "Unable to sign out.",
+      tone: "error",
+      action: { label: "Retry" },
+    });
+
+    unmount();
+
+    expect(dismissToast).not.toHaveBeenCalled();
+
+    mocks.signOutCurrentUser.mockResolvedValueOnce(undefined);
+    act(() => {
+      getToast(0).action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(2));
+  });
+
+  it("ACCOUNT-05 publishes a late failure and retries it after the owner unmounts", async () => {
+    const request = deferred<void>();
+    const retry = deferred<void>();
+    mocks.signOutCurrentUser.mockReturnValueOnce(request.promise).mockReturnValueOnce(retry.promise);
+    const { result, unmount } = renderHook(() => useSignOut());
+    let operation!: Promise<void>;
+
+    act(() => {
+      operation = result.current.signOut();
+    });
+    unmount();
+    await actAsync(async () => {
+      request.reject(new Error("Late sign-out failure"));
+      await expect(operation).rejects.toThrow("Late sign-out failure");
+    });
+
+    const failureToast = getToast(0);
+    expect(failureToast).toMatchObject({ message: "Unable to sign out.", tone: "error", action: { label: "Retry" } });
+
+    act(() => {
+      failureToast.action?.onClick();
+    });
+
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(vi.mocked(dismissToast).mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signOutCurrentUser.mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY
+    );
+
+    await actAsync(async () => {
+      retry.resolve();
+      await retry.promise;
+    });
+
+    expect(showToast).toHaveBeenLastCalledWith({ message: "Signed out.", tone: "success" });
+  });
+
+  it("ACCOUNT-11 publishes a replacement failure and invalidates the stale Retry", async () => {
+    mocks.signOutCurrentUser
+      .mockRejectedValueOnce(new Error("Sign-out failed"))
+      .mockRejectedValueOnce(new Error("Retry failed"));
+    const { result } = renderHook(() => useSignOut());
+
+    await actAsync(async () => {
+      await expect(result.current.signOut()).rejects.toThrow("Sign-out failed");
+    });
+    const firstFailureToast = getToast(0);
+
+    act(() => {
+      firstFailureToast.action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(2));
+
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(getToast(1)).toMatchObject({
+      message: "Unable to sign out.",
+      tone: "error",
+      action: { label: "Retry" },
+    });
+    expect(getToast(1).action?.onClick).not.toBe(firstFailureToast.action?.onClick);
+    expect(result.current.pending).toBe(false);
+
+    act(() => {
+      firstFailureToast.action?.onClick();
+    });
+
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(dismissToast).not.toHaveBeenCalledWith(2);
+
+    mocks.signOutCurrentUser.mockResolvedValueOnce(undefined);
+    act(() => {
+      getToast(1).action?.onClick();
+    });
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledTimes(3));
+  });
+
+  it("ACCOUNT-11 invalidates an earlier failure before an out-of-order success is published", async () => {
+    const earlierRequest = deferred<void>();
+    const laterRequest = deferred<void>();
+    mocks.signOutCurrentUser.mockReturnValueOnce(earlierRequest.promise).mockReturnValueOnce(laterRequest.promise);
+    const { result: earlierResult, unmount } = renderHook(() => useSignOut());
+    let earlierOperation!: Promise<void>;
+
+    act(() => {
+      earlierOperation = earlierResult.current.signOut();
+    });
+    unmount();
+
+    const { result: laterResult } = renderHook(() => useSignOut());
+    let laterOperation!: Promise<void>;
+
+    act(() => {
+      laterOperation = laterResult.current.signOut();
+    });
+
+    await actAsync(async () => {
+      earlierRequest.reject(new Error("Earlier sign-out failed"));
+      await expect(earlierOperation).rejects.toThrow("Earlier sign-out failed");
+    });
+    const staleFailureToast = getToast(0);
+
+    await actAsync(async () => {
+      laterRequest.resolve();
+      await laterOperation;
+    });
+
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
+    expect(vi.mocked(dismissToast).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(showToast).mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY
+    );
+    expect(showToast).toHaveBeenLastCalledWith({ message: "Signed out.", tone: "success" });
+
+    act(() => {
+      staleFailureToast.action?.onClick();
+    });
+
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(2);
+    expect(dismissToast).toHaveBeenCalledExactlyOnceWith(1);
   });
 });

--- a/src/pages/account/ui/AccountPage.spec.tsx
+++ b/src/pages/account/ui/AccountPage.spec.tsx
@@ -53,7 +53,7 @@ describe("AccountPage", () => {
     updatePreferences(createPreferences({ appearance: { darkMode: false } }));
   });
 
-  it("shows the anonymous identity and offers Google sign-in", () => {
+  it("ACCOUNT-01 shows the anonymous identity and offers Google sign-in", () => {
     renderPage();
 
     expect(screen.getByRole("heading", { level: 1, name: "Account" })).toBeVisible();
@@ -63,7 +63,7 @@ describe("AccountPage", () => {
     expect(screen.getByRole("button", { name: "Sign in with Google" })).toBeEnabled();
   });
 
-  it("shows the linked identity and offers sign-out", () => {
+  it("ACCOUNT-03 shows the linked identity and offers sign-out", () => {
     replaceAuthSession({
       displayName: "Test User",
       isAnonymous: false,
@@ -78,7 +78,7 @@ describe("AccountPage", () => {
     expect(screen.getByRole("button", { name: "Sign out" })).toBeEnabled();
   });
 
-  it("navigates home when the user presses the route shortcut", async () => {
+  it("NAVIGATION-02 navigates home when the user presses the route shortcut", async () => {
     renderPage();
 
     fireEvent.keyDown(window, { key: "t" });
@@ -86,7 +86,92 @@ describe("AccountPage", () => {
     expect(await screen.findByText("Home Page")).toBeVisible();
   });
 
-  it("lets the user retry a failed sign-in", async () => {
+  it("ACCOUNT-06 lets the user retry a failed sign-in without another mounted action", async () => {
+    const retry = Promise.withResolvers<{ user: Record<string, never> }>();
+    vi.mocked(linkWithPopup)
+      .mockRejectedValueOnce(new Error("Sign-in failed"))
+      .mockReturnValueOnce(retry.promise as never);
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "Sign in with Google" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign in.");
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    const signInButton = screen.getByRole("button", { name: "Sign in with Google" });
+    expect(signInButton).toBeDisabled();
+    expect(signInButton).toHaveAttribute("aria-busy", "true");
+    await userEvent.click(signInButton);
+    expect(linkWithPopup).toHaveBeenCalledTimes(2);
+
+    await actAsync(async () => {
+      retry.resolve({ user: {} });
+      await retry.promise;
+    });
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(screen.getByRole("status")).toHaveTextContent("Signed in.");
+    expect(signInButton).toBeEnabled();
+  });
+
+  it("ACCOUNT-07 lets the user retry a failed sign-out without another mounted action", async () => {
+    const retry = Promise.withResolvers<void>();
+    replaceAuthSession({
+      displayName: "Test User",
+      isAnonymous: false,
+      status: "authenticated",
+      uid: "linked-user",
+    });
+    vi.mocked(signOut).mockRejectedValueOnce(new Error("Sign-out failed")).mockReturnValueOnce(retry.promise);
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    const signOutButton = screen.getByRole("button", { name: "Sign out" });
+    expect(signOutButton).toBeDisabled();
+    expect(signOutButton).toHaveAttribute("aria-busy", "true");
+    await userEvent.click(signOutButton);
+    expect(signOut).toHaveBeenCalledTimes(2);
+
+    await actAsync(async () => {
+      retry.resolve();
+      await retry.promise;
+    });
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(screen.getByRole("status")).toHaveTextContent("Signed out.");
+    expect(signOutButton).toBeEnabled();
+  });
+
+  it("ACCOUNT-06 removes the old Retry when the normal sign-in button reruns the command", async () => {
+    const rerun = Promise.withResolvers<{ user: Record<string, never> }>();
+    vi.mocked(linkWithPopup)
+      .mockRejectedValueOnce(new Error("Sign-in failed"))
+      .mockReturnValueOnce(rerun.promise as never);
+    renderPage();
+
+    const signInButton = screen.getByRole("button", { name: "Sign in with Google" });
+    await userEvent.click(signInButton);
+    expect(await screen.findByRole("button", { name: "Retry" })).toBeVisible();
+
+    await userEvent.click(signInButton);
+
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(signInButton).toBeDisabled();
+    expect(signInButton).toHaveAttribute("aria-busy", "true");
+    await userEvent.click(signInButton);
+    expect(linkWithPopup).toHaveBeenCalledTimes(2);
+
+    await actAsync(async () => {
+      rerun.resolve({ user: {} });
+      await rerun.promise;
+    });
+  });
+
+  it("ACCOUNT-08 keeps sign-in Retry available after leaving the Account page", async () => {
     vi.mocked(linkWithPopup)
       .mockRejectedValueOnce(new Error("Sign-in failed"))
       .mockResolvedValueOnce({ user: {} } as never);
@@ -95,45 +180,19 @@ describe("AccountPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Sign in with Google" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign in.");
 
+    fireEvent.keyDown(window, { key: "t" });
+
+    expect(await screen.findByText("Home Page")).toBeVisible();
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to sign in.");
+
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
     expect(screen.getByRole("status")).toHaveTextContent("Signed in.");
+    expect(linkWithPopup).toHaveBeenCalledTimes(2);
   });
 
-  it("lets the user retry a failed sign-out", async () => {
-    replaceAuthSession({
-      displayName: "Test User",
-      isAnonymous: false,
-      status: "authenticated",
-      uid: "linked-user",
-    });
-    vi.mocked(signOut).mockRejectedValueOnce(new Error("Sign-out failed")).mockResolvedValueOnce(undefined);
-    renderPage();
-
-    await userEvent.click(screen.getByRole("button", { name: "Sign out" }));
-    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign out.");
-
-    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
-    expect(screen.getByRole("status")).toHaveTextContent("Signed out.");
-  });
-
-  it("dismisses its sign-in failure when leaving the Account page", async () => {
-    vi.mocked(linkWithPopup).mockRejectedValueOnce(new Error("Sign-in failed"));
-    renderPage();
-
-    await userEvent.click(screen.getByRole("button", { name: "Sign in with Google" }));
-    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign in.");
-
-    fireEvent.keyDown(window, { key: "t" });
-
-    expect(await screen.findByText("Home Page")).toBeVisible();
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-  });
-
-  it("does not show a sign-in failure that arrives after leaving the Account page", async () => {
+  it("ACCOUNT-02 shows a sign-in failure that arrives after leaving the Account page", async () => {
     const request = Promise.withResolvers<never>();
     vi.mocked(linkWithPopup).mockReturnValue(request.promise);
     renderPage();
@@ -147,6 +206,6 @@ describe("AccountPage", () => {
       await request.promise.catch(() => undefined);
     });
 
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to sign in.");
   });
 });

--- a/src/shared/firebase/index.ts
+++ b/src/shared/firebase/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { initializeApp } from "firebase/app";
-import { connectAuthEmulator, getAuth } from "firebase/auth";
+import { beforeAuthStateChanged, connectAuthEmulator, getAuth } from "firebase/auth";
 import { connectFirestoreEmulator, initializeFirestore, persistentLocalCache } from "firebase/firestore";
 
 const projectId = import.meta.env.VITE_PROJECT_ID;
@@ -29,6 +29,23 @@ const authHost = import.meta.env.VITE_AUTH_HOST;
 const authPort = import.meta.env.VITE_AUTH_PORT;
 if (useFirebaseEmulators && authHost && authPort) {
   connectAuthEmulator(auth, `http://${authHost}:${authPort}`);
+}
+
+if (import.meta.env.VITE_USE_FIREBASE_EMULATORS === "true") {
+  beforeAuthStateChanged(auth, (nextUser) => {
+    const failureKey = "tango-e2e-fail-sign-out-once";
+    if (nextUser !== null || window.sessionStorage.getItem(failureKey) !== "armed") return;
+
+    window.sessionStorage.setItem(failureKey, "consumed");
+    // Sign-out has no emulator request to intercept, so E2E releases this public transition hook after route replacement.
+    return new Promise<void>((_resolve, reject) => {
+      window.addEventListener(
+        "tango-e2e-release-sign-out-failure",
+        () => reject(new Error("E2E_AUTH_SIGN_OUT_FAILURE")),
+        { once: true }
+      );
+    });
+  });
 }
 
 const dbHost = import.meta.env.VITE_DB_HOST;

--- a/test/e2e/account.spec.ts
+++ b/test/e2e/account.spec.ts
@@ -1,6 +1,9 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "./fixtures";
 
+const signOutFailureKey = "tango-e2e-fail-sign-out-once";
+const signOutFailureReleaseEvent = "tango-e2e-release-sign-out-failure";
+
 const accountUid = async (page: Page) => {
   const value = await page.getByText("User ID", { exact: true }).locator("xpath=parent::*").locator("dd").textContent();
   if (value == null || value.trim() === "") throw new Error("Account User ID is unavailable");
@@ -29,12 +32,17 @@ const openGooglePopup = async (page: Page, buttonName: "Retry" | "Sign in with G
   return popup;
 };
 
-const completeGooglePopup = async (
-  page: Page,
-  namespace: string,
-  buttonName: "Retry" | "Sign in with Google" = "Sign in with Google"
-) => {
+const waitForGoogleFailure = (page: Page) =>
+  // Firebase detects a closed desktop popup after its polling and auth-event grace periods.
+  expect(page.getByRole("alert")).toContainText("Unable to sign in.", { timeout: 12_000 });
+
+const closeGooglePopup = async (page: Page, buttonName: "Retry" | "Sign in with Google") => {
   const popup = await openGooglePopup(page, buttonName);
+  await popup.close();
+  await waitForGoogleFailure(page);
+};
+
+const completeOpenGooglePopup = async (popup: Page, namespace: string) => {
   await popup.getByRole("button", { name: "Add new account" }).click();
   await popup.locator("#email-input").fill(`${namespace}@example.test`);
   await popup.locator("#display-name-input").fill(`E2E ${namespace}`);
@@ -44,10 +52,35 @@ const completeGooglePopup = async (
   ]);
 };
 
-const closeGooglePopup = async (page: Page) => {
-  const popup = await openGooglePopup(page, "Sign in with Google");
-  await expect(popup.getByRole("button", { name: "Add new account" })).toBeVisible();
-  await popup.close();
+const completeGooglePopup = async (
+  page: Page,
+  namespace: string,
+  buttonName: "Retry" | "Sign in with Google" = "Sign in with Google"
+) => {
+  const popup = await openGooglePopup(page, buttonName);
+  await completeOpenGooglePopup(popup, namespace);
+};
+
+const armSignOutFailure = (page: Page) =>
+  page.evaluate((failureKey) => window.sessionStorage.setItem(failureKey, "armed"), signOutFailureKey);
+
+const waitForSignOutFailureRelease = (page: Page) =>
+  expect
+    .poll(() => page.evaluate((failureKey) => window.sessionStorage.getItem(failureKey), signOutFailureKey), {
+      message: "sign-out failure hook was not reached",
+      timeout: 5000,
+    })
+    .toBe("consumed");
+
+const releaseSignOutFailure = (page: Page) =>
+  page.evaluate((eventName) => window.dispatchEvent(new Event(eventName)), signOutFailureReleaseEvent);
+
+const failSignOut = async (page: Page, buttonName: "Retry" | "Sign out") => {
+  await armSignOutFailure(page);
+  await page.getByRole("button", { name: buttonName, exact: true }).click();
+  await waitForSignOutFailureRelease(page);
+  await releaseSignOutFailure(page);
+  await expect(page.getByRole("alert")).toContainText("Unable to sign out.");
 };
 
 test("ACCOUNT-01 Google linking preserves the anonymous identity and its data", async ({
@@ -85,14 +118,20 @@ test("ACCOUNT-02 A closed Google popup can be retried successfully", async ({ fi
   await fixture.apply(page, { auth: false });
   await page.goto("/account");
 
-  await closeGooglePopup(page);
-  // Firebase polls for user-closed popups with a randomized delay of up to ten seconds.
-  await expect(page.getByRole("alert")).toContainText("Unable to sign in.", { timeout: 12_000 });
+  const popup = await openGooglePopup(page, "Sign in with Google");
+  await page.bringToFront();
+  await page.keyboard.press("t");
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await popup.close();
+  await waitForGoogleFailure(page);
   await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
 
   await completeGooglePopup(page, namespace.uid, "Retry");
   await expect(page.getByRole("alert")).toHaveCount(0);
   await expect(page.getByRole("status").filter({ hasText: "Signed in." })).toBeVisible();
+  await page.goto("/account");
   await expect(page.getByText("Signed in with Google")).toBeVisible();
 });
 
@@ -138,4 +177,139 @@ test("ACCOUNT-04 Authentication initialization recovers after Reload", async ({ 
   await page.getByRole("button", { name: "Reload" }).click();
 
   await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+});
+
+test("ACCOUNT-05 A late sign-out failure can be retried after leaving Account", async ({ fixture, page }) => {
+  await fixture.apply(page);
+  await page.goto("/account");
+  await expect(page.getByText("Signed in with Google")).toBeVisible();
+  const originalUid = await accountUid(page);
+
+  await armSignOutFailure(page);
+  await page.getByRole("button", { name: "Sign out" }).click();
+  await waitForSignOutFailureRelease(page);
+  await page.keyboard.press("t");
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await releaseSignOutFailure(page);
+  await expect(page.getByRole("alert")).toContainText("Unable to sign out.");
+  await page.getByRole("button", { name: "Retry" }).click();
+
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: "Signed out." })).toBeVisible();
+  await page.goto("/account");
+  await expect(page.getByText("Anonymous account")).toBeVisible();
+  expect(await accountUid(page)).not.toBe(originalUid);
+});
+
+test("ACCOUNT-06 Mounted sign-in reruns prevent duplicate actions", async ({ fixture, page, namespace }) => {
+  test.slow();
+  await fixture.apply(page, { auth: false });
+  await page.goto("/account");
+  await closeGooglePopup(page, "Sign in with Google");
+
+  await page.keyboard.press("t");
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await page.getByRole("button", { name: "Open account" }).click();
+  await expect(page.getByRole("alert")).toContainText("Unable to sign in.");
+
+  const normalRerunPopup = await openGooglePopup(page, "Sign in with Google");
+  const signInButton = page.getByRole("button", { name: "Sign in with Google", exact: true });
+  await expect(page.getByRole("button", { name: "Retry" })).toHaveCount(0);
+  await expect(signInButton).toBeDisabled();
+  await expect(signInButton).toHaveAttribute("aria-busy", "true");
+  await normalRerunPopup.close();
+  await waitForGoogleFailure(page);
+
+  const retryPopup = await openGooglePopup(page, "Retry");
+  await expect(page.getByRole("button", { name: "Retry" })).toHaveCount(0);
+  await expect(signInButton).toBeDisabled();
+  await expect(signInButton).toHaveAttribute("aria-busy", "true");
+  await completeOpenGooglePopup(retryPopup, namespace.uid);
+
+  await expect(page.getByRole("status").filter({ hasText: "Signed in." })).toBeVisible();
+});
+
+test("ACCOUNT-07 A mounted sign-out Retry prevents another action", async ({ fixture, page }) => {
+  await fixture.apply(page);
+  await page.goto("/account");
+  await failSignOut(page, "Sign out");
+
+  await page.keyboard.press("t");
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await page.getByRole("button", { name: "Open account" }).click();
+  await expect(page.getByRole("alert")).toContainText("Unable to sign out.");
+
+  await armSignOutFailure(page);
+  await page.getByRole("button", { name: "Retry" }).click();
+  await waitForSignOutFailureRelease(page);
+  const signOutButton = page.getByRole("button", { name: "Sign out", exact: true });
+  await expect(page.getByRole("button", { name: "Retry" })).toHaveCount(0);
+  await expect(signOutButton).toBeDisabled();
+  await expect(signOutButton).toHaveAttribute("aria-busy", "true");
+  await releaseSignOutFailure(page);
+  await expect(page.getByRole("alert")).toContainText("Unable to sign out.");
+
+  await signOutButton.click();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: "Signed out." })).toBeVisible();
+});
+
+test("ACCOUNT-08 A visible sign-in failure survives route replacement", async ({ fixture, page, namespace }) => {
+  await fixture.apply(page, { auth: false });
+  await page.goto("/account");
+  await closeGooglePopup(page, "Sign in with Google");
+
+  await page.keyboard.press("t");
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("Unable to sign in.");
+  await completeGooglePopup(page, namespace.uid, "Retry");
+
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: "Signed in." })).toBeVisible();
+});
+
+test("ACCOUNT-09 A visible sign-out failure survives route replacement", async ({ fixture, page }) => {
+  await fixture.apply(page);
+  await page.goto("/account");
+  await failSignOut(page, "Sign out");
+
+  await page.keyboard.press("t");
+  await expect(page.getByRole("heading", { level: 1, name: "Decks" })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("Unable to sign out.");
+  await page.getByRole("button", { name: "Retry" }).click();
+
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: "Signed out." })).toBeVisible();
+});
+
+test("ACCOUNT-10 A replacement sign-in failure provides a fresh Retry", async ({ fixture, page, namespace }) => {
+  test.slow();
+  await fixture.apply(page, { auth: false });
+  await page.goto("/account");
+  await closeGooglePopup(page, "Sign in with Google");
+
+  const retryPopup = await openGooglePopup(page, "Retry");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await retryPopup.close();
+  await waitForGoogleFailure(page);
+  await expect(page.getByRole("alert")).toHaveCount(1);
+  await completeGooglePopup(page, namespace.uid, "Retry");
+
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: "Signed in." })).toBeVisible();
+});
+
+test("ACCOUNT-11 A replacement sign-out failure provides a fresh Retry", async ({ fixture, page }) => {
+  await fixture.apply(page);
+  await page.goto("/account");
+  await failSignOut(page, "Sign out");
+
+  await failSignOut(page, "Retry");
+  await expect(page.getByRole("alert")).toHaveCount(1);
+  await page.getByRole("button", { name: "Retry" }).click();
+
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: "Signed out." })).toBeVisible();
 });


### PR DESCRIPTION
## Related issue

Fixes #1409

## Summary

- Keep sign-in and sign-out result Toasts available after the Account page is replaced.
- Keep pending state Page-local while routing Retry actions through the currently mounted Account owner when available.
- Invalidate stale Retry callbacks by their own Toast IDs before newer results are published.
- Expand Account unit, component, and E2E coverage, including an emulator-only delayed sign-out failure control.

## Testing

- `mise run check` (116 files, 690 tests)
- `mise run e2e -- test/e2e/account.spec.ts` (11 tests)