### PR TITLE
feat(#953): Add Study card recovery UI

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -118,6 +118,9 @@
 | SWIPE-24 | read | [Help dialog に現在の操作 mapping を表示できる](./study-controls.md#swipe-24) |
 | SWIPE-25 | write | [Help button の表示設定を reload 後も維持できる](./study-controls.md#swipe-25) |
 | SWIPE-26 | batch | [展開した tag filter を保存して学習 session に適用できる](./study-session.md#swipe-26) |
+| SWIPE-27 | read | [remote target Card の欠損理由を表示して学習設定へ復帰できる](./study-session.md#swipe-27) |
+| SWIPE-28 | read | [remote target Card の確認失敗後に Retry して同じ Card へ復帰できる](./study-session.md#swipe-28) |
+| SWIPE-29 | read | [local target Card の欠損理由を表示して学習設定へ復帰できる](./study-session.md#swipe-29) |
 
 ### Study Back Text
 

--- a/docs/e2e/fixture/README.md
+++ b/docs/e2e/fixture/README.md
@@ -8,6 +8,7 @@
 - `auth.users` は mock する認証 identity を表す。
 - `remote` は Firestore emulator に保存する Deck / Card を表す。
 - `browser` は localStorage に保存する preference、local-only data、Study session を表す。
+- `remote.absentCards` と `browser.absentCards` は Study session が参照するが persistence には存在しない Card identity を表す。
 - fixture YAML にはアプリケーション上の永続状態を記述し、Firestore 固有の serialization は記述しない。
 - 認証失敗、network failure、dialog の表示状態など永続状態ではない前提は fixture に含めず、各ケースの `Given` に記述する。
 - YAML alias は使用しない。
@@ -54,6 +55,15 @@
 - `deletedAt: null`
 - `createdAt: 0`
 - `updatedAt: 0`
+
+### Absent Card
+
+- `absentCards` は `id` と `deckId` だけを持ち、remote identity では `uid` も指定する。
+- absent Card は namespace と参照 validation の対象だが、Firestore emulator または browser storage へ document として seed しない。
+- active / tombstoned Card と同じ ID を重複して宣言できない。
+- remote absent Card の Deck と owner、local absent Card の Deck は既存の参照先と一致させる。
+- absent Card は少なくとも1つの Study session から参照されなければならない。
+- tombstone は absent Card へ変換せず、通常の Card の `deletedAt` で物理 document として表す。
 
 ### Study session
 

--- a/docs/e2e/fixture/study-session-local-absent.yaml
+++ b/docs/e2e/fixture/study-session-local-absent.yaml
@@ -1,0 +1,11 @@
+extends: local-deck-with-cards.yaml
+browser:
+  absentCards:
+    - id: missing-card
+      deckId: deck-1
+  studySessions:
+    deck-1:
+      sessionId: session-1
+      deckId: deck-1
+      cardOrderIds: [missing-card]
+      currentIndex: 0

--- a/docs/e2e/fixture/study-session-remote-absent.yaml
+++ b/docs/e2e/fixture/study-session-remote-absent.yaml
@@ -1,0 +1,19 @@
+extends: study-session-start.yaml
+remote:
+  cards:
+    - id: tombstoned-card
+      deckId: deck-1
+      uid: user-1
+      frontText: deleted
+      backText: deleted answer
+      uniqueKey: deleted
+      deletedAt: 1
+  absentCards:
+    - id: missing-card
+      uid: user-1
+      deckId: deck-1
+browser:
+  studySessions:
+    deck-1:
+      cardOrderIds: [missing-card, tombstoned-card]
+      currentIndex: 0

--- a/docs/e2e/study-session.md
+++ b/docs/e2e/study-session.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-学習 session の開始・再開・再作成・完了・永続化が、filter の選択と保存、学習上限、Deck ごとの分離を維持できることを確認する。
+学習 session の開始・再開・再作成・完了・永続化と、target Card を利用できない場合の復旧が、filter の選択と保存、学習上限、Deck ごとの分離を維持できることを確認する。
 
 ## テストケース
 
@@ -16,6 +16,9 @@
 | SWIPE-11 | batch | [複数 Deck の学習 session を独立して維持できる](#swipe-11) |
 | SWIPE-17 | write | [local-only Deck の学習結果と session を reload 後も維持できる](#swipe-17) |
 | SWIPE-26 | batch | [展開した tag filter を保存して学習 session に適用できる](#swipe-26) |
+| SWIPE-27 | read | [remote target Card の欠損理由を表示して学習設定へ復帰できる](#swipe-27) |
+| SWIPE-28 | read | [remote target Card の確認失敗後に Retry して同じ Card へ復帰できる](#swipe-28) |
+| SWIPE-29 | read | [local target Card の欠損理由を表示して学習設定へ復帰できる](#swipe-29) |
 
 <a id="swipe-06"></a>
 
@@ -201,4 +204,82 @@ Then:
 - 対象 Deck の保存済み tag filter に対象 tag だけが含まれる。
 - session には対象 tag を持つ Card だけが含まれる。
 - 対象 Card の front text が表示される。
+- browser error が発生しない。
+
+<a id="swipe-27"></a>
+
+### SWIPE-27 remote target Card の欠損理由を表示して学習設定へ復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-remote-absent`](./fixture/study-session-remote-absent.yaml)
+- 認証済みユーザーが所有する remote Deck に進行中の学習 session が存在する。
+- session の target Card は、server に存在しないか tombstone として保存されている。
+
+When:
+
+- missing target と tombstoned target の学習画面を開き、それぞれの recovery action で学習設定へ戻る。
+
+Then:
+
+- target の確認中は loading state が表示され、session は削除されない。
+- server-confirmed missing と tombstone を区別する説明が表示される。
+- Retry は表示されず、`Back to study setup` action が focus される。
+- reason screen を automatic redirect で隠さず、recovery action を実行するまでは同じ URL と session の位置を維持する。
+- recovery action 後は対象 session が削除され、同じ Deck の学習設定へ移動する。
+- recovery を Study completion として表示しない。
+- browser error が発生しない。
+
+<a id="swipe-28"></a>
+
+### SWIPE-28 remote target Card の確認失敗後に Retry して同じ Card へ復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-remote-absent`](./fixture/study-session-remote-absent.yaml)
+- 認証済みユーザーが所有する remote Deck に進行中の学習 session が存在する。
+- target Card の single-document verification だけが permission error になる。
+
+When:
+
+- verification error 画面から session-preserving `Exit` で Deck 一覧へ戻り、同じ session を Continue する。
+- `Retry` を実行し、確認が pending の間に target Card が active として確認できる状態へ戻る。
+
+Then:
+
+- target Card が存在しないとは断定しない error explanation と `Retry`、`Exit` が表示される。
+- error 表示時は `Retry` が focus される。
+- `Exit` 後も session と current position が維持される。
+- Retry pending 中は `Retry` が loading かつ disabled になり、同じ verification を重複実行できない。
+- Retry 成功後は同じ Card の front text が表示され、Card に focus context が戻る。
+- verification error と Retry pending の間も session と current position が維持される。
+- browser error が発生しない。
+
+<a id="swipe-29"></a>
+
+### SWIPE-29 local target Card の欠損理由を表示して学習設定へ復帰できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`study-session-local-absent`](./fixture/study-session-local-absent.yaml)
+- browser storage に local-only Deck と進行中の学習 session が存在する。
+- session の target Card は local Card persistence に存在しない。
+
+When:
+
+- 対象 Deck の学習画面を開き、recovery action で学習設定へ戻る。
+
+Then:
+
+- local target がこの device に保存されていないことを説明する reason screen が表示される。
+- Retry は表示されず、`Back to study setup` action が focus される。
+- reason screen を automatic redirect で隠さず、recovery action を実行するまでは同じ URL と session を維持する。
+- recovery action 後は対象 session が削除され、同じ Deck の学習設定へ移動する。
+- recovery を Study completion として表示しない。
 - browser error が発生しない。

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,10 @@ service cloud.firestore {
       function belongsToDeck() {
         return getDeck(request.resource.data.deckId).data.uid == request.auth.uid
       }
-      allow read: if isOwner() || isPublic();
+      // Authenticated single-document verification must distinguish an absent target from a forbidden existing Card.
+      allow get: if (request.auth != null && !exists(/databases/$(database)/documents/card/$(cardId))) ||
+                    isOwner() || isPublic();
+      allow list: if isOwner() || isPublic();
       allow create: if isValid() && belongsToDeck();
       allow update: if isValidOwner() && belongsToDeck();
       allow delete: if isOwner();

--- a/src/app/i18n/resources.ts
+++ b/src/app/i18n/resources.ts
@@ -30,6 +30,40 @@ export const resources = {
         goHome: "Go home",
         goBack: "Go back",
       },
+      studyRecovery: {
+        verifying: {
+          title: "Verifying study session…",
+          description: "Checking whether the current card is still available.",
+        },
+        remoteMissing: {
+          title: "This study card is unavailable.",
+          description: "The card could not be found. Return to study setup to continue with the available cards.",
+        },
+        remoteTombstoned: {
+          title: "This study card was deleted.",
+          description: "Return to study setup to continue with the available cards.",
+        },
+        localMissing: {
+          title: "This local study card is missing.",
+          description: "The card is no longer stored on this device. Return to study setup to continue.",
+        },
+        verificationError: {
+          title: "We couldn’t verify this study card.",
+          description: "The card might still be available. Retry, or exit without losing your place.",
+        },
+        invalid: {
+          title: "This study session can’t be resumed.",
+          description: "Its saved position is invalid. Return to study setup to start again.",
+        },
+        missingDeck: {
+          title: "Study deck unavailable.",
+          description: "This deck could not be found.",
+        },
+        retry: "Retry",
+        exit: "Exit",
+        backToSetup: "Back to study setup",
+        backToDeckList: "Back to deck list",
+      },
       score: {
         aria: "Score {{score}}, {{cue}}",
         positive: "positive",
@@ -146,6 +180,40 @@ export const resources = {
         page: "ページが見つかりません",
         goHome: "ホームへ",
         goBack: "戻る",
+      },
+      studyRecovery: {
+        verifying: {
+          title: "学習セッションを確認しています…",
+          description: "現在のカードを引き続き利用できるか確認しています。",
+        },
+        remoteMissing: {
+          title: "この学習カードは利用できません。",
+          description: "カードが見つかりませんでした。学習設定に戻り、利用可能なカードで続けてください。",
+        },
+        remoteTombstoned: {
+          title: "この学習カードは削除されました。",
+          description: "学習設定に戻り、利用可能なカードで続けてください。",
+        },
+        localMissing: {
+          title: "このローカル学習カードが見つかりません。",
+          description: "この端末にはカードが保存されていません。学習設定に戻って続けてください。",
+        },
+        verificationError: {
+          title: "この学習カードを確認できませんでした。",
+          description: "カードはまだ利用できる可能性があります。再試行するか、現在位置を残したまま終了してください。",
+        },
+        invalid: {
+          title: "この学習セッションは再開できません。",
+          description: "保存された位置が無効です。学習設定に戻ってやり直してください。",
+        },
+        missingDeck: {
+          title: "学習デッキを利用できません。",
+          description: "このデッキが見つかりませんでした。",
+        },
+        retry: "再試行",
+        exit: "終了",
+        backToSetup: "学習設定に戻る",
+        backToDeckList: "デッキ一覧に戻る",
       },
       score: {
         aria: "スコア {{score}}、{{cue}}",

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -9,7 +9,17 @@ import type {
   RemoteCardRead,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  onSnapshot,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 
 import { mapStudyProgressDocument, type StudyProgress } from "@/entities/study-progress/@x/card";
 import { db } from "@/shared/firebase";
@@ -27,6 +37,12 @@ export interface CardRead {
   card: RemoteCardRead;
   progress: StudyProgress;
 }
+
+/** Server-confirmed physical state for one remote Card document. */
+export type RemoteCardReadResult =
+  | { status: "active"; read: CardRead }
+  | { status: "missing" }
+  | { status: "tombstoned" };
 
 /** Maps one physical Card document into independent Card and StudyProgress read models. */
 const mapCardRead = (id: CardId, value: unknown): CardRead => {
@@ -81,6 +97,16 @@ export const subscribeCards = (uid: string, onError: (error: Error) => void): ((
 export const fetchCardReads = async (uid: string): Promise<CardRead[]> => {
   const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
   return mapActiveCardReads(snapshot.docs);
+};
+
+/** Reads one Card from the server without treating a collection snapshot miss as deletion. */
+export const fetchRemoteCardRead = async (uid: string, cardId: CardId): Promise<RemoteCardReadResult> => {
+  const snapshot = await getDocFromServer(doc(db, CARD_COLLECTION, cardId));
+  if (!snapshot.exists()) return { status: "missing" };
+
+  const read = mapCardRead(cardId, snapshot.data());
+  if (read.card.uid !== uid) throw new Error("Card owner does not match the authenticated user");
+  return read.card.deletedAt === null ? { status: "active", read } : { status: "tombstoned" };
 };
 
 /** Writes a new physical Card document with synchronized creation and update timestamps. */

--- a/src/entities/card/api/remote-read.spec.ts
+++ b/src/entities/card/api/remote-read.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn((...parts: unknown[]) => parts),
+  getDocFromServer: vi.fn(),
+  getDocsFromServer: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  doc: mocks.doc,
+  getDocFromServer: mocks.getDocFromServer,
+  getDocsFromServer: mocks.getDocsFromServer,
+  onSnapshot: vi.fn(),
+  query: mocks.query,
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  where: vi.fn(),
+}));
+vi.mock("@/shared/firebase", () => ({ db: "db" }));
+
+import { fetchRemoteCardRead } from "./firestore";
+
+const cardDocument = (overrides: Record<string, unknown> = {}) => ({
+  frontText: "Front",
+  backText: "Back",
+  tags: [],
+  uniqueKey: "key-card",
+  deckId: "deck-a",
+  uid: "uid-a",
+  createdAt: 1,
+  updatedAt: 2,
+  deletedAt: null,
+  score: 3,
+  numberOfSeen: 4,
+  ...overrides,
+});
+
+const resolveDocument = (value: unknown) => {
+  mocks.getDocFromServer.mockResolvedValue({ exists: () => true, data: () => value });
+};
+
+describe("SWIPE-27 SWIPE-28 single remote Card read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns one separated active Card read without querying the collection", async () => {
+    resolveDocument(cardDocument({ lastSeenAt: 5 }));
+
+    await expect(fetchRemoteCardRead("uid-a", "card-a")).resolves.toEqual({
+      status: "active",
+      read: {
+        card: expect.objectContaining({ id: "card-a", deckId: "deck-a", uid: "uid-a" }),
+        progress: expect.objectContaining({ cardId: "card-a", score: 3, numberOfSeen: 4, lastSeenAt: 5 }),
+      },
+    });
+    expect(mocks.doc).toHaveBeenCalledWith("db", "card", "card-a");
+    expect(mocks.getDocsFromServer).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes a missing document from a tombstone", async () => {
+    mocks.getDocFromServer.mockResolvedValueOnce({ exists: () => false });
+    await expect(fetchRemoteCardRead("uid-a", "missing")).resolves.toEqual({ status: "missing" });
+
+    resolveDocument(cardDocument({ deletedAt: 3 }));
+    await expect(fetchRemoteCardRead("uid-a", "deleted")).resolves.toEqual({ status: "tombstoned" });
+  });
+
+  it("rejects owner mismatches and malformed physical documents", async () => {
+    resolveDocument(cardDocument({ uid: "uid-b" }));
+    await expect(fetchRemoteCardRead("uid-a", "foreign")).rejects.toThrow("owner does not match");
+
+    resolveDocument(cardDocument({ tags: [42] }));
+    await expect(fetchRemoteCardRead("uid-a", "invalid")).rejects.toThrow('Invalid Firestore card document "invalid"');
+  });
+});

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,11 +1,11 @@
 export { subscribeCards } from "./api/firestore";
 /** @public Separated read operations for the cross-Entity Card document boundary. */
-export { fetchCardReads, subscribeCardReads } from "./api/firestore";
+export { fetchCardReads, fetchRemoteCardRead, subscribeCardReads } from "./api/firestore";
 /** @public Separated read contract for the cross-Entity Card document boundary. */
-export type { CardRead } from "./api/firestore";
+export type { CardRead, RemoteCardReadResult } from "./api/firestore";
 export { generateCardId } from "./api/id";
 export { createCard, deleteCard, editCard, mutateCards } from "./api/mutations";
-export { useCard, useCards, useCardsByDeckId } from "./model/hooks";
+export { useCard, useCards, useCardsByDeckId, useLocalCardsHydrated } from "./model/hooks";
 export { cardContentSchema } from "./model/schema";
 export { clearRemoteCards } from "./model/store";
 export type {

--- a/src/entities/card/model/hooks.ts
+++ b/src/entities/card/model/hooks.ts
@@ -1,8 +1,18 @@
+import * as React from "react";
 import { useStore } from "zustand";
 
 import { filterCardsByDeckId, filterTagsByDeckId } from "./rules";
 import { cardStore } from "./store";
 import type { Card, CardId } from "./types";
+
+const subscribeLocalCardsHydration = (onStoreChange: () => void): (() => void) => {
+  const stopHydrating = cardStore.persist.onHydrate(onStoreChange);
+  const stopHydrated = cardStore.persist.onFinishHydration(onStoreChange);
+  return () => {
+    stopHydrating();
+    stopHydrated();
+  };
+};
 
 // Reads remote and local Cards as one ordered collection.
 export const useCards = (): Card[] => {
@@ -16,6 +26,10 @@ export const useCard = (id: CardId | undefined): Card | undefined =>
     cardStore,
     (state) => state.remoteCards.find((card) => card.id === id) ?? state.localCards.find((card) => card.id === id)
   );
+
+// Local absence becomes authoritative only after persisted Cards have finished hydrating.
+export const useLocalCardsHydrated = (): boolean =>
+  React.useSyncExternalStore(subscribeLocalCardsHydration, cardStore.persist.hasHydrated, () => false);
 
 // Reads the Cards and available tags owned by one Deck.
 export const useCardsByDeckId = (deckId: string): { cards: Card[]; tags: string[] } => {

--- a/src/entities/card/ui/FrontText.spec.tsx
+++ b/src/entities/card/ui/FrontText.spec.tsx
@@ -8,7 +8,7 @@ import "@testing-library/jest-dom/vitest";
 
 import { FrontText } from "./FrontText";
 
-describe("FrontText", () => {
+describe("SWIPE-28 FrontText", () => {
   it("preserves content and click interaction", () => {
     const onClick = vi.fn();
     render(<FrontText text="A very long front without spaces: abcdefghijklmnopqrstuvwxyz" onClick={onClick} />);
@@ -32,5 +32,11 @@ describe("FrontText", () => {
     fireEvent.keyDown(screen.getByRole("button", { name: "Front" }), { key: "Enter" });
 
     expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("restores focus when Study resumes after verification Retry", () => {
+    render(<FrontText text="Recovered front" onClick={vi.fn()} autoFocus />);
+
+    expect(screen.getByRole("button", { name: "Recovered front" })).toHaveFocus();
   });
 });

--- a/src/entities/card/ui/FrontText.tsx
+++ b/src/entities/card/ui/FrontText.tsx
@@ -5,7 +5,7 @@
  */
 
 import cx from "classnames";
-import type * as React from "react";
+import * as React from "react";
 import { useButtonInteraction } from "@/shared/ui/button-interaction";
 import { MathContent, Title } from "@/shared/ui/content";
 
@@ -13,6 +13,7 @@ export interface FrontTextProps {
   text: string;
   category?: string;
   onClick?: () => void;
+  autoFocus?: boolean;
 }
 
 /**
@@ -22,9 +23,16 @@ export interface FrontTextProps {
  */
 export const FrontText: React.FC<FrontTextProps> = (props) => {
   const clickInteraction = useButtonInteraction<HTMLDivElement>(props.onClick);
+  const frontRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (props.autoFocus) frontRef.current?.focus();
+  }, [props.autoFocus]);
+
   return (
     <div
       id="frontText"
+      ref={frontRef}
       className={cx(
         "mx-auto flex h-full w-full min-w-0 max-w-content items-center justify-center break-words py-section-gap pl-[calc(var(--spacing-study-inline)+env(safe-area-inset-left))] pr-[calc(var(--spacing-study-inline)+env(safe-area-inset-right))] text-ink"
       )}

--- a/src/entities/study-progress/api/mutations.spec.ts
+++ b/src/entities/study-progress/api/mutations.spec.ts
@@ -14,7 +14,7 @@ vi.mock("./firestore", () => ({ editRemoteStudyProgress: mocks.editRemoteStudyPr
 
 import { editStudyProgress } from "./mutations";
 
-describe("StudyProgress mutations", () => {
+describe("SWIPE-27 SWIPE-28 SWIPE-29 StudyProgress mutations", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("updates local Card progress without writing to Firestore", async () => {
@@ -50,6 +50,36 @@ describe("StudyProgress mutations", () => {
       cardId: "remote",
       score: 2,
     });
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("writes progress for a verified remote Card before the Card store catches up", async () => {
+    await editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "remote" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editRemoteStudyProgress).toHaveBeenCalledExactlyOnceWith("user", {
+      cardId: "remote",
+      score: 2,
+    });
+    expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("writes progress for a resolved local Card despite an ambiguous global lookup", async () => {
+    mocks.findCardById.mockReturnValue({ id: "local", deckId: "deck", uid: "user" });
+
+    await editStudyProgress("user", { cardId: "local", score: 2 }, { persistence: "local", cardId: "local" });
+
+    expect(mocks.findCardById).not.toHaveBeenCalled();
+    expect(mocks.editLocalCardStudyProgress).toHaveBeenCalledExactlyOnceWith({ id: "local", score: 2 });
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a resolved persistence identity for another Card", async () => {
+    await expect(
+      editStudyProgress("user", { cardId: "remote", score: 2 }, { persistence: "remote", cardId: "other-card" })
+    ).rejects.toThrow("Resolved Card identity does not match progress");
+
+    expect(mocks.editRemoteStudyProgress).not.toHaveBeenCalled();
     expect(mocks.editLocalCardStudyProgress).not.toHaveBeenCalled();
   });
 

--- a/src/entities/study-progress/api/mutations.ts
+++ b/src/entities/study-progress/api/mutations.ts
@@ -1,12 +1,28 @@
 import { editLocalCardStudyProgress, findCardById } from "@/entities/card/@x/study-progress";
 import { omitUndefined } from "@/shared/lib/omitUndefined";
 import { studyProgressEditSchema } from "../model/schema";
-import type { StudyProgressEdit } from "../model/types";
+import type { StudyProgressEdit, StudyProgressTarget } from "../model/types";
 import { editRemoteStudyProgress } from "./firestore";
 
 // Routes progress through the Card's persistence mode so session movement can still wait for a durable save.
-export const editStudyProgress = async (uid: string, progress: StudyProgressEdit): Promise<void> => {
+export const editStudyProgress = async (
+  uid: string,
+  progress: StudyProgressEdit,
+  target?: StudyProgressTarget
+): Promise<void> => {
   const edit = studyProgressEditSchema.parse(progress);
+  if (target !== undefined) {
+    if (target.cardId !== edit.cardId) throw new Error("Resolved Card identity does not match progress");
+    if (target.persistence === "remote") {
+      await editRemoteStudyProgress(uid, edit);
+      return;
+    }
+
+    const { cardId: id, ...fields } = edit;
+    editLocalCardStudyProgress(omitUndefined({ id, ...fields }));
+    return;
+  }
+
   const card = findCardById(edit.cardId);
   if (card === undefined) throw new Error(`Card "${edit.cardId}" was not found`);
 

--- a/src/entities/study-progress/index.ts
+++ b/src/entities/study-progress/index.ts
@@ -1,1 +1,2 @@
 export { editStudyProgress } from "./api/mutations";
+export type { StudyProgressTarget } from "./model/types";

--- a/src/entities/study-progress/model/types.ts
+++ b/src/entities/study-progress/model/types.ts
@@ -29,6 +29,9 @@ export interface StudyProgressDocumentFields {
 /** Firestore patch shape: cardId selects the document and every progress field is independently optional. */
 export type StudyProgressEdit = Partial<StudyProgress> & Pick<StudyProgress, "cardId">;
 
+/** Persistence identity already resolved by the consuming model, independent of ambiguous same-ID store entries. */
+export type StudyProgressTarget = { persistence: "local"; cardId: CardId } | { persistence: "remote"; cardId: CardId };
+
 /** Learning outcome derived from one study interaction. */
 export type StudyRating = "mastered" | "not-mastered" | "unrated";
 

--- a/src/entities/study-session/index.ts
+++ b/src/entities/study-session/index.ts
@@ -13,6 +13,7 @@ export {
   getStudySession,
   moveStudySession,
   removeStudySession,
+  removeStudySessionIfCurrent,
   setStudySessionIndex,
   startStudy,
   touchStudySession,

--- a/src/entities/study-session/model/rules.spec.ts
+++ b/src/entities/study-session/model/rules.spec.ts
@@ -72,7 +72,7 @@ describe("canMoveStudySession", () => {
   });
 });
 
-describe("resolveStudySession", () => {
+describe("SWIPE-27 SWIPE-29 resolveStudySession", () => {
   const cards = [{ id: "card-1", frontText: "front" }];
 
   it("resolves the Card at the active session position", () => {
@@ -85,14 +85,15 @@ describe("resolveStudySession", () => {
     });
   });
 
-  it("waits while Cards have not loaded", () => {
-    expect(resolveStudySession(session, [])).toEqual({ status: "preparing" });
+  it("reports target absence without inferring whether the snapshot has loaded", () => {
+    expect(resolveStudySession(session, [])).toEqual({ status: "absent", session, cardId: "card-2" });
+    expect(resolveStudySession(session, cards)).toEqual({ status: "absent", session, cardId: "card-2" });
   });
 
-  it("rejects a missing session, empty position, or absent loaded Card", () => {
+  it("rejects a missing session or empty position", () => {
     expect(resolveStudySession(undefined, cards)).toEqual({ status: "invalid" });
-    expect(resolveStudySession({ ...session, cardOrderIds: [] }, [])).toEqual({ status: "invalid" });
-    expect(resolveStudySession(session, cards)).toEqual({ status: "invalid" });
+    const emptySession = { ...session, cardOrderIds: [] };
+    expect(resolveStudySession(emptySession, [])).toEqual({ status: "invalid", session: emptySession });
   });
 });
 

--- a/src/entities/study-session/model/rules.ts
+++ b/src/entities/study-session/model/rules.ts
@@ -103,7 +103,7 @@ export const selectStudyCards = <TCard extends StudyCardSelectionCard>(
 const getCurrentStudySessionCardId = (session: StudySession): StudySession["cardOrderIds"][number] | undefined =>
   session.cardOrderIds[session.currentIndex];
 
-// Resolves whether an active session can study now, is waiting for Cards, or is invalid.
+// Reports snapshot absence without guessing whether an external read has completed.
 export const resolveStudySession = <Card extends StudySessionCard>(
   session: StudySession | undefined,
   cards: readonly Card[]
@@ -111,13 +111,12 @@ export const resolveStudySession = <Card extends StudySessionCard>(
   if (session == null) return { status: "invalid" };
 
   const cardId = getCurrentStudySessionCardId(session);
-  if (cardId == null) return { status: "invalid" };
+  if (cardId == null) return { status: "invalid", session };
 
   const card = cards.find(({ id }) => id === cardId);
   if (card != null) return { status: "studying", session, card };
 
-  // An empty collection can still be an in-flight read; loaded Cards prove that the persisted Card is absent.
-  return { status: cards.length === 0 ? "preparing" : "invalid" };
+  return { status: "absent", session, cardId };
 };
 
 // Collapses control actions into the movement, exit, or no-op effects understood by a study session.

--- a/src/entities/study-session/model/store.spec.ts
+++ b/src/entities/study-session/model/store.spec.ts
@@ -11,6 +11,7 @@ import {
   getStudySession,
   moveStudySession,
   removeStudySession,
+  removeStudySessionIfCurrent,
   setStudySessionIndex,
   startStudy,
   studySessionStore,
@@ -34,7 +35,7 @@ const setVersionedStorage = (state: unknown, version: number): void => {
   localStorage.setItem(STUDY_STORAGE_KEY, JSON.stringify({ state, version }));
 };
 
-describe("study store", () => {
+describe("SWIPE-01 SWIPE-27 SWIPE-29 study store", () => {
   const store = studySessionStore;
 
   beforeEach(() => {
@@ -179,6 +180,21 @@ describe("study store", () => {
     expect(store.getState().sessionsByDeckId).toEqual({
       "deck-2": expect.objectContaining({ deckId: "deck-2" }),
     });
+  });
+
+  it("removes only the session identity and position that were verified", () => {
+    startSession("deck-1", ["card-1", "card-2"]);
+    const verified = getStudySession("deck-1");
+    if (verified == null) throw new Error("Expected an active study session");
+
+    setStudySessionIndex("deck-1", 1);
+    expect(removeStudySessionIfCurrent(verified)).toBe(false);
+    expect(getStudySession("deck-1")?.currentIndex).toBe(1);
+
+    const current = getStudySession("deck-1");
+    if (current == null) throw new Error("Expected an active study session");
+    expect(removeStudySessionIfCurrent(current)).toBe(true);
+    expect(getStudySession("deck-1")).toBeUndefined();
   });
 
   it("clears both memory and persisted storage", () => {

--- a/src/entities/study-session/model/store.ts
+++ b/src/entities/study-session/model/store.ts
@@ -140,6 +140,18 @@ export const removeStudySession = (deckId: DeckId): void => {
   });
 };
 
+// Destructive recovery must not remove a session that changed after the invalid state was observed.
+export const removeStudySessionIfCurrent = (previous: StudySession): boolean => {
+  let removed = false;
+  studySessionStore.setState((state) => {
+    const current = state.sessionsByDeckId[previous.deckId];
+    if (!isStudySessionPositionUnchanged(previous, current)) return;
+    delete state.sessionsByDeckId[previous.deckId];
+    removed = true;
+  });
+  return removed;
+};
+
 // Clears every live and persisted study session.
 export const clearStudySessions = (): void => {
   // Publish the empty state before durable cleanup so auth changes cannot expose the previous user's sessions.

--- a/src/entities/study-session/model/types.ts
+++ b/src/entities/study-session/model/types.ts
@@ -50,7 +50,8 @@ export type StudySessionSwipePlan =
 /** Minimal Card identity needed to resolve a study session position. */
 export type StudySessionCard = { id: StudySession["cardOrderIds"][number] };
 
-/** Resolution of an active study session against the currently loaded Cards. */
+/** Resolution of an active study session against one provided Card snapshot. */
 export type ResolvedStudySession<Card extends StudySessionCard> =
-  | { status: "preparing" | "invalid" }
+  | { status: "invalid"; session?: StudySession }
+  | { status: "absent"; session: StudySession; cardId: StudySession["cardOrderIds"][number] }
   | { status: "studying"; session: StudySession; card: Card };

--- a/src/pages/study-session/model/useStudy.spec.tsx
+++ b/src/pages/study-session/model/useStudy.spec.tsx
@@ -13,13 +13,15 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { actAsync } from "@/test/act";
-import { createDeck, createPreferences } from "@/test/factories";
+import { createDeck, createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as Preferences | null,
   cards: [] as Card[],
   deck: undefined as Deck | undefined,
   editStudyProgress: vi.fn(),
+  fetchRemoteCardRead: vi.fn(),
+  localCardsHydrated: true,
   showToast: vi.fn(),
   touchStudySession: vi.fn(),
 }));
@@ -35,7 +37,9 @@ vi.mock("@/entities/preference", async (importOriginal) => ({
 }));
 vi.mock("@/entities/card", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/card")>()),
+  fetchRemoteCardRead: mocks.fetchRemoteCardRead,
   useCards: () => mocks.cards,
+  useLocalCardsHydrated: () => mocks.localCardsHydrated,
 }));
 vi.mock("@/entities/deck", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/entities/deck")>()),
@@ -88,14 +92,40 @@ const cards: Card[] = ["card-1", "card-2"].map((id) => ({
   lastSeenAt: 0,
 }));
 
-describe("useStudy", () => {
+const activeRemoteRead = (card: Extract<Card, { uid: string }>) => {
+  const { score, numberOfSeen, lastSeenAt, nextSeeingAt, interval, ...cardRead } = card;
+  return {
+    status: "active" as const,
+    read: {
+      card: cardRead,
+      progress: {
+        cardId: card.id,
+        score,
+        numberOfSeen,
+        ...(lastSeenAt !== undefined ? { lastSeenAt } : {}),
+        ...(nextSeeingAt !== undefined ? { nextSeeingAt } : {}),
+        ...(interval !== undefined ? { interval } : {}),
+      },
+    },
+  };
+};
+
+const remoteCardAt = (index: number): Extract<Card, { uid: string }> => {
+  const card = cards[index];
+  if (card == null || !("uid" in card)) throw new Error("Expected a remote Card fixture");
+  return card;
+};
+
+describe("SWIPE-01 SWIPE-08 SWIPE-27 SWIPE-28 SWIPE-29 useStudy", () => {
   beforeEach(() => {
     clearStudySessions();
     localStorage.clear();
     vi.clearAllMocks();
     mocks.editStudyProgress.mockResolvedValue(undefined);
+    mocks.fetchRemoteCardRead.mockReset();
+    mocks.localCardsHydrated = true;
     mocks.cards = cards;
-    mocks.deck = createDeck({ id: deckId, category: "raw" });
+    mocks.deck = createDeck({ id: deckId, uid: "user-1", category: "raw" });
     mocks.preferences = createPreferences({
       cardInterval: 1,
       defaultAutoPlay: false,
@@ -138,13 +168,255 @@ describe("useStudy", () => {
       durationMs: 900,
       dismissible: false,
     });
-    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }));
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
   });
 
-  it("reports preparing while the session card is not available", () => {
+  it("reports unavailable only after the server confirms a missing remote target", async () => {
     mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
     const { result } = renderHook(() => useStudy(deckId));
-    expect(result.current.status).toBe("preparing");
+
+    expect(result.current.status).toBe("verifying");
+    await waitFor(() => expect(result.current).toMatchObject({ status: "unavailable", reason: "remote-missing" }));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("distinguishes a tombstoned remote target from a missing document", async () => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "tombstoned" });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await waitFor(() => expect(result.current).toMatchObject({ status: "unavailable", reason: "remote-tombstoned" }));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("waits for local hydration before treating a missing Card as authoritative", () => {
+    mocks.cards = [];
+    mocks.deck = createLocalDeck({ id: deckId, category: "raw" });
+    mocks.localCardsHydrated = false;
+    const { result, rerender } = renderHook(() => useStudy(deckId));
+
+    expect(result.current.status).toBe("verifying");
+    mocks.localCardsHydrated = true;
+    rerender();
+
+    expect(result.current).toMatchObject({ status: "unavailable", reason: "local-missing" });
+    expect(mocks.fetchRemoteCardRead).not.toHaveBeenCalled();
+    expect(getStudySession(deckId)).toBeDefined();
+
+    act(() => {
+      if (result.current.status !== "unavailable") throw new Error("Expected unavailable Study state");
+      result.current.recover();
+    });
+    expect(getStudySession(deckId)).toBeUndefined();
+  });
+
+  it("removes a confirmed unavailable session only through explicit identity-checked recovery", async () => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    if (result.current.status !== "unavailable") throw new Error("Expected unavailable Study state");
+
+    let recovered = false;
+    act(() => {
+      recovered = result.current.status === "unavailable" && result.current.recover();
+    });
+
+    expect(recovered).toBe(true);
+    expect(getStudySession(deckId)).toBeUndefined();
+  });
+
+  it("does not remove a replacement session through stale recovery", async () => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockResolvedValue({ status: "missing" });
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    if (result.current.status !== "unavailable") throw new Error("Expected unavailable Study state");
+    const { recover } = result.current;
+    const previousSessionId = getStudySession(deckId)?.sessionId;
+
+    act(() => startStudy(deckId, cards, { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    const replacementSessionId = getStudySession(deckId)?.sessionId;
+    expect(replacementSessionId).not.toBe(previousSessionId);
+
+    let recovered = true;
+    act(() => {
+      recovered = recover();
+    });
+    expect(recovered).toBe(false);
+    expect(getStudySession(deckId)?.sessionId).toBe(replacementSessionId);
+  });
+
+  it("deduplicates Retry while pending and restores the verified Card without replacing the session", async () => {
+    const retryRead = Promise.withResolvers<ReturnType<typeof activeRemoteRead>>();
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead
+      .mockRejectedValueOnce(new Error("network failure"))
+      .mockReturnValueOnce(retryRead.promise);
+    const { result } = renderHook(() => useStudy(deckId));
+
+    await waitFor(() => expect(result.current).toMatchObject({ status: "verification-error", retrying: false }));
+    const sessionId = getStudySession(deckId)?.sessionId;
+    act(() => {
+      if (result.current.status !== "verification-error") throw new Error("Expected verification error state");
+      result.current.retry();
+      result.current.retry();
+    });
+
+    expect(result.current).toMatchObject({ status: "verification-error", retrying: true });
+    expect(mocks.fetchRemoteCardRead).toHaveBeenCalledTimes(2);
+    await actAsync(async () => {
+      retryRead.resolve(activeRemoteRead(remoteCardAt(0)));
+      await retryRead.promise;
+    });
+
+    await waitFor(() =>
+      expect(result.current).toMatchObject({ status: "studying", focusCard: true, card: { frontText: "card-1" } })
+    );
+    expect(getStudySession(deckId)?.sessionId).toBe(sessionId);
+    expect(getStudySession(deckId)?.currentIndex).toBe(0);
+  });
+
+  it("keeps the session recoverable when Retry also fails", async () => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockRejectedValue(new Error("network failure"));
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(result.current).toMatchObject({ status: "verification-error", retrying: false }));
+
+    act(() => {
+      if (result.current.status !== "verification-error") throw new Error("Expected verification error state");
+      result.current.retry();
+    });
+
+    await waitFor(() => {
+      expect(mocks.fetchRemoteCardRead).toHaveBeenCalledTimes(2);
+      expect(result.current).toMatchObject({ status: "verification-error", retrying: false });
+    });
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it.each([
+    ["missing", "remote-missing"],
+    ["tombstoned", "remote-tombstoned"],
+  ] as const)("maps a Retry-confirmed %s target to %s recovery", async (status, reason) => {
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockRejectedValueOnce(new Error("network failure")).mockResolvedValueOnce({ status });
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(result.current).toMatchObject({ status: "verification-error", retrying: false }));
+
+    act(() => {
+      if (result.current.status !== "verification-error") throw new Error("Expected verification error state");
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current).toMatchObject({ status: "unavailable", reason }));
+    expect(getStudySession(deckId)).toBeDefined();
+  });
+
+  it("ignores a verification result after the session target is replaced", async () => {
+    const oldRead = Promise.withResolvers<{ status: "missing" }>();
+    const replacementRead = Promise.withResolvers<{ status: "missing" }>();
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead.mockImplementation((_uid: string, cardId: string) =>
+      cardId === "card-1" ? oldRead.promise : replacementRead.promise
+    );
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(mocks.fetchRemoteCardRead).toHaveBeenCalledWith("user-1", "card-1"));
+    const previousSessionId = getStudySession(deckId)?.sessionId;
+
+    act(() => startStudy(deckId, [remoteCardAt(1)], { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    await waitFor(() => expect(mocks.fetchRemoteCardRead).toHaveBeenCalledWith("user-1", "card-2"));
+    await actAsync(async () => {
+      oldRead.resolve({ status: "missing" });
+      await oldRead.promise;
+    });
+
+    expect(result.current.status).toBe("verifying");
+    expect(getStudySession(deckId)?.sessionId).not.toBe(previousSessionId);
+    expect(getStudySession(deckId)?.cardOrderIds).toEqual(["card-2"]);
+
+    await actAsync(async () => {
+      replacementRead.resolve({ status: "missing" });
+      await replacementRead.promise;
+    });
+  });
+
+  it("ignores a stale Retry result when a restarted session reuses the same Card ID", async () => {
+    const staleRetry = Promise.withResolvers<ReturnType<typeof activeRemoteRead>>();
+    const restartedVerification = Promise.withResolvers<{ status: "missing" }>();
+    mocks.cards = [];
+    mocks.fetchRemoteCardRead
+      .mockRejectedValueOnce(new Error("network failure"))
+      .mockReturnValueOnce(staleRetry.promise)
+      .mockReturnValueOnce(restartedVerification.promise);
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(result.current).toMatchObject({ status: "verification-error", retrying: false }));
+    const previousSessionId = getStudySession(deckId)?.sessionId;
+
+    act(() => {
+      if (result.current.status !== "verification-error") throw new Error("Expected verification error state");
+      result.current.retry();
+    });
+    expect(result.current).toMatchObject({ status: "verification-error", retrying: true });
+
+    act(() => startStudy(deckId, cards, { shuffled: false, maxNumberOfCardsToLearn: 0 }));
+    await waitFor(() => expect(mocks.fetchRemoteCardRead).toHaveBeenCalledTimes(3));
+    const restartedSessionId = getStudySession(deckId)?.sessionId;
+    expect(restartedSessionId).not.toBe(previousSessionId);
+    expect(getStudySession(deckId)?.cardOrderIds[0]).toBe("card-1");
+
+    await actAsync(async () => {
+      staleRetry.resolve(activeRemoteRead(remoteCardAt(0)));
+      await staleRetry.promise;
+    });
+    expect(result.current.status).toBe("verifying");
+    expect(getStudySession(deckId)?.sessionId).toBe(restartedSessionId);
+
+    await actAsync(async () => {
+      restartedVerification.resolve({ status: "missing" });
+      await restartedVerification.promise;
+    });
+    await waitFor(() => expect(result.current).toMatchObject({ status: "unavailable", reason: "remote-missing" }));
+  });
+
+  it("writes the displayed local Card while a same-ID remote copy overlaps migration", async () => {
+    const localCards = [
+      createLocalCard({ id: "card-1", deckId, frontText: "local card" }),
+      createLocalCard({ id: "card-2", deckId, frontText: "next local card" }),
+    ];
+    mocks.deck = createLocalDeck({ id: deckId, category: "raw" });
+    mocks.cards = [remoteCardAt(0), ...localCards];
+    clearStudySessions();
+    startStudy(deckId, localCards, { shuffled: false, maxNumberOfCardsToLearn: 0 });
+    const { result } = renderHook(() => useStudy(deckId));
+
+    expect(result.current).toMatchObject({ status: "studying", card: { frontText: "local card" } });
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "local",
+      cardId: "card-1",
+    });
+  });
+
+  it("writes the verified remote Card while a same-ID local copy overlaps subscription catch-up", async () => {
+    const currentCard = remoteCardAt(0);
+    mocks.cards = [createLocalCard({ id: currentCard.id, deckId }), remoteCardAt(1)];
+    mocks.fetchRemoteCardRead.mockResolvedValue(activeRemoteRead(currentCard));
+    const { result } = renderHook(() => useStudy(deckId));
+    await waitFor(() => expect(result.current).toMatchObject({ status: "studying", card: { frontText: "card-1" } }));
+
+    await actAsync(() => result.current.swipeRight());
+
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-1", expect.objectContaining({ cardId: "card-1" }), {
+      persistence: "remote",
+      cardId: "card-1",
+    });
+    expect(getStudySession(deckId)?.currentIndex).toBe(1);
   });
 
   it("reports persisted control visibility and playback availability", () => {

--- a/src/pages/study-session/model/useStudy.ts
+++ b/src/pages/study-session/model/useStudy.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useCards } from "@/entities/card";
+import { useCards, useLocalCardsHydrated } from "@/entities/card";
 import { getCategory, isHighlightLanguage, useDeck } from "@/entities/deck";
 import {
   toggleShowCardDetails,
@@ -18,9 +18,10 @@ import { type StudyCompletion, useSwipe } from "./useSwipe";
 
 export const useStudy = (deckId: string) => {
   const cards = useCards();
+  const localCardsHydrated = useLocalCardsHydrated();
   const deck = useDeck(deckId);
   const preferences = usePreferences();
-  const sessionState = useStudySessionState(deckId, cards);
+  const sessionState = useStudySessionState(deck, cards, localCardsHydrated);
   const [completion, setCompletion] = React.useState<StudyCompletion>();
   const [showBackText, setShowBackText] = React.useState(false);
   const [helpOpen, setHelpOpen] = React.useState(false);
@@ -32,7 +33,20 @@ export const useStudy = (deckId: string) => {
     paused: helpOpen,
     onAdvance: hideBackText,
   });
-  const swipe = useSwipe(deckId, cards, hideBackText, setCompletion);
+  // Use the exact displayed Card because local-to-remote migration can temporarily leave both persistence modes
+  // with the same ID; swipe planning and writes must follow the Deck-scoped Card selected above.
+  const swipeCards = sessionState.status === "studying" ? [sessionState.card] : [];
+  const persistenceTarget =
+    sessionState.status === "studying"
+      ? "uid" in sessionState.card
+        ? { persistence: "remote" as const, cardId: sessionState.card.id }
+        : { persistence: "local" as const, cardId: sessionState.card.id }
+      : undefined;
+  const swipe = useSwipe(deckId, swipeCards, {
+    onCardChanged: hideBackText,
+    onCompleted: setCompletion,
+    ...(persistenceTarget !== undefined ? { target: persistenceTarget } : {}),
+  });
 
   const updateIndex = (currentIndex: number): void => {
     if (!setStudySessionIndex(deckId, currentIndex)) return;
@@ -65,12 +79,13 @@ export const useStudy = (deckId: string) => {
 
   if (deck == null) return;
   if (completion != null) return { status: "completed" as const, completion };
-  if (sessionState.status !== "studying") return { ...controls, status: sessionState.status };
+  if (sessionState.status !== "studying") return { ...controls, ...sessionState };
 
   const category = getCategory(deck.category, sessionState.card.tags);
   return {
     ...controls,
     status: "studying" as const,
+    focusCard: sessionState.focusCard,
     session: {
       currentIndex: sessionState.session.currentIndex,
       cardCount: sessionState.session.cardOrderIds.length,

--- a/src/pages/study-session/model/useStudySessionState.ts
+++ b/src/pages/study-session/model/useStudySessionState.ts
@@ -1,25 +1,262 @@
-import type { Card } from "@/entities/card";
-import type { DeckId } from "@/entities/deck";
-import { removeStudySession, resolveStudySession, touchStudySession, useStudySession } from "@/entities/study-session";
+import { type Card, type CardRead, fetchRemoteCardRead, type RemoteCardReadResult } from "@/entities/card";
+import type { Deck } from "@/entities/deck";
+import {
+  removeStudySessionIfCurrent,
+  resolveStudySession,
+  type StudySession,
+  touchStudySession,
+  useStudySession,
+} from "@/entities/study-session";
 
 import * as React from "react";
 
-export type StudySessionState = ReturnType<typeof resolveStudySession<Card>>;
+type RemoteVerification = RemoteCardReadResult | { status: "error" };
+type VerificationOrigin = "initial" | "retry";
 
-export const useStudySessionState = (deckId: DeckId, cards: readonly Card[]): StudySessionState => {
-  const session = useStudySession(deckId);
-  const sessionState = resolveStudySession(session, cards);
+type VerificationState =
+  | { key: string; requestId: number; phase: "pending"; origin: VerificationOrigin }
+  | {
+      key: string;
+      requestId: number;
+      phase: "settled";
+      origin: VerificationOrigin;
+      result: RemoteVerification;
+    };
+
+interface ActiveVerificationRequest {
+  key: string;
+  requestId: number;
+}
+
+interface VerificationRequestState {
+  sequence: number;
+  active: ActiveVerificationRequest | undefined;
+}
+
+type RemoteDeck = Extract<Deck, { localMode: false }>;
+type SnapshotState = ReturnType<typeof resolveStudySession<Card>>;
+type AbsentSnapshotState = Extract<SnapshotState, { status: "absent" }>;
+
+interface RemoteVerificationTarget {
+  uid: string;
+  cardId: string;
+  key: string;
+}
+
+interface PageStateInputs {
+  deck: Deck | undefined;
+  session: StudySession | undefined;
+  snapshotState: SnapshotState;
+  localCardsHydrated: boolean;
+  verification: VerificationState | undefined;
+}
+
+type ResolvedPageState =
+  | { status: "verifying" }
+  | {
+      status: "unavailable";
+      reason: "local-missing" | "remote-missing" | "remote-tombstoned";
+      session: StudySession;
+    }
+  | { status: "verification-error"; retrying: boolean }
+  | { status: "invalid" }
+  | { status: "studying"; session: StudySession; card: Card; focusCard: boolean };
+
+export type StudySessionState =
+  | { status: "verifying" }
+  | {
+      status: "unavailable";
+      reason: "local-missing" | "remote-missing" | "remote-tombstoned";
+      recover: () => boolean;
+    }
+  | { status: "verification-error"; retrying: boolean; retry: () => void }
+  | { status: "invalid" }
+  | { status: "studying"; session: StudySession; card: Card; focusCard: boolean };
+
+const combineCardRead = ({ card, progress }: CardRead): Card => ({
+  ...card,
+  score: progress.score,
+  numberOfSeen: progress.numberOfSeen,
+  ...(progress.lastSeenAt !== undefined ? { lastSeenAt: progress.lastSeenAt } : {}),
+  ...(progress.nextSeeingAt !== undefined ? { nextSeeingAt: progress.nextSeeingAt } : {}),
+  ...(progress.interval !== undefined ? { interval: progress.interval } : {}),
+});
+
+// The full identity rejects results from replaced sessions even when a later session reuses the same Card.
+const verificationKey = (deck: RemoteDeck, sessionId: string, cardId: string): string =>
+  [deck.uid, deck.id, sessionId, cardId].join("\u0000");
+
+const resolveRemoteSessionKey = (deck: Deck | undefined, session: StudySession | undefined): string | undefined => {
+  if (deck?.localMode !== false || session?.deckId !== deck.id) return;
+  const cardId = session.cardOrderIds[session.currentIndex];
+  return cardId === undefined ? undefined : verificationKey(deck, session.sessionId, cardId);
+};
+
+const belongsToDeckPersistence = (card: Card, deck: Deck): boolean =>
+  card.deckId === deck.id && (deck.localMode ? !("uid" in card) : "uid" in card && card.uid === deck.uid);
+
+const resolveRemoteVerificationTarget = (
+  deck: Deck | undefined,
+  session: StudySession | undefined,
+  snapshotState: SnapshotState
+): RemoteVerificationTarget | undefined => {
+  if (deck?.localMode !== false || session?.deckId !== deck.id || snapshotState.status !== "absent") return;
+
+  return {
+    uid: deck.uid,
+    cardId: snapshotState.cardId,
+    key: verificationKey(deck, snapshotState.session.sessionId, snapshotState.cardId),
+  };
+};
+
+const resolveRemoteStudyState = (
+  deck: RemoteDeck,
+  snapshotState: AbsentSnapshotState,
+  verification: VerificationState | undefined
+): ResolvedPageState => {
+  if (verification === undefined) return { status: "verifying" };
+  if (verification.phase === "pending") {
+    return verification.origin === "retry" ? { status: "verification-error", retrying: true } : { status: "verifying" };
+  }
+  if (verification.result.status === "missing") {
+    return { status: "unavailable", reason: "remote-missing", session: snapshotState.session };
+  }
+  if (verification.result.status === "tombstoned") {
+    return { status: "unavailable", reason: "remote-tombstoned", session: snapshotState.session };
+  }
+  if (verification.result.status === "error") return { status: "verification-error", retrying: false };
+  if (verification.result.read.card.deckId !== deck.id) return { status: "invalid" };
+
+  return {
+    status: "studying",
+    session: snapshotState.session,
+    card: combineCardRead(verification.result.read),
+    focusCard: verification.origin === "retry",
+  };
+};
+
+const resolvePageState = ({
+  deck,
+  session,
+  snapshotState,
+  localCardsHydrated,
+  verification,
+}: PageStateInputs): ResolvedPageState => {
+  if (
+    deck === undefined ||
+    (session !== undefined && session.deckId !== deck.id) ||
+    snapshotState.status === "invalid"
+  ) {
+    return { status: "invalid" };
+  }
+  if (snapshotState.status === "studying") {
+    return {
+      status: "studying",
+      session: snapshotState.session,
+      card: snapshotState.card,
+      // A subscription may publish the recovered Card before its single-document Retry settles.
+      // Keep the matching Retry identity long enough for the Page to restore focus on either ordering.
+      focusCard: verification?.origin === "retry",
+    };
+  }
+  if (deck.localMode) {
+    return localCardsHydrated
+      ? { status: "unavailable", reason: "local-missing", session: snapshotState.session }
+      : { status: "verifying" };
+  }
+  return resolveRemoteStudyState(deck, snapshotState, verification);
+};
+
+const beginVerification = (
+  requestState: VerificationRequestState,
+  setVerification: React.Dispatch<React.SetStateAction<VerificationState | undefined>>,
+  target: RemoteVerificationTarget,
+  origin: VerificationOrigin
+): void => {
+  // The mutable identity closes the same-render double-click window before React can publish pending state.
+  if (requestState.active?.key === target.key) return;
+
+  const requestId = requestState.sequence + 1;
+  requestState.sequence = requestId;
+  requestState.active = { key: target.key, requestId };
+  setVerification({ key: target.key, requestId, phase: "pending", origin });
+
+  const settle = (result: RemoteVerification) => {
+    const { active } = requestState;
+    if (active?.key !== target.key || active.requestId !== requestId) return;
+
+    requestState.active = undefined;
+    setVerification({ key: target.key, requestId, phase: "settled", origin, result });
+  };
+
+  void fetchRemoteCardRead(target.uid, target.cardId).then(settle, () => settle({ status: "error" }));
+};
+
+export const useStudySessionState = (
+  deck: Deck | undefined,
+  cards: readonly Card[],
+  localCardsHydrated: boolean
+): StudySessionState => {
+  const session = useStudySession(deck?.id ?? "");
+  const scopedCards = deck === undefined ? [] : cards.filter((card) => belongsToDeckPersistence(card, deck));
+  const snapshotState = resolveStudySession(session, scopedCards);
+  const [verification, setVerification] = React.useState<VerificationState>();
+  const verificationRequest = React.useRef<VerificationRequestState>({ sequence: 0, active: undefined });
+
+  const target = resolveRemoteVerificationTarget(deck, session, snapshotState);
+  const targetKey = target?.key;
+  const targetUid = target?.uid;
+  const targetCardId = target?.cardId;
+  const currentSessionKey = resolveRemoteSessionKey(deck, session);
+  const currentVerification = verification?.key === currentSessionKey ? verification : undefined;
 
   React.useEffect(() => {
-    if (sessionState.status === "studying") {
-      touchStudySession(deckId);
+    const request = verificationRequest.current;
+    if (targetKey === undefined || targetUid === undefined || targetCardId === undefined) {
+      request.active = undefined;
       return;
     }
-    if (sessionState.status === "preparing") return;
+    const nextTarget = { key: targetKey, uid: targetUid, cardId: targetCardId };
+    beginVerification(request, setVerification, nextTarget, "initial");
+    return () => {
+      if (request.active?.key === targetKey) request.active = undefined;
+    };
+  }, [targetCardId, targetKey, targetUid]);
 
-    // Invalid active progress must be removed before leaving so reopening the deck cannot repeat the same failure.
-    removeStudySession(deckId);
-  }, [deckId, sessionState.status]);
+  const state = resolvePageState({
+    deck,
+    session,
+    snapshotState,
+    localCardsHydrated,
+    verification: currentVerification,
+  });
 
-  return sessionState;
+  const studyingDeckId = state.status === "studying" ? state.session.deckId : undefined;
+  const studyingSessionId = state.status === "studying" ? state.session.sessionId : undefined;
+  React.useEffect(() => {
+    if (studyingDeckId !== undefined) touchStudySession(studyingDeckId);
+  }, [studyingDeckId, studyingSessionId]);
+
+  const invalidSession = state.status === "invalid" && deck !== undefined ? session : undefined;
+  React.useEffect(() => {
+    if (invalidSession !== undefined) removeStudySessionIfCurrent(invalidSession);
+  }, [invalidSession]);
+
+  if (state.status === "unavailable") {
+    return {
+      status: state.status,
+      reason: state.reason,
+      recover: () => removeStudySessionIfCurrent(state.session),
+    };
+  }
+  if (state.status === "verification-error") {
+    return {
+      status: state.status,
+      retrying: state.retrying,
+      retry: () => {
+        if (target !== undefined) beginVerification(verificationRequest.current, setVerification, target, "retry");
+      },
+    };
+  }
+  return state;
 };

--- a/src/pages/study-session/model/useSwipe.ts
+++ b/src/pages/study-session/model/useSwipe.ts
@@ -2,7 +2,7 @@ import { useAuthUid } from "@/entities/auth";
 import type { Card } from "@/entities/card";
 import type { DeckId } from "@/entities/deck";
 import { type SwipeDirection, usePreferences } from "@/entities/preference";
-import { editStudyProgress } from "@/entities/study-progress";
+import { editStudyProgress, type StudyProgressTarget } from "@/entities/study-progress";
 import { getStudySession, moveStudySession, planStudySessionSwipe, removeStudySession } from "@/entities/study-session";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 import { showToast, type ToastTone } from "@/shared/ui/toast";
@@ -30,11 +30,16 @@ export interface StudyCompletion {
   cardCount: number;
 }
 
+interface UseSwipeOptions {
+  onCardChanged: () => void;
+  onCompleted: (completion: StudyCompletion) => void;
+  target?: StudyProgressTarget;
+}
+
 export const useSwipe = (
   deckId: DeckId,
   cards: readonly Card[],
-  onCardChanged: () => void,
-  onCompleted: (completion: StudyCompletion) => void
+  { onCardChanged, onCompleted, target }: UseSwipeOptions
 ): SwipeState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
@@ -83,7 +88,7 @@ export const useSwipe = (
 
     swipeState.current.inProgress = true;
     // The visible card advances only after persistence succeeds, so failed writes need no session rollback.
-    const saved = await editStudyProgress(uid, swipePlan.progress).then(
+    const saved = await editStudyProgress(uid, swipePlan.progress, target).then(
       () => true,
       () => false
     );

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -6,15 +6,24 @@ import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { deleteCard, mutateCards } from "@/entities/card";
-import { createDeck } from "@/entities/deck";
+import { clearRemoteCards, deleteCard, mutateCards, type RemoteCardReadResult } from "@/entities/card";
+import { createDeck, type Deck } from "@/entities/deck";
 import { clearStudySessions, getStudySession, setStudySessionIndex, startStudy } from "@/entities/study-session";
 import { dismissToast, ToastViewport } from "@/shared/ui/toast";
-import { createLocalCard, createLocalDeck, createPreferences } from "@/test/factories";
+import {
+  createCard as createRemoteCard,
+  createDeck as createRemoteDeck,
+  createLocalCard,
+  createLocalDeck,
+  createPreferences,
+} from "@/test/factories";
 
 const mocks = vi.hoisted(() => ({
   preferences: null as unknown as Preferences,
   editStudyProgress: vi.fn(),
+  deckOverride: undefined as Deck | undefined,
+  fetchRemoteCardRead: vi.fn(),
+  localCardsHydrated: true,
   removeStudySession: vi.fn(),
   setDarkMode: vi.fn(),
   touchStudySession: vi.fn(),
@@ -25,6 +34,24 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/card", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/entities/card")>();
+  return {
+    ...original,
+    fetchRemoteCardRead: mocks.fetchRemoteCardRead,
+    useLocalCardsHydrated: () => mocks.localCardsHydrated,
+  };
+});
+vi.mock("@/entities/deck", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/entities/deck")>();
+  return {
+    ...original,
+    useDeck: (id: string) => {
+      const deck = original.useDeck(id);
+      return mocks.deckOverride ?? deck;
+    },
+  };
+});
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,
@@ -65,7 +92,7 @@ const DeckListDestination = () => {
   );
 };
 
-describe("StudySessionPage", () => {
+describe("SWIPE-01 SWIPE-08 SWIPE-10 SWIPE-24 SWIPE-27 SWIPE-28 SWIPE-29 StudySessionPage", () => {
   const deckId = "deck-id";
   const deck = createLocalDeck({ id: deckId, name: "Study deck", category: "raw" });
   const firstCard = createLocalCard({
@@ -94,6 +121,7 @@ describe("StudySessionPage", () => {
           <Routes>
             <Route path="/" element={<DeckListDestination />} />
             <Route path="/previous" element={<h1>Previous destination</h1>} />
+            <Route path="/deck/:id/start" element={<h1>Study setup destination</h1>} />
             <Route path="/deck/:id/study" element={<StudySessionPage />} />
           </Routes>
         </MemoryRouter>
@@ -109,9 +137,13 @@ describe("StudySessionPage", () => {
   beforeEach(async () => {
     document.documentElement.lang = "en";
     clearStudySessions();
+    clearRemoteCards();
+    mocks.deckOverride = undefined;
     dismissToast();
     mocks.preferences = createPreferences({ appearance: { darkMode: false } });
     mocks.editStudyProgress.mockReset().mockResolvedValue(undefined);
+    mocks.fetchRemoteCardRead.mockReset();
+    mocks.localCardsHydrated = true;
     mocks.removeStudySession.mockReset();
     mocks.setDarkMode.mockReset();
     mocks.touchStudySession.mockReset();
@@ -192,7 +224,8 @@ describe("StudySessionPage", () => {
     expect(screen.queryByText("Back two")).not.toBeInTheDocument();
     expect(mocks.editStudyProgress).toHaveBeenCalledExactlyOnceWith(
       "user-id",
-      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 })
+      expect.objectContaining({ cardId: "first-card", score: 3, numberOfSeen: 4 }),
+      { persistence: "local", cardId: "first-card" }
     );
     expect(getStudySession(deckId)?.currentIndex).toBe(1);
   });
@@ -466,30 +499,147 @@ describe("StudySessionPage", () => {
     expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
   });
 
-  it("shows loading feedback while active session cards are unavailable", async () => {
+  it("keeps a local-missing reason visible until explicit recovery returns to Study setup", async () => {
     await deleteCard("", firstCard);
     await deleteCard("", secondCard);
     clearStudySessions();
     startStudy(deckId, [firstCard], mocks.preferences.study);
+    const unavailableSession = getStudySession(deckId);
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: "Loading…" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "This local study card is missing." })).toBeVisible();
+    expect(screen.getByText(/no longer stored on this device/i)).toBeVisible();
+    expect(getStudySession(deckId)).toEqual(unavailableSession);
+    const recovery = screen.getByRole("button", { name: "Back to study setup" });
+    expect(recovery).toHaveFocus();
+
+    fireEvent.click(recovery);
+
+    expect(screen.getByRole("heading", { name: "Study setup destination" })).toBeVisible();
+    expect(getStudySession(deckId)).toBeUndefined();
   });
 
-  it("returns to the deck list when no active session exists", async () => {
+  it("keeps a structurally invalid session reason visible until the user chooses a destination", () => {
     clearStudySessions();
     renderPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Deck list destination" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "This study session can’t be resumed." })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Deck list destination" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to study setup" }));
+    expect(screen.getByRole("heading", { name: "Study setup destination" })).toBeVisible();
   });
 
   it("shows route feedback when the Deck Entity is unavailable", () => {
     renderPage("/deck/missing-deck/study");
 
-    expect(screen.getByRole("heading", { name: "Study session unavailable." })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Study deck unavailable." })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back to deck list" })).toHaveFocus();
     expect(mocks.removeStudySession).not.toHaveBeenCalled();
     expect(mocks.touchStudySession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the verifying screen resumable and offers Exit without a duplicate Retry", () => {
+    const remoteDeck = createRemoteDeck({ id: deckId, name: "Remote study deck" });
+    const remoteCard = createRemoteCard({ id: "remote-card", deckId, frontText: "Remote front" });
+    mocks.deckOverride = remoteDeck;
+    clearStudySessions();
+    startStudy(deckId, [remoteCard], mocks.preferences.study);
+    const sessionBeforeExit = getStudySession(deckId);
+    mocks.fetchRemoteCardRead.mockReturnValue(new Promise<RemoteCardReadResult>(() => undefined));
+
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "Verifying study session…" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
+
+    fireEvent.click(screen.getByRole("button", { name: "Exit" }));
+    expect(screen.getByRole("heading", { name: "Deck list destination" })).toBeVisible();
+    expect(getStudySession(deckId)).toEqual(sessionBeforeExit);
+  });
+
+  it.each([
+    [{ status: "missing" } as const, "This study card is unavailable.", /could not be found/i],
+    [{ status: "tombstoned" } as const, "This study card was deleted.", /available cards/i],
+  ])("keeps confirmed remote %s feedback visible until explicit recovery", async (result, title, description) => {
+    const remoteDeck = createRemoteDeck({ id: deckId, name: "Remote study deck" });
+    const remoteCard = createRemoteCard({ id: "remote-card", deckId, frontText: "Remote front" });
+    mocks.deckOverride = remoteDeck;
+    clearStudySessions();
+    startStudy(deckId, [remoteCard], mocks.preferences.study);
+    const unavailableSession = getStudySession(deckId);
+    mocks.fetchRemoteCardRead.mockResolvedValue(result);
+
+    renderPage();
+
+    expect(await screen.findByRole("heading", { name: title })).toBeVisible();
+    expect(screen.getByText(description)).toBeVisible();
+    expect(getStudySession(deckId)).toEqual(unavailableSession);
+    const recovery = screen.getByRole("button", { name: "Back to study setup" });
+    expect(recovery).toHaveFocus();
+
+    fireEvent.click(recovery);
+    expect(screen.getByRole("heading", { name: "Study setup destination" })).toBeVisible();
+    expect(getStudySession(deckId)).toBeUndefined();
+  });
+
+  it("disables duplicate Retry and restores focus to the same Card without losing session position", async () => {
+    const remoteDeck = createRemoteDeck({ id: deckId, name: "Remote study deck" });
+    const remoteCard = createRemoteCard({
+      id: "remote-card",
+      deckId,
+      frontText: "Recovered remote front",
+      score: 4,
+      numberOfSeen: 5,
+    });
+    mocks.deckOverride = remoteDeck;
+    clearStudySessions();
+    startStudy(deckId, [remoteCard], mocks.preferences.study);
+    const sessionBeforeRetry = getStudySession(deckId);
+    mocks.fetchRemoteCardRead.mockRejectedValueOnce(new Error("temporary verification failure"));
+
+    renderPage();
+
+    expect(await screen.findByRole("heading", { name: "We couldn’t verify this study card." })).toBeVisible();
+    const readyRetry = screen.getByRole("button", { name: "Retry" });
+    expect(readyRetry).toHaveFocus();
+    expect(getStudySession(deckId)).toEqual(sessionBeforeRetry);
+
+    let resolveRetry: ((result: RemoteCardReadResult) => void) | undefined;
+    mocks.fetchRemoteCardRead.mockImplementationOnce(
+      () =>
+        new Promise<RemoteCardReadResult>((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+    fireEvent.click(readyRetry);
+
+    const pendingRetry = screen.getByRole("button", { name: "Retry" });
+    expect(pendingRetry).toBeDisabled();
+    expect(pendingRetry).toHaveAttribute("aria-busy", "true");
+    fireEvent.click(pendingRetry);
+    expect(mocks.fetchRemoteCardRead).toHaveBeenCalledTimes(2);
+    expect(getStudySession(deckId)).toEqual(sessionBeforeRetry);
+
+    act(() => {
+      resolveRetry?.({
+        status: "active",
+        read: {
+          card: remoteCard,
+          progress: { cardId: remoteCard.id, score: remoteCard.score, numberOfSeen: remoteCard.numberOfSeen },
+        },
+      });
+    });
+
+    const recoveredCard = await screen.findByRole("button", { name: "Recovered remote front" });
+    expect(recoveredCard).toHaveFocus();
+    expect(getStudySession(deckId)).toMatchObject({
+      sessionId: sessionBeforeRetry?.sessionId,
+      cardOrderIds: sessionBeforeRetry?.cardOrderIds,
+      currentIndex: sessionBeforeRetry?.currentIndex,
+    });
   });
 
   it("rejects a route without a deck id", () => {

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -1,4 +1,5 @@
-import * as React from "react";
+import type * as React from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey, useLatest } from "react-use";
 
@@ -44,16 +45,93 @@ const shouldIgnoreStudyShortcut = (event: KeyboardEvent): boolean => {
   return event.key.startsWith("Arrow") && event.target.closest(studyShortcutSliderTarget) !== null;
 };
 
-const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) => {
-  if (state == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
+interface StudyRecoveryActions {
+  exit: () => void;
+  returnToSetup: (recover?: () => boolean) => void;
+}
 
-  if (state.status !== "studying") {
-    return state.status === "preparing" ? (
-      <RouteFeedback title="Loading…" tone="loading" />
-    ) : (
-      <RouteFeedback title="Study session unavailable." tone="not-found" />
+type Translate = ReturnType<typeof useTranslation>["t"];
+
+const unavailableCopyKey = {
+  "local-missing": "localMissing",
+  "remote-missing": "remoteMissing",
+  "remote-tombstoned": "remoteTombstoned",
+} as const;
+
+const renderStudyScreen = (state: StudyState | undefined, actions: StudyRecoveryActions, t: Translate) => {
+  if (state == null) {
+    return (
+      <RouteFeedback
+        title={t("studyRecovery.missingDeck.title")}
+        description={t("studyRecovery.missingDeck.description")}
+        tone="not-found"
+        primaryAction={{ label: t("studyRecovery.backToDeckList"), onClick: actions.exit, autoFocus: true }}
+      />
     );
   }
+
+  if (state.status === "verifying") {
+    return (
+      <RouteFeedback
+        title={t("studyRecovery.verifying.title")}
+        description={t("studyRecovery.verifying.description")}
+        tone="loading"
+        secondaryAction={{ label: t("studyRecovery.exit"), onClick: actions.exit }}
+      />
+    );
+  }
+
+  if (state.status === "unavailable") {
+    const copyKey = unavailableCopyKey[state.reason];
+    return (
+      <RouteFeedback
+        title={t(`studyRecovery.${copyKey}.title`)}
+        description={t(`studyRecovery.${copyKey}.description`)}
+        tone="not-found"
+        primaryAction={{
+          label: t("studyRecovery.backToSetup"),
+          onClick: () => actions.returnToSetup(state.recover),
+          autoFocus: true,
+        }}
+      />
+    );
+  }
+
+  if (state.status === "verification-error") {
+    return (
+      <RouteFeedback
+        key={state.retrying ? "retry-pending" : "retry-ready"}
+        title={t("studyRecovery.verificationError.title")}
+        description={t("studyRecovery.verificationError.description")}
+        tone="error"
+        primaryAction={{
+          label: t("studyRecovery.retry"),
+          onClick: state.retry,
+          disabled: state.retrying,
+          loading: state.retrying,
+          autoFocus: !state.retrying,
+        }}
+        secondaryAction={{ label: t("studyRecovery.exit"), onClick: actions.exit }}
+      />
+    );
+  }
+
+  if (state.status === "invalid") {
+    return (
+      <RouteFeedback
+        title={t("studyRecovery.invalid.title")}
+        description={t("studyRecovery.invalid.description")}
+        tone="not-found"
+        primaryAction={{
+          label: t("studyRecovery.backToSetup"),
+          onClick: () => actions.returnToSetup(),
+          autoFocus: true,
+        }}
+      />
+    );
+  }
+
+  if (state.status === "completed") return null;
 
   const swipeActions = {
     disabled: false,
@@ -66,7 +144,7 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
   return (
     <AppLayout fullscreen showHeader={false}>
       <StudySession
-        onBack={onBack}
+        onBack={actions.exit}
         onToggleCardDetails={state.toggleShowCardDetails}
         onToggleHelp={state.toggleShowHelp}
         onToggleSwipeControls={state.toggleSwipeButtonList}
@@ -100,7 +178,12 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
             }
           : {})}
         frontTextSlot={
-          <FrontText category={state.card.category} text={state.card.frontText} onClick={state.toggleBackText} />
+          <FrontText
+            category={state.card.category}
+            text={state.card.frontText}
+            onClick={state.toggleBackText}
+            autoFocus={state.focusCard}
+          />
         }
         cardOverlaySlot={
           <CardOverlay
@@ -125,9 +208,14 @@ const renderStudyScreen = (state: StudyState | undefined, onBack: () => void) =>
 
 const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const study = useStudy(deckId);
   const latestStudy = useLatest(study);
-  const goBack = () => void navigate(routes.deckList.to());
+  const exit = () => void navigate(routes.deckList.to());
+  const returnToSetup = (recover?: () => boolean) => {
+    if (recover !== undefined && !recover()) return;
+    void navigate(routes.deckStudyStart.to(deckId), { replace: true });
+  };
   const runWhileStudying = (action: StudyShortcutAction) => (event: KeyboardEvent) => {
     // Native editing and activation keys take precedence, while unrelated Study shortcuts remain
     // available after a user moves focus into the card or floating controls.
@@ -148,11 +236,6 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
   useKey("b", runWhileStudying("toggleSwipeButtonList"));
   useKey(" ", runWhileStudying("toggleAutoPlay"));
 
-  React.useEffect(() => {
-    if (study?.status !== "invalid") return;
-    void navigate(routes.deckList.to(), { replace: true });
-  }, [navigate, study?.status]);
-
   if (study?.status === "completed") {
     return (
       <AppLayout showHeader>
@@ -166,18 +249,33 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
     );
   }
 
-  return renderStudyScreen(study, goBack);
+  return renderStudyScreen(study, { exit, returnToSetup }, t);
 };
 
 export const StudySessionPage: React.FC = () => {
   const params = useParams();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
   const deckId = params.id;
   if (deckId == null) throw new Error("invalid deck id");
 
   const deck = useDeck(deckId);
 
   // Study lifecycle mutates session state, so an unavailable route Deck must not mount it.
-  if (deck == null) return <RouteFeedback title="Study session unavailable." tone="not-found" />;
+  if (deck == null) {
+    return (
+      <RouteFeedback
+        title={t("studyRecovery.missingDeck.title")}
+        description={t("studyRecovery.missingDeck.description")}
+        tone="not-found"
+        primaryAction={{
+          label: t("studyRecovery.backToDeckList"),
+          onClick: () => void navigate(routes.deckList.to(), { replace: true }),
+          autoFocus: true,
+        }}
+      />
+    );
+  }
 
   // Study state belongs to one route Deck, so id changes start a fresh Page lifecycle.
   return <ActiveStudySessionPage key={deckId} deckId={deckId} />;

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -20,6 +20,7 @@ export type ButtonProps = {
   variant?: ButtonVariant;
   size?: ButtonSize;
   children?: React.ReactNode;
+  ref?: React.Ref<HTMLButtonElement>;
   onClick?: () => void;
 };
 
@@ -46,7 +47,7 @@ const getLoadingAnnouncement = (content: React.ReactNode) =>
  * Renders label or child content with the requested variant and size while announcing and
  * disabling loading work.
  */
-export const Button: React.FC<ButtonProps> = (props) => {
+export const Button: React.FC<ButtonProps> = ({ ref, ...props }) => {
   const variant = resolveVariant(props);
   const size = resolveSize(props);
   const inactive = props.disabled || props.loading;
@@ -56,6 +57,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
   return (
     <>
       <button
+        ref={ref}
         type={props.type ?? "button"}
         hidden={props.hidden}
         className={cx(

--- a/src/shared/ui/route-feedback/RouteFeedback.spec.tsx
+++ b/src/shared/ui/route-feedback/RouteFeedback.spec.tsx
@@ -11,7 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { RouteFeedback } from "./RouteFeedback";
 
-describe("RouteFeedback", () => {
+describe("SWIPE-28 RouteFeedback", () => {
   it("renders loading feedback with a heading and description", () => {
     render(
       <RouteFeedback title="Starting Tango…" description="Preparing your decks and study progress." tone="loading" />
@@ -28,13 +28,32 @@ describe("RouteFeedback", () => {
       <RouteFeedback
         title="Unable to start Tango"
         tone="error"
-        primaryAction={{ label: "Reload", onClick: onReload }}
+        primaryAction={{ label: "Reload", onClick: onReload, autoFocus: true }}
       />
     );
 
     expect(screen.getByRole("alert")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    const reload = screen.getByRole("button", { name: "Reload" });
+    expect(reload).toHaveFocus();
+    fireEvent.click(reload);
     expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it("exposes a pending action as busy and natively disabled", () => {
+    const onRetry = vi.fn();
+    render(
+      <RouteFeedback
+        title="Unable to verify"
+        tone="error"
+        primaryAction={{ label: "Retry", onClick: onRetry, loading: true, disabled: true }}
+      />
+    );
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toBeDisabled();
+    expect(retry).toHaveAttribute("aria-busy", "true");
+    fireEvent.click(retry);
+    expect(onRetry).not.toHaveBeenCalled();
   });
 
   it("renders secondary action before primary action for not-found feedback", () => {

--- a/src/shared/ui/route-feedback/RouteFeedback.stories.tsx
+++ b/src/shared/ui/route-feedback/RouteFeedback.stories.tsx
@@ -27,6 +27,24 @@ export const ErrorState: Story = {
   },
 };
 
+export const RetryPending: Story = {
+  args: {
+    title: "Unable to verify the study card",
+    description: "The card might still be available.",
+    tone: "error",
+    primaryAction: {
+      label: "Retry",
+      onClick: fn(),
+      disabled: true,
+      loading: true,
+    },
+    secondaryAction: {
+      label: "Exit",
+      onClick: fn(),
+    },
+  },
+};
+
 export const NotFound: Story = {
   args: {
     title: "Page not found",

--- a/src/shared/ui/route-feedback/RouteFeedback.tsx
+++ b/src/shared/ui/route-feedback/RouteFeedback.tsx
@@ -4,7 +4,7 @@
  * and interaction rules.
  */
 
-import type * as React from "react";
+import * as React from "react";
 
 import { Button, type ButtonVariant } from "../button";
 import { Layout } from "../layout";
@@ -15,6 +15,9 @@ interface RouteFeedbackAction {
   label: string;
   onClick: () => void;
   variant?: ButtonVariant;
+  disabled?: boolean;
+  loading?: boolean;
+  autoFocus?: boolean;
 }
 
 export interface RouteFeedbackProps {
@@ -29,11 +32,25 @@ export interface RouteFeedbackProps {
  * Renders the Action Button user interface.
  * Renders the optional recovery action and calls its handler when the user activates the button.
  */
-const ActionButton = ({ action, defaultVariant }: { action: RouteFeedbackAction; defaultVariant: ButtonVariant }) => (
-  <Button variant={action.variant ?? defaultVariant} onClick={action.onClick}>
-    {action.label}
-  </Button>
-);
+const ActionButton = ({ action, defaultVariant }: { action: RouteFeedbackAction; defaultVariant: ButtonVariant }) => {
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (action.autoFocus && !action.disabled && !action.loading) buttonRef.current?.focus();
+  }, [action.autoFocus, action.disabled, action.loading]);
+
+  return (
+    <Button
+      ref={buttonRef}
+      variant={action.variant ?? defaultVariant}
+      {...(action.disabled !== undefined ? { disabled: action.disabled } : {})}
+      {...(action.loading !== undefined ? { loading: action.loading } : {})}
+      onClick={action.onClick}
+    >
+      {action.label}
+    </Button>
+  );
+};
 
 /**
  * Renders the Route Feedback user interface.

--- a/test/e2e/account.spec.ts
+++ b/test/e2e/account.spec.ts
@@ -118,7 +118,8 @@ test("ACCOUNT-03 Sign-out switches to a new anonymous identity boundary", async 
   await expect(page.getByRole("heading", { level: 1, name: "Deck not found" })).toBeVisible();
   await expect(page.getByText(card.frontText, { exact: true })).toHaveCount(0);
   await page.goto(`/deck/${deck.id}/study`);
-  await expect(page.getByRole("heading", { level: 1, name: "Study session unavailable." })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "Study deck unavailable." })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Back to deck list" })).toBeFocused();
   const sessions = await page.evaluate(
     () => JSON.parse(localStorage.getItem("tango-study") ?? "{}").state?.sessionsByDeckId ?? {}
   );

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -9,6 +9,7 @@ import {
 } from "@playwright/test";
 
 import {
+  type FixtureAbsentCard,
   type FixtureCard,
   type FixtureCategory,
   type FixtureDeck,
@@ -24,6 +25,7 @@ import {
 } from "./yaml-fixture";
 
 export type {
+  FixtureAbsentCard,
   FixtureCard,
   FixtureCategory,
   FixtureDeck,
@@ -381,6 +383,7 @@ export interface E2EFixture {
   user: (logicalUid?: string) => FixtureUser;
   deck: (logicalId?: string) => FixtureDeck;
   card: (logicalId?: string) => FixtureCard;
+  absentCard: (logicalId?: string) => FixtureAbsentCard;
   session: (logicalDeckId?: string) => FixtureStudySession;
   uid: (logicalUid: string) => string;
   id: (logicalId: string) => string;
@@ -506,6 +509,7 @@ function createE2EFixture(
     user: (logicalUid) => requireLogicalValue(namespaced.users, "auth user", logicalUid),
     deck: (logicalId) => requireLogicalValue(namespaced.decks, "Deck", logicalId),
     card: (logicalId) => requireLogicalValue(namespaced.cards, "Card", logicalId),
+    absentCard: (logicalId) => requireLogicalValue(namespaced.absentCards, "absent Card", logicalId),
     session: (logicalDeckId) => requireLogicalValue(namespaced.sessions, "Study session", logicalDeckId),
     uid: namespaced.uid,
     id: namespaced.id,
@@ -560,6 +564,84 @@ export const setDocument = async (collection: FirestoreCollection, id: string, d
     body: JSON.stringify({ fields }),
   });
   if (!response.ok) throw new Error(`Firestore seed failed: ${response.status} ${await response.text()}`);
+};
+
+/** Creates a target-specific permission failure without disrupting the Card collection subscription. */
+export const seedForeignOwnedCard = async (id: string): Promise<void> => {
+  const uid = `e2e-foreign-${randomUUID()}`;
+  const deckId = `${id}-foreign-deck`;
+  await setDocument("deck", deckId, { id: deckId, uid, name: "Foreign E2E Deck", isPublic: false });
+  await setDocument("card", id, {
+    id,
+    uid,
+    deckId,
+    frontText: "Foreign E2E Card",
+    backText: "Foreign E2E answer",
+    uniqueKey: "foreign-e2e-card",
+    deletedAt: null,
+  });
+};
+
+export interface FirestoreListenGate {
+  waitUntilBlocked: () => Promise<void>;
+  release: () => void;
+  matchingRequestCount: () => number;
+  dispose: () => Promise<void>;
+}
+
+const decodeRequestPayload = (request: Request) => {
+  const encoded = `${request.url()}&${request.postData() ?? ""}`.replaceAll("+", "%20");
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+};
+
+/** Holds one exact-document Listen request so Retry pending behavior can be asserted without timing sleeps. */
+export const gateNextFirestoreDocumentListen = async (page: Page, cardId: string): Promise<FirestoreListenGate> => {
+  const pattern = "**/google.firestore.v1.Firestore/Listen/channel**";
+  const documentPath = `/documents/card/${cardId}`;
+  let matchingRequestCount = 0;
+  let released = false;
+  let resolveBlocked: () => void;
+  let resolveRelease: () => void;
+  const blocked = new Promise<void>((resolve) => {
+    resolveBlocked = resolve;
+  });
+  const release = new Promise<void>((resolve) => {
+    resolveRelease = resolve;
+  });
+  const handler = async (route: Route) => {
+    const request = route.request();
+    if (request.method() !== "POST" || !decodeRequestPayload(request).includes(documentPath)) {
+      await route.fallback();
+      return;
+    }
+
+    matchingRequestCount += 1;
+    if (matchingRequestCount === 1) {
+      resolveBlocked();
+      await release;
+    }
+    await route.fallback();
+  };
+  await page.route(pattern, handler);
+
+  const releaseRequest = () => {
+    if (released) return;
+    released = true;
+    resolveRelease();
+  };
+  return {
+    waitUntilBlocked: () => blocked,
+    release: releaseRequest,
+    matchingRequestCount: () => matchingRequestCount,
+    dispose: async () => {
+      releaseRequest();
+      await page.unroute(pattern, handler);
+    },
+  };
 };
 
 export const getDocument = async (

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -1,6 +1,17 @@
 import type { Page } from "@playwright/test";
 
-import { allowExpectedFirestoreWriteFailure, expect, failNextFirestoreWrite, readLocalData, test } from "./fixtures";
+import {
+  allowExpectedFirestoreWriteFailure,
+  expect,
+  failNextFirestoreWrite,
+  gateNextFirestoreDocumentListen,
+  getDocument,
+  readLocalData,
+  seedForeignOwnedCard,
+  seedStudySessions,
+  setDocument,
+  test,
+} from "./fixtures";
 import { progressOf, readProgress, readSession } from "./study-helpers";
 
 const cardAt = <T>(cards: readonly T[], index: number) => {
@@ -421,4 +432,161 @@ test("SWIPE-25 toggles and persists the Study Help button", async ({ fixture, pa
   await expect(page.getByRole("button", { name: "Open study help" })).toHaveCount(0);
   await page.getByRole("button", { name: "Open study actions" }).click();
   await expect(page.getByRole("button", { name: "Help button" })).toHaveAttribute("aria-pressed", "false");
+});
+
+test("SWIPE-27 explains missing and deleted remote targets before explicit Study recovery", async ({
+  fixture,
+  page,
+}) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  const missingTarget = fixture.absentCard("missing-card");
+  const tombstonedTarget = fixture.card("tombstoned-card");
+  await fixture.apply(page);
+  expect(await getDocument("card", missingTarget.id)).toBeUndefined();
+  expect((await getDocument("card", tombstonedTarget.id))?.fields.deletedAt?.integerValue).toBe("1");
+
+  await test.step("server-confirmed missing target", async () => {
+    const pendingVerification = await gateNextFirestoreDocumentListen(page, missingTarget.id);
+    await page.goto(`/deck/${deck.id}/study`);
+    await pendingVerification.waitUntilBlocked();
+
+    await expect(page.getByRole("heading", { name: "Verifying study session…" })).toBeVisible();
+    await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+    pendingVerification.release();
+
+    await expect(page.getByRole("heading", { name: "This study card is unavailable." })).toBeVisible();
+    await expect(page.getByRole("status").filter({ hasText: "This study card is unavailable." })).toBeVisible();
+    await expect(
+      page.getByText("The card could not be found. Return to study setup to continue with the available cards.")
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+    await expect(page.getByRole("button", { name: "Retry" })).toHaveCount(0);
+    const recover = page.getByRole("button", { name: "Back to study setup" });
+    await expect(recover).toBeFocused();
+    await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(0);
+
+    await recover.click();
+
+    await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/start$`));
+    await expect.poll(() => readSession(page, deck.id)).toBeUndefined();
+    await expect(page.getByRole("heading", { name: "Study complete" })).toHaveCount(0);
+    await pendingVerification.dispose();
+  });
+
+  await test.step("server-confirmed tombstoned target", async () => {
+    const tombstonedSession = { ...session, currentIndex: 1 };
+    await seedStudySessions(page, { [deck.id]: tombstonedSession }, [deck.name]);
+    await page.goto(`/deck/${deck.id}/study`);
+
+    await expect(page.getByRole("heading", { name: "This study card was deleted." })).toBeVisible();
+    await expect(page.getByRole("status").filter({ hasText: "This study card was deleted." })).toBeVisible();
+    await expect(page.getByText("Return to study setup to continue with the available cards.")).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+    await expect(page.getByRole("button", { name: "Retry" })).toHaveCount(0);
+    const recover = page.getByRole("button", { name: "Back to study setup" });
+    await expect(recover).toBeFocused();
+    await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(1);
+
+    await recover.click();
+
+    await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/start$`));
+    await expect.poll(() => readSession(page, deck.id)).toBeUndefined();
+    await expect(page.getByRole("heading", { name: "Study complete" })).toHaveCount(0);
+  });
+});
+
+test("SWIPE-28 preserves the remote session while Exit and one pending Retry recover the same Card", async ({
+  fixture,
+  page,
+}) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  const target = fixture.absentCard("missing-card");
+  const recoveredFront = "Recovered study card";
+  await fixture.apply(page);
+  await seedForeignOwnedCard(target.id);
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "We couldn’t verify this study card." })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("We couldn’t verify this study card.");
+  await expect(
+    page.getByText("The card might still be available. Retry, or exit without losing your place.")
+  ).toBeVisible();
+  const initialRetry = page.getByRole("button", { name: "Retry" });
+  await expect(initialRetry).toBeFocused();
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+
+  await page.getByRole("button", { name: "Exit" }).click();
+
+  await expect(page).toHaveURL(/\/$/u);
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+  await page.getByRole("button", { name: `Continue ${deck.name}` }).click();
+  await expect(page.getByRole("heading", { name: "We couldn’t verify this study card." })).toBeVisible();
+
+  const retryVerification = await gateNextFirestoreDocumentListen(page, target.id);
+  const retry = page.getByRole("button", { name: "Retry" });
+  await retry.click();
+  await retryVerification.waitUntilBlocked();
+
+  await expect(retry).toBeDisabled();
+  await expect(retry).toHaveAttribute("aria-busy", "true");
+  await expect(page.getByRole("status").filter({ hasText: "Loading Retry" })).toBeVisible();
+  await retry.evaluate((button: HTMLButtonElement) => button.click());
+  expect(retryVerification.matchingRequestCount()).toBe(1);
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+
+  await setDocument("card", target.id, {
+    id: target.id,
+    uid: fixture.user().uid,
+    deckId: deck.id,
+    frontText: recoveredFront,
+    backText: "Recovered answer",
+    tags: [],
+    uniqueKey: "recovered-study-card",
+    score: 0,
+    numberOfSeen: 0,
+    deletedAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+  });
+  retryVerification.release();
+
+  const recoveredCard = page.getByRole("button", { name: recoveredFront, exact: true });
+  await expect(recoveredCard).toBeVisible();
+  await expect(recoveredCard).toBeFocused();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+  await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex);
+  await expect(page.getByRole("heading", { name: "Study complete" })).toHaveCount(0);
+  expect(retryVerification.matchingRequestCount()).toBe(1);
+  await retryVerification.dispose();
+});
+
+test("SWIPE-29 explains a missing local target before explicit Study recovery", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const session = fixture.session();
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}/study`);
+
+  await expect(page.getByRole("heading", { name: "This local study card is missing." })).toBeVisible();
+  await expect(page.getByRole("status").filter({ hasText: "This local study card is missing." })).toBeVisible();
+  await expect(
+    page.getByText("The card is no longer stored on this device. Return to study setup to continue.")
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/study$`));
+  await expect(page.getByRole("button", { name: "Retry" })).toHaveCount(0);
+  const recover = page.getByRole("button", { name: "Back to study setup" });
+  await expect(recover).toBeFocused();
+  await expect.poll(async () => (await readSession(page, deck.id))?.sessionId).toBe(session.sessionId);
+
+  await recover.click();
+
+  await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/start$`));
+  await expect.poll(() => readSession(page, deck.id)).toBeUndefined();
+  await expect(page.getByRole("heading", { name: "Study complete" })).toHaveCount(0);
 });

--- a/test/e2e/yaml-fixture.ts
+++ b/test/e2e/yaml-fixture.ts
@@ -56,6 +56,12 @@ export interface FixtureCard {
   interval?: number;
 }
 
+export interface FixtureAbsentCard {
+  id: string;
+  deckId: string;
+  uid?: string;
+}
+
 export interface FixtureStudySession {
   sessionId: string;
   deckId: string;
@@ -99,11 +105,12 @@ export interface FixturePreferences {
 
 export interface FixtureState {
   auth: { users: FixtureUser[] };
-  remote: { decks: FixtureDeck[]; cards: FixtureCard[] };
+  remote: { decks: FixtureDeck[]; cards: FixtureCard[]; absentCards: FixtureAbsentCard[] };
   browser: {
     preferences: FixturePreferences;
     localDecks: FixtureDeck[];
     localCards: FixtureCard[];
+    absentCards: FixtureAbsentCard[];
     studySessions: Record<string, FixtureStudySession>;
   };
 }
@@ -120,6 +127,7 @@ export interface NamespacedFixture {
   users: ReadonlyMap<string, FixtureUser>;
   decks: ReadonlyMap<string, FixtureDeck>;
   cards: ReadonlyMap<string, FixtureCard>;
+  absentCards: ReadonlyMap<string, FixtureAbsentCard>;
   sessions: ReadonlyMap<string, FixtureStudySession>;
   uid: (logicalUid: string) => string;
   id: (logicalId: string) => string;
@@ -238,6 +246,17 @@ const localCardSchema = z.strictObject({
   ...cardStateFields,
 });
 
+const remoteAbsentCardSchema = z.strictObject({
+  id: nonEmptyString,
+  deckId: nonEmptyString,
+  uid: nonEmptyString,
+});
+
+const localAbsentCardSchema = z.strictObject({
+  id: nonEmptyString,
+  deckId: nonEmptyString,
+});
+
 const swipeActionSchema = z.enum([
   "DoNothing",
   "GoBack",
@@ -311,6 +330,7 @@ const fixtureDocumentSchema = z.strictObject({
     .strictObject({
       decks: z.array(remoteDeckSchema).optional(),
       cards: z.array(remoteCardSchema).optional(),
+      absentCards: z.array(remoteAbsentCardSchema).optional(),
     })
     .optional(),
   browser: z
@@ -318,6 +338,7 @@ const fixtureDocumentSchema = z.strictObject({
       preferences: preferencesSchema.optional(),
       localDecks: z.array(localDeckSchema).optional(),
       localCards: z.array(localCardSchema).optional(),
+      absentCards: z.array(localAbsentCardSchema).optional(),
       studySessions: z.record(nonEmptyString, studySessionSchema).optional(),
       sampleDeck: sampleDeckSchema.optional(),
     })
@@ -329,6 +350,8 @@ type RawRemoteDeck = z.infer<typeof remoteDeckSchema>;
 type RawLocalDeck = z.infer<typeof localDeckSchema>;
 type RawRemoteCard = z.infer<typeof remoteCardSchema>;
 type RawLocalCard = z.infer<typeof localCardSchema>;
+type RawRemoteAbsentCard = z.infer<typeof remoteAbsentCardSchema>;
+type RawLocalAbsentCard = z.infer<typeof localAbsentCardSchema>;
 type RawPreferences = z.infer<typeof preferencesSchema>;
 type RawUser = z.infer<typeof userSchema>;
 type RawStudySession = z.infer<typeof studySessionSchema>;
@@ -754,8 +777,10 @@ interface LogicalFixtureCollections {
   users: RawUser[];
   remoteDecks: RawRemoteDeck[];
   remoteCards: RawRemoteCard[];
+  remoteAbsentCards: RawRemoteAbsentCard[];
   localDecks: RawLocalDeck[];
   localCards: RawLocalCard[];
+  localAbsentCards: RawLocalAbsentCard[];
   studySessions: Record<string, RawStudySession>;
   sampleDeck: RawSampleDeck | undefined;
   sampleCards: RawSampleCard[];
@@ -773,8 +798,10 @@ const collectLogicalFixture = (document: FixtureDocument): LogicalFixtureCollect
   } = document;
   const remoteDecks = document.remote?.decks ?? [];
   const remoteCards = document.remote?.cards ?? [];
+  const remoteAbsentCards = document.remote?.absentCards ?? [];
   const localDecks = document.browser?.localDecks ?? [];
   const localCards = document.browser?.localCards ?? [];
+  const localAbsentCards = document.browser?.absentCards ?? [];
   const studySessions = document.browser?.studySessions ?? {};
   const sampleDeck = document.browser?.sampleDeck;
   const sampleCards = parseSampleCards(sampleDeck);
@@ -782,8 +809,10 @@ const collectLogicalFixture = (document: FixtureDocument): LogicalFixtureCollect
     users,
     remoteDecks,
     remoteCards,
+    remoteAbsentCards,
     localDecks,
     localCards,
+    localAbsentCards,
     studySessions,
     sampleDeck,
     sampleCards,
@@ -801,7 +830,12 @@ const validateUniqueLogicalIds = (fixture: LogicalFixtureCollections) => {
     [...fixture.remoteDecks, ...fixture.localDecks, ...sampleDecks].map(({ id: logicalId }) => logicalId),
     "Deck ID"
   );
-  const cardIds = [...fixture.remoteCards, ...fixture.localCards].map(({ id: logicalId }) => logicalId);
+  const cardIds = [
+    ...fixture.remoteCards,
+    ...fixture.remoteAbsentCards,
+    ...fixture.localCards,
+    ...fixture.localAbsentCards,
+  ].map(({ id: logicalId }) => logicalId);
   assertUnique(cardIds.concat(fixture.sampleCardIds), "Card ID");
   assertUnique(
     Object.values(fixture.studySessions).map(({ sessionId }) => sessionId),
@@ -813,8 +847,10 @@ const validateStableApplicationIds = (fixture: LogicalFixtureCollections) => {
   const ordinaryIds = [
     ...fixture.remoteDecks.map(({ id }) => id),
     ...fixture.remoteCards.map(({ id }) => id),
+    ...fixture.remoteAbsentCards.map(({ id }) => id),
     ...fixture.localDecks.map(({ id }) => id),
     ...fixture.localCards.map(({ id }) => id),
+    ...fixture.localAbsentCards.map(({ id }) => id),
     ...Object.values(fixture.studySessions).map(({ sessionId }) => sessionId),
   ];
   const reservedId = ordinaryIds.find(isStableApplicationId);
@@ -831,7 +867,7 @@ const validateRemoteReferences = (fixture: LogicalFixtureCollections) => {
   for (const deck of fixture.remoteDecks) {
     if (!userIds.has(deck.uid)) throw new Error(`Remote Deck ${deck.id} references unknown UID ${deck.uid}`);
   }
-  for (const card of fixture.remoteCards) {
+  for (const card of [...fixture.remoteCards, ...fixture.remoteAbsentCards]) {
     if (!userIds.has(card.uid)) throw new Error(`Remote Card ${card.id} references unknown UID ${card.uid}`);
     const deck = remoteDeckById.get(card.deckId);
     if (deck === undefined) throw new Error(`Remote Card ${card.id} references unknown remote Deck ${card.deckId}`);
@@ -847,7 +883,7 @@ const localDeckIds = (fixture: LogicalFixtureCollections) =>
 
 const validateLocalReferences = (fixture: LogicalFixtureCollections) => {
   const deckIds = localDeckIds(fixture);
-  for (const card of fixture.localCards) {
+  for (const card of [...fixture.localCards, ...fixture.localAbsentCards]) {
     if (!deckIds.has(card.deckId)) {
       throw new Error(`Local Card ${card.id} references unknown local Deck ${card.deckId}`);
     }
@@ -862,7 +898,9 @@ interface SessionCardReference {
 const buildCardLookup = (fixture: LogicalFixtureCollections) => {
   const cards: SessionCardReference[] = [
     ...fixture.remoteCards.map(({ id, deckId }) => ({ id, deckId })),
+    ...fixture.remoteAbsentCards.map(({ id, deckId }) => ({ id, deckId })),
     ...fixture.localCards.map(({ id, deckId }) => ({ id, deckId })),
+    ...fixture.localAbsentCards.map(({ id, deckId }) => ({ id, deckId })),
     ...fixture.sampleCardIds.map((id) => ({ id, deckId: "sample-v1" })),
   ];
   return new Map(cards.map((card) => [card.id, card]));
@@ -896,6 +934,13 @@ const validateStudySessions = (fixture: LogicalFixtureCollections) => {
   const cardById = buildCardLookup(fixture);
   for (const [key, session] of Object.entries(fixture.studySessions)) {
     validateSession(key, session, deckIds, cardById);
+  }
+
+  const referencedCardIds = new Set(Object.values(fixture.studySessions).flatMap(({ cardOrderIds }) => cardOrderIds));
+  for (const absentCard of [...fixture.remoteAbsentCards, ...fixture.localAbsentCards]) {
+    if (!referencedCardIds.has(absentCard.id)) {
+      throw new Error(`Absent Card ${absentCard.id} must be referenced by a Study session`);
+    }
   }
 };
 
@@ -986,11 +1031,30 @@ const normalizeRemoteCards = (
     normalizeCard(card, identifiers.idFor(card.id), identifiers.idFor(card.deckId), identifiers.uidFor(card.uid)),
   ]);
 
+const normalizeRemoteAbsentCards = (
+  cards: readonly RawRemoteAbsentCard[],
+  identifiers: FixtureIdentifierMappers
+): NormalizedCollection<FixtureAbsentCard> =>
+  buildNormalizedCollection(cards, (card) => [
+    card.id,
+    {
+      id: identifiers.idFor(card.id),
+      deckId: identifiers.idFor(card.deckId),
+      uid: identifiers.uidFor(card.uid),
+    },
+  ]);
+
 const normalizeLocalCards = (
   cards: readonly RawLocalCard[],
   idFor: FixtureIdentifierMappers["idFor"]
 ): NormalizedCollection<FixtureCard> =>
   buildNormalizedCollection(cards, (card) => [card.id, normalizeCard(card, idFor(card.id), idFor(card.deckId))]);
+
+const normalizeLocalAbsentCards = (
+  cards: readonly RawLocalAbsentCard[],
+  idFor: FixtureIdentifierMappers["idFor"]
+): NormalizedCollection<FixtureAbsentCard> =>
+  buildNormalizedCollection(cards, (card) => [card.id, { id: idFor(card.id), deckId: idFor(card.deckId) }]);
 
 const normalizeSampleDeck = (
   sampleDeck: RawSampleDeck | undefined,
@@ -1041,12 +1105,15 @@ const normalizeSessions = (
   };
 };
 
-const validateRuntimeIds = (
-  users: NormalizedCollection<FixtureUser>,
-  decks: NormalizedCollection<FixtureDeck>,
-  cards: NormalizedCollection<FixtureCard>,
-  sessions: NormalizedSessions
-) => {
+interface RuntimeFixtureCollections {
+  users: NormalizedCollection<FixtureUser>;
+  decks: NormalizedCollection<FixtureDeck>;
+  cards: NormalizedCollection<FixtureCard>;
+  absentCards: NormalizedCollection<FixtureAbsentCard>;
+  sessions: NormalizedSessions;
+}
+
+const validateRuntimeIds = ({ users, decks, cards, absentCards, sessions }: RuntimeFixtureCollections) => {
   assertUnique(
     users.values.map(({ uid: runtimeUid }) => runtimeUid),
     "runtime auth UID"
@@ -1056,7 +1123,7 @@ const validateRuntimeIds = (
     "runtime Deck ID"
   );
   assertUnique(
-    cards.values.map(({ id: runtimeId }) => runtimeId),
+    [...cards.values, ...absentCards.values].map(({ id: runtimeId }) => runtimeId),
     "runtime Card ID"
   );
   assertUnique(
@@ -1085,8 +1152,11 @@ export const namespaceFixture = (
     normalizeLocalCards(logical.localCards, identifiers.idFor),
     normalizeSampleCards(logical.sampleDeck, logical.sampleCards, identifiers.idFor)
   );
+  const remoteAbsentCards = normalizeRemoteAbsentCards(logical.remoteAbsentCards, identifiers);
+  const localAbsentCards = normalizeLocalAbsentCards(logical.localAbsentCards, identifiers.idFor);
+  const absentCards = mergeNormalizedCollections(remoteAbsentCards, localAbsentCards);
   const sessions = normalizeSessions(logical.studySessions, identifiers.idFor);
-  validateRuntimeIds(users, decks, cards, sessions);
+  validateRuntimeIds({ users, decks, cards, absentCards, sessions });
 
   const remoteDeckCount = logical.remoteDecks.length;
   const remoteCardCount = logical.remoteCards.length;
@@ -1097,17 +1167,20 @@ export const namespaceFixture = (
       remote: {
         decks: decks.values.slice(0, remoteDeckCount),
         cards: cards.values.slice(0, remoteCardCount),
+        absentCards: remoteAbsentCards.values,
       },
       browser: {
         preferences: normalizePreferences(document.browser?.preferences),
         localDecks: decks.values.slice(remoteDeckCount),
         localCards: cards.values.slice(remoteCardCount),
+        absentCards: localAbsentCards.values,
         studySessions: sessions.byDeckId,
       },
     },
     users: users.lookup,
     decks: decks.lookup,
     cards: cards.lookup,
+    absentCards: absentCards.lookup,
     sessions: sessions.lookup,
     uid: identifiers.uidFor,
     id: identifiers.idFor,

--- a/test/integration/firestore/rules.spec.ts
+++ b/test/integration/firestore/rules.spec.ts
@@ -4,7 +4,7 @@
  * "should create a deck", "should update a deck".
  */
 
-import { it, describe, beforeEach, beforeAll, afterAll } from "vitest";
+import { it, describe, beforeEach, beforeAll, afterAll, expect } from "vitest";
 import * as fs from "node:fs";
 import {
   assertFails,
@@ -12,12 +12,12 @@ import {
   initializeTestEnvironment,
   type RulesTestEnvironment,
 } from "@firebase/rules-unit-testing";
-import { setDoc, doc, getDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { collection, deleteDoc, doc, getDoc, getDocs, query, setDoc, updateDoc, where } from "firebase/firestore";
 import * as Uuid from "uuid";
 
 const uuid = Uuid.v4;
 
-describe("firestore/rule", () => {
+describe("SWIPE-27 SWIPE-28 firestore/rule", () => {
   let testEnv: RulesTestEnvironment;
 
   const createData = async (path: string, id: string, data: object) => {
@@ -85,6 +85,21 @@ describe("firestore/rule", () => {
         await assertSucceeds(getDoc(doc(db, "card", id)));
       });
 
+      it("should confirm that a card is missing", async () => {
+        const snapshot = await assertSucceeds(getDoc(doc(db, "card", uuid())));
+        expect(snapshot.exists()).toBe(false);
+      });
+
+      it("should keep card lists scoped to their owner", async () => {
+        const [ownedId, foreignId] = [uuid(), uuid()];
+        await createData("card", ownedId, { uid: "uid" });
+        await createData("card", foreignId, { uid: "other" });
+
+        const ownedCards = await assertSucceeds(getDocs(query(collection(db, "card"), where("uid", "==", "uid"))));
+        expect(ownedCards.docs.map(({ id }) => id)).toEqual([ownedId]);
+        await assertFails(getDocs(collection(db, "card")));
+      });
+
       it("should create a card", async () => {
         const [deckId, id] = [uuid(), uuid()];
         await createData("deck", deckId, { uid: "uid" });
@@ -145,10 +160,16 @@ describe("firestore/rule", () => {
     });
 
     describe("card", () => {
-      it("should not read a card", async () => {
-        const id = uuid();
-        await createData("card", id, { uid: "uid" });
-        await assertFails(getDoc(doc(db, "card", id)));
+      it("should not read another owner's private card", async () => {
+        const [deckId, cardId] = [uuid(), uuid()];
+        await createData("deck", deckId, { uid: "uid", isPublic: false });
+        await createData("card", cardId, { uid: "uid", deckId });
+        await assertFails(getDoc(doc(db, "card", cardId)));
+      });
+
+      it("should let an authenticated non-owner confirm that a card is missing", async () => {
+        const snapshot = await assertSucceeds(getDoc(doc(db, "card", uuid())));
+        expect(snapshot.exists()).toBe(false);
       });
 
       it("should read a public card", async () => {
@@ -220,6 +241,10 @@ describe("firestore/rule", () => {
         const id = uuid();
         await createData("card", id, { uid: "uid" });
         await assertFails(getDoc(doc(db, "card", id)));
+      });
+
+      it("should not confirm missing cards without authentication", async () => {
+        await assertFails(getDoc(doc(db, "card", uuid())));
       });
 
       it("should read a public card", async () => {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,8 +8,16 @@ import "@/test/initializeTestFirestore";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, fetchCardReads, mutateCards, subscribeCards } from "@/entities/card";
+import {
+  deleteCard,
+  editCard,
+  fetchCardReads,
+  fetchRemoteCardRead,
+  mutateCards,
+  subscribeCards,
+} from "@/entities/card";
 import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
+import { deleteCard as deleteRemoteCard } from "@/entities/card/api/firestore";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
 import { createCard, createDeck as createDeckFixture, createRemoteDeckInput } from "@/test/factories";
@@ -19,7 +27,7 @@ vi.mock("@/shared/firebase", async () => ({
   db: (await import("@/test/initializeTestFirestore")).testDb,
 }));
 
-describe("Query realtime subscriptions", () => {
+describe("SWIPE-27 SWIPE-28 Query realtime subscriptions", () => {
   beforeEach(() => {
     cardStore.setState({ remoteCards: [], localCards: [] });
     deckStore.setState({ remoteDecks: [], localDecks: [] });
@@ -51,6 +59,19 @@ describe("Query realtime subscriptions", () => {
     });
   });
 
+  it("confirms missing and tombstoned Card documents through a single server read", async () => {
+    const uid = "uid";
+    const deck = createDeckFixture({ id: crypto.randomUUID(), uid });
+    const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid });
+    await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
+
+    await expect(fetchRemoteCardRead(uid, crypto.randomUUID())).resolves.toEqual({ status: "missing" });
+
+    await mutateCards(uid, [{ kind: "create", card }]);
+    await deleteRemoteCard(uid, card);
+    await expect(fetchRemoteCardRead(uid, card.id)).resolves.toEqual({ status: "tombstoned" });
+  });
+
   it("delivers initial, update, and delete snapshots without a cursor", async () => {
     const uid = "uid";
     const errors: Error[] = [];
@@ -58,6 +79,8 @@ describe("Query realtime subscriptions", () => {
     const stopCards = subscribeCards(uid, (error) => errors.push(error));
 
     try {
+      await expect(fetchRemoteCardRead(uid, crypto.randomUUID())).resolves.toEqual({ status: "missing" });
+
       const deck = createDeckFixture({ id: crypto.randomUUID(), uid });
       const card = createCard({ id: crypto.randomUUID(), deckId: deck.id, uid });
       await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));


### PR DESCRIPTION
## Related issue

Fixes #953
Fixes #947

Parent: #208

Supersedes #1367

## Summary

- distinguish Study target verification, confirmed absence, tombstones, and transient failures without automatic redirects
- preserve resumable sessions while exposing accessible Retry, Exit, and setup recovery actions
- add exact persistence routing plus SWIPE-27/28/29 fixtures, specifications, and browser coverage

## Testing

- mise run check (706 unit tests)
- focused Firestore integration tests (36 tests)
- mise run e2e (81 browser tests)