### PR TITLE
[No issue] Simplify failed deck creation

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -69,7 +69,7 @@
 | DECK-07 | batch | [local-only Deck と Card を remote へ移行できる](./deck-transfer.md#deck-07) |
 | DECK-08 | read | [Deck の Card を CSV で export できる](./deck-transfer.md#deck-08) |
 | DECK-09 | write | [空の remote Deck を作成して reload 後も確認できる](./deck-management.md#deck-09) |
-| DECK-10 | write | [remote Deck の作成失敗後に重複なく再試行できる](./deck-management.md#deck-10) |
+| DECK-10 | write | [remote Deck の作成失敗を通知できる](./deck-management.md#deck-10) |
 | DECK-11 | write | [空の local-only Deck を作成して reload 後も確認できる](./deck-management.md#deck-11) |
 | DECK-12 | read | [未保存の Deck 編集内容を離脱前に確認できる](./deck-management.md#deck-12) |
 

--- a/docs/e2e/deck-management.md
+++ b/docs/e2e/deck-management.md
@@ -13,7 +13,7 @@ Deck の作成・編集・削除が保存先の境界を守り、失敗後の再
 | DECK-04 | read | [Deck の削除を取り消せる](#deck-04) |
 | DECK-05 | batch | [Deck の削除失敗後に再試行できる](#deck-05) |
 | DECK-09 | write | [空の remote Deck を作成して reload 後も確認できる](#deck-09) |
-| DECK-10 | write | [remote Deck の作成失敗後に重複なく再試行できる](#deck-10) |
+| DECK-10 | write | [remote Deck の作成失敗を通知できる](#deck-10) |
 | DECK-11 | write | [空の local-only Deck を作成して reload 後も確認できる](#deck-11) |
 | DECK-12 | read | [未保存の Deck 編集内容を離脱前に確認できる](#deck-12) |
 
@@ -141,7 +141,7 @@ Then:
 
 <a id="deck-10"></a>
 
-### DECK-10 remote Deck の作成失敗後に重複なく再試行できる
+### DECK-10 remote Deck の作成失敗を通知できる
 
 カテゴリ: `write`
 
@@ -149,21 +149,19 @@ Given:
 
 - Fixture: [`empty`](./fixture/empty.yaml)
 - ユーザーとして認証されている。
-- remote Deck の最初の作成要求が失敗している。
-- 作成失敗が共通 toast で処理され、入力した name と category、remote の保存先、作成対象の Deck ID が維持されている。
-- 次の作成要求は成功できる。
+- remote Deck の作成要求が失敗する。
 
 When:
 
-- 入力と保存先を変更せずに同じ Deck の作成を再試行し、Deck 一覧を reload する。
+- Deck の作成画面で name、category、source URL、改行変換を入力し、local-only を無効にして保存する。
 
 Then:
 
-- Deck の作成成功が共通 toast で表示され、失敗 toast は残らない。
-- 維持されていた Deck ID の Deck が現在の UID の remote data に一つだけ存在する。
-- 作成した Deck の name、category、remote の保存先が最初の作成要求から維持されている。
-- browser storage に同じ Deck の local-only duplicate が存在しない。
-- 最初の作成失敗に伴う未処理の browser error が発生しない。
+- Deck の作成失敗が共通 toast で表示される。
+- 入力した内容がフォームに残っている。
+- local-only の選択を変更できる。
+- remote data と browser storage に Deck が作成されていない。
+- 作成失敗に伴う未処理の browser error が発生しない。
 
 <a id="deck-11"></a>
 

--- a/src/pages/deck-create/model/useDeckCreateForm.ts
+++ b/src/pages/deck-create/model/useDeckCreateForm.ts
@@ -22,10 +22,7 @@ const dismissOwnedToast = (toastId: React.RefObject<ToastId | undefined>) => {
 
 export const useDeckCreateForm = ({ onCreated }: UseDeckCreateFormOptions) => {
   const uid = useAuthUid();
-  // A failed response may hide a successful write, so retries must reuse this Deck identity.
-  const [deckId] = React.useState(generateDeckId);
   const isMounted = useMountedGuard();
-  const [hasSaveError, setHasSaveError] = React.useState(false);
   const saveErrorToastId = React.useRef<ToastId | undefined>(undefined);
   const form = useForm<DeckFormFields>({
     defaultValues: { name: "", category: "", convertToBr: false, localMode: false },
@@ -38,7 +35,7 @@ export const useDeckCreateForm = ({ onCreated }: UseDeckCreateFormOptions) => {
 
   const submit = async (values: DeckFormFields) => {
     dismissSaveError();
-    setHasSaveError(false);
+    const deckId = generateDeckId();
     try {
       const deck = {
         id: deckId,
@@ -55,8 +52,7 @@ export const useDeckCreateForm = ({ onCreated }: UseDeckCreateFormOptions) => {
       }
     } catch {
       if (isMounted()) {
-        setHasSaveError(true);
-        saveErrorToastId.current = showToast({ message: "Unable to create this deck. Try again.", tone: "error" });
+        saveErrorToastId.current = showToast({ message: "Unable to create this deck.", tone: "error" });
       }
     }
   };
@@ -64,15 +60,12 @@ export const useDeckCreateForm = ({ onCreated }: UseDeckCreateFormOptions) => {
     void form.handleSubmit(submit)(event);
   };
 
-  // A retry must keep using react-hook-form's original persistence mode after a failed write.
-  const isLocalModeLocked = form.formState.isSubmitting || hasSaveError;
-
   return {
     categories: CATEGORY,
     dismissSaveError,
     form,
     isDirty: form.formState.isDirty,
-    isLocalModeLocked,
+    isLocalModeLocked: form.formState.isSubmitting,
     onSubmit: onFormSubmit,
   };
 };

--- a/src/pages/deck-create/ui/DeckCreatePage.spec.tsx
+++ b/src/pages/deck-create/ui/DeckCreatePage.spec.tsx
@@ -129,43 +129,38 @@ describe("DECK-09 DECK-10 DECK-11 DeckCreatePage", () => {
     });
   });
 
-  it("keeps entered values, Deck ID, and persistence mode across retries", async () => {
+  it("reports a creation failure without locking the form for a special retry flow", async () => {
     mocks.createDeck.mockRejectedValueOnce(new Error("write failed"));
     renderPage();
     const name = screen.getByRole("textbox", { name: "Name" });
+    const category = screen.getByRole("combobox");
     const sourceUrl = screen.getByRole("textbox", { name: "Source URL" });
     const convertLineBreaks = screen.getByRole("checkbox", { name: "Convert line breaks" });
 
-    await userEvent.type(name, "Retry deck");
-    await userEvent.type(sourceUrl, "https://example.com/retry.csv");
+    await userEvent.type(name, "Failed deck");
+    await userEvent.selectOptions(category, "typescript");
+    await userEvent.type(sourceUrl, "https://example.com/failed.csv");
     await userEvent.click(convertLineBreaks);
     await userEvent.click(screen.getByRole("button", { name: "Create deck" }));
 
-    expect(await screen.findByText("Unable to create this deck. Try again.")).toBeVisible();
-    expect(name).toHaveValue("Retry deck");
-    expect(sourceUrl).toHaveValue("https://example.com/retry.csv");
+    expect(await screen.findByText("Unable to create this deck.")).toBeVisible();
+    expect(name).toHaveValue("Failed deck");
+    expect(category).toHaveValue("typescript");
+    expect(sourceUrl).toHaveValue("https://example.com/failed.csv");
     expect(convertLineBreaks).toBeChecked();
     const localMode = screen.getByRole("checkbox", { name: "Local only" });
-    expect(localMode).toBeDisabled();
+    expect(localMode).toBeEnabled();
     expect(localMode).not.toBeChecked();
-    await userEvent.click(screen.getByRole("button", { name: "Create deck" }));
-    expect(mocks.createDeck).toHaveBeenCalledTimes(2);
+    await userEvent.click(localMode);
+    expect(localMode).toBeChecked();
     expect(mocks.generateDeckId).toHaveBeenCalledOnce();
-    expect(mocks.createDeck).toHaveBeenNthCalledWith(1, "user-id", {
+    expect(mocks.createDeck).toHaveBeenCalledExactlyOnceWith("user-id", {
       id: "new-deck",
       localMode: false,
-      name: "Retry deck",
-      category: "",
+      name: "Failed deck",
+      category: "typescript",
       convertToBr: true,
-      url: "https://example.com/retry.csv",
-    });
-    expect(mocks.createDeck).toHaveBeenNthCalledWith(2, "user-id", {
-      id: "new-deck",
-      localMode: false,
-      name: "Retry deck",
-      category: "",
-      convertToBr: true,
-      url: "https://example.com/retry.csv",
+      url: "https://example.com/failed.csv",
     });
   });
 
@@ -175,11 +170,11 @@ describe("DECK-09 DECK-10 DECK-11 DeckCreatePage", () => {
 
     await userEvent.type(screen.getByRole("textbox", { name: "Name" }), "Cancelled deck");
     await userEvent.click(screen.getByRole("button", { name: "Create deck" }));
-    expect(await screen.findByText("Unable to create this deck. Try again.")).toBeVisible();
+    expect(await screen.findByText("Unable to create this deck.")).toBeVisible();
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.queryByText("Unable to create this deck. Try again.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unable to create this deck.")).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Discard changes" }));
     expect(await screen.findByRole("heading", { name: "Deck list destination" })).toBeVisible();
   });

--- a/test/e2e/deck.spec.ts
+++ b/test/e2e/deck.spec.ts
@@ -17,6 +17,7 @@ const openDeckDeleteDialog = async (page: Page, deckName: string) => {
   return page.getByRole("alertdialog", { name: "Delete deck?" });
 };
 
+// Click the visible Switch label because the Firebase emulator banner can intercept pointer events on its sr-only input.
 const clickCheckboxLabel = async (page: Page, name: string) => {
   const checkbox = page.getByRole("checkbox", { name, exact: true });
   await checkbox.locator("xpath=parent::label").click();
@@ -258,7 +259,7 @@ test("DECK-10 reports a failed remote create without locking the form", async ({
   await page.getByRole("textbox", { name: "Name" }).fill(name);
   await page.getByRole("combobox").selectOption(category);
   await page.getByRole("textbox", { name: "Source URL" }).fill(sourceUrl);
-  await page.getByRole("checkbox", { name: "Convert line breaks" }).check();
+  await clickCheckboxLabel(page, "Convert line breaks");
   await page.getByRole("button", { name: "Create deck" }).click();
   await expect(page.getByRole("alert")).toContainText("Unable to create this deck.");
   await expect.poll(fault.wasTriggered).toBe(true);
@@ -271,7 +272,7 @@ test("DECK-10 reports a failed remote create without locking the form", async ({
   await expect(page.getByRole("checkbox", { name: "Convert line breaks" })).toBeChecked();
   const localMode = page.getByRole("checkbox", { name: "Local only" });
   await expect(localMode).toBeEnabled();
-  await localMode.check();
+  await clickCheckboxLabel(page, "Local only");
   await expect(localMode).toBeChecked();
 
   const remote = await listDocuments("deck");

--- a/test/e2e/deck.spec.ts
+++ b/test/e2e/deck.spec.ts
@@ -240,57 +240,46 @@ test("DECK-09 creates one empty remote Deck without a local duplicate", async ({
   expect(local.cards).toEqual([]);
 });
 
-test("DECK-10 retries a failed remote create with the same ID and no duplicate", async ({
+test("DECK-10 reports a failed remote create without locking the form", async ({
   fixture,
   page,
   browserErrors,
   namespace,
 }) => {
-  const name = `${namespace.caseId} retry deck`;
+  const name = `${namespace.caseId} failed deck`;
   const category = "typescript";
+  const sourceUrl = "https://example.com/failed.csv";
   const { uid } = fixture.user();
   await fixture.apply(page);
   await page.goto("/");
   await page.getByRole("button", { name: "Create deck" }).click();
-  let attemptedDeckId: string | undefined;
-  page.on("request", (request) => {
-    if (!request.url().includes("google.firestore.v1.Firestore/Write/channel")) return;
-    const body = decodeURIComponent((request.postData() ?? "").replaceAll("+", "%20"));
-    attemptedDeckId ??= /\/documents\/deck\/([a-zA-Z0-9-]+)/.exec(body)?.[1];
-  });
   const fault = await failNextFirestoreWrite(page, { collection: "deck" });
   allowExpectedFirestoreWriteFailure(browserErrors);
   await page.getByRole("textbox", { name: "Name" }).fill(name);
   await page.getByRole("combobox").selectOption(category);
+  await page.getByRole("textbox", { name: "Source URL" }).fill(sourceUrl);
+  await page.getByRole("checkbox", { name: "Convert line breaks" }).check();
   await page.getByRole("button", { name: "Create deck" }).click();
-  await expect(page.getByRole("alert")).toContainText("Unable to create this deck. Try again.");
+  await expect(page.getByRole("alert")).toContainText("Unable to create this deck.");
   await expect.poll(fault.wasTriggered).toBe(true);
   await fault.waitForFailure();
   await fault.dispose();
-  expect(attemptedDeckId).toBeDefined();
 
   await expect(page.getByRole("textbox", { name: "Name" })).toHaveValue(name);
   await expect(page.getByRole("combobox")).toHaveValue(category);
-  await expect(page.getByRole("checkbox", { name: "Local only" })).not.toBeChecked();
-  await page.getByRole("button", { name: "Create deck" }).click();
-  await expect(page).toHaveURL(/\/deck\/(?!new$)[^/]+$/);
-  await expect(page.getByRole("alert")).toHaveCount(0);
-  await expect(page.getByRole("status").filter({ hasText: `Created deck “${name}”.` })).toBeVisible();
-  const deckId = new URL(page.url()).pathname.split("/").at(-1);
-  if (deckId === undefined) throw new Error("Created Deck ID is missing");
-  expect(deckId).toBe(attemptedDeckId);
+  await expect(page.getByRole("textbox", { name: "Source URL" })).toHaveValue(sourceUrl);
+  await expect(page.getByRole("checkbox", { name: "Convert line breaks" })).toBeChecked();
+  const localMode = page.getByRole("checkbox", { name: "Local only" });
+  await expect(localMode).toBeEnabled();
+  await localMode.check();
+  await expect(localMode).toBeChecked();
 
-  await page.goto("/");
-  await page.reload();
-  const deckArticle = page.getByRole("button", { name: `View ${name}` }).locator("xpath=ancestor::article[1]");
-  await expect(deckArticle).toContainText(category);
   const remote = await listDocuments("deck");
   const owned = remote.filter(
     ({ fields }) =>
       fields.uid?.stringValue === uid && (fields.name as { stringValue?: string } | undefined)?.stringValue === name
   );
-  expect(owned.map(documentId)).toEqual([deckId]);
-  expect(owned.map(({ fields }) => fields.category?.stringValue)).toEqual([category]);
+  expect(owned).toEqual([]);
   const local = await readLocalData(page);
   expect(local.decks).toEqual([]);
   expect(local.cards).toEqual([]);


### PR DESCRIPTION
## Related issue

None.

## Summary

- remove retry-specific Deck ID retention and storage-mode locking after failed creation
- keep the form editable and show a concise failure toast
- update DECK-10 specifications and tests for the simplified failure flow

## Testing

- `mise run check` (116 test files, 681 tests passed)
- mandatory reviewer subagent: no findings
- Playwright DECK-10 runtime test not run