### PR TITLE
[No issue] Simplify stale branch and worktree cleanup

### DIFF
--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 cutoff=$(($(date +%s) - 7 * 24 * 60 * 60))
 current_worktree=$(git rev-parse --show-toplevel)
+git fetch origin --prune
 open_pr_branches=$(gh api --paginate 'repos/{owner}/{repo}/pulls?state=open&per_page=100' --jq '.[].head.ref')
 
 has_open_pr() {
@@ -72,5 +73,18 @@ while IFS=$'\t' read -r timestamp branch; do
     failed=1
   fi
 done < <(git for-each-ref --format='%(committerdate:unix)%09%(refname:lstrip=2)' refs/heads)
+
+while IFS=$'\t' read -r timestamp tip branch; do
+  if [[ "$branch" == HEAD || "$branch" == main ]] || has_open_pr "$branch" ||
+    is_checked_out "$branch" || ((timestamp > cutoff)); then
+    continue
+  fi
+
+  if git push --force-with-lease="refs/heads/$branch:$tip" origin --delete "refs/heads/$branch"; then
+    printf 'Removed stale remote branch: %s\n' "$branch"
+  else
+    failed=1
+  fi
+done < <(git for-each-ref --format='%(committerdate:unix)%09%(objectname)%09%(refname:lstrip=3)' refs/remotes/origin)
 
 exit "$failed"

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -2,11 +2,7 @@
 set -euo pipefail
 
 run_branch_delete_guard() {
-  local transaction_state=${1:-}
-  local expected_ref=${CLEANUP_EXPECTED_REF:?}
-  local expected_tip=${CLEANUP_EXPECTED_TIP:?}
-  local rejected_marker=${CLEANUP_REJECTED_MARKER:?}
-  local invoked_marker=${CLEANUP_GUARD_INVOKED_MARKER:?}
+  local state=${1:-}
   local old_oid=""
   local new_oid=""
   local ref_name=""
@@ -14,43 +10,24 @@ run_branch_delete_guard() {
   local unexpected=""
   local actual_tip
 
-  case $transaction_state in
+  case $state in
     preparing | prepared) ;;
     *) return 0 ;;
   esac
 
-  if ! : >"$invoked_marker"; then
-    printf 'Failed to record branch deletion guard state\n' >&2
-    return 1
-  fi
-
+  : >"${CLEANUP_GUARD_INVOKED_MARKER:?}"
   if ! IFS=' ' read -r old_oid new_oid ref_name extra || IFS= read -r unexpected; then
-    printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
     return 1
   fi
-  if [[ -n "$extra" || "$ref_name" != "$expected_ref" ]] ||
-    [[ ${#old_oid} -ne ${#expected_tip} || ${#new_oid} -ne ${#expected_tip} ]]; then
-    printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
+  if [[ -n "$extra" || "$ref_name" != "${CLEANUP_EXPECTED_REF:?}" ]] ||
+    [[ -z "$new_oid" || "$new_oid" == *[!0]* ]]; then
     return 1
   fi
-  case $old_oid in
-    '' | *[!0]*)
-      printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
-      return 1
-      ;;
-  esac
-  case $new_oid in
-    '' | *[!0]*)
-      printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
-      return 1
-      ;;
-  esac
 
-  if [[ "$transaction_state" == prepared ]]; then
-    if ! actual_tip=$(git rev-parse --verify "$expected_ref" 2>/dev/null) || [[ "$actual_tip" != "$expected_tip" ]]; then
-      if ! : >"$rejected_marker"; then
-        printf 'Failed to record a concurrent branch update for %s\n' "$expected_ref" >&2
-      fi
+  if [[ "$state" == prepared ]]; then
+    if ! actual_tip=$(git rev-parse --verify "$CLEANUP_EXPECTED_REF" 2>/dev/null) ||
+      [[ "$actual_tip" != "${CLEANUP_EXPECTED_TIP:?}" ]]; then
+      : >"${CLEANUP_REJECTED_MARKER:?}"
       return 1
     fi
   fi
@@ -75,7 +52,6 @@ fi
 current_worktree=${current_worktree%x}
 current_worktree=${current_worktree%$'\n'}
 
-stale_after_seconds=$((7 * 24 * 60 * 60))
 if ! current_time=$(date +%s); then
   printf 'Failed to read the current time\n' >&2
   exit 1
@@ -86,7 +62,7 @@ case $current_time in
     exit 1
     ;;
 esac
-stale_cutoff=$((current_time - stale_after_seconds))
+stale_cutoff=$((current_time - 7 * 24 * 60 * 60))
 
 temp_dir=$(mktemp -d /tmp/cleanup-branches.XXXXXX)
 remove_temp_dir() {
@@ -94,19 +70,21 @@ remove_temp_dir() {
 }
 trap remove_temp_dir EXIT
 
+open_pr_file=$temp_dir/open-prs
 worktree_list_file=$temp_dir/worktrees
 branch_list_file=$temp_dir/branches
-checkout_activity_file=$temp_dir/checkout-activity
-live_checkout_activity_file=$temp_dir/live-checkout-activity
-checkout_worktree_list_file=$temp_dir/checkout-worktrees
-head_reflog_file=$temp_dir/head-reflog
 git_config_names_file=$temp_dir/git-config-names
 branch_delete_error_file=$temp_dir/branch-delete-error
 branch_delete_rejected_marker=$temp_dir/branch-delete-rejected
 branch_delete_guard_invoked_marker=$temp_dir/branch-delete-guard-invoked
 branch_delete_guard_path=$temp_dir/branch-delete-guard
 branch_delete_guard_name=cleanup-branch-guard-$$-$RANDOM
-: >"$live_checkout_activity_file"
+
+if ! gh api --paginate 'repos/{owner}/{repo}/pulls?state=open&per_page=100' \
+  --jq '.[] | [.head.ref, .head.sha] | @tsv' >"$open_pr_file"; then
+  printf 'Failed to list open pull requests\n' >&2
+  exit 1
+fi
 
 script_source=$0
 if [[ "$script_source" != */* ]]; then
@@ -121,9 +99,8 @@ if ! script_directory=$(cd -- "$script_directory" && pwd -P); then
   printf 'Failed to locate the cleanup script\n' >&2
   exit 1
 fi
-script_path=$script_directory/$script_name
-if [[ ! -x "$script_path" ]] || ! ln -s -- "$script_path" "$branch_delete_guard_path"; then
-  printf 'Failed to prepare the branch deletion guard\n' >&2
+if ! ln -s -- "$script_directory/$script_name" "$branch_delete_guard_path"; then
+  printf 'Failed to prepare guarded branch deletion\n' >&2
   exit 1
 fi
 
@@ -133,203 +110,82 @@ if ! git help --config >"$git_config_names_file" ||
   branch_delete_guard_supported=0
 fi
 
-# Reflog time records local ref movement, unlike a commit date that may predate a newly created branch.
-reflog_selector_timestamp() {
-  local selector=$1
-  local timestamp
+branch_has_open_pr() {
+  local branch=$1
+  local pr_branch
+  local pr_tip
 
-  timestamp=${selector##*@\{}
-  if [[ "$timestamp" == "$selector" || "$timestamp" != *\} ]]; then
-    return 1
-  fi
-  timestamp=${timestamp%\}}
-  case $timestamp in
-    '' | *[!0-9]*) return 1 ;;
-  esac
-
-  printf '%s\n' "$timestamp"
+  while IFS=$'\t' read -r pr_branch pr_tip; do
+    [[ "$pr_branch" == "$branch" ]] && return 0
+  done <"$open_pr_file"
+  return 1
 }
 
-last_reflog_update() {
+tip_has_open_pr() {
+  local tip=$1
+  local pr_branch
+  local pr_tip
+
+  while IFS=$'\t' read -r pr_branch pr_tip; do
+    [[ "$pr_tip" == "$tip" ]] && return 0
+  done <"$open_pr_file"
+  return 1
+}
+
+commit_time() {
   local repository_path=$1
   local ref=$2
-  local selector
-
-  if ! selector=$(git -C "$repository_path" reflog show -1 --date=unix --format='%gD' "$ref" 2>/dev/null); then
-    return 1
-  fi
-
-  reflog_selector_timestamp "$selector"
-}
-
-reflog_metadata_timestamp() {
-  local metadata=$1
-  local without_timezone
   local timestamp
 
-  without_timezone=${metadata% *}
-  if [[ "$without_timezone" == "$metadata" ]]; then
+  if ! timestamp=$(git -C "$repository_path" log -1 --format=%ct "$ref" 2>/dev/null); then
     return 1
   fi
-  timestamp=${without_timezone##* }
   case $timestamp in
     '' | *[!0-9]*) return 1 ;;
   esac
 
   printf '%s\n' "$timestamp"
-}
-
-worktree_head_log_path() {
-  local worktree=$1
-  local head_log
-
-  if ! head_log=$(git -C "$worktree" rev-parse --path-format=absolute --git-path logs/HEAD 2>/dev/null); then
-    return 1
-  fi
-  if [[ -z "$head_log" || ! -f "$head_log" || ! -r "$head_log" || ! -s "$head_log" ]]; then
-    return 1
-  fi
-
-  printf '%s\n' "$head_log"
-}
-
-worktree_head_last_update() {
-  local worktree=$1
-  local head_log
-  local last_entry
-  local metadata
-
-  if ! head_log=$(worktree_head_log_path "$worktree") || ! last_entry=$(tail -n 1 -- "$head_log"); then
-    return 1
-  fi
-  metadata=${last_entry%%$'\t'*}
-
-  reflog_metadata_timestamp "$metadata"
-}
-
-append_worktree_checkout_activity() {
-  local worktree=$1
-  local output_file=$2
-  local head_log
-  local metadata
-  local subject
-  local timestamp
-  local transition
-  local checkout_from
-  local checkout_to
-
-  if ! head_log=$(worktree_head_log_path "$worktree") || ! cp -- "$head_log" "$head_reflog_file"; then
-    printf 'Failed to read worktree checkout history: %s\n' "$worktree" >&2
-    return 1
-  fi
-
-  while IFS=$'\t' read -r metadata subject; do
-    case $subject in
-      checkout:\ moving\ from\ *\ to\ *)
-        if ! timestamp=$(reflog_metadata_timestamp "$metadata"); then
-          printf 'Failed to read worktree checkout history: %s\n' "$worktree" >&2
-          return 1
-        fi
-        transition=${subject#checkout: moving from }
-        checkout_from=${transition%% to *}
-        checkout_to=${transition#* to }
-        if [[ -n "$checkout_from" ]] && ! printf '%s\t%s\n' "$timestamp" "$checkout_from" >>"$output_file"; then
-          printf 'Failed to record worktree checkout history: %s\n' "$worktree" >&2
-          return 1
-        fi
-        if [[ -n "$checkout_to" ]] && ! printf '%s\t%s\n' "$timestamp" "$checkout_to" >>"$output_file"; then
-          printf 'Failed to record worktree checkout history: %s\n' "$worktree" >&2
-          return 1
-        fi
-        ;;
-    esac
-  done <"$head_reflog_file"
-}
-
-snapshot_checkout_activity() {
-  local output_file=$1
-  local field
-  local record_path=""
-  local snapshot_failed=0
-
-  if ! : >"$output_file"; then
-    printf 'Failed to prepare worktree checkout history\n' >&2
-    return 1
-  fi
-  if ! git worktree list --porcelain -z >"$checkout_worktree_list_file"; then
-    printf 'Failed to list worktrees while reading checkout history\n' >&2
-    return 1
-  fi
-
-  while IFS= read -r -d '' field; do
-    if [[ -z "$field" ]]; then
-      if [[ -n "$record_path" ]] && ! append_worktree_checkout_activity "$record_path" "$output_file"; then
-        snapshot_failed=1
-      fi
-      record_path=""
-    elif [[ "$field" == "worktree "* ]]; then
-      record_path=${field#worktree }
-    fi
-  done <"$checkout_worktree_list_file"
-
-  if [[ -n "$record_path" ]] && ! append_worktree_checkout_activity "$record_path" "$output_file"; then
-    snapshot_failed=1
-  fi
-
-  ((snapshot_failed == 0))
-}
-
-branch_last_update() {
-  local branch=$1
-  local branch_timestamp
-  local checkout_timestamp
-  local checkout_branch
-
-  if ! branch_timestamp=$(last_reflog_update "$current_worktree" "refs/heads/$branch"); then
-    return 1
-  fi
-
-  while IFS=$'\t' read -r checkout_timestamp checkout_branch; do
-    if [[ "$checkout_branch" == "$branch" ]] && ((checkout_timestamp > branch_timestamp)); then
-      branch_timestamp=$checkout_timestamp
-    fi
-  done <"$checkout_activity_file"
-  while IFS=$'\t' read -r checkout_timestamp checkout_branch; do
-    if [[ "$checkout_branch" == "$branch" ]] && ((checkout_timestamp > branch_timestamp)); then
-      branch_timestamp=$checkout_timestamp
-    fi
-  done <"$live_checkout_activity_file"
-
-  printf '%s\n' "$branch_timestamp"
-}
-
-worktree_last_update() {
-  local worktree=$1
-  local branch=$2
-  local head_timestamp
-  local branch_timestamp
-
-  if ! head_timestamp=$(worktree_head_last_update "$worktree"); then
-    return 1
-  fi
-
-  # A recent checkout only updates the worktree HEAD, while a branch update may not touch that HEAD log.
-  if [[ -n "$branch" ]]; then
-    if ! branch_timestamp=$(last_reflog_update "$current_worktree" "refs/heads/$branch"); then
-      return 1
-    fi
-    if ((branch_timestamp > head_timestamp)); then
-      head_timestamp=$branch_timestamp
-    fi
-  fi
-
-  printf '%s\n' "$head_timestamp"
 }
 
 timestamp_is_stale() {
   local timestamp=$1
 
   ((timestamp <= stale_cutoff))
+}
+
+branch_is_checked_out() {
+  local branch=$1
+  local worktrees
+
+  if ! worktrees=$(git worktree list --porcelain); then
+    return 2
+  fi
+
+  grep -Fqx "branch refs/heads/$branch" <<<"$worktrees"
+}
+
+delete_branch_with_expected_tip() {
+  local branch=$1
+  local expected_tip=$2
+
+  if ! rm -f -- "$branch_delete_error_file" "$branch_delete_rejected_marker" "$branch_delete_guard_invoked_marker"; then
+    return 2
+  fi
+  if CLEANUP_BRANCH_DELETE_GUARD=1 \
+    CLEANUP_EXPECTED_REF="refs/heads/$branch" \
+    CLEANUP_EXPECTED_TIP="$expected_tip" \
+    CLEANUP_REJECTED_MARKER="$branch_delete_rejected_marker" \
+    CLEANUP_GUARD_INVOKED_MARKER="$branch_delete_guard_invoked_marker" \
+    git \
+      -c "hook.$branch_delete_guard_name.event=reference-transaction" \
+      -c "hook.$branch_delete_guard_name.command=$branch_delete_guard_path" \
+      branch -D -- "$branch" 2>"$branch_delete_error_file"; then
+    [[ -f "$branch_delete_guard_invoked_marker" ]] || return 2
+    return 0
+  fi
+
+  [[ -f "$branch_delete_rejected_marker" ]] && return 10
+  return 2
 }
 
 worktree_paths=()
@@ -369,55 +225,6 @@ done <"$worktree_list_file"
 removed_worktrees=0
 removed_branches=0
 failed=0
-checkout_activity_complete=1
-
-# Checkout does not move a branch ref, so preserve HEAD history before removing worktrees that own it.
-if ! snapshot_checkout_activity "$checkout_activity_file"; then
-  checkout_activity_complete=0
-  failed=1
-fi
-
-branch_is_checked_out() {
-  local branch=$1
-  local worktrees
-
-  if ! worktrees=$(git worktree list --porcelain); then
-    return 2
-  fi
-
-  grep -Fqx "branch refs/heads/$branch" <<<"$worktrees"
-}
-
-delete_branch_with_expected_tip() {
-  local branch=$1
-  local expected_tip=$2
-
-  if ! rm -f -- "$branch_delete_error_file" "$branch_delete_rejected_marker" "$branch_delete_guard_invoked_marker"; then
-    printf 'Failed to prepare guarded branch deletion: %s\n' "$branch" >&2
-    return 2
-  fi
-
-  if CLEANUP_BRANCH_DELETE_GUARD=1 \
-    CLEANUP_EXPECTED_REF="refs/heads/$branch" \
-    CLEANUP_EXPECTED_TIP="$expected_tip" \
-    CLEANUP_REJECTED_MARKER="$branch_delete_rejected_marker" \
-    CLEANUP_GUARD_INVOKED_MARKER="$branch_delete_guard_invoked_marker" \
-    git \
-      -c "hook.$branch_delete_guard_name.event=reference-transaction" \
-      -c "hook.$branch_delete_guard_name.command=$branch_delete_guard_path" \
-      branch -D -- "$branch" 2>"$branch_delete_error_file"; then
-    if [[ ! -f "$branch_delete_guard_invoked_marker" ]]; then
-      printf 'Branch deletion guard did not run for %s\n' "$branch" >"$branch_delete_error_file"
-      return 2
-    fi
-    return 0
-  fi
-
-  if [[ -f "$branch_delete_rejected_marker" ]]; then
-    return 10
-  fi
-  return 2
-}
 
 for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
   worktree=${worktree_paths[index]}
@@ -432,54 +239,43 @@ for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
     continue
   fi
 
-  if ! head_before=$(git -C "$worktree" rev-parse HEAD 2>/dev/null); then
+  if ! head_before=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) ||
+    ! commit_time_before=$(commit_time "$worktree" HEAD); then
     printf 'Skipping unreadable worktree: %s\n' "$worktree" >&2
     failed=1
     continue
   fi
 
+  if { [[ -n "$branch" ]] && branch_has_open_pr "$branch"; } ||
+    { [[ -z "$branch" ]] && tip_has_open_pr "$head_before"; }; then
+    printf 'Skipping worktree for open pull request: %s\n' "$worktree" >&2
+    continue
+  fi
+
+  if ! timestamp_is_stale "$commit_time_before"; then
+    continue
+  fi
+
   if ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
     printf 'Skipping worktree whose status could not be read: %s\n' "$worktree" >&2
     failed=1
     continue
   fi
-
   if [[ -n "$worktree_status" ]]; then
     printf 'Skipping worktree with uncommitted changes: %s\n' "$worktree" >&2
     continue
   fi
 
-  if ! last_update=$(worktree_last_update "$worktree" "$branch"); then
-    printf 'Skipping worktree whose reflog state could not be read: %s\n' "$worktree" >&2
-    failed=1
-    continue
-  fi
-
-  if ! timestamp_is_stale "$last_update"; then
-    continue
-  fi
-
-  # Re-evaluation prevents a checkout, reset, or file edit during cleanup from becoming stale deletion.
-  if ! head_after=$(git -C "$worktree" rev-parse HEAD 2>/dev/null); then
+  # Recheck immediately before removal so a concurrent commit or file edit is preserved.
+  if ! head_after=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) ||
+    ! commit_time_after=$(commit_time "$worktree" HEAD) ||
+    ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
     printf 'Skipping worktree whose cleanup state could not be read: %s\n' "$worktree" >&2
     failed=1
     continue
   fi
-  if ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
-    printf 'Skipping worktree whose status could not be read: %s\n' "$worktree" >&2
-    failed=1
-    continue
-  fi
-  if [[ -n "$worktree_status" ]]; then
-    printf 'Skipping worktree updated during cleanup: %s\n' "$worktree" >&2
-    continue
-  fi
-  if ! confirmed_last_update=$(worktree_last_update "$worktree" "$branch"); then
-    printf 'Skipping worktree whose reflog state could not be read: %s\n' "$worktree" >&2
-    failed=1
-    continue
-  fi
-  if [[ "$head_after" != "$head_before" ]] || ! timestamp_is_stale "$confirmed_last_update"; then
+  if [[ "$head_after" != "$head_before" || -n "$worktree_status" ]] ||
+    ! timestamp_is_stale "$commit_time_after"; then
     printf 'Skipping worktree updated during cleanup: %s\n' "$worktree" >&2
     continue
   fi
@@ -493,108 +289,82 @@ for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
   fi
 done
 
-if ((checkout_activity_complete)) && ! snapshot_checkout_activity "$live_checkout_activity_file"; then
-  checkout_activity_complete=0
-  failed=1
-fi
-
-if ((checkout_activity_complete && branch_delete_guard_supported)); then
-  if ! git for-each-ref --format='%(refname:lstrip=2)' refs/heads >"$branch_list_file"; then
-    printf 'Failed to list local branches\n' >&2
-    exit 1
-  fi
-
-  while IFS= read -r branch; do
-    if [[ -z "$branch" || "$branch" == main ]]; then
-      continue
-    fi
-
-    if branch_is_checked_out "$branch"; then
-      continue
-    elif (( $? == 2 )); then
-      printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
-      failed=1
-      continue
-    fi
-
-    if ! expected_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
-      printf 'Skipping branch whose tip could not be read: %s\n' "$branch" >&2
-      failed=1
-      continue
-    fi
-
-    if ! last_update=$(branch_last_update "$branch"); then
-      printf 'Skipping branch whose reflog state could not be read: %s\n' "$branch" >&2
-      failed=1
-      continue
-    fi
-
-    if ! timestamp_is_stale "$last_update"; then
-      continue
-    fi
-
-    if ! snapshot_checkout_activity "$live_checkout_activity_file"; then
-      printf 'Skipping remaining local branches because checkout history could not be refreshed\n' >&2
-      checkout_activity_complete=0
-      failed=1
-      break
-    fi
-
-    # The transaction guard checks the expected tip after Git locks the ref. This preserves branch
-    # porcelain's checked-out protection and config cleanup without deleting a concurrently updated tip.
-    if branch_is_checked_out "$branch"; then
-      printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
-      continue
-    elif (( $? == 2 )); then
-      printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
-      failed=1
-      continue
-    fi
-    if ! confirmed_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
-      printf 'Skipping branch whose cleanup state could not be read: %s\n' "$branch" >&2
-      failed=1
-      continue
-    fi
-    if ! confirmed_last_update=$(branch_last_update "$branch"); then
-      printf 'Skipping branch whose reflog state could not be read: %s\n' "$branch" >&2
-      failed=1
-      continue
-    fi
-    if [[ "$confirmed_tip" != "$expected_tip" ]] || ! timestamp_is_stale "$confirmed_last_update"; then
-      printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
-      continue
-    fi
-
-    if delete_branch_with_expected_tip "$branch" "$expected_tip"; then
-      printf 'Removed stale local branch: %s\n' "$branch"
-      removed_branches=$((removed_branches + 1))
-    else
-      delete_status=$?
-      if ((delete_status == 10)); then
-        printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
-      elif branch_is_checked_out "$branch"; then
-        printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
-      elif (( $? == 2 )); then
-        printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
-        failed=1
-      else
-        if [[ -s "$branch_delete_error_file" ]]; then
-          sed -n 'p' "$branch_delete_error_file" >&2
-        fi
-        printf 'Failed to remove stale local branch: %s\n' "$branch" >&2
-        failed=1
-      fi
-    fi
-  done <"$branch_list_file"
-elif ((checkout_activity_complete == 0)); then
-  printf 'Skipping local branch cleanup because worktree checkout history could not be read\n' >&2
-  if ((failed == 0)); then
-    failed=1
-  fi
-else
+if ((branch_delete_guard_supported == 0)); then
   printf 'Skipping local branch cleanup because Git does not support guarded branch deletion\n' >&2
-  failed=1
+  printf 'Removed %d worktree(s) and %d local branch(es)\n' "$removed_worktrees" "$removed_branches"
+  exit 1
 fi
+
+if ! git for-each-ref --format='%(committerdate:unix)%09%(refname:lstrip=2)' refs/heads >"$branch_list_file"; then
+  printf 'Failed to list local branches\n' >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r branch_time branch; do
+  if [[ -z "$branch" || "$branch" == main ]] || branch_has_open_pr "$branch"; then
+    continue
+  fi
+  case $branch_time in
+    '' | *[!0-9]*)
+      printf 'Skipping branch whose commit time could not be read: %s\n' "$branch" >&2
+      failed=1
+      continue
+      ;;
+  esac
+  if ! timestamp_is_stale "$branch_time"; then
+    continue
+  fi
+
+  if branch_is_checked_out "$branch"; then
+    continue
+  elif (( $? == 2 )); then
+    printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
+    failed=1
+    continue
+  fi
+
+  if ! expected_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
+    printf 'Skipping branch whose tip could not be read: %s\n' "$branch" >&2
+    failed=1
+    continue
+  fi
+
+  # Git branch deletion retains its checked-out protection and removes branch-specific config.
+  if branch_is_checked_out "$branch"; then
+    printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
+    continue
+  elif (( $? == 2 )); then
+    printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
+    failed=1
+    continue
+  fi
+  if ! confirmed_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null) ||
+    ! confirmed_time=$(commit_time "$current_worktree" "refs/heads/$branch"); then
+    printf 'Skipping branch whose cleanup state could not be read: %s\n' "$branch" >&2
+    failed=1
+    continue
+  fi
+  if [[ "$confirmed_tip" != "$expected_tip" ]] || ! timestamp_is_stale "$confirmed_time"; then
+    printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
+    continue
+  fi
+
+  if delete_branch_with_expected_tip "$branch" "$expected_tip"; then
+    printf 'Removed stale local branch: %s\n' "$branch"
+    removed_branches=$((removed_branches + 1))
+  else
+    delete_status=$?
+    if ((delete_status == 10)); then
+      printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
+    else
+      if [[ -s "$branch_delete_error_file" ]]; then
+        sed -n 'p' "$branch_delete_error_file" >&2
+      fi
+      printf 'Failed to remove stale local branch: %s\n' "$branch" >&2
+      failed=1
+    fi
+  fi
+done <"$branch_list_file"
 
 printf 'Removed %d worktree(s) and %d local branch(es)\n' "$removed_worktrees" "$removed_branches"
 

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -1,371 +1,81 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-run_branch_delete_guard() {
-  local state=${1:-}
-  local old_oid=""
-  local new_oid=""
-  local ref_name=""
-  local extra=""
-  local unexpected=""
-  local actual_tip
+cutoff=$(($(date +%s) - 7 * 24 * 60 * 60))
+current_worktree=$(git rev-parse --show-toplevel)
+open_pr_branches=$(gh api --paginate 'repos/{owner}/{repo}/pulls?state=open&per_page=100' --jq '.[].head.ref')
 
-  case $state in
-    preparing | prepared) ;;
-    *) return 0 ;;
-  esac
-
-  : >"${CLEANUP_GUARD_INVOKED_MARKER:?}"
-  if ! IFS=' ' read -r old_oid new_oid ref_name extra || IFS= read -r unexpected; then
-    return 1
-  fi
-  if [[ -n "$extra" || "$ref_name" != "${CLEANUP_EXPECTED_REF:?}" ]] ||
-    [[ -z "$new_oid" || "$new_oid" == *[!0]* ]]; then
-    return 1
-  fi
-
-  if [[ "$state" == prepared ]]; then
-    if ! actual_tip=$(git rev-parse --verify "$CLEANUP_EXPECTED_REF" 2>/dev/null) ||
-      [[ "$actual_tip" != "${CLEANUP_EXPECTED_TIP:?}" ]]; then
-      : >"${CLEANUP_REJECTED_MARKER:?}"
-      return 1
-    fi
-  fi
+has_open_pr() {
+  grep -Fqx -- "$1" <<<"$open_pr_branches"
 }
 
-if [[ ${CLEANUP_BRANCH_DELETE_GUARD:-} == 1 ]]; then
-  run_branch_delete_guard "${1:-}"
-  exit
-fi
-
-# The sentinel preserves trailing newlines that may be part of the worktree path.
-if ! current_worktree=$(
-  set +e
-  git rev-parse --show-toplevel
-  status=$?
-  printf x
-  exit "$status"
-); then
-  printf 'Failed to identify the current worktree\n' >&2
-  exit 1
-fi
-current_worktree=${current_worktree%x}
-current_worktree=${current_worktree%$'\n'}
-
-if ! current_time=$(date +%s); then
-  printf 'Failed to read the current time\n' >&2
-  exit 1
-fi
-case $current_time in
-  '' | *[!0-9]*)
-    printf 'Failed to read the current time\n' >&2
-    exit 1
-    ;;
-esac
-stale_cutoff=$((current_time - 7 * 24 * 60 * 60))
-
-temp_dir=$(mktemp -d /tmp/cleanup-branches.XXXXXX)
-remove_temp_dir() {
-  rm -rf -- "$temp_dir"
-}
-trap remove_temp_dir EXIT
-
-open_pr_file=$temp_dir/open-prs
-worktree_list_file=$temp_dir/worktrees
-branch_list_file=$temp_dir/branches
-git_config_names_file=$temp_dir/git-config-names
-branch_delete_error_file=$temp_dir/branch-delete-error
-branch_delete_rejected_marker=$temp_dir/branch-delete-rejected
-branch_delete_guard_invoked_marker=$temp_dir/branch-delete-guard-invoked
-branch_delete_guard_path=$temp_dir/branch-delete-guard
-branch_delete_guard_name=cleanup-branch-guard-$$-$RANDOM
-
-if ! gh api --paginate 'repos/{owner}/{repo}/pulls?state=open&per_page=100' \
-  --jq '.[] | [.head.ref, .head.sha] | @tsv' >"$open_pr_file"; then
-  printf 'Failed to list open pull requests\n' >&2
-  exit 1
-fi
-
-script_source=$0
-if [[ "$script_source" != */* ]]; then
-  if ! script_source=$(command -v "$script_source"); then
-    printf 'Failed to locate the cleanup script\n' >&2
-    exit 1
-  fi
-fi
-script_directory=${script_source%/*}
-script_name=${script_source##*/}
-if ! script_directory=$(cd -- "$script_directory" && pwd -P); then
-  printf 'Failed to locate the cleanup script\n' >&2
-  exit 1
-fi
-if ! ln -s -- "$script_directory/$script_name" "$branch_delete_guard_path"; then
-  printf 'Failed to prepare guarded branch deletion\n' >&2
-  exit 1
-fi
-
-branch_delete_guard_supported=1
-if ! git help --config >"$git_config_names_file" ||
-  ! grep -Fqx 'hook.<friendly-name>.event' "$git_config_names_file"; then
-  branch_delete_guard_supported=0
-fi
-
-branch_has_open_pr() {
-  local branch=$1
-  local pr_branch
-  local pr_tip
-
-  while IFS=$'\t' read -r pr_branch pr_tip; do
-    [[ "$pr_branch" == "$branch" ]] && return 0
-  done <"$open_pr_file"
-  return 1
-}
-
-tip_has_open_pr() {
-  local tip=$1
-  local pr_branch
-  local pr_tip
-
-  while IFS=$'\t' read -r pr_branch pr_tip; do
-    [[ "$pr_tip" == "$tip" ]] && return 0
-  done <"$open_pr_file"
-  return 1
-}
-
-commit_time() {
-  local repository_path=$1
-  local ref=$2
+is_stale() {
   local timestamp
-
-  if ! timestamp=$(git -C "$repository_path" log -1 --format=%ct "$ref" 2>/dev/null); then
-    return 1
-  fi
-  case $timestamp in
-    '' | *[!0-9]*) return 1 ;;
-  esac
-
-  printf '%s\n' "$timestamp"
+  timestamp=$(git -C "$1" log -1 --format=%ct "${2:-HEAD}") || return 1
+  ((timestamp <= cutoff))
 }
-
-timestamp_is_stale() {
-  local timestamp=$1
-
-  ((timestamp <= stale_cutoff))
-}
-
-branch_is_checked_out() {
-  local branch=$1
-  local worktrees
-
-  if ! worktrees=$(git worktree list --porcelain); then
-    return 2
-  fi
-
-  grep -Fqx "branch refs/heads/$branch" <<<"$worktrees"
-}
-
-delete_branch_with_expected_tip() {
-  local branch=$1
-  local expected_tip=$2
-
-  if ! rm -f -- "$branch_delete_error_file" "$branch_delete_rejected_marker" "$branch_delete_guard_invoked_marker"; then
-    return 2
-  fi
-  if CLEANUP_BRANCH_DELETE_GUARD=1 \
-    CLEANUP_EXPECTED_REF="refs/heads/$branch" \
-    CLEANUP_EXPECTED_TIP="$expected_tip" \
-    CLEANUP_REJECTED_MARKER="$branch_delete_rejected_marker" \
-    CLEANUP_GUARD_INVOKED_MARKER="$branch_delete_guard_invoked_marker" \
-    git \
-      -c "hook.$branch_delete_guard_name.event=reference-transaction" \
-      -c "hook.$branch_delete_guard_name.command=$branch_delete_guard_path" \
-      branch -D -- "$branch" 2>"$branch_delete_error_file"; then
-    [[ -f "$branch_delete_guard_invoked_marker" ]] || return 2
-    return 0
-  fi
-
-  [[ -f "$branch_delete_rejected_marker" ]] && return 10
-  return 2
-}
-
-worktree_paths=()
-worktree_branches=()
-worktree_locked=()
-main_worktree=""
-record_path=""
-record_branch=""
-record_locked=0
-
-if ! git worktree list --porcelain -z >"$worktree_list_file"; then
-  printf 'Failed to list worktrees\n' >&2
-  exit 1
-fi
-
-# NUL-delimited parsing keeps destructive cleanup safe for every valid worktree path.
-while IFS= read -r -d '' field; do
-  if [[ -z "$field" ]]; then
-    if [[ -n "$record_path" ]]; then
-      worktree_paths+=("$record_path")
-      worktree_branches+=("$record_branch")
-      worktree_locked+=("$record_locked")
-    fi
-    record_path=""
-    record_branch=""
-    record_locked=0
-  elif [[ "$field" == "worktree "* ]]; then
-    record_path=${field#worktree }
-    [[ -z "$main_worktree" ]] && main_worktree=$record_path
-  elif [[ "$field" == "branch refs/heads/"* ]]; then
-    record_branch=${field#branch refs/heads/}
-  elif [[ "$field" == "locked" || "$field" == "locked "* ]]; then
-    record_locked=1
-  fi
-done <"$worktree_list_file"
 
 removed_worktrees=0
 removed_branches=0
 failed=0
+primary_worktree=""
+worktree=""
+branch=""
+locked=0
 
-for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
-  worktree=${worktree_paths[index]}
-  branch=${worktree_branches[index]}
+remove_worktree() {
+  local status
 
-  if [[ "$worktree" == "$main_worktree" || "$worktree" == "$current_worktree" || "$branch" == main ]]; then
-    continue
-  fi
+  [[ -n "$worktree" ]] || return 0
+  [[ -n "$primary_worktree" ]] || primary_worktree=$worktree
+  status=$(git -C "$worktree" status --porcelain --untracked-files=all) || return 0
 
-  if ((worktree_locked[index])); then
-    printf 'Skipping locked worktree: %s\n' "$worktree" >&2
-    continue
-  fi
-
-  if ! head_before=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) ||
-    ! commit_time_before=$(commit_time "$worktree" HEAD); then
-    printf 'Skipping unreadable worktree: %s\n' "$worktree" >&2
-    failed=1
-    continue
-  fi
-
-  if { [[ -n "$branch" ]] && branch_has_open_pr "$branch"; } ||
-    { [[ -z "$branch" ]] && tip_has_open_pr "$head_before"; }; then
-    printf 'Skipping worktree for open pull request: %s\n' "$worktree" >&2
-    continue
-  fi
-
-  if ! timestamp_is_stale "$commit_time_before"; then
-    continue
-  fi
-
-  if ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
-    printf 'Skipping worktree whose status could not be read: %s\n' "$worktree" >&2
-    failed=1
-    continue
-  fi
-  if [[ -n "$worktree_status" ]]; then
-    printf 'Skipping worktree with uncommitted changes: %s\n' "$worktree" >&2
-    continue
-  fi
-
-  # Recheck immediately before removal so a concurrent commit or file edit is preserved.
-  if ! head_after=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) ||
-    ! commit_time_after=$(commit_time "$worktree" HEAD) ||
-    ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
-    printf 'Skipping worktree whose cleanup state could not be read: %s\n' "$worktree" >&2
-    failed=1
-    continue
-  fi
-  if [[ "$head_after" != "$head_before" || -n "$worktree_status" ]] ||
-    ! timestamp_is_stale "$commit_time_after"; then
-    printf 'Skipping worktree updated during cleanup: %s\n' "$worktree" >&2
-    continue
+  if [[ "$worktree" == "$primary_worktree" || "$worktree" == "$current_worktree" || "$branch" == main ]] ||
+    ((locked)) || { [[ -n "$branch" ]] && has_open_pr "$branch"; } ||
+    ! is_stale "$worktree" || [[ -n "$status" ]]; then
+    return
   fi
 
   if git worktree remove -- "$worktree"; then
     printf 'Removed stale worktree: %s\n' "$worktree"
     removed_worktrees=$((removed_worktrees + 1))
   else
-    printf 'Failed to remove stale worktree: %s\n' "$worktree" >&2
     failed=1
   fi
-done
+}
 
-if ((branch_delete_guard_supported == 0)); then
-  printf 'Skipping local branch cleanup because Git does not support guarded branch deletion\n' >&2
-  printf 'Removed %d worktree(s) and %d local branch(es)\n' "$removed_worktrees" "$removed_branches"
-  exit 1
-fi
-
-if ! git for-each-ref --format='%(committerdate:unix)%09%(refname:lstrip=2)' refs/heads >"$branch_list_file"; then
-  printf 'Failed to list local branches\n' >&2
-  exit 1
-fi
-
-while IFS=$'\t' read -r branch_time branch; do
-  if [[ -z "$branch" || "$branch" == main ]] || branch_has_open_pr "$branch"; then
-    continue
-  fi
-  case $branch_time in
-    '' | *[!0-9]*)
-      printf 'Skipping branch whose commit time could not be read: %s\n' "$branch" >&2
-      failed=1
-      continue
+while IFS= read -r line; do
+  case $line in
+    "")
+      remove_worktree
+      worktree=""
+      branch=""
+      locked=0
       ;;
+    "worktree "*) worktree=${line#worktree } ;;
+    "branch refs/heads/"*) branch=${line#branch refs/heads/} ;;
+    locked*) locked=1 ;;
   esac
-  if ! timestamp_is_stale "$branch_time"; then
+done < <(git worktree list --porcelain; printf '\n')
+
+checked_out_branches=$(git worktree list --porcelain | sed -n 's|^branch refs/heads/||p')
+
+is_checked_out() {
+  grep -Fqx -- "$1" <<<"$checked_out_branches"
+}
+
+while IFS=$'\t' read -r timestamp branch; do
+  if [[ "$branch" == main ]] || has_open_pr "$branch" || is_checked_out "$branch" || ((timestamp > cutoff)); then
     continue
   fi
 
-  if branch_is_checked_out "$branch"; then
-    continue
-  elif (( $? == 2 )); then
-    printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
-    failed=1
-    continue
-  fi
-
-  if ! expected_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
-    printf 'Skipping branch whose tip could not be read: %s\n' "$branch" >&2
-    failed=1
-    continue
-  fi
-
-  # Git branch deletion retains its checked-out protection and removes branch-specific config.
-  if branch_is_checked_out "$branch"; then
-    printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
-    continue
-  elif (( $? == 2 )); then
-    printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
-    failed=1
-    continue
-  fi
-  if ! confirmed_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null) ||
-    ! confirmed_time=$(commit_time "$current_worktree" "refs/heads/$branch"); then
-    printf 'Skipping branch whose cleanup state could not be read: %s\n' "$branch" >&2
-    failed=1
-    continue
-  fi
-  if [[ "$confirmed_tip" != "$expected_tip" ]] || ! timestamp_is_stale "$confirmed_time"; then
-    printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
-    continue
-  fi
-
-  if delete_branch_with_expected_tip "$branch" "$expected_tip"; then
+  if git branch -D -- "$branch"; then
     printf 'Removed stale local branch: %s\n' "$branch"
     removed_branches=$((removed_branches + 1))
   else
-    delete_status=$?
-    if ((delete_status == 10)); then
-      printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
-    else
-      if [[ -s "$branch_delete_error_file" ]]; then
-        sed -n 'p' "$branch_delete_error_file" >&2
-      fi
-      printf 'Failed to remove stale local branch: %s\n' "$branch" >&2
-      failed=1
-    fi
+    failed=1
   fi
-done <"$branch_list_file"
+done < <(git for-each-ref --format='%(committerdate:unix)%09%(refname:lstrip=2)' refs/heads)
 
 printf 'Removed %d worktree(s) and %d local branch(es)\n' "$removed_worktrees" "$removed_branches"
-
 exit "$failed"

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -15,8 +15,6 @@ is_stale() {
   ((timestamp <= cutoff))
 }
 
-removed_worktrees=0
-removed_branches=0
 failed=0
 primary_worktree=""
 worktree=""
@@ -38,7 +36,6 @@ remove_worktree() {
 
   if git worktree remove -- "$worktree"; then
     printf 'Removed stale worktree: %s\n' "$worktree"
-    removed_worktrees=$((removed_worktrees + 1))
   else
     failed=1
   fi
@@ -71,11 +68,9 @@ while IFS=$'\t' read -r timestamp branch; do
 
   if git branch -D -- "$branch"; then
     printf 'Removed stale local branch: %s\n' "$branch"
-    removed_branches=$((removed_branches + 1))
   else
     failed=1
   fi
 done < <(git for-each-ref --format='%(committerdate:unix)%09%(refname:lstrip=2)' refs/heads)
 
-printf 'Removed %d worktree(s) and %d local branch(es)\n' "$removed_worktrees" "$removed_branches"
 exit "$failed"

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -1,6 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+run_branch_delete_guard() {
+  local transaction_state=${1:-}
+  local expected_ref=${CLEANUP_EXPECTED_REF:?}
+  local expected_tip=${CLEANUP_EXPECTED_TIP:?}
+  local rejected_marker=${CLEANUP_REJECTED_MARKER:?}
+  local invoked_marker=${CLEANUP_GUARD_INVOKED_MARKER:?}
+  local old_oid=""
+  local new_oid=""
+  local ref_name=""
+  local extra=""
+  local unexpected=""
+  local actual_tip
+
+  case $transaction_state in
+    preparing | prepared) ;;
+    *) return 0 ;;
+  esac
+
+  if ! : >"$invoked_marker"; then
+    printf 'Failed to record branch deletion guard state\n' >&2
+    return 1
+  fi
+
+  if ! IFS=' ' read -r old_oid new_oid ref_name extra || IFS= read -r unexpected; then
+    printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
+    return 1
+  fi
+  if [[ -n "$extra" || "$ref_name" != "$expected_ref" ]] ||
+    [[ ${#old_oid} -ne ${#expected_tip} || ${#new_oid} -ne ${#expected_tip} ]]; then
+    printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
+    return 1
+  fi
+  case $old_oid in
+    '' | *[!0]*)
+      printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
+      return 1
+      ;;
+  esac
+  case $new_oid in
+    '' | *[!0]*)
+      printf 'Unexpected branch deletion transaction for %s\n' "$expected_ref" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ "$transaction_state" == prepared ]]; then
+    if ! actual_tip=$(git rev-parse --verify "$expected_ref" 2>/dev/null) || [[ "$actual_tip" != "$expected_tip" ]]; then
+      if ! : >"$rejected_marker"; then
+        printf 'Failed to record a concurrent branch update for %s\n' "$expected_ref" >&2
+      fi
+      return 1
+    fi
+  fi
+}
+
+if [[ ${CLEANUP_BRANCH_DELETE_GUARD:-} == 1 ]]; then
+  run_branch_delete_guard "${1:-}"
+  exit
+fi
+
 # The sentinel preserves trailing newlines that may be part of the worktree path.
 if ! current_worktree=$(
   set +e
@@ -15,20 +75,18 @@ fi
 current_worktree=${current_worktree%x}
 current_worktree=${current_worktree%$'\n'}
 
-if ! git fetch --prune origin; then
-  printf 'Failed to refresh remote branches\n' >&2
+stale_after_seconds=$((7 * 24 * 60 * 60))
+if ! current_time=$(date +%s); then
+  printf 'Failed to read the current time\n' >&2
   exit 1
 fi
-
-if ! git show-ref --verify --quiet refs/remotes/origin/main; then
-  printf 'origin/main does not exist\n' >&2
-  exit 1
-fi
-
-if ! repository=$(gh repo view --json nameWithOwner --jq .nameWithOwner); then
-  printf 'Failed to identify the GitHub repository\n' >&2
-  exit 1
-fi
+case $current_time in
+  '' | *[!0-9]*)
+    printf 'Failed to read the current time\n' >&2
+    exit 1
+    ;;
+esac
+stale_cutoff=$((current_time - stale_after_seconds))
 
 temp_dir=$(mktemp -d /tmp/cleanup-branches.XXXXXX)
 remove_temp_dir() {
@@ -36,93 +94,242 @@ remove_temp_dir() {
 }
 trap remove_temp_dir EXIT
 
-pr_list_file=$temp_dir/pulls.tsv
 worktree_list_file=$temp_dir/worktrees
 branch_list_file=$temp_dir/branches
+checkout_activity_file=$temp_dir/checkout-activity
+live_checkout_activity_file=$temp_dir/live-checkout-activity
+checkout_worktree_list_file=$temp_dir/checkout-worktrees
+head_reflog_file=$temp_dir/head-reflog
+git_config_names_file=$temp_dir/git-config-names
+branch_delete_error_file=$temp_dir/branch-delete-error
+branch_delete_rejected_marker=$temp_dir/branch-delete-rejected
+branch_delete_guard_invoked_marker=$temp_dir/branch-delete-guard-invoked
+branch_delete_guard_path=$temp_dir/branch-delete-guard
+branch_delete_guard_name=cleanup-branch-guard-$$-$RANDOM
+: >"$live_checkout_activity_file"
 
-# Keep the repository field non-empty so Bash preserves every TSV column.
-if ! gh api --paginate "repos/$repository/pulls?state=all&per_page=100" \
-  --jq '.[] | [(.head.repo.full_name // "-"), .head.ref, .head.sha, .state] | @tsv' >"$pr_list_file"; then
-  printf 'Failed to list pull requests\n' >&2
+script_source=$0
+if [[ "$script_source" != */* ]]; then
+  if ! script_source=$(command -v "$script_source"); then
+    printf 'Failed to locate the cleanup script\n' >&2
+    exit 1
+  fi
+fi
+script_directory=${script_source%/*}
+script_name=${script_source##*/}
+if ! script_directory=$(cd -- "$script_directory" && pwd -P); then
+  printf 'Failed to locate the cleanup script\n' >&2
+  exit 1
+fi
+script_path=$script_directory/$script_name
+if [[ ! -x "$script_path" ]] || ! ln -s -- "$script_path" "$branch_delete_guard_path"; then
+  printf 'Failed to prepare the branch deletion guard\n' >&2
   exit 1
 fi
 
-tip_is_on_remote() {
-  local tip=$1
-  local remote_refs
+branch_delete_guard_supported=1
+if ! git help --config >"$git_config_names_file" ||
+  ! grep -Fqx 'hook.<friendly-name>.event' "$git_config_names_file"; then
+  branch_delete_guard_supported=0
+fi
 
-  if ! remote_refs=$(git for-each-ref --contains="$tip" --format='%(refname)' refs/remotes); then
-    return 2
+# Reflog time records local ref movement, unlike a commit date that may predate a newly created branch.
+reflog_selector_timestamp() {
+  local selector=$1
+  local timestamp
+
+  timestamp=${selector##*@\{}
+  if [[ "$timestamp" == "$selector" || "$timestamp" != *\} ]]; then
+    return 1
   fi
+  timestamp=${timestamp%\}}
+  case $timestamp in
+    '' | *[!0-9]*) return 1 ;;
+  esac
 
-  [[ -n "$remote_refs" ]]
+  printf '%s\n' "$timestamp"
 }
 
-find_cleanup_reason() {
-  local branch=$1
-  local tip=$2
-  local status
+last_reflog_update() {
+  local repository_path=$1
+  local ref=$2
+  local selector
 
-  if [[ -z "$branch" ]]; then
-    if tip_is_on_remote "$tip"; then
-      return 1
-    else
-      status=$?
-      if ((status != 1)); then
-        return 2
-      fi
-    fi
-
-    printf 'detached tip unreachable from remote branches'
-    return 0
-  fi
-
-  if git merge-base --is-ancestor "$tip" origin/main; then
-    printf 'merged'
-    return 0
-  else
-    status=$?
-    if ((status != 1)); then
-      return 2
-    fi
-  fi
-
-  if git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+  if ! selector=$(git -C "$repository_path" reflog show -1 --date=unix --format='%gD' "$ref" 2>/dev/null); then
     return 1
-  else
-    status=$?
-    if ((status != 1)); then
-      return 2
-    fi
   fi
 
-  local head_repository
-  local pr_branch
-  local pr_oid
-  local pr_state
-  local matches_closed_pr=0
+  reflog_selector_timestamp "$selector"
+}
 
-  # A reused branch name is safe only when no open PR exists and a closed PR records this exact tip.
-  while IFS=$'\t' read -r head_repository pr_branch pr_oid pr_state; do
-    if [[ "$head_repository" != "$repository" || "$pr_branch" != "$branch" ]]; then
-      continue
+reflog_metadata_timestamp() {
+  local metadata=$1
+  local without_timezone
+  local timestamp
+
+  without_timezone=${metadata% *}
+  if [[ "$without_timezone" == "$metadata" ]]; then
+    return 1
+  fi
+  timestamp=${without_timezone##* }
+  case $timestamp in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+
+  printf '%s\n' "$timestamp"
+}
+
+worktree_head_log_path() {
+  local worktree=$1
+  local head_log
+
+  if ! head_log=$(git -C "$worktree" rev-parse --path-format=absolute --git-path logs/HEAD 2>/dev/null); then
+    return 1
+  fi
+  if [[ -z "$head_log" || ! -f "$head_log" || ! -r "$head_log" || ! -s "$head_log" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$head_log"
+}
+
+worktree_head_last_update() {
+  local worktree=$1
+  local head_log
+  local last_entry
+  local metadata
+
+  if ! head_log=$(worktree_head_log_path "$worktree") || ! last_entry=$(tail -n 1 -- "$head_log"); then
+    return 1
+  fi
+  metadata=${last_entry%%$'\t'*}
+
+  reflog_metadata_timestamp "$metadata"
+}
+
+append_worktree_checkout_activity() {
+  local worktree=$1
+  local output_file=$2
+  local head_log
+  local metadata
+  local subject
+  local timestamp
+  local transition
+  local checkout_from
+  local checkout_to
+
+  if ! head_log=$(worktree_head_log_path "$worktree") || ! cp -- "$head_log" "$head_reflog_file"; then
+    printf 'Failed to read worktree checkout history: %s\n' "$worktree" >&2
+    return 1
+  fi
+
+  while IFS=$'\t' read -r metadata subject; do
+    case $subject in
+      checkout:\ moving\ from\ *\ to\ *)
+        if ! timestamp=$(reflog_metadata_timestamp "$metadata"); then
+          printf 'Failed to read worktree checkout history: %s\n' "$worktree" >&2
+          return 1
+        fi
+        transition=${subject#checkout: moving from }
+        checkout_from=${transition%% to *}
+        checkout_to=${transition#* to }
+        if [[ -n "$checkout_from" ]] && ! printf '%s\t%s\n' "$timestamp" "$checkout_from" >>"$output_file"; then
+          printf 'Failed to record worktree checkout history: %s\n' "$worktree" >&2
+          return 1
+        fi
+        if [[ -n "$checkout_to" ]] && ! printf '%s\t%s\n' "$timestamp" "$checkout_to" >>"$output_file"; then
+          printf 'Failed to record worktree checkout history: %s\n' "$worktree" >&2
+          return 1
+        fi
+        ;;
+    esac
+  done <"$head_reflog_file"
+}
+
+snapshot_checkout_activity() {
+  local output_file=$1
+  local field
+  local record_path=""
+  local snapshot_failed=0
+
+  if ! : >"$output_file"; then
+    printf 'Failed to prepare worktree checkout history\n' >&2
+    return 1
+  fi
+  if ! git worktree list --porcelain -z >"$checkout_worktree_list_file"; then
+    printf 'Failed to list worktrees while reading checkout history\n' >&2
+    return 1
+  fi
+
+  while IFS= read -r -d '' field; do
+    if [[ -z "$field" ]]; then
+      if [[ -n "$record_path" ]] && ! append_worktree_checkout_activity "$record_path" "$output_file"; then
+        snapshot_failed=1
+      fi
+      record_path=""
+    elif [[ "$field" == "worktree "* ]]; then
+      record_path=${field#worktree }
     fi
+  done <"$checkout_worktree_list_file"
 
-    if [[ "$pr_state" == open ]]; then
+  if [[ -n "$record_path" ]] && ! append_worktree_checkout_activity "$record_path" "$output_file"; then
+    snapshot_failed=1
+  fi
+
+  ((snapshot_failed == 0))
+}
+
+branch_last_update() {
+  local branch=$1
+  local branch_timestamp
+  local checkout_timestamp
+  local checkout_branch
+
+  if ! branch_timestamp=$(last_reflog_update "$current_worktree" "refs/heads/$branch"); then
+    return 1
+  fi
+
+  while IFS=$'\t' read -r checkout_timestamp checkout_branch; do
+    if [[ "$checkout_branch" == "$branch" ]] && ((checkout_timestamp > branch_timestamp)); then
+      branch_timestamp=$checkout_timestamp
+    fi
+  done <"$checkout_activity_file"
+  while IFS=$'\t' read -r checkout_timestamp checkout_branch; do
+    if [[ "$checkout_branch" == "$branch" ]] && ((checkout_timestamp > branch_timestamp)); then
+      branch_timestamp=$checkout_timestamp
+    fi
+  done <"$live_checkout_activity_file"
+
+  printf '%s\n' "$branch_timestamp"
+}
+
+worktree_last_update() {
+  local worktree=$1
+  local branch=$2
+  local head_timestamp
+  local branch_timestamp
+
+  if ! head_timestamp=$(worktree_head_last_update "$worktree"); then
+    return 1
+  fi
+
+  # A recent checkout only updates the worktree HEAD, while a branch update may not touch that HEAD log.
+  if [[ -n "$branch" ]]; then
+    if ! branch_timestamp=$(last_reflog_update "$current_worktree" "refs/heads/$branch"); then
       return 1
     fi
-
-    if [[ "$pr_oid" == "$tip" ]]; then
-      matches_closed_pr=1
+    if ((branch_timestamp > head_timestamp)); then
+      head_timestamp=$branch_timestamp
     fi
-  done <"$pr_list_file"
-
-  if ((matches_closed_pr)); then
-    printf 'closed PR without remote branch'
-    return 0
   fi
 
-  return 1
+  printf '%s\n' "$head_timestamp"
+}
+
+timestamp_is_stale() {
+  local timestamp=$1
+
+  ((timestamp <= stale_cutoff))
 }
 
 worktree_paths=()
@@ -159,6 +366,17 @@ while IFS= read -r -d '' field; do
   fi
 done <"$worktree_list_file"
 
+removed_worktrees=0
+removed_branches=0
+failed=0
+checkout_activity_complete=1
+
+# Checkout does not move a branch ref, so preserve HEAD history before removing worktrees that own it.
+if ! snapshot_checkout_activity "$checkout_activity_file"; then
+  checkout_activity_complete=0
+  failed=1
+fi
+
 branch_is_checked_out() {
   local branch=$1
   local worktrees
@@ -170,15 +388,42 @@ branch_is_checked_out() {
   grep -Fqx "branch refs/heads/$branch" <<<"$worktrees"
 }
 
-removed_worktrees=0
-removed_branches=0
-failed=0
+delete_branch_with_expected_tip() {
+  local branch=$1
+  local expected_tip=$2
+
+  if ! rm -f -- "$branch_delete_error_file" "$branch_delete_rejected_marker" "$branch_delete_guard_invoked_marker"; then
+    printf 'Failed to prepare guarded branch deletion: %s\n' "$branch" >&2
+    return 2
+  fi
+
+  if CLEANUP_BRANCH_DELETE_GUARD=1 \
+    CLEANUP_EXPECTED_REF="refs/heads/$branch" \
+    CLEANUP_EXPECTED_TIP="$expected_tip" \
+    CLEANUP_REJECTED_MARKER="$branch_delete_rejected_marker" \
+    CLEANUP_GUARD_INVOKED_MARKER="$branch_delete_guard_invoked_marker" \
+    git \
+      -c "hook.$branch_delete_guard_name.event=reference-transaction" \
+      -c "hook.$branch_delete_guard_name.command=$branch_delete_guard_path" \
+      branch -D -- "$branch" 2>"$branch_delete_error_file"; then
+    if [[ ! -f "$branch_delete_guard_invoked_marker" ]]; then
+      printf 'Branch deletion guard did not run for %s\n' "$branch" >"$branch_delete_error_file"
+      return 2
+    fi
+    return 0
+  fi
+
+  if [[ -f "$branch_delete_rejected_marker" ]]; then
+    return 10
+  fi
+  return 2
+}
 
 for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
   worktree=${worktree_paths[index]}
   branch=${worktree_branches[index]}
 
-  if [[ "$worktree" == "$main_worktree" || "$worktree" == "$current_worktree" ]]; then
+  if [[ "$worktree" == "$main_worktree" || "$worktree" == "$current_worktree" || "$branch" == main ]]; then
     continue
   fi
 
@@ -193,17 +438,6 @@ for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
     continue
   fi
 
-  if cleanup_reason=$(find_cleanup_reason "$branch" "$head_before"); then
-    :
-  else
-    reason_status=$?
-    if ((reason_status == 2)); then
-      printf 'Skipping worktree whose cleanup state could not be read: %s\n' "$worktree" >&2
-      failed=1
-    fi
-    continue
-  fi
-
   if ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
     printf 'Skipping worktree whose status could not be read: %s\n' "$worktree" >&2
     failed=1
@@ -215,78 +449,152 @@ for ((index = 0; index < ${#worktree_paths[@]}; index++)); do
     continue
   fi
 
-  # Re-evaluation prevents a fetch or checkout during cleanup from invalidating the deletion reason.
-  if [[ "$(git -C "$worktree" rev-parse HEAD)" != "$head_before" ]] ||
-    ! confirmed_reason=$(find_cleanup_reason "$branch" "$head_before"); then
+  if ! last_update=$(worktree_last_update "$worktree" "$branch"); then
+    printf 'Skipping worktree whose reflog state could not be read: %s\n' "$worktree" >&2
+    failed=1
+    continue
+  fi
+
+  if ! timestamp_is_stale "$last_update"; then
+    continue
+  fi
+
+  # Re-evaluation prevents a checkout, reset, or file edit during cleanup from becoming stale deletion.
+  if ! head_after=$(git -C "$worktree" rev-parse HEAD 2>/dev/null); then
+    printf 'Skipping worktree whose cleanup state could not be read: %s\n' "$worktree" >&2
+    failed=1
+    continue
+  fi
+  if ! worktree_status=$(git -C "$worktree" status --porcelain --untracked-files=all); then
+    printf 'Skipping worktree whose status could not be read: %s\n' "$worktree" >&2
+    failed=1
+    continue
+  fi
+  if [[ -n "$worktree_status" ]]; then
+    printf 'Skipping worktree updated during cleanup: %s\n' "$worktree" >&2
+    continue
+  fi
+  if ! confirmed_last_update=$(worktree_last_update "$worktree" "$branch"); then
+    printf 'Skipping worktree whose reflog state could not be read: %s\n' "$worktree" >&2
+    failed=1
+    continue
+  fi
+  if [[ "$head_after" != "$head_before" ]] || ! timestamp_is_stale "$confirmed_last_update"; then
     printf 'Skipping worktree updated during cleanup: %s\n' "$worktree" >&2
     continue
   fi
 
   if git worktree remove -- "$worktree"; then
-    printf 'Removed %s worktree: %s\n' "$confirmed_reason" "$worktree"
+    printf 'Removed stale worktree: %s\n' "$worktree"
     removed_worktrees=$((removed_worktrees + 1))
   else
-    printf 'Failed to remove %s worktree: %s\n' "$cleanup_reason" "$worktree" >&2
+    printf 'Failed to remove stale worktree: %s\n' "$worktree" >&2
     failed=1
   fi
 done
 
-if ! git for-each-ref --format='%(refname:short)' refs/heads >"$branch_list_file"; then
-  printf 'Failed to list local branches\n' >&2
-  exit 1
+if ((checkout_activity_complete)) && ! snapshot_checkout_activity "$live_checkout_activity_file"; then
+  checkout_activity_complete=0
+  failed=1
 fi
 
-while IFS= read -r branch; do
-  if [[ -z "$branch" || "$branch" == main ]]; then
-    continue
+if ((checkout_activity_complete && branch_delete_guard_supported)); then
+  if ! git for-each-ref --format='%(refname:lstrip=2)' refs/heads >"$branch_list_file"; then
+    printf 'Failed to list local branches\n' >&2
+    exit 1
   fi
 
-  if branch_is_checked_out "$branch"; then
-    continue
-  elif (( $? == 2 )); then
-    printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
-    failed=1
-    continue
-  fi
+  while IFS= read -r branch; do
+    if [[ -z "$branch" || "$branch" == main ]]; then
+      continue
+    fi
 
-  if ! expected_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
-    continue
-  fi
+    if branch_is_checked_out "$branch"; then
+      continue
+    elif (( $? == 2 )); then
+      printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
+      failed=1
+      continue
+    fi
 
-  if cleanup_reason=$(find_cleanup_reason "$branch" "$expected_tip"); then
-    :
-  else
-    reason_status=$?
-    if ((reason_status == 2)); then
+    if ! expected_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
+      printf 'Skipping branch whose tip could not be read: %s\n' "$branch" >&2
+      failed=1
+      continue
+    fi
+
+    if ! last_update=$(branch_last_update "$branch"); then
+      printf 'Skipping branch whose reflog state could not be read: %s\n' "$branch" >&2
+      failed=1
+      continue
+    fi
+
+    if ! timestamp_is_stale "$last_update"; then
+      continue
+    fi
+
+    if ! snapshot_checkout_activity "$live_checkout_activity_file"; then
+      printf 'Skipping remaining local branches because checkout history could not be refreshed\n' >&2
+      checkout_activity_complete=0
+      failed=1
+      break
+    fi
+
+    # The transaction guard checks the expected tip after Git locks the ref. This preserves branch
+    # porcelain's checked-out protection and config cleanup without deleting a concurrently updated tip.
+    if branch_is_checked_out "$branch"; then
+      printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
+      continue
+    elif (( $? == 2 )); then
+      printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
+      failed=1
+      continue
+    fi
+    if ! confirmed_tip=$(git rev-parse "refs/heads/$branch" 2>/dev/null); then
       printf 'Skipping branch whose cleanup state could not be read: %s\n' "$branch" >&2
       failed=1
+      continue
     fi
-    continue
-  fi
+    if ! confirmed_last_update=$(branch_last_update "$branch"); then
+      printf 'Skipping branch whose reflog state could not be read: %s\n' "$branch" >&2
+      failed=1
+      continue
+    fi
+    if [[ "$confirmed_tip" != "$expected_tip" ]] || ! timestamp_is_stale "$confirmed_last_update"; then
+      printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
+      continue
+    fi
 
-  # Git's branch deletion preserves checked-out protection and removes branch-specific config.
-  if branch_is_checked_out "$branch"; then
-    printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
-    continue
-  elif (( $? == 2 )); then
-    printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
+    if delete_branch_with_expected_tip "$branch" "$expected_tip"; then
+      printf 'Removed stale local branch: %s\n' "$branch"
+      removed_branches=$((removed_branches + 1))
+    else
+      delete_status=$?
+      if ((delete_status == 10)); then
+        printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
+      elif branch_is_checked_out "$branch"; then
+        printf 'Skipping branch checked out during cleanup: %s\n' "$branch" >&2
+      elif (( $? == 2 )); then
+        printf 'Failed to verify whether branch is checked out: %s\n' "$branch" >&2
+        failed=1
+      else
+        if [[ -s "$branch_delete_error_file" ]]; then
+          sed -n 'p' "$branch_delete_error_file" >&2
+        fi
+        printf 'Failed to remove stale local branch: %s\n' "$branch" >&2
+        failed=1
+      fi
+    fi
+  done <"$branch_list_file"
+elif ((checkout_activity_complete == 0)); then
+  printf 'Skipping local branch cleanup because worktree checkout history could not be read\n' >&2
+  if ((failed == 0)); then
     failed=1
-    continue
   fi
-  if [[ "$(git rev-parse "refs/heads/$branch")" != "$expected_tip" ]] ||
-    ! confirmed_reason=$(find_cleanup_reason "$branch" "$expected_tip"); then
-    printf 'Skipping branch updated during cleanup: %s\n' "$branch" >&2
-    continue
-  fi
-
-  if git branch -D -- "$branch"; then
-    printf 'Removed %s local branch: %s\n' "$confirmed_reason" "$branch"
-    removed_branches=$((removed_branches + 1))
-  else
-    printf 'Failed to remove %s local branch: %s\n' "$cleanup_reason" "$branch" >&2
-    failed=1
-  fi
-done <"$branch_list_file"
+else
+  printf 'Skipping local branch cleanup because Git does not support guarded branch deletion\n' >&2
+  failed=1
+fi
 
 printf 'Removed %d worktree(s) and %d local branch(es)\n' "$removed_worktrees" "$removed_branches"
 


### PR DESCRIPTION
## Related issue

None

## Summary

- Delete clean worktrees and local or origin branches whose tip commit is at least seven days old.
- Keep branches with open pull requests and protect main, current, checked-out, locked, and dirty targets.
- Fetch origin before cleanup and use a force-with-lease when deleting remote branches.

## Testing

- bash -n scripts/cleanup-branches.sh
- Temporary Git repository fixture covering stale and recent local/remote branches, open pull requests, dirty and locked worktrees, ignored-only worktrees, concurrent remote updates, and same-name remote tags
- mise run check (116 test files, 681 tests)