### PR TITLE
[No issue] Show swipe direction icons in feedback

### DIFF
--- a/.devcontainer/compose.e2e.yaml
+++ b/.devcontainer/compose.e2e.yaml
@@ -29,6 +29,9 @@ services:
   browser:
     image: mcr.microsoft.com/playwright:v1.61.1-noble
     init: true
+    # The CLI is installed only to start this disposable server; waiting for a registry audit can keep port 3000 closed.
+    environment:
+      NPM_CONFIG_AUDIT: "false"
     # Chromium workers need the host IPC namespace so parallel runs do not exhaust Docker's 64 MB /dev/shm default.
     ipc: host
     user: pwuser

--- a/docs/e2e/study-actions.md
+++ b/docs/e2e/study-actions.md
@@ -36,7 +36,7 @@ Then:
 - 現在だった Card の difficulty が mastered rule に従って 1 下がり、学習回数が 1 増えて保存される。
 - session の位置が次の Card へ進む。
 - 次の Card の front text が表示される。
-- 実行した swipe 方向が共通 toast で短時間表示される。
+- 実行した swipe 方向が、言語に依存しないアイコンとして共通 toast で短時間表示される。
 - browser error が発生しない。
 
 <a id="swipe-03"></a>

--- a/src/pages/study-session/ui/StudySessionPage.spec.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.spec.tsx
@@ -246,7 +246,12 @@ describe("StudySessionPage [SETTINGS-04] [SWIPE-02] [SWIPE-03] [SWIPE-10] [SWIPE
     await user.keyboard("{ArrowRight}");
 
     await waitFor(() => expect(screen.getByText("Front two")).toBeVisible());
-    expect(screen.getByText("Swiped right")).toBeVisible();
+    expect(screen.getByTestId("swipe-feedback-direction")).toHaveAttribute(
+      "data-swipe-feedback-direction",
+      "cardSwipeRight"
+    );
+    expect(screen.getByRole("status", { name: "Toast notifications" })).toHaveTextContent("Swiped right");
+    expect(screen.getAllByText("Swiped right")).toHaveLength(1);
     expect(screen.queryByRole("button", { name: "Dismiss notification" })).not.toBeInTheDocument();
   });
 
@@ -268,7 +273,11 @@ describe("StudySessionPage [SETTINGS-04] [SWIPE-02] [SWIPE-03] [SWIPE-10] [SWIPE
       await request.promise;
     });
 
-    expect(await screen.findByText("右へスワイプしました")).toBeVisible();
+    expect(await screen.findByRole("status", { name: "トースト通知" })).toHaveTextContent("右へスワイプしました");
+    expect(screen.getByTestId("swipe-feedback-direction")).toHaveAttribute(
+      "data-swipe-feedback-direction",
+      "cardSwipeRight"
+    );
     expect(screen.queryByText("Swiped right")).not.toBeInTheDocument();
     expect(screen.getByText("Front two")).toBeVisible();
   });

--- a/src/pages/study-session/ui/StudySessionPage.tsx
+++ b/src/pages/study-session/ui/StudySessionPage.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type { TFunction } from "i18next";
+import { AiOutlineArrowDown, AiOutlineArrowLeft, AiOutlineArrowRight, AiOutlineArrowUp } from "react-icons/ai";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey, useLatest } from "react-use";
@@ -27,12 +28,12 @@ type StudyShortcutAction =
   | "toggleSwipeButtonList"
   | "toggleAutoPlay";
 
-const swipeFeedbackKeys = {
-  cardSwipeUp: "studySession.feedback.swipedUp",
-  cardSwipeDown: "studySession.feedback.swipedDown",
-  cardSwipeLeft: "studySession.feedback.swipedLeft",
-  cardSwipeRight: "studySession.feedback.swipedRight",
-} as const satisfies Record<SwipeDirection, string>;
+const swipeFeedbackPresentation = {
+  cardSwipeUp: { icon: AiOutlineArrowUp, labelKey: "studySession.feedback.swipedUp" },
+  cardSwipeDown: { icon: AiOutlineArrowDown, labelKey: "studySession.feedback.swipedDown" },
+  cardSwipeLeft: { icon: AiOutlineArrowLeft, labelKey: "studySession.feedback.swipedLeft" },
+  cardSwipeRight: { icon: AiOutlineArrowRight, labelKey: "studySession.feedback.swipedRight" },
+} as const satisfies Record<SwipeDirection, { icon: typeof AiOutlineArrowUp; labelKey: string }>;
 
 const SWIPE_FEEDBACK_DURATION_MS = 900;
 const SWIPE_FEEDBACK_TONE = "neutral" satisfies ToastTone;
@@ -138,8 +139,17 @@ const ActiveStudySessionPage: React.FC<{ deckId: string }> = ({ deckId }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const study = useStudy(deckId, (direction) => {
+    const { icon: Icon, labelKey } = swipeFeedbackPresentation[direction];
     showToast({
-      message: t(swipeFeedbackKeys[direction]),
+      message: t(labelKey),
+      visualContent: (
+        <Icon
+          aria-hidden="true"
+          className="text-3xl"
+          data-swipe-feedback-direction={direction}
+          data-testid="swipe-feedback-direction"
+        />
+      ),
       tone: SWIPE_FEEDBACK_TONE,
       durationMs: SWIPE_FEEDBACK_DURATION_MS,
       dismissible: false,

--- a/src/shared/ui/toast/Toast.spec.tsx
+++ b/src/shared/ui/toast/Toast.spec.tsx
@@ -15,7 +15,7 @@ const displayToast = (input: ShowToastInput) => {
   return id;
 };
 
-describe("SETTINGS-04 Toast", () => {
+describe("Toast [SETTINGS-04] [SWIPE-02]", () => {
   beforeEach(() => dismissToast());
 
   afterEach(() => {
@@ -159,6 +159,20 @@ describe("SETTINGS-04 Toast", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent("Swiped right");
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows visual content while announcing its textual meaning", () => {
+    render(<ToastViewport />);
+    displayToast({
+      message: "Swiped right",
+      visualContent: <span data-testid="direction-icon">→</span>,
+      dismissible: false,
+      durationMs: null,
+    });
+
+    expect(screen.getByTestId("direction-icon")).toBeVisible();
+    expect(screen.getByRole("status")).toHaveTextContent("Information: Swiped right");
+    expect(screen.getAllByText("Swiped right")).toHaveLength(1);
   });
 
   it.each(["neutral", "success"] as const)("automatically dismisses %s notifications after four seconds", (tone) => {

--- a/src/shared/ui/toast/Toast.stories.tsx
+++ b/src/shared/ui/toast/Toast.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
+import { AiOutlineArrowRight } from "react-icons/ai";
 
 import type { ToastTone } from ".";
 import { ToastViewport } from "./Toast";
@@ -9,6 +10,7 @@ interface ToastStoryProps {
   message: string;
   tone: ToastTone;
   dismissible?: boolean;
+  visualContent?: React.ReactNode;
 }
 
 const useStoryToast = (props: ToastStoryProps) => {
@@ -18,9 +20,10 @@ const useStoryToast = (props: ToastStoryProps) => {
       tone: props.tone,
       durationMs: null,
       dismissible: props.dismissible ?? true,
+      visualContent: props.visualContent,
     });
     return () => dismissToast(id);
-  }, [props.dismissible, props.message, props.tone]);
+  }, [props.dismissible, props.message, props.tone, props.visualContent]);
 };
 
 const ToastStory = (props: ToastStoryProps) => {
@@ -57,6 +60,13 @@ export const LongMessage: Story = {
 };
 export const NonInteractive: Story = {
   args: { dismissible: false, message: "Swiped right" },
+};
+export const DirectionIcon: Story = {
+  args: {
+    dismissible: false,
+    message: "Swiped right",
+    visualContent: <AiOutlineArrowRight aria-hidden="true" className="text-3xl" />,
+  },
 };
 export const Dark: Story = {
   args: { tone: "success", message: "Dark-mode notification" },

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -15,6 +15,7 @@ import {
 
 interface ToastProps {
   message: string;
+  visualContent: React.ReactNode | undefined;
   tone: ToastTone;
   dismissible: boolean;
   onDismiss: () => void;
@@ -40,7 +41,16 @@ const Toast = (props: ToastProps) => {
       )}
     >
       <span className="sr-only">{t(presentation.labelKey)}: </span>
-      <span className="min-w-0 break-words">{props.message}</span>
+      {props.visualContent === undefined ? (
+        <span className="min-w-0 break-words">{props.message}</span>
+      ) : (
+        <>
+          <span className="sr-only">{props.message}</span>
+          <span aria-hidden="true" className="inline-flex shrink-0 items-center justify-center">
+            {props.visualContent}
+          </span>
+        </>
+      )}
       {props.dismissible ? (
         <button
           type="button"
@@ -97,6 +107,7 @@ export const ToastViewport = <T extends HTMLElement = HTMLElement>({
     <Toast
       key={activeToast.id}
       message={activeToast.message}
+      visualContent={activeToast.visualContent}
       tone={activeToast.tone}
       dismissible={activeToast.dismissible && !modalActive}
       onDismiss={() => dismissToast(activeToast.id)}

--- a/src/shared/ui/toast/model.ts
+++ b/src/shared/ui/toast/model.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { createStore } from "zustand/vanilla";
 
 export type ToastId = number;
@@ -6,6 +7,8 @@ export type ToastTone = "neutral" | "success" | "warning" | "error";
 
 export interface ShowToastInput {
   message: string;
+  /** Replaces the visible message while keeping the text available to the live-region announcement. */
+  visualContent?: ReactNode;
   tone?: ToastTone;
   durationMs?: number | null;
   dismissible?: boolean;
@@ -14,6 +17,7 @@ export interface ShowToastInput {
 export interface ToastState {
   id: ToastId;
   message: string;
+  visualContent: ReactNode | undefined;
   tone: ToastTone;
   durationMs: number | null;
   dismissible: boolean;
@@ -148,6 +152,7 @@ export const showToast = (input: ShowToastInput): ToastId => {
     current: {
       id,
       message: input.message,
+      visualContent: input.visualContent,
       tone,
       durationMs: input.durationMs === undefined ? DEFAULT_DURATION_MS[tone] : input.durationMs,
       dismissible: input.dismissible ?? true,

--- a/test/e2e/swipe.spec.ts
+++ b/test/e2e/swipe.spec.ts
@@ -45,7 +45,10 @@ test("SWIPE-02 saves mastered progress and advances to the next Card", async ({ 
   await page.getByRole("button", { name: "Swipe up" }).click();
 
   const feedback = page.getByRole("status").filter({ hasText: "Swiped up" });
+  const directionIcon = page.getByTestId("swipe-feedback-direction");
   await expect(feedback).toBeVisible();
+  await expect(directionIcon).toHaveAttribute("data-swipe-feedback-direction", "cardSwipeUp");
+  await expect(directionIcon).toBeVisible();
   await expect(page.getByRole("button", { name: "Dismiss notification" })).toHaveCount(0);
   await expect(page.getByText(nextCard.frontText, { exact: true })).toBeVisible();
   await expect
@@ -56,6 +59,7 @@ test("SWIPE-02 saves mastered progress and advances to the next Card", async ({ 
     });
   await expect.poll(async () => (await readSession(page, deck.id))?.currentIndex).toBe(session.currentIndex + 1);
   await expect(feedback).toHaveCount(0, { timeout: 2000 });
+  await expect(directionIcon).toHaveCount(0);
 });
 
 test("SWIPE-03 saves non-mastered progress and advances to the next Card", async ({ fixture, page }) => {


### PR DESCRIPTION
## Related issue

None

## Summary

- Show language-independent direction icons for deck swipe feedback.
- Keep localized swipe descriptions in the Toast live region for assistive technology.
- Cover visual Toast content in unit tests, Storybook, and the SWIPE-02 E2E contract.
- Prevent the disposable Playwright server from blocking on an npm audit during CI startup.

## Testing

- `mise run check` (120 test files, 695 tests passed)
- `mise run e2e` (browser healthy and SWIPE-02 passed; 77 of 78 passed locally, with ACCOUNT-02 affected by a transient Firestore Listen 400)
- GitHub Actions (all checks passed, including E2E)