### PR TITLE
No issue: Add bulk difficulty changes to Card List

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -95,6 +95,8 @@
 | CARD-16 | write | [Card の削除失敗後に再試行できる](./card-management.md#card-16) |
 | CARD-17 | read | [未保存の Card 編集内容を離脱前に確認できる](./card-management.md#card-17) |
 | CARD-18 | write | [Card 一覧の difficulty 保存失敗後に再試行できる](./card-list-actions.md#card-18) |
+| CARD-19 | batch | [表示中の Card の difficulty をまとめて変更できる](./card-list-actions.md#card-19) |
+| CARD-20 | batch | [Card の一括 difficulty 変更を部分失敗後に再試行できる](./card-list-actions.md#card-20) |
 
 ### Study
 

--- a/docs/e2e/card-list-actions.md
+++ b/docs/e2e/card-list-actions.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-Card 一覧上の swipe と filter が、Card の学習状態と一覧表示へ正しく反映されることを確認する。
+Card 一覧上の swipe、filter、一括変更が、Card の学習状態と一覧表示へ正しく反映されることを確認する。
 
 ## テストケース
 
@@ -12,6 +12,8 @@ Card 一覧上の swipe と filter が、Card の学習状態と一覧表示へ�
 | CARD-06 | write | [Card の左 swipe で difficulty を上げられる](#card-06) |
 | CARD-10 | write | [difficulty と tag の filter を保存して Card 一覧へ反映できる](#card-10) |
 | CARD-18 | write | [Card 一覧の difficulty 保存失敗後に再試行できる](#card-18) |
+| CARD-19 | batch | [表示中の Card の difficulty をまとめて変更できる](#card-19) |
+| CARD-20 | batch | [Card の一括 difficulty 変更を部分失敗後に再試行できる](#card-20) |
 
 <a id="card-05"></a>
 
@@ -100,5 +102,62 @@ Then:
 
 - 保存失敗の feedback が消える。
 - 対象 Card の difficulty が最初の操作前より 1 下がって表示される。
+- 変更対象ではない Card の difficulty は変更されない。
+- 最初の保存失敗に伴う未処理の browser error が発生しない。
+
+<a id="card-19"></a>
+
+### CARD-19 表示中の Card の difficulty をまとめて変更できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`remote-deck-with-cards`](./fixture/remote-deck-with-cards.yaml)
+- 認証済みユーザーが所有する Deck に、difficulty が異なる複数の Card が存在する。
+- 保存前の difficulty filter draft に一致する Card と、一致しない Card が存在する。
+
+When:
+
+- Card 一覧で difficulty filter draft を変更し、一致する Card だけを表示する。
+- 表示中の Card に適用する新しい difficulty を選択し、確認 dialog を開く。
+- keyboard で dialog 内を移動した後、Escape で一度キャンセルし、再度開いて一括変更を実行する。
+- 保存完了後に画面を reload する。
+
+Then:
+
+- 確認画面は非破壊操作の dialog として、表示中の Card 件数と選択した新しい difficulty を表示する。
+- dialog を開くとキャンセルへ focus し、Tab と Shift+Tab で focus が dialog 外へ移動せず、背景の scroll を抑止する。
+- Escape では変更せずに dialog を閉じ、focus と背景の scroll を一括変更の起点へ復元する。
+- 確認中と保存中は画面 shortcut でほかの route へ移動しない。
+- filter draft に一致していたすべての Card の difficulty が、選択した値へ変更される。
+- filter draft に一致しなかった Card の difficulty は変更されない。
+- browser error が発生しない。
+
+<a id="card-20"></a>
+
+### CARD-20 Card の一括 difficulty 変更を部分失敗後に再試行できる
+
+カテゴリ: `batch`
+
+Given:
+
+- Fixture: [`remote-deck-with-cards`](./fixture/remote-deck-with-cards.yaml)
+- 認証済みユーザーが所有する Deck に、一括変更の対象となる複数の Card が存在する。
+- 最初の一括変更では対象 Card の1件だけが保存に失敗し、ほかの対象 Card は保存に成功する。
+- 次の一括変更ではすべての対象 Card を保存できる。
+
+When:
+
+- 表示中の Card に適用する新しい difficulty を選択し、確認 dialog から一括変更を実行する。
+- 部分失敗後も保持された対象と difficulty のまま、確認 dialog から一括変更を再試行する。
+- 保存完了後に画面を reload する。
+
+Then:
+
+- 保存中は dialog が pending 状態を示し、確認とキャンセルを無効化して focus を dialog 内に保つ。
+- 最初の試行後に成功件数と失敗件数が通知され、確認 dialog は同じ対象件数と difficulty を保持する。
+- 最初の試行で成功した Card の difficulty は保持される。
+- 再試行後は対象となったすべての Card の difficulty が、最初に選択した値へ変更される。
 - 変更対象ではない Card の difficulty は変更されない。
 - 最初の保存失敗に伴う未処理の browser error が発生しない。

--- a/src/app/i18n/resources.ts
+++ b/src/app/i18n/resources.ts
@@ -212,6 +212,27 @@ export const resources = {
         count_other: "{{count}} cards",
         add: "Add card",
         closeCard: "Close card",
+        bulkDifficulty: {
+          title: "Change difficulty",
+          target_one: "{{count}} visible card",
+          target_other: "{{count}} visible cards",
+          newDifficulty: "New difficulty",
+          placeholder: "Choose difficulty",
+          request: "Change difficulty",
+          success_one: "Set {{count}} card to difficulty {{difficulty}}.",
+          success_other: "Set {{count}} cards to difficulty {{difficulty}}.",
+          partialFailure_one:
+            "Updated {{successCount}} of {{totalCount}}. {{count}} card could not be updated. Try again.",
+          partialFailure_other:
+            "Updated {{successCount}} of {{totalCount}}. {{count}} cards could not be updated. Try again.",
+          dialog: {
+            title: "Change card difficulty?",
+            description_one: "Set {{count}} visible card to difficulty {{difficulty}}.",
+            description_other: "Set {{count}} visible cards to difficulty {{difficulty}}.",
+            cancel: "Cancel",
+            confirm: "Apply change",
+          },
+        },
         filters: {
           title: "Filters",
           noFilters: "No filters",
@@ -791,6 +812,27 @@ export const resources = {
         count_other: "{{count}}枚",
         add: "カードを追加",
         closeCard: "カードを閉じる",
+        bulkDifficulty: {
+          title: "難易度をまとめて変更",
+          target_one: "表示中のカード{{count}}枚",
+          target_other: "表示中のカード{{count}}枚",
+          newDifficulty: "変更後の難易度",
+          placeholder: "難易度を選択",
+          request: "難易度を変更",
+          success_one: "{{count}}枚のカードを難易度{{difficulty}}に変更しました。",
+          success_other: "{{count}}枚のカードを難易度{{difficulty}}に変更しました。",
+          partialFailure_one:
+            "{{totalCount}}枚中{{successCount}}枚を更新しました。{{count}}枚を更新できませんでした。もう一度お試しください。",
+          partialFailure_other:
+            "{{totalCount}}枚中{{successCount}}枚を更新しました。{{count}}枚を更新できませんでした。もう一度お試しください。",
+          dialog: {
+            title: "カードの難易度を変更しますか？",
+            description_one: "表示中のカード{{count}}枚を難易度{{difficulty}}に変更します。",
+            description_other: "表示中のカード{{count}}枚を難易度{{difficulty}}に変更します。",
+            cancel: "キャンセル",
+            confirm: "変更を適用",
+          },
+        },
         filters: {
           title: "フィルター",
           noFilters: "フィルターなし",

--- a/src/pages/card-list/model/useCardListState.ts
+++ b/src/pages/card-list/model/useCardListState.ts
@@ -4,7 +4,14 @@ import { useAuthUid } from "@/entities/auth";
 import { deleteCard, mustFindCardById, type Card, type CardId, useCardsByDeckId } from "@/entities/card";
 import { type Deck, getCategory, isHighlightLanguage } from "@/entities/deck";
 import { usePreferences } from "@/entities/preference";
-import { calculateDifficulty, editStudyProgress, type StudyRating } from "@/entities/study-progress";
+import {
+  calculateDifficulty,
+  type Difficulty,
+  editStudyProgress,
+  MAX_DIFFICULTY,
+  MIN_DIFFICULTY,
+  type StudyRating,
+} from "@/entities/study-progress";
 import { selectStudyCards } from "@/entities/study-session";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 import { dismissToast, showToast, type ToastId } from "@/shared/ui/toast";
@@ -24,13 +31,31 @@ interface CardListAnswer {
   dark: boolean;
 }
 
+interface BulkDifficultyRequest {
+  cardIds: CardId[];
+  difficulty: Difficulty;
+}
+
+type BulkDifficultySaveResult =
+  | { outcome: "success"; cardCount: number; difficulty: Difficulty }
+  | { outcome: "partial-failure"; failureCount: number; successCount: number; totalCount: number };
+
 export interface CardListState {
   tags: string[];
   cards: CardListItem[];
   answer: CardListAnswer | undefined;
+  bulkDifficulty: Difficulty | null;
+  bulkDifficultyMaximum: number;
+  bulkDifficultyMinimum: number;
+  bulkDifficultyPending: boolean;
+  bulkDifficultyTarget: { cardCount: number; difficulty: number } | undefined;
   deletionTarget: { frontText: string } | undefined;
   deletionPending: boolean;
   mutationPending: boolean;
+  onChangeBulkDifficulty: (difficulty: Difficulty | null) => void;
+  onRequestBulkDifficulty: () => void;
+  onCancelBulkDifficulty: () => void;
+  onConfirmBulkDifficulty: () => Promise<BulkDifficultySaveResult | undefined>;
   onShowCard: (id: CardId) => void;
   onCloseCard: () => void;
   onSwipedLeft: (id: CardId) => void;
@@ -48,12 +73,17 @@ const buildCardListItem = (card: Card): CardListItem => ({
   tags: card.tags,
 });
 
+const isBulkDifficultyOption = (difficulty: Difficulty): boolean =>
+  Number.isInteger(difficulty) && difficulty >= MIN_DIFFICULTY && difficulty <= MAX_DIFFICULTY;
+
 export const useCardListState = (deck: Deck): CardListState => {
   const uid = useAuthUid();
   const preferences = usePreferences();
   const { cards: deckCards, tags } = useCardsByDeckId(deck.id);
   const isMounted = useMountedGuard();
   const [shownCard, setShownCard] = React.useState<Card>();
+  const [bulkDifficulty, setBulkDifficulty] = React.useState<Difficulty | null>(null);
+  const [bulkDifficultyRequest, setBulkDifficultyRequest] = React.useState<BulkDifficultyRequest>();
   const [deletionTarget, setDeletionTarget] = React.useState<Card>();
   const [mutationPending, setMutationPending] = React.useState(false);
   const mutationPendingRef = React.useRef(false);
@@ -95,6 +125,56 @@ export const useCardListState = (deck: Deck): CardListState => {
       if (isMounted()) {
         errorToastId.current = showToast({ message: "Unable to save changes. Try again.", tone: "error" });
       }
+    } finally {
+      finishMutation();
+    }
+  };
+
+  const requestBulkDifficulty = () => {
+    if (bulkDifficulty == null || cards.length === 0 || mutationPendingRef.current) return;
+    dismissErrorToast();
+    // Freeze the visible result set before confirmation so filter/subscription changes cannot
+    // silently alter which Cards the approved operation targets.
+    setBulkDifficultyRequest({
+      cardIds: cards.map(({ id }) => id),
+      difficulty: bulkDifficulty,
+    });
+  };
+
+  const cancelBulkDifficulty = () => {
+    // biome-ignore lint/suspicious/noUnnecessaryConditions: Escape or Cancel can arrive before React publishes the pending state.
+    if (mutationPendingRef.current) return;
+    dismissErrorToast();
+    setBulkDifficultyRequest(undefined);
+  };
+
+  const confirmBulkDifficulty = async () => {
+    if (bulkDifficultyRequest == null || !beginMutation()) return;
+    const request = bulkDifficultyRequest;
+    try {
+      // Absolute-value retries are intentionally idempotent. Let every independent write settle
+      // before unlocking the list so a partial failure cannot overlap the user's retry.
+      const results = await Promise.allSettled(
+        request.cardIds.map((cardId) => editStudyProgress(uid, { cardId, difficulty: request.difficulty }))
+      );
+      if (!isMounted()) return;
+      const failureCount = results.filter(({ status }) => status === "rejected").length;
+      if (failureCount === 0) {
+        setBulkDifficultyRequest(undefined);
+        setBulkDifficulty(null);
+        return {
+          outcome: "success" as const,
+          cardCount: request.cardIds.length,
+          difficulty: request.difficulty,
+        };
+      }
+
+      return {
+        outcome: "partial-failure" as const,
+        failureCount,
+        successCount: request.cardIds.length - failureCount,
+        totalCount: request.cardIds.length,
+      };
     } finally {
       finishMutation();
     }
@@ -142,6 +222,17 @@ export const useCardListState = (deck: Deck): CardListState => {
     tags,
     cards: cards.map(buildCardListItem),
     answer,
+    bulkDifficulty,
+    bulkDifficultyMaximum: MAX_DIFFICULTY,
+    bulkDifficultyMinimum: MIN_DIFFICULTY,
+    bulkDifficultyPending: mutationPending && bulkDifficultyRequest != null,
+    bulkDifficultyTarget:
+      bulkDifficultyRequest == null
+        ? undefined
+        : {
+            cardCount: bulkDifficultyRequest.cardIds.length,
+            difficulty: bulkDifficultyRequest.difficulty,
+          },
     mutationPending,
     deletionPending: mutationPending && deletionTarget != null,
     deletionTarget:
@@ -150,6 +241,12 @@ export const useCardListState = (deck: Deck): CardListState => {
         : {
             frontText: deletionTarget.frontText,
           },
+    onChangeBulkDifficulty: (difficulty) => {
+      if (difficulty == null || isBulkDifficultyOption(difficulty)) setBulkDifficulty(difficulty);
+    },
+    onRequestBulkDifficulty: requestBulkDifficulty,
+    onCancelBulkDifficulty: cancelBulkDifficulty,
+    onConfirmBulkDifficulty: confirmBulkDifficulty,
     onShowCard: (id: CardId) => setShownCard(mustFindCardById(cards, id)),
     onCloseCard: () => setShownCard(undefined),
     onSwipedLeft: (id: CardId) => void changeDifficulty(id, "not-mastered"),

--- a/src/pages/card-list/ui/CardList.spec.tsx
+++ b/src/pages/card-list/ui/CardList.spec.tsx
@@ -20,7 +20,7 @@ import { CardList } from "./CardList";
 const card = createCard({ id: "card-id", frontText: "Front", backText: "Back", difficulty: 5, tags: [] });
 const otherCard = createCard({ id: "other-id", frontText: "Other", backText: "Other back", tags: ["two"] });
 
-describe("CardList [CARD-01] [CARD-10]", () => {
+describe("CardList [CARD-01] [CARD-10] [CARD-19]", () => {
   it("renders the heading, zero count, and collapsed no-filter summary", () => {
     render(<CardList cards={[]} filterSlot={<div>Controls</div>} />);
 
@@ -79,6 +79,60 @@ describe("CardList [CARD-01] [CARD-10]", () => {
   it("shows filter disclosure state", () => {
     render(<CardList cards={[card]} />);
     expect(screen.getByText("Filters")).toBeVisible();
+  });
+
+  it("presents the visible Card count and delegates a bulk difficulty request", async () => {
+    const onDifficultyChange = vi.fn();
+    const onRequest = vi.fn();
+    const view = render(
+      <CardList
+        cards={[card, otherCard]}
+        bulkDifficulty={{
+          difficultyLowerBound: 1,
+          difficultyUpperBound: 10,
+          selectedDifficulty: null,
+          onDifficultyChange,
+          onRequest,
+        }}
+      />
+    );
+
+    expect(screen.getByRole("heading", { level: 2, name: "Change difficulty" })).toBeVisible();
+    expect(screen.getByText("2 visible cards")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Change difficulty" })).toBeDisabled();
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "New difficulty" }), "7");
+    expect(onDifficultyChange).toHaveBeenCalledExactlyOnceWith(7);
+
+    view.rerender(
+      <CardList
+        cards={[card, otherCard]}
+        bulkDifficulty={{
+          difficultyLowerBound: 1,
+          difficultyUpperBound: 10,
+          selectedDifficulty: 7,
+          onDifficultyChange,
+          onRequest,
+        }}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Change difficulty" }));
+    expect(onRequest).toHaveBeenCalledOnce();
+
+    view.rerender(
+      <CardList
+        cards={[]}
+        bulkDifficulty={{
+          difficultyLowerBound: 1,
+          difficultyUpperBound: 10,
+          selectedDifficulty: 7,
+          onDifficultyChange,
+          onRequest,
+        }}
+      />
+    );
+    expect(screen.getByText("0 visible cards")).toBeVisible();
+    expect(screen.getByRole("combobox", { name: "New difficulty" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Change difficulty" })).toBeDisabled();
   });
 
   it("keeps only one menu open and removes it with a missing row", async () => {

--- a/src/pages/card-list/ui/CardList.stories.tsx
+++ b/src/pages/card-list/ui/CardList.stories.tsx
@@ -66,6 +66,13 @@ const meta = {
   },
   args: {
     cards: fixture.cards.default,
+    bulkDifficulty: {
+      difficultyLowerBound: 1,
+      difficultyUpperBound: 10,
+      selectedDifficulty: null,
+      onDifficultyChange: fn(),
+      onRequest: fn(),
+    },
     filter: activeFilter,
     filterSlot: <div>Filter controls</div>,
   },
@@ -81,6 +88,22 @@ export const AddCard: Story = {
   play: async ({ args, canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole("button", { name: "Add card" }));
     await expect(args.onAddCard).toHaveBeenCalledOnce();
+  },
+};
+
+export const BulkDifficulty: Story = {
+  args: {
+    bulkDifficulty: {
+      difficultyLowerBound: 1,
+      difficultyUpperBound: 10,
+      selectedDifficulty: 7,
+      onDifficultyChange: fn(),
+      onRequest: fn(),
+    },
+  },
+  play: async ({ args, canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Change difficulty" }));
+    await expect(args.bulkDifficulty?.onRequest).toHaveBeenCalledOnce();
   },
 };
 

--- a/src/pages/card-list/ui/CardList.tsx
+++ b/src/pages/card-list/ui/CardList.tsx
@@ -14,6 +14,7 @@ import { RemovableTag } from "@/shared/ui/content";
 import { Overlay } from "@/shared/ui/feedback";
 
 import { Card, type CardActionsProps } from "./Card";
+import { BulkDifficultyPanel } from "./bulk-difficulty";
 
 interface CardListItem {
   id: CardId;
@@ -34,8 +35,17 @@ interface CardListFilterState {
   selectedTags: string[];
 }
 
+interface CardListBulkDifficultyProps {
+  difficultyLowerBound: number;
+  difficultyUpperBound: number;
+  selectedDifficulty: number | null;
+  onDifficultyChange: (difficulty: number | null) => void;
+  onRequest: () => void;
+}
+
 export interface CardListProps {
   cards: CardListItem[];
+  bulkDifficulty?: CardListBulkDifficultyProps;
   disabled?: boolean;
   filter?: CardListFilterState;
   filterSlot?: React.ReactNode;
@@ -187,6 +197,18 @@ export const CardList: React.FC<CardListProps> = (props) => {
           )}
         </div>
       </fieldset>
+
+      {props.bulkDifficulty != null ? (
+        <BulkDifficultyPanel
+          cardCount={props.cards.length}
+          difficultyLowerBound={props.bulkDifficulty.difficultyLowerBound}
+          difficultyUpperBound={props.bulkDifficulty.difficultyUpperBound}
+          selectedDifficulty={props.bulkDifficulty.selectedDifficulty}
+          disabled={props.disabled}
+          onDifficultyChange={props.bulkDifficulty.onDifficultyChange}
+          onRequest={props.bulkDifficulty.onRequest}
+        />
+      ) : null}
 
       {props.cards.length > 0 && (
         <CardListRows

--- a/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
+++ b/src/pages/card-list/ui/CardListPage.interactions.spec.tsx
@@ -75,23 +75,27 @@ const defaultOptions: RenderCardListOptions = {
   preferences: createPreferences({ appearance: { darkMode: false } }),
 };
 
+const createCardListPage = (deckId: string) => (
+  <>
+    <MemoryRouter initialEntries={[`/deck/${deckId}`]}>
+      <Routes>
+        <Route path="/" element={<h1>Deck list destination</h1>} />
+        <Route path="/settings" element={<h1>Settings destination</h1>} />
+        <Route path="/deck/:id" element={<CardListPage />} />
+        <Route path="/card/:id/edit" element={<h1>Card editor destination</h1>} />
+      </Routes>
+    </MemoryRouter>
+    <ToastViewport />
+  </>
+);
+
 const renderCardList = (overrides: Partial<RenderCardListOptions> = {}) => {
   const options = { ...defaultOptions, ...overrides };
   mocks.deck = options.deck;
   mocks.cards = options.cards;
   mocks.preferences = options.preferences;
 
-  return render(
-    <>
-      <MemoryRouter initialEntries={[`/deck/${options.deck.id}`]}>
-        <Routes>
-          <Route path="/deck/:id" element={<CardListPage />} />
-          <Route path="/card/:id/edit" element={<h1>Card editor destination</h1>} />
-        </Routes>
-      </MemoryRouter>
-      <ToastViewport />
-    </>
-  );
+  return render(createCardListPage(options.deck.id));
 };
 
 const swipeRight = (article: HTMLElement) => {
@@ -100,7 +104,7 @@ const swipeRight = (article: HTMLElement) => {
   fireEvent.mouseUp(document, { clientX: 100, clientY: 0 });
 };
 
-describe("CARD-02 CARD-04 CARD-05 CARD-06 CARD-10 CARD-16 CARD-18 CardListPage interactions", () => {
+describe("CARD-02 CARD-04 CARD-05 CARD-06 CARD-10 CARD-16 CARD-18 CARD-19 CARD-20 CardListPage interactions", () => {
   beforeEach(() => {
     dismissToast();
     vi.clearAllMocks();
@@ -168,6 +172,137 @@ describe("CARD-02 CARD-04 CARD-05 CARD-06 CARD-10 CARD-16 CARD-18 CardListPage i
     await userEvent.click(screen.getByRole("button", { name: "View Front" }));
 
     expect(screen.getByLabelText("Close card")).toHaveTextContent(languageCard.backText);
+  });
+
+  it("sets the requested difficulty only on the Cards visible when confirmation opens", async () => {
+    const otherVisibleCard = createCard({
+      id: "other-visible-card",
+      deckId: deck.id,
+      frontText: "Other visible",
+      difficulty: 4,
+      tags: ["react"],
+    });
+    const hiddenCard = createCard({
+      id: "hidden-card",
+      deckId: deck.id,
+      frontText: "Hidden",
+      difficulty: 6,
+      tags: ["react"],
+    });
+    const view = renderCardList({ cards: [card, otherVisibleCard, hiddenCard] });
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "New difficulty" }), "7");
+    await userEvent.click(screen.getByRole("button", { name: "Change difficulty" }));
+    const dialog = screen.getByRole("dialog", { name: "Change card difficulty?" });
+    expect(dialog).toHaveTextContent("Set 2 visible cards to difficulty 7.");
+    expect(mocks.editStudyProgress).not.toHaveBeenCalled();
+
+    mocks.cards = [card, hiddenCard];
+    view.rerender(createCardListPage(deck.id));
+    expect(screen.getByText("1 card")).toBeVisible();
+    expect(dialog).toHaveTextContent("Set 2 visible cards to difficulty 7.");
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Apply change" }));
+
+    await waitFor(() => expect(mocks.editStudyProgress).toHaveBeenCalledTimes(2));
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-id", { cardId: card.id, difficulty: 7 });
+    expect(mocks.editStudyProgress).toHaveBeenCalledWith("user-id", {
+      cardId: otherVisibleCard.id,
+      difficulty: 7,
+    });
+    expect(mocks.editStudyProgress).not.toHaveBeenCalledWith("user-id", {
+      cardId: hiddenCard.id,
+      difficulty: 7,
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Change card difficulty?" })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole("combobox", { name: "New difficulty" })).toHaveValue("");
+    expect(screen.getByText("Set 2 cards to difficulty 7.")).toBeVisible();
+  });
+
+  it("waits for every bulk write and retains the confirmed snapshot for an idempotent retry", async () => {
+    const otherVisibleCard = createCard({
+      id: "other-visible-card",
+      deckId: deck.id,
+      frontText: "Other visible",
+      difficulty: 4,
+      tags: ["react"],
+    });
+    const remainingWrite = Promise.withResolvers<void>();
+    mocks.editStudyProgress.mockRejectedValueOnce(new Error("first bulk write failed"));
+    mocks.editStudyProgress.mockReturnValueOnce(remainingWrite.promise);
+    renderCardList({ cards: [card, otherVisibleCard] });
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "New difficulty" }), "7");
+    await userEvent.click(screen.getByRole("button", { name: "Change difficulty" }));
+    const dialog = screen.getByRole("dialog", { name: "Change card difficulty?" });
+    const confirm = within(dialog).getByRole("button", { name: "Apply change" });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(mocks.editStudyProgress).toHaveBeenCalledTimes(2));
+    expect(dialog).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByText(/could not be updated/)).not.toBeInTheDocument();
+
+    await actAsync(async () => {
+      remainingWrite.resolve();
+      await remainingWrite.promise;
+    });
+
+    expect(await screen.findByText("Updated 1 of 2. 1 card could not be updated. Try again.")).toBeVisible();
+    expect(screen.getByRole("dialog", { name: "Change card difficulty?" })).toHaveTextContent(
+      "Set 2 visible cards to difficulty 7."
+    );
+    expect(screen.getByRole("combobox", { name: "New difficulty" })).toHaveValue("7");
+
+    await userEvent.click(screen.getByRole("button", { name: "Apply change" }));
+
+    await waitFor(() => expect(mocks.editStudyProgress).toHaveBeenCalledTimes(4));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Change card difficulty?" })).not.toBeInTheDocument()
+    );
+    expect(screen.queryByText(/could not be updated/)).not.toBeInTheDocument();
+    expect(screen.getByText("Set 2 cards to difficulty 7.")).toBeVisible();
+  });
+
+  it("uses singular failure copy when the only bulk write fails", async () => {
+    mocks.editStudyProgress.mockRejectedValueOnce(new Error("bulk write failed"));
+    renderCardList();
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "New difficulty" }), "7");
+    await userEvent.click(screen.getByRole("button", { name: "Change difficulty" }));
+    await userEvent.click(screen.getByRole("button", { name: "Apply change" }));
+
+    expect(await screen.findByText("Updated 0 of 1. 1 card could not be updated. Try again.")).toBeVisible();
+  });
+
+  it("ignores screen shortcuts while bulk confirmation is open or pending", async () => {
+    const write = Promise.withResolvers<void>();
+    mocks.editStudyProgress.mockReturnValueOnce(write.promise);
+    renderCardList();
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "New difficulty" }), "7");
+    await userEvent.click(screen.getByRole("button", { name: "Change difficulty" }));
+    const dialog = screen.getByRole("dialog", { name: "Change card difficulty?" });
+
+    fireEvent.keyDown(window, { key: "s" });
+    fireEvent.keyDown(window, { key: "t" });
+    expect(dialog).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Settings destination" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Deck list destination" })).not.toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Apply change" }));
+    await waitFor(() => expect(dialog).toHaveAttribute("aria-busy", "true"));
+    fireEvent.keyDown(window, { key: "s" });
+    fireEvent.keyDown(window, { key: "t" });
+    expect(dialog).toBeVisible();
+
+    await actAsync(async () => {
+      write.resolve();
+      await write.promise;
+    });
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
   });
 
   it("closes a failed deletion and retries after reopening the same Card", async () => {

--- a/src/pages/card-list/ui/CardListPage.tsx
+++ b/src/pages/card-list/ui/CardListPage.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { useKey } from "react-use";
@@ -9,11 +9,13 @@ import { DifficultyIndicator } from "@/entities/study-progress";
 import { DeckFilterForm, useDeckFilterState } from "@/features/deck-filter";
 import { routes } from "@/shared/router";
 import { DestructiveActionDialog } from "@/shared/ui/destructive-action-dialog";
+import { dismissToast, showToast, type ToastId } from "@/shared/ui/toast";
 import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
 import { useCardListState } from "../model/useCardListState";
 import { CardList } from "./CardList";
+import { BulkDifficultyDialog } from "./bulk-difficulty";
 
 const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
   const { t } = useTranslation();
@@ -32,10 +34,85 @@ const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
   const difficultyMax = deckFilter.difficultyMax === deckFilter.difficultyUpperBound ? null : deckFilter.difficultyMax;
   const difficultyMin = deckFilter.difficultyMin === deckFilter.difficultyLowerBound ? null : deckFilter.difficultyMin;
   const busy = state.mutationPending || deckFilter.saving;
+  const dialogOpen = state.bulkDifficultyTarget != null || state.deletionTarget != null;
+  const bulkErrorToastId = React.useRef<ToastId | undefined>(undefined);
+
+  useKey(
+    "t",
+    () => {
+      if (!dialogOpen) void navigate(routes.deckList.to());
+    },
+    undefined,
+    [dialogOpen, navigate]
+  );
+  useKey(
+    "s",
+    () => {
+      if (!dialogOpen) void navigate(routes.settings.to());
+    },
+    undefined,
+    [dialogOpen, navigate]
+  );
+
+  const dismissBulkErrorToast = () => {
+    if (bulkErrorToastId.current === undefined) return;
+    dismissToast(bulkErrorToastId.current);
+    bulkErrorToastId.current = undefined;
+  };
+
+  React.useEffect(
+    () => () => {
+      if (bulkErrorToastId.current !== undefined) dismissToast(bulkErrorToastId.current);
+    },
+    []
+  );
+
+  const requestBulkDifficulty = () => {
+    dismissBulkErrorToast();
+    state.onRequestBulkDifficulty();
+  };
+
+  const cancelBulkDifficulty = () => {
+    dismissBulkErrorToast();
+    state.onCancelBulkDifficulty();
+  };
+
+  const confirmBulkDifficulty = async () => {
+    dismissBulkErrorToast();
+    const result = await state.onConfirmBulkDifficulty();
+    if (result === undefined) return;
+    if (result.outcome === "success") {
+      showToast({
+        message: t("cardList.bulkDifficulty.success", {
+          count: result.cardCount,
+          difficulty: result.difficulty,
+        }),
+        tone: "success",
+      });
+      return;
+    }
+
+    bulkErrorToastId.current = showToast({
+      message: t("cardList.bulkDifficulty.partialFailure", {
+        count: result.failureCount,
+        successCount: result.successCount,
+        totalCount: result.totalCount,
+      }),
+      tone: "error",
+    });
+  };
 
   return (
     <AppLayout showHeader={state.answer == null}>
-      {state.deletionTarget != null ? (
+      {state.bulkDifficultyTarget != null ? (
+        <BulkDifficultyDialog
+          cardCount={state.bulkDifficultyTarget.cardCount}
+          difficulty={state.bulkDifficultyTarget.difficulty}
+          pending={state.bulkDifficultyPending}
+          onCancel={cancelBulkDifficulty}
+          onConfirm={confirmBulkDifficulty}
+        />
+      ) : state.deletionTarget != null ? (
         <DestructiveActionDialog
           title={t("cardList.deletion.title")}
           targetLabel={t("cardList.deletion.targetLabel")}
@@ -54,6 +131,13 @@ const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
       ) : null}
       <CardList
         cards={state.cards}
+        bulkDifficulty={{
+          difficultyLowerBound: state.bulkDifficultyMinimum,
+          difficultyUpperBound: state.bulkDifficultyMaximum,
+          selectedDifficulty: state.bulkDifficulty,
+          onDifficultyChange: state.onChangeBulkDifficulty,
+          onRequest: requestBulkDifficulty,
+        }}
         disabled={busy}
         renderDifficulty={(difficulty) => <DifficultyIndicator className="shrink-0" difficulty={difficulty} />}
         onAddCard={() => void navigate(routes.cardCreate.to(deck.id))}
@@ -90,12 +174,8 @@ const AvailableCardListPage: React.FC<{ deck: Deck }> = ({ deck }) => {
 export const CardListPage: React.FC = () => {
   const { t } = useTranslation();
   const params = useParams();
-  const navigate = useNavigate();
   const deckId = params.id;
   if (deckId == null) throw new Error("invalid deck id");
-
-  useKey("t", () => void navigate(routes.deckList.to()));
-  useKey("s", () => void navigate(routes.settings.to()));
 
   const deck = useDeck(deckId);
   if (deck == null) {

--- a/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyDialog.spec.tsx
+++ b/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyDialog.spec.tsx
@@ -1,0 +1,156 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { dismissToast, showToast, ToastViewport } from "@/shared/ui/toast";
+
+import { BulkDifficultyDialog } from "./BulkDifficultyDialog";
+
+const defaultProps = {
+  cardCount: 2,
+  difficulty: 7,
+  onCancel: vi.fn(),
+  onConfirm: vi.fn(),
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  dismissToast();
+  document.body.style.overflow = "";
+});
+
+describe("BulkDifficultyDialog [CARD-19] [CARD-20]", () => {
+  it("uses a non-destructive dialog to summarize the frozen change", () => {
+    render(<BulkDifficultyDialog {...defaultProps} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Change card difficulty?" });
+    expect(dialog).toHaveAccessibleDescription("Set 2 visible cards to difficulty 7.");
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("focuses Cancel first, traps focus, and closes with Escape", async () => {
+    const onCancel = vi.fn();
+    render(<BulkDifficultyDialog {...defaultProps} onCancel={onCancel} />);
+    const description = screen.getByText("Set 2 visible cards to difficulty 7.");
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    const confirm = screen.getByRole("button", { name: "Apply change" });
+
+    expect(cancel).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(description).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(confirm).toHaveFocus();
+    await userEvent.tab();
+    expect(description).toHaveFocus();
+
+    fireEvent.keyDown(description, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("locks body scrolling and restores body state and trigger focus on close", async () => {
+    document.body.style.overflow = "clip";
+    const Example = () => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open bulk change
+          </button>
+          {open ? <BulkDifficultyDialog {...defaultProps} onCancel={() => setOpen(false)} /> : null}
+        </>
+      );
+    };
+    render(<Example />);
+    const trigger = screen.getByRole("button", { name: "Open bulk change" });
+
+    await userEvent.click(trigger);
+    expect(document.body).toHaveStyle({ overflow: "hidden" });
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(document.body).toHaveStyle({ overflow: "clip" });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("announces pending work and prevents confirmation, cancellation, and Escape", async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(<BulkDifficultyDialog {...defaultProps} pending onCancel={onCancel} onConfirm={onConfirm} />);
+
+    const dialog = screen.getByRole("dialog");
+    const description = screen.getByText("Set 2 visible cards to difficulty 7.");
+    expect(dialog).toHaveAttribute("aria-busy", "true");
+    expect(description).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply change" })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Apply change" }));
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("moves focus inside before confirmation transitions to pending", () => {
+    const Example = () => {
+      const [pending, setPending] = React.useState(false);
+      return <BulkDifficultyDialog {...defaultProps} pending={pending} onConfirm={() => setPending(true)} />;
+    };
+    render(<Example />);
+    const confirm = screen.getByRole("button", { name: "Apply change" });
+    confirm.focus();
+
+    fireEvent.click(confirm);
+
+    expect(screen.getByText("Set 2 visible cards to difficulty 7.")).toHaveFocus();
+  });
+
+  it("prevents duplicate confirmation before pending props update", () => {
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          // This promise intentionally stays pending to exercise the pre-render submission lock.
+        })
+    );
+    const onCancel = vi.fn();
+    render(<BulkDifficultyDialog {...defaultProps} onCancel={onCancel} onConfirm={onConfirm} />);
+    const confirm = screen.getByRole("button", { name: "Apply change" });
+
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("keeps persistent Toast interaction and focus within the active dialog", async () => {
+    const Example = () => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Reopen bulk change
+          </button>
+          {open ? <BulkDifficultyDialog {...defaultProps} /> : null}
+          <ToastViewport />
+        </>
+      );
+    };
+    render(<Example />);
+    const trigger = screen.getByRole("button", { name: "Reopen bulk change" });
+    let toastId = 0;
+    act(() => {
+      toastId = showToast({ message: "Bulk change failed", tone: "error", durationMs: null });
+    });
+
+    await userEvent.click(trigger);
+
+    expect(screen.queryByRole("button", { name: "Dismiss notification" })).not.toBeInTheDocument();
+    trigger.focus();
+    act(() => dismissToast(toastId));
+    expect(screen.getByText("Set 2 visible cards to difficulty 7.")).toHaveFocus();
+  });
+});

--- a/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyDialog.stories.tsx
+++ b/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyDialog.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+
+import { BulkDifficultyDialog } from "./BulkDifficultyDialog";
+
+const meta = {
+  title: "Pages/Card List/BulkDifficultyDialog",
+  component: BulkDifficultyDialog,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  args: {
+    cardCount: 4,
+    difficulty: 7,
+    onCancel: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof BulkDifficultyDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Confirmation: Story = {};
+
+export const Pending: Story = {
+  args: { pending: true },
+};
+
+export const Mobile: Story = {
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+};
+
+export const Dark: Story = {
+  globals: { theme: "dark" },
+};
+
+export const Japanese: Story = {
+  parameters: { locale: "ja" },
+};

--- a/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyDialog.tsx
+++ b/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyDialog.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
+import { Button } from "@/shared/ui/button";
+import { useToastModalFocusTarget } from "@/shared/ui/toast";
+
+export interface BulkDifficultyDialogProps {
+  cardCount: number;
+  difficulty: number;
+  pending?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+/** Confirms a non-destructive bulk difficulty change and owns the modal accessibility behavior. */
+export const BulkDifficultyDialog: React.FC<BulkDifficultyDialogProps> = (props) => {
+  const { t } = useTranslation();
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const cancelRef = React.useRef<HTMLButtonElement>(null);
+  const descriptionRef = React.useRef<HTMLParagraphElement>(null);
+  const confirmingRef = React.useRef(false);
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+  useToastModalFocusTarget(dialogRef, descriptionRef);
+
+  React.useEffect(() => {
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    cancelRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!props.pending) return;
+    // Both actions become disabled while saving, so focus must move before the browser can drop it outside the dialog.
+    descriptionRef.current?.focus();
+  }, [props.pending]);
+
+  const trapFocus = (event: KeyboardEvent) => {
+    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableElementSelector) ?? []);
+    const [first] = focusable;
+    const last = focusable.at(-1);
+    if (first == null || last == null) {
+      event.preventDefault();
+      return;
+    }
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const handleCancel = () => {
+    // Once confirmation starts, the snapshot must stay fixed until that attempt settles.
+    if (props.pending || confirmingRef.current) return;
+    props.onCancel();
+  };
+
+  const handleKeyDownEvent = React.useEffectEvent((event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      handleCancel();
+    } else if (event.key === "Tab") {
+      trapFocus(event);
+    }
+  });
+
+  React.useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+    dialog.addEventListener("keydown", handleKeyDownEvent);
+    return () => dialog.removeEventListener("keydown", handleKeyDownEvent);
+  }, []);
+
+  const handleConfirm = () => {
+    if (props.pending || confirmingRef.current) return;
+    confirmingRef.current = true;
+    try {
+      void Promise.resolve(props.onConfirm())
+        .catch(() => {
+          // Callers own the retry state and user feedback; consuming the rejection prevents an unhandled promise.
+        })
+        .finally(() => {
+          confirmingRef.current = false;
+        });
+    } catch (error) {
+      confirmingRef.current = false;
+      throw error;
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-canvas/70 px-shell-gutter py-6">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        aria-busy={props.pending || undefined}
+        className="max-h-full w-full max-w-reading overflow-y-auto rounded-surface border border-border bg-surface-elevated p-4 text-ink shadow-elevated sm:p-6"
+      >
+        <h2 id={titleId} className="text-title font-bold">
+          {t("cardList.bulkDifficulty.dialog.title")}
+        </h2>
+        <p
+          id={descriptionId}
+          ref={descriptionRef}
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: This remains the dialog's focus target while both actions are disabled.
+          tabIndex={0}
+          className="mt-4 rounded-control bg-surface-muted p-3 text-body text-ink-muted outline-none focus-visible:ring-2 focus-visible:ring-focus"
+        >
+          {t("cardList.bulkDifficulty.dialog.description", {
+            count: props.cardCount,
+            difficulty: props.difficulty,
+          })}
+        </p>
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            ref={cancelRef}
+            type="button"
+            disabled={props.pending}
+            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-control border border-border bg-transparent px-4 py-2 font-bold text-ink hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={handleCancel}
+          >
+            {t("cardList.bulkDifficulty.dialog.cancel")}
+          </button>
+          <Button variant="primary" loading={Boolean(props.pending)} onClick={handleConfirm}>
+            {t("cardList.bulkDifficulty.dialog.confirm")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyPanel.spec.tsx
+++ b/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyPanel.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BulkDifficultyPanel } from "./BulkDifficultyPanel";
+
+const defaultProps = {
+  cardCount: 3,
+  difficultyLowerBound: 1,
+  difficultyUpperBound: 10,
+  selectedDifficulty: null,
+  onDifficultyChange: vi.fn(),
+  onRequest: vi.fn(),
+};
+
+describe("BulkDifficultyPanel [CARD-19] [CARD-20]", () => {
+  it("labels the visible-card target and offers every integer difficulty", () => {
+    render(<BulkDifficultyPanel {...defaultProps} />);
+
+    expect(screen.getByRole("region", { name: "Change difficulty" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Change difficulty" })).toBeInTheDocument();
+    expect(screen.getByText("3 visible cards")).toBeInTheDocument();
+
+    const select = screen.getByRole("combobox", { name: "New difficulty" });
+    expect(
+      within(select)
+        .getAllByRole("option")
+        .map((option) => option.textContent)
+    ).toEqual(["Choose difficulty", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
+    expect(screen.getByRole("button", { name: "Change difficulty" })).toBeDisabled();
+  });
+
+  it("reports integer and cleared selections before requesting the change", async () => {
+    const onDifficultyChange = vi.fn();
+    const onRequest = vi.fn();
+    const Example = () => {
+      const [selectedDifficulty, setSelectedDifficulty] = React.useState<number | null>(null);
+      return (
+        <BulkDifficultyPanel
+          {...defaultProps}
+          selectedDifficulty={selectedDifficulty}
+          onDifficultyChange={(difficulty) => {
+            onDifficultyChange(difficulty);
+            setSelectedDifficulty(difficulty);
+          }}
+          onRequest={onRequest}
+        />
+      );
+    };
+    render(<Example />);
+    const select = screen.getByRole("combobox", { name: "New difficulty" });
+    const request = screen.getByRole("button", { name: "Change difficulty" });
+
+    await userEvent.selectOptions(select, "7");
+    expect(onDifficultyChange).toHaveBeenLastCalledWith(7);
+    expect(request).toBeEnabled();
+
+    await userEvent.click(request);
+    expect(onRequest).toHaveBeenCalledOnce();
+
+    await userEvent.selectOptions(select, "");
+    expect(onDifficultyChange).toHaveBeenLastCalledWith(null);
+    expect(request).toBeDisabled();
+  });
+
+  it("disables all controls when there are no visible cards or the list is busy", () => {
+    const view = render(<BulkDifficultyPanel {...defaultProps} cardCount={0} selectedDifficulty={5} />);
+
+    expect(screen.getByRole("combobox", { name: "New difficulty" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Change difficulty" })).toBeDisabled();
+
+    view.rerender(<BulkDifficultyPanel {...defaultProps} selectedDifficulty={5} disabled />);
+    expect(screen.getByRole("combobox", { name: "New difficulty" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Change difficulty" })).toBeDisabled();
+  });
+});

--- a/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyPanel.stories.tsx
+++ b/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyPanel.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+
+import { BulkDifficultyPanel } from "./BulkDifficultyPanel";
+
+const meta = {
+  title: "Pages/Card List/BulkDifficultyPanel",
+  component: BulkDifficultyPanel,
+  tags: ["autodocs"],
+  args: {
+    cardCount: 8,
+    difficultyLowerBound: 1,
+    difficultyUpperBound: 10,
+    selectedDifficulty: 6,
+    onDifficultyChange: fn(),
+    onRequest: fn(),
+  },
+} satisfies Meta<typeof BulkDifficultyPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { cardCount: 0, selectedDifficulty: null },
+};
+
+export const Unselected: Story = {
+  args: { selectedDifficulty: null },
+};
+
+export const Pending: Story = {
+  args: { disabled: true },
+};
+
+export const Mobile: Story = {
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+};
+
+export const Dark: Story = {
+  globals: { theme: "dark" },
+};
+
+export const Japanese: Story = {
+  parameters: { locale: "ja" },
+};

--- a/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyPanel.tsx
+++ b/src/pages/card-list/ui/bulk-difficulty/BulkDifficultyPanel.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/shared/ui/button";
+import { Select } from "@/shared/ui/forms";
+
+export interface BulkDifficultyPanelProps {
+  cardCount: number;
+  difficultyLowerBound: number;
+  difficultyUpperBound: number;
+  selectedDifficulty: number | null;
+  disabled?: boolean | undefined;
+  onDifficultyChange: (difficulty: number | null) => void;
+  onRequest: () => void;
+}
+
+const createDifficultyOptions = (lowerBound: number, upperBound: number) => {
+  const options: { label: string; value: string }[] = [];
+  for (let difficulty = lowerBound; difficulty <= upperBound; difficulty += 1) {
+    options.push({ label: String(difficulty), value: String(difficulty) });
+  }
+  return options;
+};
+
+/** Presents the bulk difficulty controls for the cards currently visible in the list. */
+export const BulkDifficultyPanel: React.FC<BulkDifficultyPanelProps> = (props) => {
+  const { t } = useTranslation();
+  const titleId = React.useId();
+  const selectId = React.useId();
+  const controlsDisabled = props.disabled || props.cardCount === 0;
+  const options = [
+    { label: t("cardList.bulkDifficulty.placeholder"), value: "" },
+    ...createDifficultyOptions(props.difficultyLowerBound, props.difficultyUpperBound),
+  ];
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="rounded-surface border border-border bg-surface p-3 text-ink shadow-surface sm:p-4"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <h2 id={titleId} className="font-bold">
+          {t("cardList.bulkDifficulty.title")}
+        </h2>
+        <p className="text-caption text-ink-muted">{t("cardList.bulkDifficulty.target", { count: props.cardCount })}</p>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+        <label htmlFor={selectId} className="min-w-0">
+          <span className="mb-1 block text-body font-medium">{t("cardList.bulkDifficulty.newDifficulty")}</span>
+          <Select
+            id={selectId}
+            options={options}
+            value={props.selectedDifficulty == null ? "" : String(props.selectedDifficulty)}
+            disabled={controlsDisabled}
+            onChange={(event) => {
+              const difficulty = event.currentTarget.value;
+              props.onDifficultyChange(difficulty === "" ? null : Number(difficulty));
+            }}
+          />
+        </label>
+        <Button
+          variant="primary"
+          className="w-full sm:w-auto"
+          disabled={controlsDisabled || props.selectedDifficulty == null}
+          onClick={props.onRequest}
+        >
+          {t("cardList.bulkDifficulty.request")}
+        </Button>
+      </div>
+    </section>
+  );
+};

--- a/src/pages/card-list/ui/bulk-difficulty/index.ts
+++ b/src/pages/card-list/ui/bulk-difficulty/index.ts
@@ -1,0 +1,2 @@
+export { BulkDifficultyDialog } from "./BulkDifficultyDialog";
+export { BulkDifficultyPanel } from "./BulkDifficultyPanel";

--- a/test/e2e/card-resilience.spec.ts
+++ b/test/e2e/card-resilience.spec.ts
@@ -115,3 +115,79 @@ test("CARD-18 retries the same Card-list difficulty change after a handled failu
   await page.reload();
   await expectDifficulty(page, card.frontText, expectedDifficulty);
 });
+
+test("CARD-20 retries a partially failed bulk difficulty change with the same absolute value", async ({
+  fixture,
+  page,
+  browserErrors,
+}) => {
+  const deck = fixture.deck();
+  const failedCard = fixture.card("card-1");
+  const successfulCard = fixture.card("card-2");
+  const excludedCard = fixture.card("card-3");
+  const newDifficulty = 7;
+  await fixture.apply(page);
+  await page.goto(`/deck/${deck.id}`);
+  await page.getByText("Filters", { exact: true }).click();
+  await page.getByRole("combobox", { name: "Maximum difficulty" }).selectOption("4");
+  const fault = await failNextFirestoreWrite(page, { collection: "card", id: failedCard.id });
+  allowExpectedFirestoreWriteFailure(browserErrors);
+
+  const difficulty = page.getByRole("combobox", { name: "New difficulty" });
+  await difficulty.selectOption(String(newDifficulty));
+  await page.getByRole("button", { name: "Change difficulty" }).click();
+  const dialog = page.getByRole("dialog", { name: "Change card difficulty?" });
+  const applyChange = dialog.getByRole("button", { name: "Apply change" });
+  await dialog.evaluate((element) => {
+    const { documentElement } = element.ownerDocument;
+    documentElement.dataset.bulkDifficultyPendingObserved = "false";
+    const observer = new MutationObserver(() => {
+      const buttons = [...element.querySelectorAll("button")];
+      if (
+        element.getAttribute("aria-busy") === "true" &&
+        buttons.length > 0 &&
+        buttons.every((button) => button.disabled) &&
+        element.contains(element.ownerDocument.activeElement)
+      ) {
+        documentElement.dataset.bulkDifficultyPendingObserved = "true";
+        observer.disconnect();
+      }
+    });
+    observer.observe(element, { attributeFilter: ["aria-busy", "disabled"], attributes: true, subtree: true });
+  });
+  await applyChange.click();
+
+  await expect(page.getByRole("alert")).toContainText("Updated 1 of 2. 1 card could not be updated. Try again.");
+  expect(await page.locator("html").getAttribute("data-bulk-difficulty-pending-observed")).toBe("true");
+  await expect.poll(fault.wasTriggered).toBe(true);
+  await fault.waitForFailure();
+  await fault.dispose();
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(`Set 2 visible cards to difficulty ${String(newDifficulty)}.`);
+  await expect(difficulty).toHaveValue(String(newDifficulty));
+  await expect
+    .poll(async () => (await requireDocument("card", failedCard.id)).fields.difficulty?.integerValue)
+    .toBe(String(failedCard.difficulty));
+  await expect
+    .poll(async () => (await requireDocument("card", successfulCard.id)).fields.difficulty?.integerValue)
+    .toBe(String(newDifficulty));
+
+  await applyChange.click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await Promise.all(
+    [failedCard, successfulCard].map((card) =>
+      expect
+        .poll(async () => (await requireDocument("card", card.id)).fields.difficulty?.integerValue)
+        .toBe(String(newDifficulty))
+    )
+  );
+  await expect
+    .poll(async () => (await requireDocument("card", excludedCard.id)).fields.difficulty?.integerValue)
+    .toBe(String(excludedCard.difficulty));
+  await page.reload();
+
+  await expectDifficulty(page, failedCard.frontText, newDifficulty);
+  await expectDifficulty(page, successfulCard.frontText, newDifficulty);
+  await expectDifficulty(page, excludedCard.frontText, excludedCard.difficulty);
+});

--- a/test/e2e/card.spec.ts
+++ b/test/e2e/card.spec.ts
@@ -344,3 +344,75 @@ test("CARD-14 creates one local Card and keeps it across reload", async ({ fixtu
     )
   ).toEqual([]);
 });
+
+test("CARD-19 changes the difficulty of only the Cards visible in the filter draft", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const matchingCards = [fixture.card("card-1"), fixture.card("card-2")];
+  const excludedCard = fixture.card("card-3");
+  const newDifficulty = 7;
+  await fixture.apply(page);
+
+  await page.goto(`/deck/${deck.id}`);
+  await page.getByText("Filters", { exact: true }).click();
+  await page.getByRole("combobox", { name: "Maximum difficulty" }).selectOption("4");
+  await Promise.all(
+    matchingCards.map((card) => expect(page.getByRole("button", { name: `View ${card.frontText}` })).toBeVisible())
+  );
+  await expect(page.getByRole("button", { name: `View ${excludedCard.frontText}` })).toHaveCount(0);
+
+  await page.getByRole("combobox", { name: "New difficulty" }).selectOption(String(newDifficulty));
+  const trigger = page.getByRole("button", { name: "Change difficulty" });
+  await trigger.click();
+  const dialog = page.getByRole("dialog", { name: "Change card difficulty?" });
+  const description = dialog.getByText(
+    `Set ${String(matchingCards.length)} visible cards to difficulty ${String(newDifficulty)}.`
+  );
+  const cancel = dialog.getByRole("button", { name: "Cancel" });
+  const applyChange = dialog.getByRole("button", { name: "Apply change" });
+  await expect(dialog).toContainText(
+    `Set ${String(matchingCards.length)} visible cards to difficulty ${String(newDifficulty)}.`
+  );
+  await expect(cancel).toBeFocused();
+  await page.keyboard.press("s");
+  await page.keyboard.press("t");
+  await expect(dialog).toBeVisible();
+  await expect(page).toHaveURL(`/deck/${deck.id}`);
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe("hidden");
+  await page.keyboard.press("Shift+Tab");
+  await expect(description).toBeFocused();
+  await page.keyboard.press("Shift+Tab");
+  await expect(applyChange).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(description).toBeFocused();
+  await page.keyboard.press("Escape");
+
+  await expect(dialog).not.toBeVisible();
+  await expect(trigger).toBeFocused();
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe("");
+  await Promise.all(
+    matchingCards.map((card) =>
+      expect
+        .poll(async () => (await requireDocument("card", card.id)).fields.difficulty?.integerValue)
+        .toBe(String(card.difficulty))
+    )
+  );
+
+  await trigger.click();
+  await applyChange.click();
+  await expect(dialog).not.toBeVisible();
+
+  await Promise.all(
+    matchingCards.map((card) =>
+      expect
+        .poll(async () => (await requireDocument("card", card.id)).fields.difficulty?.integerValue)
+        .toBe(String(newDifficulty))
+    )
+  );
+  await expect
+    .poll(async () => (await requireDocument("card", excludedCard.id)).fields.difficulty?.integerValue)
+    .toBe(String(excludedCard.difficulty));
+  await page.reload();
+
+  await Promise.all(matchingCards.map((card) => expectDifficulty(page, card.frontText, newDifficulty)));
+  await expectDifficulty(page, excludedCard.frontText, excludedCard.difficulty);
+});


### PR DESCRIPTION
## Summary

- add bulk difficulty controls for all Cards visible through the current filter draft
- snapshot target IDs at confirmation time and support idempotent retries after partial failures
- add accessible dialog behavior, English/Japanese copy, Storybook states, and CARD-19/CARD-20 coverage

## Testing

- mise run check (709 tests passed)
- npm run test:storybook (392 tests passed)
- full Playwright E2E in the Docker stack with the local Playwright 1.61.1 runner override (80 tests passed)