### PR TITLE
[No issue] Fix Storybook dependency setup and add CI checks

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,0 +1,46 @@
+name: Storybook
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  storybook:
+    name: Storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      STORYBOOK_DISABLE_TELEMETRY: "1"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+
+      - run: mise run init
+
+      - name: Install Storybook Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Exercise the mise task's CLI startup path explicitly; smoke-test exits after successful startup.
+      - name: Check Storybook startup
+        timeout-minutes: 5
+        run: mise run storybook -- -- --ci --smoke-test --host 127.0.0.1 --port 6006 --exact-port
+
+      - name: Build Storybook
+        run: mise run build-storybook
+
+      - name: Run Storybook tests
+        run: mise run test-storybook
+
+      - name: Upload Storybook diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: storybook-diagnostics
+          path: |
+            debug-storybook.log
+            test-results/storybook/
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
       contents: read
     uses: ./.github/workflows/integration.yaml
 
+  storybook:
+    name: Storybook
+    uses: ./.github/workflows/storybook.yaml
+
   checks:
     name: Test / ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -47,15 +51,12 @@ jobs:
       matrix:
         include:
           - name: Build
-            command: npm run build:sample && npm run build && npm run build:storybook
+            command: npm run build:sample && npm run build
           - name: Code quality
             command: npm run build:sample && npm run fmt && npm run lint
           - name: Unit coverage
             command: npm run build:sample && npm run test:coverage
             coverage: true
-          - name: Storybook
-            command: npm run build:sample && npm run test:storybook
-            storybook: true
           - name: Sample
             command: npm run fmt:sample && npm run test:sample
     steps:
@@ -70,10 +71,6 @@ jobs:
         run: npm install --global npm@12.0.1
 
       - run: npm ci
-
-      - name: Install Storybook Chromium
-        if: ${{ matrix.storybook }}
-        run: npx playwright install --with-deps chromium
 
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}
@@ -118,7 +115,7 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [checks, dependency-review, e2e, integration]
+    needs: [checks, dependency-review, e2e, integration, storybook]
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
@@ -128,10 +125,12 @@ jobs:
           E2E_RESULT: ${{ needs.e2e.result }}
           EVENT_NAME: ${{ github.event_name }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
+          STORYBOOK_RESULT: ${{ needs.storybook.result }}
         run: |
           test "$CHECKS_RESULT" = success
           test "$E2E_RESULT" = success
           test "$INTEGRATION_RESULT" = success
+          test "$STORYBOOK_RESULT" = success
           if [ "$EVENT_NAME" = pull_request ]; then
             test "$DEPENDENCY_REVIEW_RESULT" = success
           else

--- a/mise.toml
+++ b/mise.toml
@@ -50,7 +50,8 @@ depends = ["//sample:build", "dev-up"]
 run = "npm start -- --open --mode dev"
 
 [tasks.storybook]
-depends = ["//sample:build"]
+# Sync dependencies after pulls so preview imports resolve before the dev server starts.
+depends = ["init-deps", "//sample:build"]
 run = "npm run storybook"
 
 [tasks.test]


### PR DESCRIPTION
## Related issue

None

## Summary

`mise run storybook` could start successfully but fail to render its preview after a dependency-changing pull because local packages were stale (reproduced with missing `react-i18next` and `i18next`). Make the task run `init-deps` before starting Storybook so dependencies match the package lock.

Add `storybook.yaml` to check the mise startup path with a bounded smoke test, build Storybook, and run its browser tests. Move existing Storybook checks into this reusable workflow, require its success in the aggregate `Test` job, and upload diagnostics on failure.

## Testing

- Reproduced missing i18n dependencies and Vite import-resolution errors in the regular checkout.
- Restored dependencies and verified the running Storybook renders the Deck List story with its interaction test passing.
- Updated mise task ran dependency installation before its successful startup smoke test.
- `mise run check`: passed after the fix (121 unit test files, 708 tests).
- Storybook build and browser suite previously passed (62 files, 379 tests).
- Reviewer subagent: no findings on the final change.
- GitHub-hosted execution of the latest commit is not yet verified.
