### PR TITLE
[No issue] Remove public Knip suppressions and unused Card exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repository Instructions
 
 - Be simple.
+- Do not suppress Knip findings with `@public`; remove unused code instead.
 - Before editing files, fetch `origin/main`, then create a `git worktree` at `.worktrees/$BRANCH` from it.
 - Do not work directly on `main`.
 - Do not commit files ignored by `.gitignore`.

--- a/src/entities/card/api/firestore.ts
+++ b/src/entities/card/api/firestore.ts
@@ -9,7 +9,7 @@ import type {
   RemoteCardRead,
 } from "../model/types";
 
-import { collection, doc, getDocsFromServer, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
+import { collection, doc, onSnapshot, query, setDoc, updateDoc, where } from "firebase/firestore";
 
 import { mapStudyProgressDocument, type StudyProgress } from "@/entities/study-progress/@x/card";
 import { db } from "@/shared/firebase";
@@ -22,8 +22,8 @@ import { parseCardDocument } from "./document";
 
 const CARD_COLLECTION = "card";
 
-/** @public Cross-Entity read contract for the two models sharing one physical Card document. */
-export interface CardRead {
+/** Cross-Entity read contract for the two models sharing one physical Card document. */
+interface CardRead {
   card: RemoteCardRead;
   progress: StudyProgress;
 }
@@ -42,8 +42,7 @@ const mapCardRead = (id: CardId, value: unknown): CardRead => {
 const mapActiveCardReads = (documents: ReadonlyArray<{ id: string; data: () => unknown }>): CardRead[] =>
   documents.map((document) => mapCardRead(document.id, document.data())).filter(({ card }) => card.deletedAt === null);
 
-/** @public Lets later consumers adopt separated reads without changing current Card state in this PR. */
-export const subscribeCardReads = (
+const subscribeCardReads = (
   uid: string,
   onReads: (reads: CardRead[]) => void,
   onError: (error: Error) => void
@@ -76,12 +75,6 @@ const combineCardRead = ({ card, progress }: CardRead): RemoteCard => {
 /** Keeps existing Card subscribers on the combined read model until #604. */
 export const subscribeCards = (uid: string, onError: (error: Error) => void): (() => void) =>
   subscribeCardReads(uid, (reads) => replaceRemoteCards(reads.map(combineCardRead)), onError);
-
-/** @public Fetch counterpart to subscribeCardReads for the separated read boundary. */
-export const fetchCardReads = async (uid: string): Promise<CardRead[]> => {
-  const snapshot = await getDocsFromServer(query(collection(db, CARD_COLLECTION), where("uid", "==", uid)));
-  return mapActiveCardReads(snapshot.docs);
-};
 
 /** Writes a new physical Card document with synchronized creation and update timestamps. */
 const createCardDocument = async (card: CardCreate): Promise<void> => {

--- a/src/entities/card/api/subscription.spec.tsx
+++ b/src/entities/card/api/subscription.spec.tsx
@@ -25,7 +25,7 @@ vi.mock("firebase/firestore", async (importOriginal) => {
 });
 vi.mock("@/shared/firebase", () => ({ db: "db" }));
 
-import { subscribeCardReads, subscribeCards } from "./firestore";
+import { subscribeCards } from "./firestore";
 
 // Builds a Firestore-like Card document with optional field overrides.
 const cardDocument = (id: string, overrides: Record<string, unknown> = {}) => ({
@@ -59,51 +59,6 @@ describe("Card Firestore subscription [CARD-01]", () => {
     mocks.onSnapshot.mockReturnValue(vi.fn());
   });
 
-  it("exposes separate Card and StudyProgress reads from each snapshot", () => {
-    const onReads = vi.fn();
-    subscribeCardReads("uid-a", onReads, vi.fn());
-
-    act(() =>
-      getSnapshotHandler()({
-        docs: [
-          cardDocument("active", {
-            lastSeenAt: 50,
-            nextSeeingAt: Timestamp.fromMillis(60),
-            interval: 7,
-            url: "https://example.com/card",
-          }),
-          cardDocument("deleted", { deletedAt: 3 }),
-        ],
-      })
-    );
-
-    expect(onReads).toHaveBeenCalledExactlyOnceWith([
-      {
-        card: {
-          id: "active",
-          frontText: "Remote front",
-          backText: "Remote back",
-          tags: ["science"],
-          uniqueKey: "key-active",
-          deckId: "deck-a",
-          uid: "uid-a",
-          createdAt: 1,
-          updatedAt: 2,
-          deletedAt: null,
-          url: "https://example.com/card",
-        },
-        progress: {
-          cardId: "active",
-          difficulty: 3,
-          numberOfSeen: 4,
-          lastSeenAt: 50,
-          nextSeeingAt: new Date(60),
-          interval: 7,
-        },
-      },
-    ]);
-  });
-
   it("fully replaces active Cards from each snapshot", () => {
     const localCard = createLocalCard({ id: "local", frontText: "Local front" });
     cardStore.setState({ localCards: [localCard] });
@@ -129,6 +84,10 @@ describe("Card Firestore subscription [CARD-01]", () => {
     expect(result.current).toEqual([
       expect.objectContaining({
         id: "active",
+        frontText: "Remote front",
+        difficulty: 3,
+        numberOfSeen: 4,
+        tags: ["science"],
         lastSeenAt: 50,
         nextSeeingAt: new Date(60),
         interval: 7,
@@ -145,7 +104,7 @@ describe("Card Firestore subscription [CARD-01]", () => {
 
   it("reports invalid Firestore documents", () => {
     const onError = vi.fn();
-    subscribeCardReads("uid-a", vi.fn(), onError);
+    subscribeCards("uid-a", onError);
 
     act(() => getSnapshotHandler()({ docs: [cardDocument("invalid", { nextSeeingAt: null })] }));
 
@@ -157,7 +116,7 @@ describe("Card Firestore subscription [CARD-01]", () => {
   it("reports Firestore subscription errors", () => {
     const onError = vi.fn();
     const error = new Error("listener failed");
-    subscribeCardReads("uid-a", vi.fn(), onError);
+    subscribeCards("uid-a", onError);
 
     getErrorHandler()(error);
 

--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -1,8 +1,4 @@
 export { subscribeCards } from "./api/firestore";
-/** @public Separated read operations for the cross-Entity Card document boundary. */
-export { fetchCardReads, subscribeCardReads } from "./api/firestore";
-/** @public Separated read contract for the cross-Entity Card document boundary. */
-export type { CardRead } from "./api/firestore";
 export { generateCardId } from "./api/id";
 export { createCard, deleteCard, editCard, mutateCards } from "./api/mutations";
 export { useCard, useCards, useCardsByDeckId } from "./model/hooks";

--- a/src/entities/card/testing.ts
+++ b/src/entities/card/testing.ts
@@ -1,3 +1,3 @@
-/** @public Testing-only entry point for installing deterministic remote Card snapshots. */
+/** Testing-only entry point for installing deterministic remote Card snapshots. */
 export { replaceRemoteCards } from "./model/store";
 export type { LocalCard, RemoteCard } from "./model/types";

--- a/src/entities/deck/testing.ts
+++ b/src/entities/deck/testing.ts
@@ -1,2 +1,2 @@
-/** @public Testing-only entry point for installing deterministic remote Deck snapshots. */
+/** Testing-only entry point for installing deterministic remote Deck snapshots. */
 export { replaceRemoteDecks } from "./model/store";

--- a/src/entities/preference/testing.ts
+++ b/src/entities/preference/testing.ts
@@ -1,3 +1,3 @@
-/** @public Testing-only entry point for replacing the complete Preferences snapshot. */
+/** Testing-only entry point for replacing the complete Preferences snapshot. */
 export { replacePreferences } from "./model/store";
 export type { PartialPreferences as PreferencesFixture } from "./model/store";

--- a/steiger.config.ts
+++ b/steiger.config.ts
@@ -1,7 +1,7 @@
 import fsd from "@feature-sliced/steiger-plugin";
 import { defineConfig } from "steiger";
 
-/** @public Loaded by Steiger rather than imported by application code. */
+/** Loaded by Steiger rather than imported by application code. */
 export default defineConfig([
   ...fsd.configs.recommended,
   {

--- a/test/integration/firestore/subscriptions.spec.ts
+++ b/test/integration/firestore/subscriptions.spec.ts
@@ -8,7 +8,7 @@ import "@/test/initializeTestFirestore";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteApp, getApps } from "firebase/app";
 
-import { deleteCard, editCard, fetchCardReads, mutateCards, subscribeCards } from "@/entities/card";
+import { deleteCard, editCard, mutateCards, subscribeCards } from "@/entities/card";
 import { createDeck, deleteDeck, editDeck, subscribeDecks } from "@/entities/deck";
 import { cardStore } from "@/entities/card/model/store";
 import { deckStore } from "@/entities/deck/model/store";
@@ -29,7 +29,7 @@ describe("Query realtime subscriptions [CARD-01] [CARD-10]", () => {
     await Promise.all(getApps().map(deleteApp));
   });
 
-  it("fetches separated Card reads through the public read API", async () => {
+  it("loads Card content and study information from the initial snapshot", async () => {
     const uid = "uid";
     const deck = createDeckFixture({ id: crypto.randomUUID(), uid, name: "Fetched Deck" });
     const card = createCard({
@@ -43,12 +43,18 @@ describe("Query realtime subscriptions [CARD-01] [CARD-10]", () => {
     await createDeck(uid, createRemoteDeckInput({ id: deck.id, name: deck.name }));
     await mutateCards(uid, [{ kind: "create", card }]);
 
-    const reads = await fetchCardReads(uid);
-
-    expect(reads).toContainEqual({
-      card: expect.objectContaining({ id: card.id, frontText: "Fetched Card" }),
-      progress: expect.objectContaining({ cardId: card.id, difficulty: 2, numberOfSeen: 3 }),
-    });
+    const onError = vi.fn();
+    const stopCards = subscribeCards(uid, onError);
+    try {
+      await vi.waitFor(() => {
+        expect(cardStore.getState().remoteCards).toContainEqual(
+          expect.objectContaining({ id: card.id, frontText: "Fetched Card", difficulty: 2, numberOfSeen: 3 })
+        );
+      });
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      stopCards();
+    }
   });
 
   it("delivers initial, update, and delete snapshots without a cursor", async () => {


### PR DESCRIPTION
## Related issue

None.

## Summary

Ban `@public` suppression of Knip findings in AGENTS.md and remove existing tags. Remove the unused Card fetch API and public re-exports identified by Knip, keeping subscription helpers private. Exercise Card content, study fields, and errors through the production subscription API in the existing tests.

## Testing

- `mise run check` passed.
- `npm run test:integration -- test/integration/firestore/subscriptions.spec.ts` passed (3 tests).
- Required reviewer completed with no findings.
