### PR TITLE
[No issue] Improve mobile CardForm with tabs and compact tags

### DIFF
--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -97,6 +97,7 @@
 | CARD-18 | write | [Card 一覧の difficulty 保存失敗後に再試行できる](./card-list-actions.md#card-18) |
 | CARD-19 | batch | [表示中の Card の difficulty をまとめて変更できる](./card-list-actions.md#card-19) |
 | CARD-20 | batch | [Card の一括 difficulty 変更を部分失敗後に再試行できる](./card-list-actions.md#card-20) |
+| CARD-21 | read | [Card の未表示の面にある入力エラーを修正できる](./card-management.md#card-21) |
 
 ### Study
 

--- a/docs/e2e/card-management.md
+++ b/docs/e2e/card-management.md
@@ -17,6 +17,7 @@ Card の作成・編集・削除が保存先の境界を守り、失敗後の再
 | CARD-15 | write | [remote Card の作成失敗後に重複なく再試行できる](#card-15) |
 | CARD-16 | write | [Card の削除失敗後に再試行できる](#card-16) |
 | CARD-17 | read | [未保存の Card 編集内容を離脱前に確認できる](#card-17) |
+| CARD-21 | read | [Card の未表示の面にある入力エラーを修正できる](#card-21) |
 
 <a id="card-03"></a>
 
@@ -32,12 +33,16 @@ Given:
 
 When:
 
-- 対象 Card の front text、back text、tags を変更して保存し、画面を reload して編集画面を再度開く。
+- 対象 Card の front / back tab を切り替えて本文を編集し、back text を拡大画面でも変更する。
+- 拡大画面を閉じ、1行の tags 要約から選択画面を開いて tags を変更して保存し、画面を reload して編集画面を再度開く。
 
 Then:
 
 - Card の更新成功が共通 toast で表示される。
 - 編集画面に変更後の front text、back text、tags が表示される。
+- tab と拡大画面を切り替えても両面の入力内容が維持され、拡大画面を閉じると起点へ focus が戻る。
+- tags の全候補は選択画面だけに表示され、閉じた状態は最大2個と残りの件数を1行に表示する。
+- 選択画面は既存の独自 tag も扱え、閉じて開き直しても選択が維持される。
 - browser error が発生しない。
 
 <a id="card-04"></a>
@@ -231,4 +236,28 @@ Then:
 - dialog 表示中に toast が消えるか置き換わっても、focus は Keep editing に維持される。
 - 2回目の離脱では Deck 一覧へ1回だけ遷移する。
 - 永続化された Card の front text は変更されない。
+- browser error が発生しない。
+
+<a id="card-21"></a>
+
+### CARD-21 Card の未表示の面にある入力エラーを修正できる
+
+カテゴリ: `read`
+
+Given:
+
+- Fixture: [`remote-deck-with-cards`](./fixture/remote-deck-with-cards.yaml)
+- 認証済みユーザーが所有する Card の編集画面を開いている。
+
+When:
+
+- front text と back text を空にし、Back tab を表示した状態で保存を試みる。
+- Back tab に切り替えて拡大編集画面を開き、入力エラーを確認して閉じる。
+
+Then:
+
+- 最初の入力エラーがある Front tab が選択され、対象の入力欄へ focus が移る。
+- 両面の tab にエラーが示され、Back tab を選ぶと back text の入力エラーも確認できる。
+- 拡大編集画面でも入力エラーが表示され、入力欄の accessible description として読み取れる。
+- 未入力の値は維持され、Card は保存されず元の永続データが変更されない。
 - browser error が発生しない。

--- a/src/app/i18n/resources.ts
+++ b/src/app/i18n/resources.ts
@@ -159,6 +159,10 @@ export const resources = {
       },
       cardForm: {
         back: "Back to cards",
+        content: "Card content",
+        expand: "Expand",
+        expandSide: "Expand {{side}}",
+        done: "Done",
         create: {
           eyebrow: "Card creator",
           title: "Create card",
@@ -182,6 +186,9 @@ export const resources = {
         tags: {
           title: "Tags",
           description: "Organize this card for filtering and study sessions.",
+          edit: "Edit tags",
+          select: "Select tags",
+          empty: "No tags",
         },
         information: {
           title: "Card information",
@@ -746,6 +753,10 @@ export const resources = {
       },
       cardForm: {
         back: "カード一覧に戻る",
+        content: "カードの内容",
+        expand: "拡大",
+        expandSide: "{{side}}を拡大",
+        done: "完了",
         create: {
           eyebrow: "カード作成",
           title: "カードを作成",
@@ -769,6 +780,9 @@ export const resources = {
         tags: {
           title: "タグ",
           description: "フィルターや学習セッション用にカードを分類します。",
+          edit: "タグを編集",
+          select: "タグを選択",
+          empty: "未選択",
         },
         information: {
           title: "カード情報",

--- a/src/features/card-form/ui/CardFields.spec.tsx
+++ b/src/features/card-form/ui/CardFields.spec.tsx
@@ -1,0 +1,117 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { cardContentSchema } from "@/entities/card";
+
+import { CardFields, type CardFormFields } from "./CardFields";
+
+vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
+
+const initialValues: CardFormFields = { frontText: "Front", backText: "Back", tags: ["language", "custom"] };
+
+const FormHarness = ({ onSubmit = vi.fn() }: { onSubmit?: (values: CardFormFields) => void }) => {
+  const form = useForm<CardFormFields>({
+    defaultValues: initialValues,
+    resolver: zodResolver(cardContentSchema.omit({ uniqueKey: true })),
+  });
+  return (
+    <form onSubmit={form.handleSubmit((values) => onSubmit(values))}>
+      <CardFields categories={["language", "math"]} form={form} />
+      <button type="submit">Save</button>
+    </form>
+  );
+};
+
+describe("CARD-03 CardFields editing", () => {
+  it("keeps both drafts across tabs and expanded editing, then submits the selected tags", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<FormHarness onSubmit={onSubmit} />);
+    expect(screen.queryByRole("textbox", { name: "Back text" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    await user.clear(screen.getByRole("textbox", { name: "Front text" }));
+    await user.type(screen.getByRole("textbox", { name: "Front text" }), "Updated front");
+    await user.click(screen.getByRole("tab", { name: "Back" }));
+    await user.click(screen.getByRole("button", { name: "Expand Back" }));
+    const editor = screen.getByRole("dialog", { name: "Back text" });
+    const expandedInput = within(editor).getByRole("textbox", { name: "Back text" });
+    await user.clear(expandedInput);
+    await user.type(expandedInput, "Updated back");
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand Back" })).toHaveFocus();
+    expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Updated back");
+    await user.click(screen.getByRole("tab", { name: "Front" }));
+    expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Updated front");
+
+    const tagsTrigger = screen.getByRole("button", { name: "Edit tags" });
+    await user.click(tagsTrigger);
+    const tagsDialog = screen.getByRole("dialog", { name: "Select tags" });
+    await user.click(within(tagsDialog).getByRole("checkbox", { name: "custom" }));
+    expect(within(tagsDialog).getByRole("checkbox", { name: "custom" })).not.toBeChecked();
+    await user.click(within(tagsDialog).getByRole("checkbox", { name: "custom" }));
+    await user.click(within(tagsDialog).getByRole("checkbox", { name: "math" }));
+    await user.click(within(tagsDialog).getByRole("button", { name: "Done" }));
+    expect(tagsTrigger).toHaveFocus();
+    expect(tagsTrigger).toHaveTextContent("+1");
+    expect(tagsTrigger).toHaveAccessibleDescription("language, custom, math");
+    await user.click(tagsTrigger);
+    expect(screen.getByRole("checkbox", { name: "math" })).toBeChecked();
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      frontText: "Updated front",
+      backText: "Updated back",
+      tags: ["language", "custom", "math"],
+    });
+  });
+
+  it("switches sides with arrow and endpoint keys while keeping tab focus", async () => {
+    const user = userEvent.setup();
+    render(<FormHarness />);
+    const front = screen.getByRole("tab", { name: "Front" });
+    const back = screen.getByRole("tab", { name: "Back" });
+    await user.click(front);
+    await user.keyboard("{ArrowRight}");
+    expect(back).toHaveFocus();
+    expect(back).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Back");
+    await user.keyboard("{Home}");
+    expect(front).toHaveFocus();
+    await user.keyboard("{End}");
+    expect(back).toHaveFocus();
+    await user.keyboard("{ArrowLeft}");
+    expect(front).toHaveFocus();
+  });
+});
+
+describe("CARD-21 CardFields validation", () => {
+  it("reveals and focuses an invalid Back while preserving the valid Front", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<FormHarness onSubmit={onSubmit} />);
+    await user.click(screen.getByRole("tab", { name: "Back" }));
+    await user.clear(screen.getByRole("textbox", { name: "Back text" }));
+    await user.click(screen.getByRole("tab", { name: "Front" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Back text is required.")).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Back text" })).toHaveFocus();
+    expect(screen.getByRole("tab", { name: "Back" })).toHaveAttribute("aria-selected", "true");
+    expect(onSubmit).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Expand Back" }));
+    const editor = screen.getByRole("dialog", { name: "Back text" });
+    const expandedInput = within(editor).getByRole("textbox", { name: "Back text" });
+    expect(expandedInput).toBeInvalid();
+    expect(expandedInput).toHaveAccessibleDescription("Back text is required.");
+    expect(within(editor).getByRole("alert")).toHaveTextContent("Back text is required.");
+    expect(within(editor).getByRole("alert")).toBeVisible();
+    await user.click(within(editor).getByRole("button", { name: "Done" }));
+    await user.click(screen.getByRole("tab", { name: "Front" }));
+    expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Front");
+  });
+});

--- a/src/features/card-form/ui/CardFields.stories.tsx
+++ b/src/features/card-form/ui/CardFields.stories.tsx
@@ -54,11 +54,43 @@ export const Interaction: Story = {
     await userEvent.type(frontText, "Updated prompt");
     await expect(frontText).toHaveValue("Updated prompt");
 
+    await userEvent.click(canvas.getByRole("tab", { name: "Back" }));
+    await userEvent.click(canvas.getByRole("tab", { name: "Front" }));
+    await expect(canvas.getByRole("textbox", { name: "Front text" })).toHaveValue("Updated prompt");
+    await userEvent.click(canvas.getByRole("button", { name: "Edit tags" }));
     const firstTag = canvas.getByRole("checkbox", { name: "raw" });
     await expect(firstTag).not.toBeChecked();
     await userEvent.click(firstTag);
     await expect(firstTag).toBeChecked();
+    await userEvent.click(canvas.getByRole("button", { name: "Done" }));
   },
 };
 export const Mobile: Story = { ...LongContent, globals: { viewport: { value: "iphonex", isRotated: false } } };
 export const Dark: Story = { ...LongContent, globals: { theme: "dark" } };
+
+export const Empty: Story = { args: { card: { ...fixture.card.default, frontText: "", backText: "", tags: [] } } };
+export const Back: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Back" }));
+  },
+};
+export const Expanded: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Back" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Expand Back" }));
+  },
+};
+export const ExpandedValidationError: Story = {
+  ...Expanded,
+  args: { card: { ...fixture.card.default, frontText: "", backText: "" }, validationError: true },
+};
+export const TagSelection: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Edit tags" }));
+  },
+};
+export const MobileBack: Story = {
+  ...Back,
+  ...LongContent,
+  globals: { viewport: { value: "iphonex", isRotated: false } },
+};

--- a/src/features/card-form/ui/CardFields.tsx
+++ b/src/features/card-form/ui/CardFields.tsx
@@ -1,10 +1,12 @@
-import type * as React from "react";
-import { useId } from "react";
+import * as React from "react";
+import cx from "classnames";
 import { useTranslation } from "react-i18next";
-import { type UseFormReturn, useFormState } from "react-hook-form";
+import { type UseFormReturn, useController, useFormState } from "react-hook-form";
+import { AiOutlineExpandAlt, AiOutlineRight } from "react-icons/ai";
 
-import { TagList } from "@/shared/ui/content";
-import { FormItem, Tag, Textarea } from "@/shared/ui/forms";
+import { focusableElementSelector } from "@/shared/lib/focusableElementSelector";
+import { Tag, Textarea } from "@/shared/ui/forms";
+import { useToastModalFocusTarget } from "@/shared/ui/toast";
 
 export interface CardFormFields {
   frontText: string;
@@ -17,96 +19,310 @@ export interface CardFieldsProps {
   form: UseFormReturn<CardFormFields>;
 }
 
-export const CardFields: React.FC<CardFieldsProps> = (props) => {
+type CardSide = "frontText" | "backText";
+
+interface CardFieldsDialogProps {
+  title: string;
+  expanded?: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const CardFieldsDialog = ({ title, expanded = false, onClose, children }: CardFieldsDialogProps) => {
   const { t } = useTranslation();
-  const formState = useFormState({ control: props.form.control });
-  const sectionHeadingIdPrefix = useId();
-  const frontHeadingId = `${sectionHeadingIdPrefix}-card-front-heading`;
-  const backHeadingId = `${sectionHeadingIdPrefix}-card-back-heading`;
-  const tagsHeadingId = `${sectionHeadingIdPrefix}-card-tags-heading`;
-  const frontInputId = `${sectionHeadingIdPrefix}-card-front-text`;
-  const frontErrorId = `${frontInputId}-error`;
-  const backInputId = `${sectionHeadingIdPrefix}-card-back-text`;
-  const backErrorId = `${backInputId}-error`;
+  const titleId = React.useId();
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const closeRef = React.useRef<HTMLButtonElement>(null);
+  useToastModalFocusTarget(dialogRef, closeRef);
+
+  React.useEffect(() => {
+    const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeRef.current?.focus();
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (previousFocus?.isConnected) previousFocus.focus();
+    };
+  }, []);
+
+  const handleKeyDown = React.useEffectEvent((event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    } else if (event.key === "Tab") {
+      const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(focusableElementSelector) ?? []);
+      const [first] = focusable;
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    }
+  });
+
+  React.useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+    dialog.addEventListener("keydown", handleKeyDown);
+    return () => dialog.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-canvas/70 sm:items-center sm:p-6">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className={cx(
+          "flex w-full max-w-reading flex-col border border-border bg-surface-elevated text-ink shadow-elevated sm:rounded-surface",
+          expanded ? "h-dvh sm:h-[85dvh]" : "max-h-[85dvh] rounded-t-surface"
+        )}
+      >
+        {/* The page uses viewport-fit=cover, so edge-aligned dialogs must clear device cutouts and the home indicator. */}
+        <header
+          className={cx(
+            "flex shrink-0 items-center justify-between gap-4 border-b border-border pb-3 pl-[calc(1rem+env(safe-area-inset-left))] pr-[calc(1rem+env(safe-area-inset-right))]",
+            expanded ? "pt-[calc(0.75rem+env(safe-area-inset-top))] sm:pt-3" : "pt-3"
+          )}
+        >
+          <h2 id={titleId} className="min-w-0 break-words text-body font-semibold">
+            {title}
+          </h2>
+          <button
+            ref={closeRef}
+            type="button"
+            className="min-h-touch shrink-0 rounded-control px-4 font-semibold text-accent-primary hover:bg-surface-muted"
+            onClick={onClose}
+          >
+            {t("cardForm.done")}
+          </button>
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pl-[calc(1rem+env(safe-area-inset-left))] pr-[calc(1rem+env(safe-area-inset-right))]">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const CardFields = ({ categories, form }: CardFieldsProps) => {
+  const { t } = useTranslation();
+  const formState = useFormState({ control: form.control });
+  const { field: frontField } = useController({ name: "frontText", control: form.control });
+  const { field: backField } = useController({ name: "backText", control: form.control });
+  const { field: tagsField } = useController({ name: "tags", control: form.control });
+  const [activeSide, setActiveSide] = React.useState<CardSide>("frontText");
+  const [expanded, setExpanded] = React.useState(false);
+  const [tagOptions, setTagOptions] = React.useState<readonly string[] | null>(null);
+  const [validation, setValidation] = React.useState<{ count: number; side: CardSide | null }>({
+    count: formState.submitCount,
+    side: null,
+  });
+  const id = React.useId();
+  const frontTabRef = React.useRef<HTMLButtonElement>(null);
+  const backTabRef = React.useRef<HTMLButtonElement>(null);
+
+  // A failed submission must reveal its first invalid side before React Hook Form can focus that input.
+  if (validation.count !== formState.submitCount) {
+    const side = formState.errors.frontText ? "frontText" : formState.errors.backText ? "backText" : null;
+    setValidation({ count: formState.submitCount, side });
+    if (side) setActiveSide(side);
+  }
+  React.useEffect(() => {
+    if (validation.side) form.setFocus(validation.side);
+  }, [form, validation]);
+
+  const sides = [
+    {
+      name: "frontText",
+      title: t("cardForm.front.title"),
+      label: t("cardForm.front.label"),
+      field: frontField,
+    },
+    {
+      name: "backText",
+      title: t("cardForm.backSide.title"),
+      label: t("cardForm.backSide.label"),
+      field: backField,
+    },
+  ] as const;
+  const active = activeSide === "frontText" ? sides[0] : sides[1];
+  const activeError = formState.errors[activeSide];
+  const expandedErrorId = `${id}-expanded-error`;
+  const tags = tagsField.value;
+  const tagsSummaryId = `${id}-tags-summary`;
+
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    let nextSide: CardSide;
+    if (event.key === "Home") nextSide = "frontText";
+    else if (event.key === "End") nextSide = "backText";
+    else if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      nextSide = activeSide === "frontText" ? "backText" : "frontText";
+    } else return;
+    event.preventDefault();
+    setActiveSide(nextSide);
+    (nextSide === "frontText" ? frontTabRef : backTabRef).current?.focus();
+  };
 
   return (
     <>
-      <section
-        aria-labelledby={frontHeadingId}
-        className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
-      >
-        <div>
-          <h2 id={frontHeadingId} className="text-title font-semibold text-ink">
-            {t("cardForm.front.title")}
-          </h2>
-          <p className="mt-1 text-caption text-ink-muted">{t("cardForm.front.description")}</p>
-        </div>
-        <FormItem
-          col
-          label={t("cardForm.front.label")}
-          inputId={frontInputId}
-          errorId={frontErrorId}
-          {...(formState.errors.frontText?.message !== undefined ? { error: formState.errors.frontText.message } : {})}
+      <section className="min-w-0 space-y-3" aria-label={t("cardForm.content")}>
+        <div
+          role="tablist"
+          aria-label={t("cardForm.content")}
+          className="flex gap-1 rounded-control bg-surface-muted p-1"
         >
-          <Textarea
-            rows={8}
-            {...props.form.register("frontText")}
-            id={frontInputId}
-            aria-invalid={formState.errors.frontText != null || undefined}
-            aria-describedby={formState.errors.frontText !== undefined ? frontErrorId : undefined}
-          />
-        </FormItem>
-      </section>
-      <section
-        aria-labelledby={backHeadingId}
-        className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
-      >
-        <div>
-          <h2 id={backHeadingId} className="text-title font-semibold text-ink">
-            {t("cardForm.backSide.title")}
-          </h2>
-          <p className="mt-1 text-caption text-ink-muted">{t("cardForm.backSide.description")}</p>
-        </div>
-        <FormItem
-          col
-          label={t("cardForm.backSide.label")}
-          inputId={backInputId}
-          errorId={backErrorId}
-          {...(formState.errors.backText?.message !== undefined ? { error: formState.errors.backText.message } : {})}
-        >
-          <Textarea
-            rows={8}
-            {...props.form.register("backText")}
-            id={backInputId}
-            aria-invalid={formState.errors.backText != null || undefined}
-            aria-describedby={formState.errors.backText !== undefined ? backErrorId : undefined}
-          />
-        </FormItem>
-      </section>
-      <section
-        aria-labelledby={tagsHeadingId}
-        className="space-y-4 rounded-surface border border-border bg-surface p-4 md:p-5"
-      >
-        <div>
-          <h2 id={tagsHeadingId} className="text-title font-semibold text-ink">
-            {t("cardForm.tags.title")}
-          </h2>
-          <p className="mt-1 text-caption text-ink-muted">{t("cardForm.tags.description")}</p>
-        </div>
-        <TagList>
-          {props.categories.map((category) => (
-            <Tag
-              className="mr-1 mb-1"
-              primary
-              small
-              key={category}
-              label={category}
-              {...props.form.register("tags")}
-              value={category}
-            />
+          {sides.map((side) => (
+            <button
+              key={side.name}
+              ref={side.name === "frontText" ? frontTabRef : backTabRef}
+              type="button"
+              role="tab"
+              id={`${id}-${side.name}-tab`}
+              aria-controls={`${id}-${side.name}-panel`}
+              aria-selected={activeSide === side.name}
+              aria-describedby={formState.errors[side.name] ? `${id}-${side.name}-error` : undefined}
+              tabIndex={activeSide === side.name ? 0 : -1}
+              onClick={() => setActiveSide(side.name)}
+              onKeyDown={handleTabKeyDown}
+              className={cx(
+                "min-h-touch min-w-0 flex-1 rounded-control px-3 py-2 text-body font-semibold",
+                activeSide === side.name
+                  ? "bg-surface text-accent-primary shadow-surface"
+                  : "text-ink-muted hover:bg-surface"
+              )}
+            >
+              {side.title}
+              {formState.errors[side.name] != null && (
+                <span aria-hidden="true" className="ml-2 text-danger">
+                  ●
+                </span>
+              )}
+            </button>
           ))}
-        </TagList>
+        </div>
+        {sides.map((side) => {
+          const inputId = `${id}-${side.name}`;
+          const errorId = `${inputId}-error`;
+          const error = formState.errors[side.name];
+          return (
+            <div
+              key={side.name}
+              role="tabpanel"
+              id={`${inputId}-panel`}
+              aria-labelledby={`${inputId}-tab`}
+              hidden={activeSide !== side.name}
+              className="space-y-2"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <label htmlFor={inputId} className="text-caption font-medium text-ink-muted">
+                  {side.label}
+                </label>
+                <button
+                  type="button"
+                  aria-label={t("cardForm.expandSide", { side: side.title })}
+                  onClick={() => setExpanded(true)}
+                  className="inline-flex min-h-touch items-center gap-2 rounded-control px-3 text-caption font-semibold text-accent-primary hover:bg-surface-muted"
+                >
+                  <AiOutlineExpandAlt aria-hidden="true" />
+                  {t("cardForm.expand")}
+                </button>
+              </div>
+              <Textarea
+                {...side.field}
+                id={inputId}
+                rows={12}
+                className="min-h-[min(45dvh,24rem)] text-lg leading-relaxed"
+                aria-invalid={error != null || undefined}
+                aria-describedby={error ? errorId : undefined}
+              />
+              {error?.message !== undefined && (
+                <p id={errorId} role="alert" className="text-caption font-medium text-danger">
+                  {error.message}
+                </p>
+              )}
+            </div>
+          );
+        })}
       </section>
+      <button
+        type="button"
+        aria-label={t("cardForm.tags.edit")}
+        aria-describedby={tagsSummaryId}
+        aria-haspopup="dialog"
+        aria-expanded={tagOptions !== null}
+        onClick={() => {
+          // Keep imported tags in the open list even after deselection so they can be selected again.
+          setTagOptions([...new Set([...categories, ...tags])]);
+        }}
+        className="flex min-h-14 w-full min-w-0 items-center gap-2 rounded-control border border-border bg-surface px-3 py-2 text-left hover:bg-surface-muted"
+      >
+        <span className="shrink-0 text-caption text-ink-muted">{t("cardForm.tags.title")}</span>
+        <span className="flex min-w-0 flex-1 items-center gap-1">
+          {tags.length === 0 && (
+            <span className="truncate text-caption text-ink-muted">{t("cardForm.tags.empty")}</span>
+          )}
+          {tags.slice(0, 2).map((tag) => (
+            <span
+              key={tag}
+              className="max-w-28 truncate rounded bg-accent-primary/10 px-2 py-1 text-xs text-accent-primary"
+            >
+              {tag}
+            </span>
+          ))}
+          {tags.length > 2 && <span className="shrink-0 text-caption text-ink-muted">+{tags.length - 2}</span>}
+        </span>
+        <AiOutlineRight className="shrink-0 text-accent-primary" aria-hidden="true" />
+        <span id={tagsSummaryId} className="sr-only">
+          {tags.length === 0 ? t("cardForm.tags.empty") : tags.join(", ")}
+        </span>
+      </button>
+      {tagOptions !== null && (
+        <CardFieldsDialog title={t("cardForm.tags.select")} onClose={() => setTagOptions(null)}>
+          <fieldset className="flex flex-wrap gap-2" aria-label={t("cardForm.tags.title")}>
+            {tagOptions.map((tag) => (
+              <Tag
+                key={tag}
+                label={tag}
+                value={tag}
+                wrap
+                checked={tags.includes(tag)}
+                onChange={(event) =>
+                  tagsField.onChange(event.target.checked ? [...tags, tag] : tags.filter((value) => value !== tag))
+                }
+                onBlur={tagsField.onBlur}
+              />
+            ))}
+          </fieldset>
+        </CardFieldsDialog>
+      )}
+      {expanded ? (
+        <CardFieldsDialog title={active.label} expanded onClose={() => setExpanded(false)}>
+          <div className="flex h-full min-h-0 flex-col gap-2">
+            {/* Keep the registered focus target in its tab while both editors share the same form value. */}
+            <Textarea
+              value={active.field.value}
+              onChange={active.field.onChange}
+              onBlur={active.field.onBlur}
+              aria-label={active.label}
+              aria-invalid={activeError != null || undefined}
+              aria-describedby={activeError ? expandedErrorId : undefined}
+              className="min-h-48 flex-1 resize-none text-xl leading-relaxed"
+            />
+            {activeError?.message !== undefined && (
+              <p id={expandedErrorId} role="alert" className="shrink-0 text-caption font-medium text-danger">
+                {activeError.message}
+              </p>
+            )}
+          </div>
+        </CardFieldsDialog>
+      ) : null}
     </>
   );
 };

--- a/src/pages/card-create/ui/CardCreatePage.spec.tsx
+++ b/src/pages/card-create/ui/CardCreatePage.spec.tsx
@@ -13,7 +13,7 @@ vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 
 import { CardCreatePage } from "./CardCreatePage";
 
-describe("CardCreatePage", () => {
+describe("CARD-13 CARD-14 CardCreatePage", () => {
   const deck = createLocalDeck({ id: "target-deck", name: "Target deck" });
   const renderPage = (deckId = deck.id) =>
     render(
@@ -46,6 +46,7 @@ describe("CardCreatePage", () => {
     renderPage();
 
     await userEvent.type(screen.getByRole("textbox", { name: "Front text" }), "Created front");
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
     await userEvent.type(screen.getByRole("textbox", { name: "Back text" }), "Created back");
     await userEvent.click(screen.getByRole("button", { name: "Create card" }));
 

--- a/src/pages/card-create/ui/CardCreator.spec.tsx
+++ b/src/pages/card-create/ui/CardCreator.spec.tsx
@@ -40,10 +40,11 @@ const CardCreatorHarness = ({ onCreated = vi.fn() }: { onCreated?: (cardId: stri
 
 const enterRequiredValues = async () => {
   await userEvent.type(screen.getByRole("textbox", { name: "Front text" }), "Front value");
+  await userEvent.click(screen.getByRole("tab", { name: "Back" }));
   await userEvent.type(screen.getByRole("textbox", { name: "Back text" }), "Back value");
 };
 
-describe("CardCreator", () => {
+describe("CARD-13 CARD-14 CARD-15 CardCreator", () => {
   beforeEach(async () => {
     dismissToast();
     await createDeck("", deck);
@@ -80,6 +81,7 @@ describe("CardCreator", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Create card" }));
     expect(await screen.findByText("Unable to create this card. Try again.")).toBeVisible();
+    await userEvent.click(screen.getByRole("tab", { name: "Front" }));
     expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Front value");
 
     await userEvent.click(screen.getByRole("button", { name: "Create card" }));

--- a/src/pages/card-create/ui/CardCreator.stories.tsx
+++ b/src/pages/card-create/ui/CardCreator.stories.tsx
@@ -50,6 +50,7 @@ export const Saving: Story = { args: { isSaving: true } };
 export const Interaction: Story = {
   play: async ({ args, canvas, userEvent }) => {
     await userEvent.type(canvas.getByRole("textbox", { name: "Front text" }), "Hello");
+    await userEvent.click(canvas.getByRole("tab", { name: "Back" }));
     await userEvent.type(canvas.getByRole("textbox", { name: "Back text" }), "Hola");
     await userEvent.click(canvas.getByRole("button", { name: "Create card" }));
     await expect(args.onSubmit).toHaveBeenCalledOnce();

--- a/src/pages/card-create/ui/CardCreator.tsx
+++ b/src/pages/card-create/ui/CardCreator.tsx
@@ -5,7 +5,6 @@ import { type UseFormReturn, useFormState } from "react-hook-form";
 
 import { CardFields, type CardFormFields } from "@/features/card-form";
 import { Button } from "@/shared/ui/button";
-import { Form } from "@/shared/ui/forms";
 
 export interface CardCreatorProps {
   categories: readonly string[];
@@ -21,23 +20,20 @@ export const CardCreator: React.FC<CardCreatorProps> = ({ categories, deckName, 
 
   return (
     <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
-      <header className="mb-section-gap">
+      <header className="mb-5">
         <button
           type="button"
           disabled={formState.isSubmitting}
-          className="mb-4 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
+          className="mb-1 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
           onClick={onCancel}
         >
           <AiOutlineArrowLeft aria-hidden="true" />
           {t("cardForm.back")}
         </button>
-        <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">
-          {t("cardForm.create.eyebrow")}
-        </p>
-        <h1 className="mt-1 break-words text-display font-bold text-ink">{t("cardForm.create.title")}</h1>
-        <p className="mt-2 text-body text-ink-muted">{t("cardForm.create.description", { deckName })}</p>
+        <h1 className="mt-1 break-words text-title font-bold text-ink">{t("cardForm.create.title")}</h1>
+        <p className="mt-2 text-caption text-ink-muted">{t("cardForm.create.description", { deckName })}</p>
       </header>
-      <Form onSubmit={onSubmit}>
+      <form className="w-full space-y-4" onSubmit={onSubmit}>
         <CardFields categories={categories} form={form} />
         <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-4">
           <Button variant="quiet" type="button" onClick={onCancel}>
@@ -47,7 +43,7 @@ export const CardCreator: React.FC<CardCreatorProps> = ({ categories, deckName, 
             <span>{t(formState.isSubmitting ? "cardForm.actions.creating" : "cardForm.actions.create")}</span>
           </Button>
         </div>
-      </Form>
+      </form>
     </section>
   );
 };

--- a/src/pages/card-form/ui/CardEditor.spec.tsx
+++ b/src/pages/card-form/ui/CardEditor.spec.tsx
@@ -61,7 +61,7 @@ const StoredCardEditorHarness = (props: { cardId: CardId; onCancel: () => void; 
   );
 };
 
-describe("CARD-03 CARD-09 CARD-12 CardEditor", () => {
+describe("CARD-03 CARD-09 CARD-12 CARD-21 CardEditor", () => {
   const deckId = "card-edit-deck";
   const cardId = "card-id";
   const renderForm = (onSaved = vi.fn(), onCancel = vi.fn()) =>
@@ -95,12 +95,15 @@ describe("CARD-03 CARD-09 CARD-12 CardEditor", () => {
     const onSaved = vi.fn();
     const view = renderForm(onSaved);
     const frontText = screen.getByRole("textbox", { name: "Front text" });
-    const backText = screen.getByRole("textbox", { name: "Back text" });
     await userEvent.clear(frontText);
     await userEvent.type(frontText, "Updated front");
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
+    const backText = screen.getByRole("textbox", { name: "Back text" });
     await userEvent.clear(backText);
     await userEvent.type(backText, "Updated back");
+    await userEvent.click(screen.getByRole("button", { name: "Edit tags" }));
     await userEvent.click(screen.getByRole("checkbox", { name: "math" }));
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
@@ -108,7 +111,9 @@ describe("CARD-03 CARD-09 CARD-12 CardEditor", () => {
     renderForm();
 
     expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Updated front");
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
     expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Updated back");
+    await userEvent.click(screen.getByRole("button", { name: "Edit tags" }));
     expect(screen.getByRole("checkbox", { name: "math" })).toBeChecked();
   });
 
@@ -179,16 +184,20 @@ describe("CARD-03 CARD-09 CARD-12 CardEditor", () => {
     ]);
 
     expect(frontText).toHaveValue("Unsaved front");
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
     expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Back text");
   });
 
   it("keeps stored values unchanged when validation rejects the form", async () => {
     const view = renderForm();
     await userEvent.clear(screen.getByRole("textbox", { name: "Front text" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
     await userEvent.clear(screen.getByRole("textbox", { name: "Back text" }));
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect(await screen.findByText("Front text is required.")).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Front text" })).toHaveFocus();
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
     expect(screen.getByText("Back text is required.")).toBeVisible();
     view.unmount();
     renderForm();

--- a/src/pages/card-form/ui/CardEditor.tsx
+++ b/src/pages/card-form/ui/CardEditor.tsx
@@ -6,7 +6,6 @@ import type { UseFormReturn } from "react-hook-form";
 import type { CardId } from "@/entities/card";
 import { CardFields, type CardFormFields } from "@/features/card-form";
 import { Button } from "@/shared/ui/button";
-import { Form } from "@/shared/ui/forms";
 
 export interface CardEditorProps {
   cardInfo: { uniqueKey: string; id: CardId; createdAt?: number; lastSeenAt?: number };
@@ -25,26 +24,22 @@ export const CardEditor: React.FC<CardEditorProps> = ({ cardInfo, categories, fo
 
   return (
     <section className="mx-auto w-full max-w-reading rounded-surface border border-border bg-surface p-4 md:p-6">
-      <header className="mb-section-gap">
+      <header className="mb-5">
         <button
           type="button"
           disabled={isSaving}
-          className="mb-4 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
+          className="mb-1 inline-flex min-h-touch items-center gap-2 rounded-control px-2 text-caption font-semibold text-ink-muted transition-colors duration-fast ease-calm hover:bg-surface-muted"
           onClick={onCancel}
         >
           <AiOutlineArrowLeft aria-hidden="true" />
           {t("cardForm.back")}
         </button>
-        <p className="text-caption font-bold uppercase tracking-wider text-accent-primary">
-          {t("cardForm.edit.eyebrow")}
-        </p>
-        <h1 className="mt-1 break-words text-display font-bold text-ink">{t("cardForm.edit.title")}</h1>
-        <p className="mt-2 text-body text-ink-muted">{t("cardForm.edit.description")}</p>
+        <h1 className="mt-1 break-words text-title font-bold text-ink">{t("cardForm.edit.title")}</h1>
       </header>
-      <Form onSubmit={onSubmit}>
+      <form className="w-full space-y-4" onSubmit={onSubmit}>
         <fieldset className="contents" disabled={isSaving}>
           <CardFields categories={categories} form={form} />
-          <details className="rounded-surface border border-border bg-surface-muted p-4">
+          <details className="border-t border-border text-caption">
             <summary className="flex min-h-touch cursor-pointer items-center font-semibold text-ink">
               {t("cardForm.information.title")}
             </summary>
@@ -80,7 +75,7 @@ export const CardEditor: React.FC<CardEditorProps> = ({ cardInfo, categories, fo
             <span>{t(isSaving ? "cardForm.actions.saving" : "cardForm.actions.save")}</span>
           </Button>
         </div>
-      </Form>
+      </form>
     </section>
   );
 };

--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -107,6 +107,7 @@ describe("CARD-03 CARD-09 CARD-12 CARD-17 CardFormPage", () => {
     });
 
     expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Delayed front");
+    await userEvent.click(screen.getByRole("tab", { name: "Back" }));
     expect(screen.getByRole("textbox", { name: "Back text" })).toHaveValue("Delayed back");
   });
 

--- a/test/e2e/card.spec.ts
+++ b/test/e2e/card.spec.ts
@@ -85,9 +85,16 @@ test("CARD-03 persists edited front, back, and tags across reload", async ({ fix
   await page.getByRole("button", { name: `Open actions for ${card.frontText}` }).click();
   await page.getByRole("menuitem", { name: "Edit" }).click();
   await page.getByRole("textbox", { name: "Front text" }).fill(changed.frontText);
-  await page.getByRole("textbox", { name: "Back text" }).fill(changed.backText);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
+  await page.getByRole("button", { name: "Expand Back" }).click();
+  const expandedEditor = page.getByRole("dialog", { name: "Back text" });
+  await expandedEditor.getByRole("textbox", { name: "Back text" }).fill(changed.backText);
+  await expandedEditor.getByRole("button", { name: "Done" }).click();
+  await expect(page.getByRole("button", { name: "Expand Back" })).toBeFocused();
+  await page.getByRole("button", { name: "Edit tags" }).click();
   await clickCheckboxLabel(page, "math");
   await clickCheckboxLabel(page, "python");
+  await page.getByRole("button", { name: "Done" }).click();
   await page.getByRole("button", { name: "Save changes" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));
   await expect(page.getByRole("status").filter({ hasText: `Updated card “${changed.frontText}”.` })).toBeVisible();
@@ -95,8 +102,11 @@ test("CARD-03 persists edited front, back, and tags across reload", async ({ fix
   await page.getByRole("button", { name: `Open actions for ${changed.frontText}` }).click();
   await page.getByRole("menuitem", { name: "Edit" }).click();
 
+  await page.getByRole("tab", { name: "Front", exact: true }).click();
   await expect(page.getByRole("textbox", { name: "Front text" })).toHaveValue(changed.frontText);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue(changed.backText);
+  await page.getByRole("button", { name: "Edit tags" }).click();
   await expect(page.getByRole("checkbox", { name: "math" })).not.toBeChecked();
   await expect(page.getByRole("checkbox", { name: "typescript" })).toBeChecked();
   await expect(page.getByRole("checkbox", { name: "python" })).toBeChecked();
@@ -205,13 +215,16 @@ test("CARD-09 retries the same Card edit after a handled failure", async ({
   const fault = await failNextFirestoreWrite(page, { collection: "card", id: card.id });
   allowExpectedFirestoreWriteFailure(browserErrors);
   await page.getByRole("textbox", { name: "Front text" }).fill(changedFront);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await page.getByRole("textbox", { name: "Back text" }).fill(changedBack);
   await page.getByRole("button", { name: "Save changes" }).click();
   await expect(page.getByRole("alert")).toContainText("Unable to save changes. Try again.");
   await expect.poll(fault.wasTriggered).toBe(true);
   await fault.waitForFailure();
   await fault.dispose();
+  await page.getByRole("tab", { name: "Front", exact: true }).click();
   await expect(page.getByRole("textbox", { name: "Front text" })).toHaveValue(changedFront);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue(changedBack);
 
   await page.getByRole("button", { name: "Save changes" }).click();
@@ -291,6 +304,7 @@ test("CARD-13 creates one remote Card and keeps it across reload", async ({ fixt
   await page.getByRole("button", { name: "Add card" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/card/new$`));
   await page.getByRole("textbox", { name: "Front text" }).fill(frontText);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await page.getByRole("textbox", { name: "Back text" }).fill(backText);
   await page.getByRole("button", { name: "Create card" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));
@@ -325,6 +339,7 @@ test("CARD-14 creates one local Card and keeps it across reload", async ({ fixtu
   await page.getByRole("button", { name: "Add card" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}/card/new$`));
   await page.getByRole("textbox", { name: "Front text" }).fill(frontText);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await page.getByRole("textbox", { name: "Back text" }).fill(backText);
   await page.getByRole("button", { name: "Create card" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));
@@ -418,4 +433,34 @@ test("CARD-19 changes the difficulty of only the Cards visible in the filter dra
   await page.getByRole("button", { name: "Clear limits" }).click();
   await Promise.all(matchingCards.map((card) => expectDifficulty(page, card.frontText, newDifficulty)));
   await expectDifficulty(page, excludedCard.frontText, excludedCard.difficulty);
+});
+
+test("CARD-21 reveals the first invalid side without saving empty text", async ({ fixture, page }) => {
+  const deck = fixture.deck();
+  const card = fixture.card();
+  await fixture.apply(page);
+  const before = await requireDocument("card", card.id);
+  await page.goto(`/deck/${deck.id}`);
+  await page.getByRole("button", { name: `Open actions for ${card.frontText}` }).click();
+  await page.getByRole("menuitem", { name: "Edit" }).click();
+  await page.getByRole("textbox", { name: "Front text" }).fill("");
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
+  await page.getByRole("textbox", { name: "Back text" }).fill("");
+  await page.getByRole("button", { name: "Save changes" }).click();
+
+  await expect(page.getByRole("tab", { name: "Front", exact: true })).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByRole("textbox", { name: "Front text" })).toBeFocused();
+  await expect(page.getByText("Front text is required.")).toBeVisible();
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
+  await expect(page.getByText("Back text is required.")).toBeVisible();
+  await page.getByRole("button", { name: "Expand Back" }).click();
+  const expandedEditor = page.getByRole("dialog", { name: "Back text" });
+  await expect(expandedEditor.getByRole("textbox", { name: "Back text" })).toHaveAttribute("aria-invalid", "true");
+  await expect(expandedEditor.getByRole("textbox", { name: "Back text" })).toHaveAccessibleDescription(
+    "Back text is required."
+  );
+  await expect(expandedEditor.getByText("Back text is required.")).toBeVisible();
+  await expandedEditor.getByRole("button", { name: "Done" }).click();
+  await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue("");
+  expect(await requireDocument("card", card.id)).toEqual(before);
 });

--- a/test/e2e/creation.spec.ts
+++ b/test/e2e/creation.spec.ts
@@ -71,6 +71,7 @@ test("CARD-15 retries a failed remote Card create with the same ID and no duplic
   const fault = await failNextFirestoreWrite(page, { collection: "card" });
   allowExpectedFirestoreWriteFailure(browserErrors);
   await page.getByRole("textbox", { name: "Front text" }).fill(frontText);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await page.getByRole("textbox", { name: "Back text" }).fill(backText);
   await page.getByRole("button", { name: "Create card" }).click();
   await expect(page.getByRole("alert")).toContainText("Unable to create this card. Try again.");
@@ -79,7 +80,9 @@ test("CARD-15 retries a failed remote Card create with the same ID and no duplic
   await fault.dispose();
   expect(attemptedCardId).toBeDefined();
 
+  await page.getByRole("tab", { name: "Front", exact: true }).click();
   await expect(page.getByRole("textbox", { name: "Front text" })).toHaveValue(frontText);
+  await page.getByRole("tab", { name: "Back", exact: true }).click();
   await expect(page.getByRole("textbox", { name: "Back text" })).toHaveValue(backText);
   await page.getByRole("button", { name: "Create card" }).click();
   await expect(page).toHaveURL(new RegExp(`/deck/${deck.id}$`));


### PR DESCRIPTION
## Related issue

None.

## Summary

The stacked text fields and always-visible tag list leave little editing space on mobile. Use Front/Back tabs with larger text areas in both card creation and editing, and let either side expand into a full-screen mobile editor.

Show tags in a single row with up to two labels and a remaining count; open the complete selection in a bottom sheet. Preserve drafts and tag selections across transitions, restore focus when dialogs close, reveal the first invalid tab on submission, and show validation errors inside the expanded editor. Dialog spacing accounts for device safe areas.

## Testing

- `mise run check`: passed, including 711 tests across 124 files after integrating current main.
- Related CardFields, CardEditor, and CardCreator Storybook tests: 23 passed.
- E2E CARD-03, CARD-09, CARD-13, CARD-14, CARD-15, and CARD-21: all 6 passed.
- CARD-13 now checks both expanded editors, full-viewport backdrops, and the tag sheet's bottom edge at 390x844. The regression failed at `y = -16` before the creation form spacing fix and passed afterward.
- Final custom reviewer pass: no findings.
