### PR TITLE
[No issue] Add convenient useAuth interface for account identity

### DIFF
--- a/src/entities/auth/index.ts
+++ b/src/entities/auth/index.ts
@@ -1,3 +1,4 @@
+export { useAuth } from "./model/queries/useAuth";
 export { useAuthSession } from "./model/queries/useAuthSession";
 export { useAuthUid } from "./model/queries/useAuthUid";
 export { getAuthSession } from "./model/queries/getAuthSession";

--- a/src/entities/auth/model/queries/useAuth.spec.ts
+++ b/src/entities/auth/model/queries/useAuth.spec.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { replaceAuthSession } from "../actions/replaceAuthSession";
+import { useAuth } from "./useAuth";
+
+describe("useAuth [ACCOUNT-01] [ACCOUNT-03] [ACCOUNT-04]", () => {
+  beforeEach(() => replaceAuthSession({ status: "initializing" }));
+
+  it("keeps the anonymous identity when linking a Google account", () => {
+    const anonymousSession = {
+      status: "authenticated" as const,
+      uid: "anonymous-user",
+      displayName: null,
+      isAnonymous: true,
+    };
+    replaceAuthSession(anonymousSession);
+    const { result } = renderHook(useAuth);
+
+    expect(result.current).toEqual({ uid: "anonymous-user", displayName: null, isAnonymous: true });
+
+    const linkedSession = { ...anonymousSession, displayName: "Test User", isAnonymous: false };
+    act(() => replaceAuthSession(linkedSession));
+
+    expect(result.current).toEqual({ uid: "anonymous-user", displayName: "Test User", isAnonymous: false });
+  });
+
+  it("clears the linked identity during sign-out and exposes the new anonymous session", () => {
+    replaceAuthSession({
+      status: "authenticated",
+      uid: "linked-user",
+      displayName: "Test User",
+      isAnonymous: false,
+    });
+    const { result } = renderHook(useAuth);
+
+    act(() => replaceAuthSession({ status: "unauthenticated" }));
+
+    expect(result.current).toEqual({ uid: "", displayName: null, isAnonymous: true });
+
+    const anonymousSession = {
+      status: "authenticated" as const,
+      uid: "new-anonymous-user",
+      displayName: null,
+      isAnonymous: true,
+    };
+    act(() => replaceAuthSession(anonymousSession));
+
+    expect(result.current).toEqual({ uid: "new-anonymous-user", displayName: null, isAnonymous: true });
+  });
+
+  it.each([
+    { status: "error" as const, error: new Error("authentication failed") },
+    { status: "initializing" as const },
+    { status: "unauthenticated" as const },
+    { status: "authenticating" as const, attemptId: Symbol("attempt") },
+  ])("does not expose an identity while authentication is $status", (session) => {
+    replaceAuthSession(session);
+    const { result } = renderHook(useAuth);
+
+    expect(result.current).toEqual({ uid: "", displayName: null, isAnonymous: true });
+  });
+});

--- a/src/entities/auth/model/queries/useAuth.ts
+++ b/src/entities/auth/model/queries/useAuth.ts
@@ -1,0 +1,13 @@
+import { useAuthSession } from "./useAuthSession";
+
+export const useAuth = () => {
+  const authSession = useAuthSession();
+  const session = authSession.status === "authenticated" ? authSession : undefined;
+
+  return {
+    // Treat missing sessions as anonymous for presentation until authentication supplies an identity.
+    isAnonymous: session?.isAnonymous ?? true,
+    displayName: session?.displayName ?? null,
+    uid: session?.uid ?? "",
+  };
+};

--- a/src/pages/account/model/useAccountPageModel.ts
+++ b/src/pages/account/model/useAccountPageModel.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useStore } from "zustand";
 
-import { useAuthSession } from "@/entities/auth";
+import { useAuth } from "@/entities/auth";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 
 import { signIn as signInAction } from "./actions/signIn";
@@ -17,11 +17,11 @@ const useAccountPageState = () => {
 };
 
 export const useAccountPageModel = () => {
-  const authSession = useAuthSession();
+  const auth = useAuth();
   const { pageState, store, isMounted } = useAccountPageState();
 
   return {
-    authSession,
+    auth,
     pageState,
     signIn: () => void signInAction(store, isMounted),
     signOut: () => void signOutAction(store, isMounted),

--- a/src/pages/account/ui/AccountPage.tsx
+++ b/src/pages/account/ui/AccountPage.tsx
@@ -10,17 +10,16 @@ import { AccountView } from "./AccountView";
 
 export const AccountPage: React.FC = () => {
   const navigate = useNavigate();
-  const { authSession, pageState, signIn, signOut } = useAccountPageModel();
-  const session = authSession.status === "authenticated" ? authSession : undefined;
+  const { auth, pageState, signIn, signOut } = useAccountPageModel();
 
   useKey("t", () => void navigate(routes.deckList.to()));
 
   return (
     <AppLayout showHeader>
       <AccountView
-        isLoggedIn={session != null && !session.isAnonymous}
-        displayName={session?.displayName ?? null}
-        uid={session?.uid ?? ""}
+        isLoggedIn={!auth.isAnonymous}
+        displayName={auth.displayName}
+        uid={auth.uid}
         signInPending={pageState.signIn.pending}
         signOutPending={pageState.signOut.pending}
         onSignIn={signIn}


### PR DESCRIPTION
## Related issue

None

## Summary

Add `useAuth` so pages can always read `auth.isAnonymous`, `auth.displayName`, and `auth.uid` without narrowing the authentication lifecycle state. When no authenticated session exists, the hook returns `true`, `null`, and an empty string respectively.

Update the Account page to use these properties directly, preserving its existing identity display and sign-in behavior.

## Testing

- `mise run check` passed, including 715 tests across 124 files.
- Cover account linking, sign-out, and fallback values during authentication startup and failure.
- Reviewer completed with no findings.
