### PR TITLE
refactor(account): move runAccountAction to useAccountPageModel and localize toast messages (No issue)

### DIFF
--- a/src/app/i18n/resources.ts
+++ b/src/app/i18n/resources.ts
@@ -43,6 +43,12 @@ export const resources = {
           notAvailable: "Not available",
           userId: "User ID",
         },
+        toast: {
+          signInSuccess: "Signed in.",
+          signInFailure: "Unable to sign in.",
+          signOutSuccess: "Signed out.",
+          signOutFailure: "Unable to sign out.",
+        },
       },
       header: {
         switchToLightMode: "Switch to light mode",
@@ -635,6 +641,12 @@ export const resources = {
           noName: "名前がありません",
           notAvailable: "利用できません",
           userId: "ユーザーID",
+        },
+        toast: {
+          signInSuccess: "ログインしました。",
+          signInFailure: "ログインできません。",
+          signOutSuccess: "ログアウトしました。",
+          signOutFailure: "ログアウトできません。",
         },
       },
       header: {

--- a/src/pages/account/model/actions/runAccountAction.spec.tsx
+++ b/src/pages/account/model/actions/runAccountAction.spec.tsx
@@ -1,0 +1,133 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMountedGuard } from "@/shared/lib/useMountedGuard";
+import { showToast } from "@/shared/ui/toast";
+import { actAsync } from "@/test/act";
+
+import { runAccountAction } from "./runAccountAction";
+import { createAccountPageStore } from "../store";
+
+const mocks = vi.hoisted(() => ({
+  action: vi.fn<() => Promise<unknown>>(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/shared/ui/toast", () => ({ showToast: mocks.showToast }));
+
+const deferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+};
+
+describe("ACCOUNT-02 ACCOUNT-03 runAccountAction", () => {
+  beforeEach(() => {
+    mocks.action.mockReset();
+    mocks.action.mockResolvedValue(undefined);
+    vi.mocked(showToast).mockReset();
+    vi.mocked(showToast).mockReturnValue(1);
+  });
+
+  it("keeps operation pending when requested again before completion", async () => {
+    const request = deferred<void>();
+    mocks.action.mockReturnValue(request.promise);
+    const store = createAccountPageStore();
+    const { result } = renderHook(useMountedGuard);
+
+    let operation!: Promise<void>;
+    let duplicateOperation!: Promise<void>;
+    act(() => {
+      operation = runAccountAction(mocks.action, store, result.current, {
+        operation: "signIn",
+        success: "Signed in.",
+        failure: "Unable to sign in.",
+      });
+      duplicateOperation = runAccountAction(mocks.action, store, result.current, {
+        operation: "signIn",
+        success: "Signed in.",
+        failure: "Unable to sign in.",
+      });
+    });
+
+    await actAsync(async () => {
+      await duplicateOperation;
+    });
+
+    expect(store.getState().signIn.pending).toBe(true);
+
+    await actAsync(async () => {
+      request.resolve();
+      await operation;
+    });
+
+    expect(store.getState().signIn.pending).toBe(false);
+    expect(showToast).toHaveBeenCalledExactlyOnceWith({ message: "Signed in.", tone: "success" });
+  });
+
+  it("allows the primary action to retry after a handled failure", async () => {
+    const failure = new Error("Action failed");
+    const retry = deferred<void>();
+    mocks.action.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
+    const store = createAccountPageStore();
+    const { result } = renderHook(useMountedGuard);
+
+    await actAsync(async () => {
+      await expect(
+        runAccountAction(mocks.action, store, result.current, {
+          operation: "signIn",
+          success: "Signed in.",
+          failure: "Unable to sign in.",
+        })
+      ).resolves.toBeUndefined();
+    });
+    expect(showToast).toHaveBeenCalledWith({ message: "Unable to sign in.", tone: "error" });
+
+    let retryOperation!: Promise<void>;
+    act(() => {
+      retryOperation = runAccountAction(mocks.action, store, result.current, {
+        operation: "signIn",
+        success: "Signed in.",
+        failure: "Unable to sign in.",
+      });
+    });
+
+    expect(store.getState().signIn.pending).toBe(true);
+
+    await actAsync(async () => {
+      retry.resolve();
+      await retryOperation;
+    });
+
+    expect(store.getState().signIn.pending).toBe(false);
+    expect(showToast).toHaveBeenLastCalledWith({ message: "Signed in.", tone: "success" });
+  });
+
+  it("does not show a failure Toast when action rejects after unmount", async () => {
+    const request = deferred<void>();
+    mocks.action.mockReturnValue(request.promise);
+    const store = createAccountPageStore();
+    const { result, unmount } = renderHook(useMountedGuard);
+    let operation!: Promise<void>;
+
+    act(() => {
+      operation = runAccountAction(mocks.action, store, result.current, {
+        operation: "signIn",
+        success: "Signed in.",
+        failure: "Unable to sign in.",
+      });
+    });
+    unmount();
+    await actAsync(async () => {
+      request.reject(new Error("Late failure"));
+      await expect(operation).resolves.toBeUndefined();
+    });
+
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/account/model/actions/signIn.spec.tsx
+++ b/src/pages/account/model/actions/signIn.spec.tsx
@@ -1,112 +1,22 @@
-import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useMountedGuard } from "@/shared/lib/useMountedGuard";
-import { showToast } from "@/shared/ui/toast";
-import { actAsync } from "@/test/act";
+import { signIn } from "./signIn";
 
 const mocks = vi.hoisted(() => ({
   signInWithGoogle: vi.fn<() => Promise<unknown>>(),
-  showToast: vi.fn(),
 }));
 
 vi.mock("../../api/signInWithGoogle", () => ({ signInWithGoogle: mocks.signInWithGoogle }));
-vi.mock("@/shared/ui/toast", () => ({ showToast: mocks.showToast }));
-
-import { signIn } from "./signIn";
-import { createAccountPageStore } from "../store";
-
-const deferred = <T,>() => {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-
-  return { promise, reject, resolve };
-};
 
 describe("ACCOUNT-02 signIn", () => {
   beforeEach(() => {
     mocks.signInWithGoogle.mockReset();
     mocks.signInWithGoogle.mockResolvedValue(undefined);
-    vi.mocked(showToast).mockReset();
-    vi.mocked(showToast).mockReturnValue(1);
   });
 
-  it("keeps sign-in pending when requested again before completion", async () => {
-    const request = deferred<void>();
-    mocks.signInWithGoogle.mockReturnValue(request.promise);
-    const store = createAccountPageStore();
-    const { result } = renderHook(useMountedGuard);
+  it("delegates execution to signInWithGoogle", async () => {
+    await signIn();
 
-    let operation!: Promise<void>;
-    let duplicateOperation!: Promise<void>;
-    act(() => {
-      operation = signIn(store, result.current);
-      duplicateOperation = signIn(store, result.current);
-    });
-
-    await actAsync(async () => {
-      await duplicateOperation;
-    });
-
-    expect(store.getState().signIn.pending).toBe(true);
-
-    await actAsync(async () => {
-      request.resolve();
-      await operation;
-    });
-
-    expect(store.getState().signIn.pending).toBe(false);
-    expect(showToast).toHaveBeenCalledExactlyOnceWith({ message: "Signed in.", tone: "success" });
-  });
-
-  it("allows the primary sign-in action to retry after a handled failure", async () => {
-    const failure = new Error("Sign-in failed");
-    const retry = deferred<void>();
-    mocks.signInWithGoogle.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
-    const store = createAccountPageStore();
-    const { result } = renderHook(useMountedGuard);
-
-    await actAsync(async () => {
-      await expect(signIn(store, result.current)).resolves.toBeUndefined();
-    });
-    expect(showToast).toHaveBeenCalledWith({ message: "Unable to sign in.", tone: "error" });
-
-    let retryOperation!: Promise<void>;
-    act(() => {
-      retryOperation = signIn(store, result.current);
-    });
-
-    expect(store.getState().signIn.pending).toBe(true);
-
-    await actAsync(async () => {
-      retry.resolve();
-      await retryOperation;
-    });
-
-    expect(store.getState().signIn.pending).toBe(false);
-    expect(showToast).toHaveBeenLastCalledWith({ message: "Signed in.", tone: "success" });
-  });
-
-  it("does not show a failure Toast when sign-in rejects after unmount", async () => {
-    const request = deferred<void>();
-    mocks.signInWithGoogle.mockReturnValue(request.promise);
-    const store = createAccountPageStore();
-    const { result, unmount } = renderHook(useMountedGuard);
-    let operation!: Promise<void>;
-
-    act(() => {
-      operation = signIn(store, result.current);
-    });
-    unmount();
-    await actAsync(async () => {
-      request.reject(new Error("Late sign-in failure"));
-      await expect(operation).resolves.toBeUndefined();
-    });
-
-    expect(showToast).not.toHaveBeenCalled();
+    expect(mocks.signInWithGoogle).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/account/model/actions/signIn.ts
+++ b/src/pages/account/model/actions/signIn.ts
@@ -1,11 +1,5 @@
-import type { AccountPageStore } from "../types";
 import { signInWithGoogle } from "../../api/signInWithGoogle";
-import { runAccountAction } from "./runAccountAction";
 
-export function signIn(store: AccountPageStore, isMounted: () => boolean): Promise<void> {
-  return runAccountAction(signInWithGoogle, store, isMounted, {
-    operation: "signIn",
-    success: "Signed in.",
-    failure: "Unable to sign in.",
-  });
+export function signIn(): Promise<unknown> {
+  return signInWithGoogle();
 }

--- a/src/pages/account/model/actions/signOut.spec.tsx
+++ b/src/pages/account/model/actions/signOut.spec.tsx
@@ -1,112 +1,22 @@
-import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useMountedGuard } from "@/shared/lib/useMountedGuard";
-import { showToast } from "@/shared/ui/toast";
-import { actAsync } from "@/test/act";
+import { signOut } from "./signOut";
 
 const mocks = vi.hoisted(() => ({
   signOutCurrentUser: vi.fn<() => Promise<void>>(),
-  showToast: vi.fn(),
 }));
 
 vi.mock("../../api/signOutCurrentUser", () => ({ signOutCurrentUser: mocks.signOutCurrentUser }));
-vi.mock("@/shared/ui/toast", () => ({ showToast: mocks.showToast }));
-
-import { signOut } from "./signOut";
-import { createAccountPageStore } from "../store";
-
-const deferred = <T,>() => {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-
-  return { promise, reject, resolve };
-};
 
 describe("ACCOUNT-03 signOut", () => {
   beforeEach(() => {
     mocks.signOutCurrentUser.mockReset();
     mocks.signOutCurrentUser.mockResolvedValue(undefined);
-    vi.mocked(showToast).mockReset();
-    vi.mocked(showToast).mockReturnValue(1);
   });
 
-  it("keeps sign-out pending when requested again before completion", async () => {
-    const request = deferred<void>();
-    mocks.signOutCurrentUser.mockReturnValue(request.promise);
-    const store = createAccountPageStore();
-    const { result } = renderHook(useMountedGuard);
+  it("delegates execution to signOutCurrentUser", async () => {
+    await signOut();
 
-    let operation!: Promise<void>;
-    let duplicateOperation!: Promise<void>;
-    act(() => {
-      operation = signOut(store, result.current);
-      duplicateOperation = signOut(store, result.current);
-    });
-
-    await actAsync(async () => {
-      await duplicateOperation;
-    });
-
-    expect(store.getState().signOut.pending).toBe(true);
-
-    await actAsync(async () => {
-      request.resolve();
-      await operation;
-    });
-
-    expect(store.getState().signOut.pending).toBe(false);
-    expect(showToast).toHaveBeenCalledExactlyOnceWith({ message: "Signed out.", tone: "success" });
-  });
-
-  it("allows the primary sign-out action to retry after a handled failure", async () => {
-    const failure = new Error("Sign-out failed");
-    const retry = deferred<void>();
-    mocks.signOutCurrentUser.mockRejectedValueOnce(failure).mockReturnValueOnce(retry.promise);
-    const store = createAccountPageStore();
-    const { result } = renderHook(useMountedGuard);
-
-    await actAsync(async () => {
-      await expect(signOut(store, result.current)).resolves.toBeUndefined();
-    });
-    expect(showToast).toHaveBeenCalledWith({ message: "Unable to sign out.", tone: "error" });
-
-    let retryOperation!: Promise<void>;
-    act(() => {
-      retryOperation = signOut(store, result.current);
-    });
-
-    expect(store.getState().signOut.pending).toBe(true);
-
-    await actAsync(async () => {
-      retry.resolve();
-      await retryOperation;
-    });
-
-    expect(store.getState().signOut.pending).toBe(false);
-    expect(showToast).toHaveBeenLastCalledWith({ message: "Signed out.", tone: "success" });
-  });
-
-  it("publishes a completed sign-out after its auth transition unmounts the owner", async () => {
-    const request = deferred<void>();
-    mocks.signOutCurrentUser.mockReturnValue(request.promise);
-    const store = createAccountPageStore();
-    const { result, unmount } = renderHook(useMountedGuard);
-    let operation!: Promise<void>;
-
-    act(() => {
-      operation = signOut(store, result.current);
-    });
-    unmount();
-    await actAsync(async () => {
-      request.resolve();
-      await operation;
-    });
-
-    expect(showToast).toHaveBeenCalledExactlyOnceWith({ message: "Signed out.", tone: "success" });
+    expect(mocks.signOutCurrentUser).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/account/model/actions/signOut.ts
+++ b/src/pages/account/model/actions/signOut.ts
@@ -1,11 +1,5 @@
-import type { AccountPageStore } from "../types";
 import { signOutCurrentUser } from "../../api/signOutCurrentUser";
-import { runAccountAction } from "./runAccountAction";
 
-export function signOut(store: AccountPageStore, isMounted: () => boolean): Promise<void> {
-  return runAccountAction(signOutCurrentUser, store, isMounted, {
-    operation: "signOut",
-    success: "Signed out.",
-    failure: "Unable to sign out.",
-  });
+export function signOut(): Promise<unknown> {
+  return signOutCurrentUser();
 }

--- a/src/pages/account/model/useAccountPageModel.ts
+++ b/src/pages/account/model/useAccountPageModel.ts
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 
 import { useAuth } from "@/entities/auth";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 
+import { runAccountAction } from "./actions/runAccountAction";
 import { signIn as signInAction } from "./actions/signIn";
 import { signOut as signOutAction } from "./actions/signOut";
 import { createAccountPageStore } from "./store";
@@ -17,13 +19,26 @@ const useAccountPageState = () => {
 };
 
 export const useAccountPageModel = () => {
+  const { t } = useTranslation();
   const auth = useAuth();
   const { pageState, store, isMounted } = useAccountPageState();
 
   return {
     auth,
     pageState,
-    signIn: () => void signInAction(store, isMounted),
-    signOut: () => void signOutAction(store, isMounted),
+
+    signIn: () =>
+      void runAccountAction(signInAction, store, isMounted, {
+        operation: "signIn",
+        success: t("account.toast.signInSuccess"),
+        failure: t("account.toast.signInFailure"),
+      }),
+
+    signOut: () =>
+      void runAccountAction(signOutAction, store, isMounted, {
+        operation: "signOut",
+        success: t("account.toast.signOutSuccess"),
+        failure: t("account.toast.signOutFailure"),
+      }),
   };
 };

--- a/src/pages/account/ui/AccountPage.spec.tsx
+++ b/src/pages/account/ui/AccountPage.spec.tsx
@@ -40,6 +40,7 @@ const renderPage = () => {
 
 describe("ACCOUNT-01 ACCOUNT-02 ACCOUNT-03 SETTINGS-04 AccountPage", () => {
   beforeEach(() => {
+    void getI18n().changeLanguage("en");
     dismissToast();
     vi.mocked(linkWithPopup).mockReset();
     vi.mocked(linkWithPopup).mockResolvedValue({ user: {} } as never);
@@ -223,5 +224,13 @@ describe("ACCOUNT-01 ACCOUNT-02 ACCOUNT-03 SETTINGS-04 AccountPage", () => {
     });
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows localized Japanese toast messages when active language is set to ja", async () => {
+    await getI18n().changeLanguage("ja");
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "Googleでログイン" }));
+    expect(screen.getByRole("status", { name: "トースト通知" })).toHaveTextContent("ログインしました。");
   });
 });


### PR DESCRIPTION
## Summary
- Refactored `useAccountPageModel` to execute `runAccountAction` directly with `signIn` and `signOut` actions.
- Simplified `signIn.ts` and `signOut.ts` to delegate directly to `signInWithGoogle` and `signOutCurrentUser`.
- Added localized toast messages under `account.toast` in `src/app/i18n/resources.ts` for English (`en`) and Japanese (`ja`).
- Added `runAccountAction.spec.tsx` and updated unit/integration tests (`signIn.spec.tsx`, `signOut.spec.tsx`, `AccountPage.spec.tsx`).

## Verification
- Passed `mise run check` (typecheck, eslint, biome, knip, steiger FSD lint, unit/integration tests).
- Verified mandatory review gate with `reviewer` subagent (0 P0 findings).