### PR TITLE
refactor(card-create): separate form submission from card creation (No issue)

### DIFF
--- a/src/pages/card-create/model/actions/submitCardCreateForm.ts
+++ b/src/pages/card-create/model/actions/submitCardCreateForm.ts
@@ -1,0 +1,24 @@
+import type { BaseSyntheticEvent, RefObject } from "react";
+import type { UseFormHandleSubmit } from "react-hook-form";
+
+import type { CardCreateFormValues } from "../useCardCreateFormState";
+
+export async function submitCardCreateForm(
+  event: BaseSyntheticEvent | undefined,
+  handleSubmit: UseFormHandleSubmit<CardCreateFormValues>,
+  pending: RefObject<boolean>,
+  onValid: (values: CardCreateFormValues) => Promise<void>
+): Promise<void> {
+  // RHF supplies presentation state; this lock closes the gap before validation resolves.
+  if (pending.current) {
+    event?.preventDefault();
+    return;
+  }
+  pending.current = true;
+  try {
+    // Await the creation callback through RHF so both submission indicators cover the entire save.
+    await handleSubmit(onValid)(event);
+  } finally {
+    pending.current = false;
+  }
+}

--- a/src/pages/card-create/model/actions/submitCardCreation.ts
+++ b/src/pages/card-create/model/actions/submitCardCreation.ts
@@ -1,54 +1,37 @@
 import { dismissSaveError } from "./dismissSaveError";
-import type { BaseSyntheticEvent, RefObject } from "react";
-import type { UseFormReturn } from "react-hook-form";
+import type { RefObject } from "react";
 import { createCard, type CardId } from "@/entities/card";
 import type { CardCreateFormValues } from "../useCardCreateFormState";
 import { showToast, type ToastId } from "@/shared/ui/toast";
 
-export const submitCardCreation = (
-  event: BaseSyntheticEvent | undefined,
+export async function submitCardCreation(
+  values: CardCreateFormValues,
   {
-    form,
     uid,
     saveErrorToastId,
     isMounted,
     onCreated,
     cardId,
     deckId,
-    pending,
   }: {
-    form: UseFormReturn<CardCreateFormValues>;
     uid: string;
     saveErrorToastId: RefObject<ToastId | undefined>;
     isMounted: () => boolean;
     onCreated: (id: CardId) => void;
     cardId: CardId;
     deckId: string;
-    pending: RefObject<boolean>;
   }
-): void => {
-  // RHF supplies presentation state; this lock closes the gap before validation resolves.
-  if (pending.current) {
-    event?.preventDefault();
-    return;
+): Promise<void> {
+  dismissSaveError(saveErrorToastId);
+  try {
+    await createCard(uid, { id: cardId, uniqueKey: cardId, deckId, ...values });
+    // Stale persistence completion must not navigate a route that has already unmounted.
+    if (isMounted()) {
+      showToast({ message: `Created card “${values.frontText}”.`, tone: "success" });
+      onCreated(cardId);
+    }
+  } catch {
+    if (isMounted())
+      saveErrorToastId.current = showToast({ message: "Unable to create this card. Try again.", tone: "error" });
   }
-  pending.current = true;
-  void form
-    .handleSubmit(async (values) => {
-      dismissSaveError(saveErrorToastId);
-      try {
-        await createCard(uid, { id: cardId, uniqueKey: cardId, deckId, ...values });
-        // Stale persistence completion must not navigate a route that has already unmounted.
-        if (isMounted()) {
-          showToast({ message: `Created card “${values.frontText}”.`, tone: "success" });
-          onCreated(cardId);
-        }
-      } catch {
-        if (isMounted())
-          saveErrorToastId.current = showToast({ message: "Unable to create this card. Try again.", tone: "error" });
-      }
-    })(event)
-    .finally(() => {
-      pending.current = false;
-    });
-};
+}

--- a/src/pages/card-create/model/useCardCreatePageModel.ts
+++ b/src/pages/card-create/model/useCardCreatePageModel.ts
@@ -1,0 +1,23 @@
+import type { BaseSyntheticEvent } from "react";
+
+import { useAuthUid } from "@/entities/auth";
+import type { CardId } from "@/entities/card";
+
+import { dismissSaveError } from "./actions/dismissSaveError";
+import { submitCardCreateForm } from "./actions/submitCardCreateForm";
+import { submitCardCreation } from "./actions/submitCardCreation";
+import { useCardCreateFormState } from "./useCardCreateFormState";
+
+export const useCardCreatePageModel = (deckId: string, onCreated: (id: CardId) => void) => {
+  const uid = useAuthUid();
+  const { form, pending, cardId, saveErrorToastId, isMounted } = useCardCreateFormState();
+
+  return {
+    form,
+    onSubmit: (event?: BaseSyntheticEvent) =>
+      void submitCardCreateForm(event, form.handleSubmit, pending, (values) =>
+        submitCardCreation(values, { uid, cardId, deckId, saveErrorToastId, isMounted, onCreated })
+      ),
+    dismissSaveError: () => dismissSaveError(saveErrorToastId),
+  };
+};

--- a/src/pages/card-create/ui/CardCreatePage.tsx
+++ b/src/pages/card-create/ui/CardCreatePage.tsx
@@ -7,36 +7,24 @@ import { routes } from "@/shared/router";
 import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
-import { useCardCreateFormState } from "../model/useCardCreateFormState";
-import { submitCardCreation } from "../model/actions/submitCardCreation";
-import { useAuthUid } from "@/entities/auth";
-import { dismissSaveError } from "../model/actions/dismissSaveError";
+import { useCardCreatePageModel } from "../model/useCardCreatePageModel";
 import { CardCreator } from "./CardCreator";
 
 const AvailableCardCreatePage: React.FC<{ deck: Deck }> = ({ deck }) => {
   const navigate = useNavigate();
   const destination = routes.cardList.to(deck.id);
-  const uid = useAuthUid();
-  const state = useCardCreateFormState();
-  const onSubmit = (event?: React.BaseSyntheticEvent) =>
-    submitCardCreation(event, {
-      uid,
-      form: state.form,
-      saveErrorToastId: state.saveErrorToastId,
-      isMounted: state.isMounted,
-      cardId: state.cardId,
-      deckId: deck.id,
-      pending: state.pending,
-      onCreated: () => void navigate(destination, { replace: true }),
-    });
+  const { form, onSubmit, dismissSaveError } = useCardCreatePageModel(
+    deck.id,
+    () => void navigate(destination, { replace: true })
+  );
   const cancel = () => {
-    dismissSaveError(state.saveErrorToastId);
+    dismissSaveError();
     void navigate(destination);
   };
 
   return (
     <AppLayout showHeader>
-      <CardCreator categories={CATEGORY} deckName={deck.name} form={state.form} onCancel={cancel} onSubmit={onSubmit} />
+      <CardCreator categories={CATEGORY} deckName={deck.name} form={form} onCancel={cancel} onSubmit={onSubmit} />
     </AppLayout>
   );
 };

--- a/src/pages/card-create/ui/CardCreator.spec.tsx
+++ b/src/pages/card-create/ui/CardCreator.spec.tsx
@@ -17,34 +17,16 @@ vi.mock("@/entities/card", async (importOriginal) => ({
   generateCardId: writes.generateCardId,
 }));
 
-import { useCardCreateFormState } from "../model/useCardCreateFormState";
-import { submitCardCreation } from "../model/actions/submitCardCreation";
+import { useCardCreatePageModel } from "../model/useCardCreatePageModel";
 import { CardCreator } from "./CardCreator";
 
 const deck = createLocalDeck({ id: "target-deck", name: "Target deck" });
 
 const CardCreatorHarness = ({ onCreated = vi.fn() }: { onCreated?: (cardId: string) => void }) => {
-  const state = useCardCreateFormState();
+  const { form, onSubmit } = useCardCreatePageModel(deck.id, onCreated);
   return (
     <>
-      <CardCreator
-        categories={CATEGORY}
-        deckName={deck.name}
-        form={state.form}
-        onCancel={vi.fn()}
-        onSubmit={(event) =>
-          submitCardCreation(event, {
-            uid: "user-id",
-            form: state.form,
-            cardId: state.cardId,
-            deckId: deck.id,
-            pending: state.pending,
-            saveErrorToastId: state.saveErrorToastId,
-            isMounted: state.isMounted,
-            onCreated,
-          })
-        }
-      />
+      <CardCreator categories={CATEGORY} deckName={deck.name} form={form} onCancel={vi.fn()} onSubmit={onSubmit} />
       <ToastViewport />
     </>
   );
@@ -99,6 +81,7 @@ describe("CARD-13 CARD-14 CARD-15 CardCreator", () => {
     await userEvent.click(screen.getByRole("button", { name: "Create card" }));
 
     await waitFor(() => expect(onCreated).toHaveBeenCalledOnce());
+    expect(screen.queryByText("Unable to create this card. Try again.")).not.toBeInTheDocument();
     expect(writes.createCard).toHaveBeenCalledTimes(2);
     expect(writes.createCard.mock.calls[0]?.[1]).toEqual(writes.createCard.mock.calls[1]?.[1]);
     expect(writes.generateCardId).toHaveBeenCalledOnce();
@@ -120,7 +103,9 @@ describe("CARD-13 CARD-14 CARD-15 CardCreator", () => {
     fireEvent.click(createButton);
 
     await waitFor(() => expect(writes.createCard).toHaveBeenCalledOnce());
+    expect(screen.getByRole("button", { name: "Creating…" })).toBeDisabled();
     act(() => finishWrite());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Create card" })).toBeEnabled());
   });
 
   it("does not navigate after an in-flight creation outlives the Page", async () => {


### PR DESCRIPTION
## Related issue

None

## Summary

Separate form validation and the submission lock from `submitCardCreation`, which now accepts validated values and returns the save Promise. Add a Page model to wire both actions while preserving retry identity, Toast feedback, and navigation guards after unmount.

## Testing

- `mise run check` passed: 125 test files, 714 tests.
- Updated Card Create coverage to use the Page model and verify pending button state and removal of the failure Toast after retry.
- Reviewer completed with no actionable findings.
