### PR TITLE
refactor(card-form): simplify saveCard input (No issue)

### DIFF
--- a/src/pages/card-form/model/actions/runCardSave.ts
+++ b/src/pages/card-form/model/actions/runCardSave.ts
@@ -1,0 +1,46 @@
+import { saveCard } from "./saveCard";
+import { dismissSaveError } from "./dismissSaveError";
+import type { RefObject } from "react";
+import type { Card } from "@/entities/card";
+import type { CardFormValues } from "../useCardFormState";
+import { showToast, type ToastId } from "@/shared/ui/toast";
+
+export async function runCardSave(
+  values: CardFormValues,
+  {
+    snapshot,
+    savingRef,
+    setIsSaving,
+    saveErrorToastId,
+    isMounted,
+    onSaved,
+  }: {
+    snapshot: Card;
+    savingRef: RefObject<boolean>;
+    setIsSaving: (saving: boolean) => void;
+    saveErrorToastId: RefObject<ToastId | undefined>;
+    isMounted: () => boolean;
+    onSaved: (deckId: Card["deckId"]) => void;
+  }
+): Promise<void> {
+  // Validation can finish for two same-tick submits before React publishes pending state.
+  if (savingRef.current) return;
+  const savedInput = { ...values, tags: [...values.tags] };
+  savingRef.current = true;
+  setIsSaving(true);
+  dismissSaveError(saveErrorToastId);
+  try {
+    await saveCard({ id: snapshot.id, ...savedInput });
+    // The initiating route owns feedback and navigation even when persistence outlives it.
+    if (isMounted()) {
+      showToast({ message: `Updated card “${savedInput.frontText}”.`, tone: "success" });
+      onSaved(snapshot.deckId);
+    }
+  } catch {
+    if (isMounted())
+      saveErrorToastId.current = showToast({ message: "Unable to save changes. Try again.", tone: "error" });
+  } finally {
+    savingRef.current = false;
+    if (isMounted()) setIsSaving(false);
+  }
+}

--- a/src/pages/card-form/model/actions/saveCard.ts
+++ b/src/pages/card-form/model/actions/saveCard.ts
@@ -1,47 +1,11 @@
-import { dismissSaveError } from "./dismissSaveError";
-import type { RefObject } from "react";
+import { getAuthSession } from "@/entities/auth";
 import { editCard, type Card } from "@/entities/card";
-import type { CardFormValues } from "../useCardFormState";
-import { showToast, type ToastId } from "@/shared/ui/toast";
 
-export const saveCard = async (
-  values: CardFormValues,
-  {
-    uid,
-    snapshot,
-    savingRef,
-    setIsSaving,
-    saveErrorToastId,
-    isMounted,
-    onSaved,
-  }: {
-    uid: string;
-    snapshot: Card;
-    savingRef: RefObject<boolean>;
-    setIsSaving: (saving: boolean) => void;
-    saveErrorToastId: RefObject<ToastId | undefined>;
-    isMounted: () => boolean;
-    onSaved: (deckId: Card["deckId"]) => void;
-  }
-): Promise<void> => {
-  // Validation can finish for two same-tick submits before React publishes pending state.
-  if (savingRef.current) return;
-  const savedInput = { ...values, tags: [...values.tags] };
-  savingRef.current = true;
-  setIsSaving(true);
-  dismissSaveError(saveErrorToastId);
-  try {
-    await editCard(uid, { id: snapshot.id, ...savedInput });
-    // The initiating route owns feedback and navigation even when persistence outlives it.
-    if (isMounted()) {
-      showToast({ message: `Updated card “${savedInput.frontText}”.`, tone: "success" });
-      onSaved(snapshot.deckId);
-    }
-  } catch {
-    if (isMounted())
-      saveErrorToastId.current = showToast({ message: "Unable to save changes. Try again.", tone: "error" });
-  } finally {
-    savingRef.current = false;
-    if (isMounted()) setIsSaving(false);
-  }
-};
+type SaveCardInput = Pick<Card, "id" | "frontText" | "backText" | "tags">;
+
+export async function saveCard(input: SaveCardInput): Promise<void> {
+  const session = getAuthSession();
+  // Match useAuthUid's sentinel so remote validation rejects unauthenticated writes while local edits remain available.
+  const uid = session.status === "authenticated" ? session.uid : "";
+  await editCard(uid, input);
+}

--- a/src/pages/card-form/ui/CardEditor.spec.tsx
+++ b/src/pages/card-form/ui/CardEditor.spec.tsx
@@ -11,7 +11,7 @@ import { dismissToast, ToastViewport } from "@/shared/ui/toast";
 import { createLocalCard, createLocalDeck } from "@/test/factories";
 
 import { useCardFormState } from "../model/useCardFormState";
-import { saveCard } from "../model/actions/saveCard";
+import { runCardSave } from "../model/actions/runCardSave";
 import { CardEditor } from "./CardEditor";
 
 const writeControls = vi.hoisted(() => ({
@@ -19,7 +19,9 @@ const writeControls = vi.hoisted(() => ({
   nextError: undefined as unknown,
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({
+  getAuthSession: () => ({ status: "authenticated", uid: "user-id", displayName: null, isAnonymous: false }),
+}));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
 vi.mock("@/entities/card", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/entities/card")>();
@@ -57,8 +59,7 @@ const AvailableCardEditorHarness = (props: { card: Card; onCancel: () => void; o
       onCancel={props.onCancel}
       onSubmit={(event) => {
         void editor.form.handleSubmit((values) =>
-          saveCard(values, {
-            uid: "user-id",
+          runCardSave(values, {
             snapshot: editor.snapshot,
             savingRef: editor.savingRef,
             setIsSaving: editor.setIsSaving,

--- a/src/pages/card-form/ui/CardFormPage.spec.tsx
+++ b/src/pages/card-form/ui/CardFormPage.spec.tsx
@@ -21,7 +21,9 @@ const mocks = vi.hoisted(() => ({
   remoteCard: undefined as Card | undefined,
 }));
 
-vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
+vi.mock("@/entities/auth", () => ({
+  getAuthSession: () => ({ status: "authenticated", uid: "user-id", displayName: null, isAnonymous: false }),
+}));
 vi.mock("@/entities/preference", () => ({
   usePreferences: () => mocks.preferences,
   setDarkMode: mocks.setDarkMode,

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -9,20 +9,17 @@ import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
 import { useCardFormState } from "../model/useCardFormState";
-import { saveCard } from "../model/actions/saveCard";
-import { useAuthUid } from "@/entities/auth";
+import { runCardSave } from "../model/actions/runCardSave";
 import { dismissSaveError } from "../model/actions/dismissSaveError";
 import { CardEditor } from "./CardEditor";
 
 const CardFormContent: React.FC<{ card: Card }> = ({ card }) => {
   const navigate = useNavigate();
   const goBack = () => navigate(-1);
-  const uid = useAuthUid();
   const editor = useCardFormState(card);
   const onSubmit = (event?: React.BaseSyntheticEvent) => {
     void editor.form.handleSubmit((values) =>
-      saveCard(values, {
-        uid,
+      runCardSave(values, {
         snapshot: editor.snapshot,
         savingRef: editor.savingRef,
         setIsSaving: editor.setIsSaving,


### PR DESCRIPTION
## Related issue

None.

## Summary

Make `saveCard` accept only `{ id, frontText, backText, tags }` and read the current authentication session internally. Move pending state, duplicate-submit protection, toast feedback, and navigation callbacks into `runCardSave`, preserving the existing editor behavior.

## Testing

- `mise run check` passed: 125 test files, 714 tests.
- Reviewer completed with no findings.
