### PR TITLE
refactor(card-form): organize model logic (No issue)

### DIFF
--- a/src/pages/card-form/model/actions/dismissSaveError.ts
+++ b/src/pages/card-form/model/actions/dismissSaveError.ts
@@ -1,8 +1,8 @@
 import type { RefObject } from "react";
 import { dismissToast, type ToastId } from "@/shared/ui/toast";
 
-export const dismissSaveError = (toastId: RefObject<ToastId | undefined>): void => {
+export function dismissSaveError(toastId: RefObject<ToastId | undefined>): void {
   if (toastId.current === undefined) return;
   dismissToast(toastId.current);
   toastId.current = undefined;
-};
+}

--- a/src/pages/card-form/model/actions/runCardSave.ts
+++ b/src/pages/card-form/model/actions/runCardSave.ts
@@ -1,26 +1,28 @@
-import { saveCard } from "./saveCard";
-import { dismissSaveError } from "./dismissSaveError";
 import type { RefObject } from "react";
-import type { Card } from "@/entities/card";
-import type { CardFormValues } from "../useCardFormState";
+
+import type { CardId } from "@/entities/card";
 import { showToast, type ToastId } from "@/shared/ui/toast";
+
+import type { CardFormValues } from "../cardFormSchema";
+import { dismissSaveError } from "./dismissSaveError";
+import { saveCard } from "./saveCard";
 
 export async function runCardSave(
   values: CardFormValues,
   {
-    snapshot,
+    cardId,
     savingRef,
     setIsSaving,
     saveErrorToastId,
     isMounted,
     onSaved,
   }: {
-    snapshot: Card;
+    cardId: CardId;
     savingRef: RefObject<boolean>;
     setIsSaving: (saving: boolean) => void;
     saveErrorToastId: RefObject<ToastId | undefined>;
     isMounted: () => boolean;
-    onSaved: (deckId: Card["deckId"]) => void;
+    onSaved: () => void;
   }
 ): Promise<void> {
   // Validation can finish for two same-tick submits before React publishes pending state.
@@ -30,7 +32,7 @@ export async function runCardSave(
   setIsSaving(true);
   dismissSaveError(saveErrorToastId);
   try {
-    await saveCard({ id: snapshot.id, ...savedInput });
+    await saveCard({ id: cardId, ...savedInput });
     // The initiating route owns feedback and navigation even when persistence outlives it.
     if (isMounted()) {
       showToast({
@@ -38,7 +40,7 @@ export async function runCardSave(
         messageParams: { name: savedInput.frontText },
         tone: "success",
       });
-      onSaved(snapshot.deckId);
+      onSaved();
     }
   } catch {
     if (isMounted()) saveErrorToastId.current = showToast({ messageKey: "toast.saveFailure", tone: "error" });

--- a/src/pages/card-form/model/cardFormSchema.ts
+++ b/src/pages/card-form/model/cardFormSchema.ts
@@ -1,0 +1,6 @@
+import type * as z from "zod";
+
+import { cardContentSchema } from "@/entities/card";
+
+export const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
+export type CardFormValues = z.infer<typeof cardFormSchema>;

--- a/src/pages/card-form/model/queries/getCardEditorInfo.ts
+++ b/src/pages/card-form/model/queries/getCardEditorInfo.ts
@@ -1,0 +1,8 @@
+import type { Card } from "@/entities/card";
+
+export const getCardEditorInfo = (card: Card) => ({
+  id: card.id,
+  uniqueKey: card.uniqueKey,
+  ...(card.createdAt ? { createdAt: card.createdAt } : {}),
+  ...(card.lastSeenAt != null ? { lastSeenAt: card.lastSeenAt } : {}),
+});

--- a/src/pages/card-form/model/queries/getCardFormValues.ts
+++ b/src/pages/card-form/model/queries/getCardFormValues.ts
@@ -1,0 +1,9 @@
+import type { Card } from "@/entities/card";
+
+import type { CardFormValues } from "../cardFormSchema";
+
+export const getCardFormValues = (card: Card): CardFormValues => ({
+  frontText: card.frontText,
+  backText: card.backText,
+  tags: [...card.tags],
+});

--- a/src/pages/card-form/model/useCardFormPageModel.ts
+++ b/src/pages/card-form/model/useCardFormPageModel.ts
@@ -1,0 +1,31 @@
+import type { BaseSyntheticEvent } from "react";
+
+import type { Card } from "@/entities/card";
+
+import { dismissSaveError } from "./actions/dismissSaveError";
+import { runCardSave } from "./actions/runCardSave";
+import { getCardEditorInfo } from "./queries/getCardEditorInfo";
+import { useCardFormState } from "./useCardFormState";
+
+export const useCardFormPageModel = (card: Card) => {
+  const { snapshot, form, savingRef, isSaving, setIsSaving, saveErrorToastId, isMounted } = useCardFormState(card);
+
+  return {
+    cardInfo: getCardEditorInfo(snapshot),
+    form,
+    isSaving,
+    // Bind navigation at submission time because its guard depends on this model's form state.
+    submitForm: (onSaved: (deckId: Card["deckId"]) => void, event?: BaseSyntheticEvent) =>
+      void form.handleSubmit((values) =>
+        runCardSave(values, {
+          cardId: snapshot.id,
+          savingRef,
+          setIsSaving,
+          saveErrorToastId,
+          isMounted,
+          onSaved: () => onSaved(snapshot.deckId),
+        })
+      )(event),
+    dismissSaveError: () => dismissSaveError(saveErrorToastId),
+  };
+};

--- a/src/pages/card-form/model/useCardFormState.ts
+++ b/src/pages/card-form/model/useCardFormState.ts
@@ -1,21 +1,14 @@
 import * as React from "react";
-import type * as z from "zod";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
-import { type Card, cardContentSchema } from "@/entities/card";
+import type { Card } from "@/entities/card";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 import { dismissToast, type ToastId } from "@/shared/ui/toast";
 
-const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });
-export type CardFormValues = z.infer<typeof cardFormSchema>;
-
-const getCardFormValues = (card: Card): CardFormValues => ({
-  frontText: card.frontText,
-  backText: card.backText,
-  tags: [...card.tags],
-});
+import { cardFormSchema, type CardFormValues } from "./cardFormSchema";
+import { getCardFormValues } from "./queries/getCardFormValues";
 
 export const useCardFormState = (card: Card) => {
   const isMounted = useMountedGuard();

--- a/src/pages/card-form/ui/CardEditor.spec.tsx
+++ b/src/pages/card-form/ui/CardEditor.spec.tsx
@@ -10,8 +10,7 @@ import { CATEGORY, createDeck } from "@/entities/deck";
 import { dismissToast, ToastViewport } from "@/shared/ui/toast";
 import { createLocalCard, createLocalDeck } from "@/test/factories";
 
-import { useCardFormState } from "../model/useCardFormState";
-import { runCardSave } from "../model/actions/runCardSave";
+import { useCardFormPageModel } from "../model/useCardFormPageModel";
 import { CardEditor } from "./CardEditor";
 
 const writeControls = vi.hoisted(() => ({
@@ -44,31 +43,15 @@ vi.mock("@/entities/deck", async (importOriginal) => ({
 }));
 
 const AvailableCardEditorHarness = (props: { card: Card; onCancel: () => void; onSaved: () => void }) => {
-  const editor = useCardFormState(props.card);
+  const { cardInfo, form, isSaving, submitForm } = useCardFormPageModel(props.card);
   return (
     <CardEditor
-      cardInfo={{
-        id: editor.snapshot.id,
-        uniqueKey: editor.snapshot.uniqueKey,
-        ...(editor.snapshot.createdAt ? { createdAt: editor.snapshot.createdAt } : {}),
-        ...(editor.snapshot.lastSeenAt != null ? { lastSeenAt: editor.snapshot.lastSeenAt } : {}),
-      }}
+      cardInfo={cardInfo}
       categories={CATEGORY}
-      form={editor.form}
-      isSaving={editor.isSaving}
+      form={form}
+      isSaving={isSaving}
       onCancel={props.onCancel}
-      onSubmit={(event) => {
-        void editor.form.handleSubmit((values) =>
-          runCardSave(values, {
-            snapshot: editor.snapshot,
-            savingRef: editor.savingRef,
-            setIsSaving: editor.setIsSaving,
-            saveErrorToastId: editor.saveErrorToastId,
-            isMounted: editor.isMounted,
-            onSaved: props.onSaved,
-          })
-        )(event);
-      }}
+      onSubmit={(event) => submitForm(props.onSaved, event)}
     />
   );
 };
@@ -184,6 +167,7 @@ describe("CARD-03 CARD-09 CARD-12 CARD-21 CardEditor", () => {
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    expect(screen.queryByText("Unable to save changes. Try again.")).not.toBeInTheDocument();
     view.unmount();
     renderForm();
     expect(screen.getByRole("textbox", { name: "Front text" })).toHaveValue("Retry front");

--- a/src/pages/card-form/ui/CardEditor.stories.tsx
+++ b/src/pages/card-form/ui/CardEditor.stories.tsx
@@ -5,10 +5,10 @@ import { fn } from "storybook/test";
 
 import type { Card } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
+import type { CardFormFields } from "@/features/card-form";
 import { withPageLayout } from "@/storybook/PageLayoutDecorator";
 import * as fixture from "@/storybook/fixture";
 
-import type { CardFormValues } from "../model/useCardFormState";
 import { CardEditor } from "./CardEditor";
 
 interface CardEditorStoryProps {
@@ -19,7 +19,7 @@ interface CardEditorStoryProps {
 }
 
 const CardEditorStory = ({ card, isSaving, validationError, onCancel }: CardEditorStoryProps) => {
-  const form = useForm<CardFormValues>({
+  const form = useForm<CardFormFields>({
     defaultValues: { frontText: card.frontText, backText: card.backText, tags: card.tags },
   });
 

--- a/src/pages/card-form/ui/CardFormContainer.tsx
+++ b/src/pages/card-form/ui/CardFormContainer.tsx
@@ -1,0 +1,42 @@
+import type * as React from "react";
+import { useNavigate } from "react-router-dom";
+
+import type { Card } from "@/entities/card";
+import { CATEGORY } from "@/entities/deck";
+import { routes, useNavigationGuard } from "@/shared/router";
+import { AppLayout } from "@/widgets/app-layout";
+
+import { useCardFormPageModel } from "../model/useCardFormPageModel";
+import { CardEditor } from "./CardEditor";
+
+export const CardFormContainer: React.FC<{ card: Card }> = ({ card }) => {
+  const navigate = useNavigate();
+  const { cardInfo, form, isSaving, submitForm, dismissSaveError } = useCardFormPageModel(card);
+  const guard = useNavigationGuard(form.formState.isDirty || isSaving);
+
+  const onSaved = (deckId: Card["deckId"]) => {
+    const cardListPath = routes.cardList.to(deckId);
+    void guard.allowNavigation({ historyAction: "REPLACE", to: cardListPath }, () =>
+      navigate(cardListPath, { replace: true })
+    );
+  };
+
+  const cancel = () => {
+    dismissSaveError();
+    void navigate(-1);
+  };
+
+  return (
+    <AppLayout showHeader>
+      {guard.element}
+      <CardEditor
+        cardInfo={cardInfo}
+        categories={CATEGORY}
+        form={form}
+        isSaving={isSaving}
+        onCancel={cancel}
+        onSubmit={(event) => submitForm(onSaved, event)}
+      />
+    </AppLayout>
+  );
+};

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -1,65 +1,11 @@
 import type * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
-import { type Card, useCard } from "@/entities/card";
-import { CATEGORY } from "@/entities/deck";
-import { routes, useNavigationGuard } from "@/shared/router";
-import { AppLayout } from "@/widgets/app-layout";
+import { useCard } from "@/entities/card";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
-import { useCardFormState } from "../model/useCardFormState";
-import { runCardSave } from "../model/actions/runCardSave";
-import { dismissSaveError } from "../model/actions/dismissSaveError";
-import { CardEditor } from "./CardEditor";
-
-const CardFormContent: React.FC<{ card: Card }> = ({ card }) => {
-  const navigate = useNavigate();
-  const goBack = () => navigate(-1);
-  const editor = useCardFormState(card);
-  const onSubmit = (event?: React.BaseSyntheticEvent) => {
-    void editor.form.handleSubmit((values) =>
-      runCardSave(values, {
-        snapshot: editor.snapshot,
-        savingRef: editor.savingRef,
-        setIsSaving: editor.setIsSaving,
-        saveErrorToastId: editor.saveErrorToastId,
-        isMounted: editor.isMounted,
-        onSaved: (deckId) => {
-          const cardListPath = routes.cardList.to(deckId);
-          void guard.allowNavigation({ historyAction: "REPLACE", to: cardListPath }, () =>
-            navigate(cardListPath, { replace: true })
-          );
-        },
-      })
-    )(event);
-  };
-  const guard = useNavigationGuard(editor.form.formState.isDirty || editor.isSaving);
-
-  const cancel = () => {
-    dismissSaveError(editor.saveErrorToastId);
-    void goBack();
-  };
-
-  return (
-    <AppLayout showHeader>
-      {guard.element}
-      <CardEditor
-        cardInfo={{
-          id: editor.snapshot.id,
-          uniqueKey: editor.snapshot.uniqueKey,
-          ...(editor.snapshot.createdAt ? { createdAt: editor.snapshot.createdAt } : {}),
-          ...(editor.snapshot.lastSeenAt != null ? { lastSeenAt: editor.snapshot.lastSeenAt } : {}),
-        }}
-        categories={CATEGORY}
-        form={editor.form}
-        isSaving={editor.isSaving}
-        onCancel={cancel}
-        onSubmit={onSubmit}
-      />
-    </AppLayout>
-  );
-};
+import { CardFormContainer } from "./CardFormContainer";
 
 export const CardFormPage: React.FC = () => {
   const { t } = useTranslation();
@@ -75,5 +21,5 @@ export const CardFormPage: React.FC = () => {
   }
 
   // Form state belongs to one route Card and must reset when the id changes.
-  return <CardFormContent key={cardId} card={card} />;
+  return <CardFormContainer key={cardId} card={card} />;
 };


### PR DESCRIPTION
## Related issue

None.

## Summary

Card editing now uses `useCardFormPageModel` to connect form state, read-only queries, and save actions. `CardFormContainer` owns routing and the unsaved-changes guard, while the state hook retains the opening snapshot, save lock, and resource cleanup.

Extract the form schema and input/metadata mappings, and narrow `runCardSave` to the Card ID and save-specific inputs. Existing editor tests exercise the Page model and verify retry-error cleanup while preserving the current editing and saving behavior.

## Testing

- `mise run check` passed: 126 test files, 726 tests; formatting, TypeScript, lint, FSD, Knip, E2E contract, and Dockerfile checks passed.
- Custom reviewer completed two review rounds with no outstanding change findings.
