### PR TITLE
refactor(account): integrate AccountPageState into store.ts (No issue)

### DIFF
--- a/src/pages/account/model/store.ts
+++ b/src/pages/account/model/store.ts
@@ -1,6 +1,9 @@
 import { createStore } from "zustand/vanilla";
 
-import type { AccountPageState } from "./types";
+export interface AccountPageState {
+  signIn: { pending: boolean };
+  signOut: { pending: boolean };
+}
 
 // Keep each operation locked across Page remounts until its own completion.
 export const accountPageStore = createStore<AccountPageState>()(() => ({

--- a/src/pages/account/model/types.ts
+++ b/src/pages/account/model/types.ts
@@ -1,4 +1,0 @@
-export interface AccountPageState {
-  signIn: { pending: boolean };
-  signOut: { pending: boolean };
-}


### PR DESCRIPTION
## Summary
Integrates `AccountPageState` interface into `src/pages/account/model/store.ts` and removes `src/pages/account/model/types.ts` to simplify the page model slice per FSD guidelines.

## Changes
- Moved `AccountPageState` type definition into `store.ts`.
- Removed `types.ts`.

## Verification
- Executed `mise run check` (passed all linters, typechecks, formatters, and 730 unit tests).
- Mandatory review gate completed by `reviewer` subagent (0 findings).