### PR TITLE
refactor(No issue): share card content input schema

### DIFF
--- a/src/entities/card/index.ts
+++ b/src/entities/card/index.ts
@@ -5,10 +5,11 @@ export { createCard, deleteCard, editCard, mutateCards } from "./api/mutations";
 export { useCard } from "./model/queries/useCard";
 export { useCards } from "./model/queries/useCards";
 export { useCardsByDeckId } from "./model/queries/useCardsByDeckId";
-export { cardContentSchema } from "./model/schema";
+export { cardContentInputSchema } from "./model/schema";
 export { clearRemoteCards } from "./model/actions/clearRemoteCards";
 export type {
   Card,
+  CardContentInput,
   CardId,
   CardMutation,
   CardRaw,

--- a/src/entities/card/model/schema.spec.ts
+++ b/src/entities/card/model/schema.spec.ts
@@ -2,7 +2,33 @@ import { describe, expect, it } from "vitest";
 
 import { createCard as createCardFixture } from "@/test/factories";
 
-import { cardContentSchema, createCardSchema, deleteCardSchema, editCardSchema } from "./schema";
+import {
+  cardContentInputSchema,
+  cardContentSchema,
+  createCardSchema,
+  deleteCardSchema,
+  editCardSchema,
+} from "./schema";
+
+describe("Card content input schema [CARD-13 CARD-21]", () => {
+  it("accepts content without asking for an identity", () => {
+    const content = { frontText: "Front", backText: "Back", tags: ["custom"] };
+
+    expect(cardContentInputSchema.parse(content)).toEqual(content);
+  });
+
+  it("reports the required fields when both sides are empty", () => {
+    expect(cardContentInputSchema.safeParse({ frontText: "", backText: "", tags: [] })).toMatchObject({
+      success: false,
+      error: {
+        issues: [
+          { path: ["frontText"], message: "Front text is required." },
+          { path: ["backText"], message: "Back text is required." },
+        ],
+      },
+    });
+  });
+});
 
 describe("Card content schema [CARD-01]", () => {
   it.each(["", "   ", "\n\t"])("rejects blank front text: %j", (frontText) => {

--- a/src/entities/card/model/schema.ts
+++ b/src/entities/card/model/schema.ts
@@ -19,6 +19,9 @@ export const cardContentSchema = z.object({
   uniqueKey: cardUniqueKeySchema,
 });
 
+// Creation assigns the identity and editing preserves it; neither asks for it as content input.
+export const cardContentInputSchema = cardContentSchema.omit({ uniqueKey: true });
+
 const editableCardFieldsSchema = cardContentSchema.extend({
   url: z.string().optional(),
   startLine: z.number().optional(),

--- a/src/entities/card/model/types.ts
+++ b/src/entities/card/model/types.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 
 import type {
+  cardContentInputSchema,
   cardCreateSchema,
   cardEditSchema,
   cardIdSchema,
@@ -27,6 +28,8 @@ export type LocalCard = z.infer<typeof localCardSchema>;
 export type PersistedCardState = z.infer<typeof persistedCardStateSchema>;
 /** Entity read model spanning both persistence modes; mutations route through the owning Deck. */
 export type Card = RemoteCard | LocalCard;
+/** Shared create/edit content without identity or persistence metadata. */
+export type CardContentInput = z.infer<typeof cardContentInputSchema>;
 /** Validated payload used to create a remote Card document. */
 export type CardCreate = z.infer<typeof cardCreateSchema>;
 /** Input accepted at the remote Card creation boundary. */

--- a/src/features/card-form/ui/CardFields.spec.tsx
+++ b/src/features/card-form/ui/CardFields.spec.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
-import { cardContentSchema } from "@/entities/card";
+import { cardContentInputSchema } from "@/entities/card";
 
 import { CardFields, type CardFormFields } from "./CardFields";
 
@@ -16,7 +16,7 @@ const initialValues: CardFormFields = { frontText: "Front", backText: "Back", ta
 const FormHarness = ({ onSubmit = vi.fn() }: { onSubmit?: (values: CardFormFields) => void }) => {
   const form = useForm<CardFormFields>({
     defaultValues: initialValues,
-    resolver: zodResolver(cardContentSchema.omit({ uniqueKey: true })),
+    resolver: zodResolver(cardContentInputSchema),
   });
   return (
     <form onSubmit={form.handleSubmit((values) => onSubmit(values))}>

--- a/src/pages/card-create/model/schema.ts
+++ b/src/pages/card-create/model/schema.ts
@@ -1,3 +1,0 @@
-import { cardContentSchema } from "@/entities/card";
-
-export const cardCreateFormSchema = cardContentSchema.omit({ uniqueKey: true });

--- a/src/pages/card-create/model/types.ts
+++ b/src/pages/card-create/model/types.ts
@@ -1,11 +1,7 @@
-import type { z } from "zod";
-
-import type { cardCreateFormSchema } from "./schema";
-
-export type CardCreateFormValues = z.infer<typeof cardCreateFormSchema>;
+import type { CardContentInput } from "@/entities/card";
 
 export interface SubmitCardCreateInput {
   uid: string;
   deckId: string;
-  values: CardCreateFormValues;
+  values: CardContentInput;
 }

--- a/src/pages/card-create/model/useCardCreatePageModel.ts
+++ b/src/pages/card-create/model/useCardCreatePageModel.ts
@@ -2,20 +2,19 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
 import { useAuthUid } from "@/entities/auth";
+import { type CardContentInput, cardContentInputSchema } from "@/entities/card";
 
 import { submit as submitAction } from "./actions/submit";
-import { cardCreateFormSchema } from "./schema";
-import type { CardCreateFormValues } from "./types";
 
 export function useCardCreatePageModel(deckId: string) {
   const uid = useAuthUid();
-  const form = useForm<CardCreateFormValues>({
+  const form = useForm<CardContentInput>({
     defaultValues: { frontText: "", backText: "", tags: [] },
-    resolver: zodResolver(cardCreateFormSchema),
+    resolver: zodResolver(cardContentInputSchema),
   });
 
   return {
     form,
-    submit: (values: CardCreateFormValues) => submitAction({ uid, deckId, values }),
+    submit: (values: CardContentInput) => submitAction({ uid, deckId, values }),
   };
 }

--- a/src/pages/card-create/ui/CardCreator.spec.tsx
+++ b/src/pages/card-create/ui/CardCreator.spec.tsx
@@ -14,15 +14,13 @@ const validation = vi.hoisted(() => ({ ready: undefined as Promise<void> | undef
 
 vi.mock("@/entities/auth", () => ({ useAuthUid: () => "user-id" }));
 vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
-vi.mock("@/entities/card", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/entities/card")>()),
-  createCard: writes.createCard,
-}));
-vi.mock("../model/schema", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../model/schema")>();
+vi.mock("@/entities/card", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/entities/card")>();
   return {
+    ...original,
+    createCard: writes.createCard,
     // Hold real schema validation so additional clicks can occur before the resolver finishes.
-    cardCreateFormSchema: original.cardCreateFormSchema.superRefine(async () => {
+    cardContentInputSchema: original.cardContentInputSchema.superRefine(async () => {
       if (validation.ready !== undefined) await validation.ready;
     }),
   };

--- a/src/pages/card-form/model/schema.ts
+++ b/src/pages/card-form/model/schema.ts
@@ -1,3 +1,0 @@
-import { cardContentSchema } from "@/entities/card";
-
-export const cardFormSchema = cardContentSchema.omit({ uniqueKey: true });

--- a/src/pages/card-form/model/types.ts
+++ b/src/pages/card-form/model/types.ts
@@ -1,10 +1,6 @@
-import type { z } from "zod";
-import type { CardId } from "@/entities/card";
-import type { cardFormSchema } from "./schema";
-
-export type CardFormValues = z.infer<typeof cardFormSchema>;
+import type { CardContentInput, CardId } from "@/entities/card";
 
 export interface SubmitCardFormInput {
   cardId: CardId;
-  values: CardFormValues;
+  values: CardContentInput;
 }

--- a/src/pages/card-form/model/useCardFormPageModel.ts
+++ b/src/pages/card-form/model/useCardFormPageModel.ts
@@ -1,24 +1,22 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
-import type { Card } from "@/entities/card";
+import { type Card, type CardContentInput, cardContentInputSchema } from "@/entities/card";
 
 import { submit as submitAction } from "./actions/submit";
-import { cardFormSchema } from "./schema";
-import type { CardFormValues } from "./types";
 
 export function useCardFormPageModel(card: Card) {
-  const form = useForm<CardFormValues>({
+  const form = useForm<CardContentInput>({
     defaultValues: {
       frontText: card.frontText,
       backText: card.backText,
       tags: [...card.tags],
     },
-    resolver: zodResolver(cardFormSchema),
+    resolver: zodResolver(cardContentInputSchema),
   });
 
   return {
     form,
-    submit: (values: CardFormValues) => submitAction({ cardId: card.id, values }),
+    submit: (values: CardContentInput) => submitAction({ cardId: card.id, values }),
   };
 }

--- a/src/pages/card-form/ui/CardEditor.stories.tsx
+++ b/src/pages/card-form/ui/CardEditor.stories.tsx
@@ -3,12 +3,11 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { fn } from "storybook/test";
 
-import type { Card } from "@/entities/card";
+import type { Card, CardContentInput } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
 import { withPageLayout } from "@/storybook/PageLayoutDecorator";
 import * as fixture from "@/storybook/fixture";
 
-import type { CardFormValues } from "../model/types";
 import { CardEditor } from "./CardEditor";
 
 interface CardEditorStoryProps {
@@ -19,7 +18,7 @@ interface CardEditorStoryProps {
 }
 
 const CardEditorStory = ({ card, isSaving, validationError, onCancel }: CardEditorStoryProps) => {
-  const form = useForm<CardFormValues>({
+  const form = useForm<CardContentInput>({
     defaultValues: { frontText: card.frontText, backText: card.backText, tags: card.tags },
   });
 

--- a/src/pages/card-form/ui/CardFormPage.tsx
+++ b/src/pages/card-form/ui/CardFormPage.tsx
@@ -3,7 +3,7 @@ import { useFormState } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { type Card, useCard } from "@/entities/card";
+import { type Card, type CardContentInput, useCard } from "@/entities/card";
 import { CATEGORY } from "@/entities/deck";
 import { useMountedGuard } from "@/shared/lib/useMountedGuard";
 import { routes, useNavigationGuard } from "@/shared/router";
@@ -11,7 +11,6 @@ import { AppLayout } from "@/widgets/app-layout";
 import { RouteNotFound } from "@/widgets/route-not-found";
 
 import { useCardFormPageModel } from "../model/useCardFormPageModel";
-import type { CardFormValues } from "../model/types";
 import { CardEditor } from "./CardEditor";
 
 const CardFormContent: React.FC<{ card: Card }> = ({ card }) => {
@@ -24,7 +23,7 @@ const CardFormContent: React.FC<{ card: Card }> = ({ card }) => {
   const isMounted = useMountedGuard();
   const cardListPath = routes.cardList.to(snapshot.deckId);
 
-  const save = async (values: CardFormValues): Promise<void> => {
+  const save = async (values: CardContentInput): Promise<void> => {
     if (!isMounted()) return;
     if (!(await submit(values))) return;
     if (!isMounted()) return;


### PR DESCRIPTION
## Related issue

None.

## Summary

- Export `cardContentInputSchema` and its inferred `CardContentInput` type from `entities/card` for both creation and editing.
- Remove the duplicated Page schemas and Page-specific form-value aliases. Update Page models, submit input types, the edit Page, and Storybook to use the shared contract.
- Reuse the shared schema in the CardFields test harness and update the CardCreator asynchronous-validation mock without removing repeated-submission coverage.
- Add schema coverage linked to CARD-13 and CARD-21 for content without identity fields and field-specific errors when both sides are empty.
- Remove the unused public `cardContentSchema` re-export; retain the schema internally for persistence validation and domain rules.

Form ownership, initial values, submit workflows, identity generation/preservation, and validation rules are unchanged.

## Validation and remaining gates

- Inspected the committed diff against main; changes are limited to the shared input contract and its consumers/tests.
- Application tests and `mise run check` were **not run** in this session. `mise` is not installed, and cloning the repository failed with `Could not resolve host: github.com`.
- The required custom `reviewer` subagent is unavailable in this session. The mandatory review workflow is **not complete**; the diff inspection above is not a substitute.
- Keep this PR as **Draft** until `mise run check` and the mandatory reviewer workflow have completed.

## Environment note

Based on main commit `28662b6586c0da28e71944f63f798ddd91b4aeac`. Because a local clone/worktree could not be created, the change was committed to a dedicated branch through the connected GitHub Git Data API. No changes were made directly to main.