### PR TITLE
docs: restrict form values to user-editable fields [No issue]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,12 @@ For every task that changes repository files:
 - Keep Entity stores limited to state, initialization, and persistence middleware. Preserve the roles of pure schemas, rules, and defaults, and keep persistence implementations in `api/`.
 - Export reusable operations through the slice public API. Within a slice, import individual modules directly and do not add internal barrel files.
 
+### Form values
+
+- Form values and form schemas must contain only fields the user can edit or select in that form. Default values, existing saved values, and programmatic updates to those fields are allowed.
+- Keep non-editable context and system-managed data, such as authenticated user IDs, fixed route parameters, generated IDs, and system timestamps, outside form values.
+- Combine validated form values with the required context and metadata in submit actions instead of adding them to the form.
+
 ## Coding Style
 
 - Prefer clear names and small functions; use comments to preserve intent that the code cannot express on its own.


### PR DESCRIPTION
## Related issue

None.

## Summary

- Add a `Form values` section to `AGENTS.md` limiting form values and schemas to fields the user can edit or select in that form.
- Explicitly allow default values, existing saved values, and programmatic updates to those editable fields.
- Keep non-editable context and system-managed metadata outside the form, and combine them with validated values in submit actions.

For example, a fixed route `deckId` belongs outside form values, while a `deckId` the user selects in the form belongs inside them.

## Validation

- Confirmed that the branch changes only `AGENTS.md`: 6 additions, 0 deletions.
- Application code and runtime behavior are unchanged.
- Tests and `mise run check` were not run because this is a documentation-only change.

## Review status

This PR is a draft. The mandatory custom `reviewer` subagent is not available in this environment, so the delegated review has not been performed and the review gate remains pending. Diff inspection is not a substitute for that review.

## Execution note

The branch was created from the current `main` commit (`28662b6586c0da28e71944f63f798ddd91b4aeac`) and the change was committed through the GitHub API. Direct Git access failed because `github.com` could not be resolved, so the required local `origin/main` fetch and worktree workflow could not be executed. No changes were made directly to `main`.
