### PR TITLE
[No issue] Revert list and settings readability changes (#1455)

### DIFF
--- a/src/pages/card-list/ui/Card.tsx
+++ b/src/pages/card-list/ui/Card.tsx
@@ -121,7 +121,7 @@ export const Card: React.FC<CardProps> = (props) => {
       {...handlers}
       aria-busy={disabled}
       className={cx(
-        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-3 transition-colors duration-fast ease-calm last:border-b-0 sm:gap-3 sm:px-4 dark:border-black",
+        "flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 transition-colors duration-fast ease-calm last:border-b-0 sm:gap-3 sm:px-4 dark:border-black",
         disabled ? "bg-surface-muted" : "bg-surface",
         !disabled && "hover:bg-surface-muted",
         props.className
@@ -138,10 +138,8 @@ export const Card: React.FC<CardProps> = (props) => {
             if (!(disabled || suppressViewClick.current)) props.goToView?.(id);
           }}
         />
-        <span className="line-clamp-2 w-full px-1 text-body font-semibold text-ink [overflow-wrap:anywhere]">
-          {props.card.frontText}
-        </span>
-        <div className="mt-1 flex w-full min-w-0 flex-col items-start gap-1 text-caption text-ink-muted sm:flex-row sm:items-center sm:gap-2">
+        <span className="w-full truncate px-1 text-body font-semibold text-ink">{props.card.frontText}</span>
+        <div className="mt-1 flex w-full min-w-0 items-center gap-2 text-caption text-ink-muted">
           <span className="shrink-0">
             {seenCount === 0 ? t("cardList.card.notStudied") : t("cardList.card.studied", { count: seenCount })}
           </span>

--- a/src/pages/deck-list/ui/DeckList.tsx
+++ b/src/pages/deck-list/ui/DeckList.tsx
@@ -48,7 +48,7 @@ const DeckListSection: React.FC<{
 
   return (
     <section aria-labelledby={headingId} className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 px-1">
+      <div className="flex items-baseline justify-between gap-3 px-1">
         <h2 id={headingId} className="text-caption font-bold uppercase tracking-wide text-ink-muted">
           {title}
         </h2>

--- a/src/pages/deck-list/ui/DeckListCard.tsx
+++ b/src/pages/deck-list/ui/DeckListCard.tsx
@@ -57,7 +57,7 @@ const formatLastStudied = (timestamp: number, t: TFunction): string => {
 };
 
 const primaryActionClassName =
-  "inline-flex min-h-touch shrink-0 items-center justify-center justify-self-start gap-1 rounded-control px-3 text-caption font-semibold transition-colors duration-fast ease-calm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
+  "inline-flex min-h-touch shrink-0 items-center justify-center gap-1 rounded-control px-3 text-caption font-semibold transition-colors duration-fast ease-calm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
 const DeckListCardStatus: React.FC<{
   deck: DeckListCardProps["deck"];
@@ -70,16 +70,13 @@ const DeckListCardStatus: React.FC<{
   const { t } = useTranslation();
 
   return (
-    <span
-      id={statusId}
-      className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-caption text-ink-muted"
-    >
+    <span id={statusId} className="mt-1 flex min-w-0 items-center gap-2 text-caption text-ink-muted">
       {deck.category !== "" && (
-        <span className="max-w-full truncate rounded-pill bg-surface-muted px-2 py-0.5 text-xs font-medium text-ink">
+        <span className="max-w-28 truncate rounded-pill bg-surface-muted px-2 py-0.5 text-xs font-medium text-ink">
           {deck.category}
         </span>
       )}
-      <span className="min-w-0 break-words tabular-nums">
+      <span className="truncate">
         {active && studySession
           ? `${String(progressValue)} / ${String(studySession.cardOrderIds.length)} · ${formatLastStudied(studySession.lastStudiedAt, t)}`
           : t("deckList.cardCount", { count: cardCount })}
@@ -136,12 +133,11 @@ export const DeckListCard: React.FC<DeckListCardProps> = (props) => {
     <article
       aria-busy={pending}
       className={cx(
-        "relative grid min-h-20 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 border-b border-border px-3 py-3 transition-colors duration-fast ease-calm last:border-b-0 sm:flex dark:border-black",
+        "relative flex min-h-20 items-center gap-2 border-b border-border px-3 py-2 transition-colors duration-fast ease-calm last:border-b-0 dark:border-black",
         pending ? "bg-surface-muted" : "hover:bg-surface-muted"
       )}
     >
-      {/* Keep the name and study status above the actions on narrow screens so they retain the full row width. */}
-      <div className="col-span-2 min-w-0 flex-1 px-1 py-1">
+      <div className="min-w-0 flex-1 px-1 py-1">
         <button
           type="button"
           aria-label={t("deckList.view", { deckName: deck.name })}
@@ -150,9 +146,7 @@ export const DeckListCard: React.FC<DeckListCardProps> = (props) => {
           onClick={withId(props.onClickName)}
           disabled={pending}
         >
-          <span className="line-clamp-2 min-w-0 text-body font-semibold text-ink [overflow-wrap:anywhere]">
-            {deck.name}
-          </span>
+          <span className="truncate text-body font-semibold text-ink">{deck.name}</span>
           {!deck.localMode ? (
             <span role="img" aria-label={t("deckList.remote")} className="shrink-0 text-ink-muted">
               <AiOutlineCloud aria-hidden="true" size={16} />

--- a/src/pages/settings/ui/SettingsForm.tsx
+++ b/src/pages/settings/ui/SettingsForm.tsx
@@ -69,7 +69,6 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
             inputId={inputIds.language}
             label={t("settings.language.label")}
             description={t("settings.language.help")}
-            controlPosition="second-row"
           >
             <Select
               {...props.form.register("language")}
@@ -252,9 +251,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = (props) => {
               <h2 id={advancedHeadingId} className="text-body font-bold text-ink">
                 {t("settings.advanced.title")}
               </h2>
-              <span className="mt-1 block text-caption leading-relaxed text-ink-muted">
-                {t("settings.advanced.description")}
-              </span>
+              <span className="block text-caption text-ink-muted">{t("settings.advanced.description")}</span>
             </span>
             <AiOutlineDown
               aria-hidden="true"

--- a/src/pages/settings/ui/SettingsSection.tsx
+++ b/src/pages/settings/ui/SettingsSection.tsx
@@ -26,7 +26,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({ title, descrip
           <h2 id={headingId} className="text-body font-bold text-ink">
             {title}
           </h2>
-          <p className="mt-1 text-caption leading-relaxed text-ink-muted">{description}</p>
+          <p className="text-caption text-ink-muted">{description}</p>
         </div>
       </div>
       <div className="divide-y divide-border border-t border-border">{children}</div>
@@ -58,7 +58,7 @@ export const SettingsRow: React.FC<SettingsRowProps> = ({
       <label htmlFor={inputId} className="block break-words text-body font-medium text-ink">
         {label}
       </label>
-      <p id={`${inputId}-description`} className="mt-1 break-words text-caption leading-relaxed text-ink-muted">
+      <p id={`${inputId}-description`} className="break-words text-caption text-ink-muted">
         {description}
       </p>
     </div>


### PR DESCRIPTION
## Related issue

None.

## Summary

Reverts #1455 (commit eacf2af1844fa5bb69cb7b3a3e278d6716dc0b97), restoring the previous card list, deck list, and settings layouts. This is the exact inverse of the original five-file change.

## Testing

- `mise run check` passed, including all 768 unit tests across 127 files.
- Required reviewer review completed with no findings.
- Verified that the inverse patch preserves subsequent changes.