### PR TITLE
[No issue] Keep production interfaces free of test-only dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ For every task that changes repository files:
 - Do not add test code for non-application code.
 - Write tests against observable behavior so they remain stable under refactoring.
 - Do not write tests that depend on implementation details.
+- Design production interfaces around production requirements. Do not add or change parameters, dependency objects, callbacks, factories, optional overrides, or exports solely to make code testable or mockable.
+- Adapt tests to existing production interfaces. Replace dependencies with test-side module mocks or spies instead of adding injection points to production code.
 
 ### Unit and Integration Tests
 

--- a/src/pages/deck-import/model/actions/prepareDeckImport.spec.ts
+++ b/src/pages/deck-import/model/actions/prepareDeckImport.spec.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("@/shared/firebase", () => ({ auth: {}, db: {} }));
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateCardId } from "@/entities/card";
+import { generateDeckId } from "@/entities/deck";
 import { prepareDeckImport } from "./prepareDeckImport";
+
+vi.mock("@/entities/card", () => ({ generateCardId: vi.fn() }));
+vi.mock("@/entities/deck", () => ({ generateDeckId: vi.fn() }));
 
 describe("prepareDeckImport [IMPORT-01]", () => {
   const row = {
@@ -11,15 +13,13 @@ describe("prepareDeckImport [IMPORT-01]", () => {
   };
   const rows = [row];
 
+  beforeEach(() => {
+    vi.mocked(generateDeckId).mockReset().mockReturnValue("deck");
+    vi.mocked(generateCardId).mockReset().mockReturnValue("card");
+  });
+
   it("prepares a new remote Deck and Card creations", () => {
-    const preparedImport = prepareDeckImport(
-      { name: "deck.csv", rows },
-      {
-        uid: "uid",
-        generateDeckId: vi.fn(() => "deck"),
-        generateCardId: vi.fn(() => "card"),
-      }
-    );
+    const preparedImport = prepareDeckImport({ name: "deck.csv", rows }, "uid");
 
     expect(preparedImport.destination).toEqual({ id: "deck", name: "deck.csv", localMode: false });
     expect(preparedImport.mutations).toEqual([
@@ -31,15 +31,11 @@ describe("prepareDeckImport [IMPORT-01]", () => {
   });
 
   it("generates a new destination for every preparation", () => {
-    const generateDeckId = vi.fn().mockReturnValueOnce("deck-1").mockReturnValueOnce("deck-2");
-    const dependencies = {
-      uid: "uid",
-      generateDeckId,
-      generateCardId: vi.fn().mockReturnValueOnce("card-1").mockReturnValueOnce("card-2"),
-    };
+    vi.mocked(generateDeckId).mockReturnValueOnce("deck-1").mockReturnValueOnce("deck-2");
+    vi.mocked(generateCardId).mockReturnValueOnce("card-1").mockReturnValueOnce("card-2");
 
-    const first = prepareDeckImport({ name: "same.csv", rows }, dependencies);
-    const second = prepareDeckImport({ name: "same.csv", rows }, dependencies);
+    const first = prepareDeckImport({ name: "same.csv", rows }, "uid");
+    const second = prepareDeckImport({ name: "same.csv", rows }, "uid");
 
     expect(first.destination.id).toBe("deck-1");
     expect(second.destination.id).toBe("deck-2");
@@ -48,14 +44,10 @@ describe("prepareDeckImport [IMPORT-01]", () => {
   });
 
   it("prepares local Deck and Card creation without an account owner", () => {
-    const preparedImport = prepareDeckImport(
-      { name: "local.csv", rows, storageMode: "local" },
-      {
-        uid: "",
-        generateDeckId: vi.fn(() => "local-deck"),
-        generateCardId: vi.fn(() => "local-card"),
-      }
-    );
+    vi.mocked(generateDeckId).mockReturnValue("local-deck");
+    vi.mocked(generateCardId).mockReturnValue("local-card");
+
+    const preparedImport = prepareDeckImport({ name: "local.csv", rows, storageMode: "local" }, "");
 
     expect(preparedImport.destination).toEqual({ id: "local-deck", name: "local.csv", localMode: true });
     expect(preparedImport.mutations).toEqual([
@@ -67,11 +59,8 @@ describe("prepareDeckImport [IMPORT-01]", () => {
   });
 
   it("requires a confirmed user for a remote import", () => {
-    expect(() =>
-      prepareDeckImport(
-        { name: "remote.csv", rows },
-        { uid: "", generateDeckId: vi.fn(() => "deck"), generateCardId: vi.fn(() => "card") }
-      )
-    ).toThrow("A confirmed user is required for remote imports");
+    expect(() => prepareDeckImport({ name: "remote.csv", rows }, "")).toThrow(
+      "A confirmed user is required for remote imports"
+    );
   });
 });

--- a/src/pages/deck-import/model/actions/prepareDeckImport.ts
+++ b/src/pages/deck-import/model/actions/prepareDeckImport.ts
@@ -1,5 +1,5 @@
-import type { CardMutation } from "@/entities/card";
-import type { DeckId, LocalDeckCreateInput, RemoteDeckCreateInput } from "@/entities/deck";
+import { generateCardId, type CardMutation } from "@/entities/card";
+import { generateDeckId, type DeckId, type LocalDeckCreateInput, type RemoteDeckCreateInput } from "@/entities/deck";
 import type { DeckImportRow } from "../../lib/cardCsv";
 import type { DeckImportStorageMode, PreparedDeckImport } from "../types";
 type DeckImportCreateInput = RemoteDeckCreateInput | LocalDeckCreateInput;
@@ -9,17 +9,7 @@ interface DeckImportSource {
   storageMode?: DeckImportStorageMode;
 }
 
-interface DeckImportPreparationDependencies {
-  uid: string;
-  generateDeckId: () => DeckId;
-  generateCardId: (row: DeckImportRow) => string;
-}
-
-const createDestination = (
-  source: DeckImportSource,
-  storageMode: DeckImportStorageMode,
-  generateDeckId: () => DeckId
-): DeckImportCreateInput => {
+const createDestination = (source: DeckImportSource, storageMode: DeckImportStorageMode): DeckImportCreateInput => {
   const id = generateDeckId();
   return storageMode === "local"
     ? { id, name: source.name, localMode: true }
@@ -31,29 +21,24 @@ const prepareCardCreations = ({
   destinationId,
   uid,
   storageMode,
-  generateCardId,
 }: {
   rows: DeckImportRow[];
   destinationId: DeckId;
   uid: string;
   storageMode: DeckImportStorageMode;
-  generateCardId: (row: DeckImportRow) => string;
 }): CardMutation[] =>
   rows.map((row) => {
-    const cardFields = { ...row.card, id: generateCardId(row), deckId: destinationId };
+    const cardFields = { ...row.card, id: generateCardId(), deckId: destinationId };
     // Local persistence stays account-agnostic; Card mutation routing follows the parent Deck's localMode.
     const card = storageMode === "local" ? cardFields : { ...cardFields, uid };
     return { kind: "create", card };
   });
 
-export function prepareDeckImport(
-  source: DeckImportSource,
-  { uid, generateDeckId, generateCardId }: DeckImportPreparationDependencies
-): PreparedDeckImport {
+export function prepareDeckImport(source: DeckImportSource, uid: string): PreparedDeckImport {
   const storageMode = source.storageMode ?? "remote";
   if (storageMode === "remote" && uid === "") throw new Error("A confirmed user is required for remote imports");
 
-  const destination = createDestination(source, storageMode, generateDeckId);
+  const destination = createDestination(source, storageMode);
 
   return {
     uid,
@@ -63,7 +48,6 @@ export function prepareDeckImport(
       destinationId: destination.id,
       uid,
       storageMode,
-      generateCardId,
     }),
   };
 }

--- a/src/pages/deck-import/model/actions/selectDeckImportFile.ts
+++ b/src/pages/deck-import/model/actions/selectDeckImportFile.ts
@@ -1,6 +1,4 @@
 import { getAuthUid } from "@/entities/auth";
-import { generateCardId } from "@/entities/card";
-import { generateDeckId } from "@/entities/deck";
 import { parseCsv } from "../../lib/cardCsv";
 import { beginFileSelection, cancelFileSelection, completeFileSelection, failFileSelection } from "../store";
 import { prepareDeckImport } from "./prepareDeckImport";
@@ -19,7 +17,7 @@ export async function selectDeckImportFile(file: File): Promise<void> {
       analysis.invalidCount === 0 && analysis.rows.length > 0
         ? prepareDeckImport(
             { name: file.name, rows: analysis.rows, storageMode: selection.storageMode },
-            { uid: selection.uid, generateDeckId, generateCardId }
+            selection.uid
           )
         : undefined;
     completeFileSelection({ kind: "selected", preview: { deckName: file.name, analysis }, preparedImport });

--- a/src/pages/deck-import/model/actions/selectDeckImportFile.ts
+++ b/src/pages/deck-import/model/actions/selectDeckImportFile.ts
@@ -15,10 +15,7 @@ export async function selectDeckImportFile(file: File): Promise<void> {
     }
     const preparedImport =
       analysis.invalidCount === 0 && analysis.rows.length > 0
-        ? prepareDeckImport(
-            { name: file.name, rows: analysis.rows, storageMode: selection.storageMode },
-            selection.uid
-          )
+        ? prepareDeckImport({ name: file.name, rows: analysis.rows, storageMode: selection.storageMode }, selection.uid)
         : undefined;
     completeFileSelection({ kind: "selected", preview: { deckName: file.name, analysis }, preparedImport });
   } catch (error: unknown) {


### PR DESCRIPTION
## Related issue

None.

## Summary

- Add an `AGENTS.md` rule prohibiting production interface changes solely for tests or mocks, including test-only parameters, dependency objects, callbacks, factories, optional overrides, and exports. Adapt tests with module mocks or spies instead.
- Remove `DeckImportPreparationDependencies` and the injected `generateDeckId` / `generateCardId` callbacks from deck import preparation and its private helpers. Import the existing Entity ID generators directly.
- Simplify the production call site and update the existing four `[IMPORT-01]` tests to mock the imported modules. Keep their existing behavioral assertions; remove the now-unnecessary Firebase mock.

## Production interface

```ts
// Before
prepareDeckImport(source, { uid, generateDeckId, generateCardId });

// After
prepareDeckImport(source, uid);
```

The captured selection UID, authentication checks, local/remote ownership behavior, and prepared IDs used by retries are unchanged. No test-specific factory or replacement injection interface is introduced.

## CI fix

Commit `93b0d57d7f78f248f6ec53c5e305e67745534d0a` fixes the Biome formatting failure in `selectDeckImportFile.ts`. The formatter requires the now-shorter `prepareDeckImport` call on one line. Only whitespace changed; no production interface, behavior, test assertion, or CI rule was changed.

## Validation

- In the original [Test run](https://github.com/her0e1c1/tango/actions/runs/34174899362), Unit coverage, Build, Sample, Storybook, E2E, Firestore integration, and Dependency Review passed. Code quality failed at formatting, before lint ran; the aggregate Test job consequently failed. Audit also passed.
- Local TypeScript token comparison and emitted-JavaScript comparison confirmed that the formatting replacement is semantically unchanged and within the configured 120-column limit. This is not a full typecheck or repository test run.
- The fix triggered a new [Test run](https://github.com/her0e1c1/tango/actions/runs/34180191559) and [Audit run](https://github.com/her0e1c1/tango/actions/runs/34180191346). See those runs for current results.
- Not run locally: `mise run check` (`mise: command not found`). Fetching `origin/main` was blocked by sandbox DNS resolution, so the existing PR branch was updated through the GitHub connector; main was not modified.
- Not completed: the mandatory custom `reviewer` subagent workflow. That runtime is not available in this session; self-review is not claimed as a substitute.

The PR remains a draft because the required reviewer gate is not complete.